### PR TITLE
feat: Session 3 — DRep Command Center

### DIFF
--- a/app/api/dashboard/competitive/route.ts
+++ b/app/api/dashboard/competitive/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+  try {
+    const supabase = getSupabaseAdmin();
+
+    // Get all active DReps sorted by score
+    const { data: allDreps, error } = await supabase
+      .from('dreps')
+      .select('id, score, info, participation_rate, rationale_rate, reliability_score, profile_completeness, effective_participation, metadata')
+      .not('info->isActive', 'eq', false)
+      .order('score', { ascending: false });
+
+    if (error || !allDreps) {
+      return NextResponse.json({ error: 'Failed to fetch DReps' }, { status: 500 });
+    }
+
+    const currentIndex = allDreps.findIndex((d: any) => d.id === drepId);
+    if (currentIndex === -1) {
+      return NextResponse.json({ error: 'DRep not found in rankings' }, { status: 404 });
+    }
+
+    const rank = currentIndex + 1;
+    const totalActive = allDreps.length;
+    const currentDrep = allDreps[currentIndex];
+
+    // Nearby DReps: 2 above and 2 below
+    const nearbyAbove = allDreps
+      .slice(Math.max(0, currentIndex - 2), currentIndex)
+      .map((d: any, i: number) => ({
+        drepId: d.id,
+        name: d.metadata?.givenName || d.id.slice(0, 16),
+        score: d.score,
+        rank: Math.max(0, currentIndex - 2) + i + 1,
+      }));
+
+    const nearbyBelow = allDreps
+      .slice(currentIndex + 1, currentIndex + 3)
+      .map((d: any, i: number) => ({
+        drepId: d.id,
+        name: d.metadata?.givenName || d.id.slice(0, 16),
+        score: d.score,
+        rank: currentIndex + 2 + i,
+      }));
+
+    // Top 10 average per pillar
+    const top10 = allDreps.slice(0, Math.min(10, allDreps.length));
+    const top10Avg = {
+      participation: Math.round(top10.reduce((s: number, d: any) => s + (d.effective_participation || 0), 0) / top10.length),
+      rationale: Math.round(top10.reduce((s: number, d: any) => s + (d.rationale_rate || 0), 0) / top10.length),
+      reliability: Math.round(top10.reduce((s: number, d: any) => s + (d.reliability_score || 0), 0) / top10.length),
+      profile: Math.round(top10.reduce((s: number, d: any) => s + (d.profile_completeness || 0), 0) / top10.length),
+    };
+
+    // Find weakest pillar relative to top 10
+    const currentPillars = {
+      participation: currentDrep.effective_participation || 0,
+      rationale: currentDrep.rationale_rate || 0,
+      reliability: currentDrep.reliability_score || 0,
+      profile: currentDrep.profile_completeness || 0,
+    };
+
+    const gaps = [
+      { pillar: 'Participation', gap: top10Avg.participation - currentPillars.participation },
+      { pillar: 'Rationale', gap: top10Avg.rationale - currentPillars.rationale },
+      { pillar: 'Reliability', gap: top10Avg.reliability - currentPillars.reliability },
+      { pillar: 'Profile', gap: top10Avg.profile - currentPillars.profile },
+    ].filter(g => g.gap > 0).sort((a, b) => b.gap - a.gap);
+
+    const distanceToTop10 = rank > 10 && allDreps.length >= 10
+      ? allDreps[9].score - currentDrep.score
+      : 0;
+
+    return NextResponse.json({
+      rank,
+      totalActive,
+      nearbyAbove,
+      nearbyBelow,
+      distanceToTop10,
+      top10FocusArea: gaps[0] || null,
+      top10Avg,
+      currentPillars,
+    });
+  } catch (err) {
+    console.error('[Competitive API] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/delegator-trends/route.ts
+++ b/app/api/dashboard/delegator-trends/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+  try {
+    const supabase = getSupabaseAdmin();
+
+    const [snapshotsResult, drepResult] = await Promise.all([
+      supabase
+        .from('drep_power_snapshots')
+        .select('epoch_no, amount_lovelace, delegator_count')
+        .eq('drep_id', drepId)
+        .order('epoch_no', { ascending: true })
+        .limit(50),
+      supabase
+        .from('dreps')
+        .select('info')
+        .eq('id', drepId)
+        .single(),
+    ]);
+
+    const snapshots = (snapshotsResult.data || []).map((s: any) => ({
+      epoch: s.epoch_no,
+      votingPowerAda: Math.round(Number(s.amount_lovelace) / 1_000_000),
+      delegatorCount: s.delegator_count,
+    }));
+
+    const currentDelegators = drepResult.data?.info?.delegatorCount || null;
+
+    return NextResponse.json({ snapshots, currentDelegators });
+  } catch (error) {
+    console.error('[Delegator Trends API] Error:', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/milestones/route.ts
+++ b/app/api/dashboard/milestones/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { MILESTONES, getAchievedMilestones, checkAndAwardMilestones } from '@/lib/milestones';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+  try {
+    const achieved = await getAchievedMilestones(drepId);
+    const achievedKeys = new Set(achieved.map(a => a.milestoneKey));
+
+    const milestones = MILESTONES.map(m => ({
+      ...m,
+      achieved: achievedKeys.has(m.key),
+      achievedAt: achieved.find(a => a.milestoneKey === m.key)?.achievedAt || null,
+    }));
+
+    return NextResponse.json({ milestones, achievedCount: achieved.length, totalCount: MILESTONES.length });
+  } catch (err) {
+    console.error('[Milestones API] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { drepId } = await request.json();
+    if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+    const newMilestones = await checkAndAwardMilestones(drepId);
+    return NextResponse.json({ newMilestones });
+  } catch (err) {
+    console.error('[Milestones POST] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/onboarding/route.ts
+++ b/app/api/dashboard/onboarding/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { parseSessionToken, isSessionExpired } from '@/lib/supabaseAuth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const wallet = request.nextUrl.searchParams.get('wallet');
+  if (!wallet) return NextResponse.json({ error: 'Missing wallet' }, { status: 400 });
+
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('users')
+    .select('onboarding_checklist')
+    .eq('wallet_address', wallet)
+    .single();
+
+  return NextResponse.json({ checklist: data?.onboarding_checklist || {} });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { sessionToken, item, completed } = await request.json();
+    if (!sessionToken || !item) return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+
+    const parsed = parseSessionToken(sessionToken);
+    if (!parsed || isSessionExpired(parsed)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const supabase = getSupabaseAdmin();
+    const { data: user } = await supabase
+      .from('users')
+      .select('onboarding_checklist')
+      .eq('wallet_address', parsed.walletAddress)
+      .single();
+
+    const checklist = user?.onboarding_checklist || {};
+    checklist[item] = completed !== false;
+
+    await supabase
+      .from('users')
+      .update({ onboarding_checklist: checklist })
+      .eq('wallet_address', parsed.walletAddress);
+
+    return NextResponse.json({ checklist });
+  } catch (err) {
+    console.error('[Onboarding API] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/representation/route.ts
+++ b/app/api/dashboard/representation/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+  try {
+    const supabase = getSupabaseAdmin();
+
+    // Get all poll responses from this DRep's delegators
+    const { data: pollResponses } = await supabase
+      .from('poll_responses')
+      .select('proposal_tx_hash, proposal_index, vote')
+      .eq('delegated_drep_id', drepId);
+
+    if (!pollResponses || pollResponses.length === 0) {
+      return NextResponse.json({ alignment: null, proposals: [], message: 'No delegator poll data' });
+    }
+
+    // Get DRep's votes
+    const { data: drepVotes } = await supabase
+      .from('drep_votes')
+      .select('proposal_tx_hash, proposal_index, vote')
+      .eq('drep_id', drepId);
+
+    if (!drepVotes) {
+      return NextResponse.json({ alignment: null, proposals: [] });
+    }
+
+    // Group poll responses by proposal
+    const proposalPolls = new Map<string, { yes: number; no: number; abstain: number }>();
+    for (const pr of pollResponses) {
+      const key = `${pr.proposal_tx_hash}-${pr.proposal_index}`;
+      if (!proposalPolls.has(key)) proposalPolls.set(key, { yes: 0, no: 0, abstain: 0 });
+      const counts = proposalPolls.get(key)!;
+      if (pr.vote === 'Yes') counts.yes++;
+      else if (pr.vote === 'No') counts.no++;
+      else counts.abstain++;
+    }
+
+    // Build DRep vote lookup
+    const drepVoteMap = new Map<string, string>();
+    for (const v of drepVotes) {
+      drepVoteMap.set(`${v.proposal_tx_hash}-${v.proposal_index}`, v.vote);
+    }
+
+    // Get proposal titles
+    const proposalKeys = [...proposalPolls.keys()];
+    const proposalIds = proposalKeys.map(k => {
+      const [txHash, index] = k.split('-');
+      return { tx_hash: txHash, proposal_index: parseInt(index) };
+    });
+
+    const titles = new Map<string, string>();
+    if (proposalIds.length > 0) {
+      const txHashes = [...new Set(proposalIds.map(p => p.tx_hash))];
+      const { data: proposals } = await supabase
+        .from('proposals')
+        .select('tx_hash, proposal_index, title')
+        .in('tx_hash', txHashes);
+      if (proposals) {
+        for (const p of proposals) {
+          titles.set(`${p.tx_hash}-${p.proposal_index}`, p.title || `Proposal ${p.tx_hash.slice(0, 8)}...`);
+        }
+      }
+    }
+
+    // Calculate alignment per proposal (min 3 delegator responses)
+    const MIN_RESPONSES = 3;
+    let alignedCount = 0;
+    let totalCompared = 0;
+    const proposalBreakdown: any[] = [];
+
+    for (const [key, counts] of proposalPolls.entries()) {
+      const total = counts.yes + counts.no + counts.abstain;
+      if (total < MIN_RESPONSES) continue;
+
+      const drepVote = drepVoteMap.get(key);
+      if (!drepVote) continue;
+
+      const majority = counts.yes >= counts.no && counts.yes >= counts.abstain ? 'Yes'
+        : counts.no >= counts.yes && counts.no >= counts.abstain ? 'No'
+        : 'Abstain';
+
+      const majorityPct = Math.round((Math.max(counts.yes, counts.no, counts.abstain) / total) * 100);
+      const aligned = drepVote === majority;
+
+      if (aligned) alignedCount++;
+      totalCompared++;
+
+      proposalBreakdown.push({
+        key,
+        title: titles.get(key) || key,
+        drepVote,
+        delegatorMajority: majority,
+        delegatorMajorityPct: majorityPct,
+        totalResponses: total,
+        aligned,
+      });
+    }
+
+    const alignmentPct = totalCompared > 0 ? Math.round((alignedCount / totalCompared) * 100) : null;
+
+    return NextResponse.json({
+      alignment: alignmentPct,
+      totalCompared,
+      alignedCount,
+      proposals: proposalBreakdown.sort((a, b) => (a.aligned ? 1 : 0) - (b.aligned ? 1 : 0)),
+    });
+  } catch (err) {
+    console.error('[Representation API] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/dashboard/simulate/route.ts
+++ b/app/api/dashboard/simulate/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { applyRationaleCurve } from '@/utils/scoring';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  const additionalVotes = parseInt(request.nextUrl.searchParams.get('votes') || '0');
+  const additionalRationales = parseInt(request.nextUrl.searchParams.get('rationales') || '0');
+
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+
+  try {
+    const supabase = getSupabaseAdmin();
+
+    const [drepResult, proposalCountResult, allDrepsResult] = await Promise.all([
+      supabase.from('dreps').select('score, info, participation_rate, rationale_rate, effective_participation, deliberation_modifier, reliability_score, profile_completeness').eq('id', drepId).single(),
+      supabase.from('proposals').select('id', { count: 'exact', head: true }),
+      supabase.from('dreps').select('score').not('info->isActive', 'eq', false).order('score', { ascending: false }),
+    ]);
+
+    const drep = drepResult.data;
+    if (!drep) return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
+
+    const totalProposals = proposalCountResult.count || 1;
+    const currentTotalVotes = drep.info?.totalVotes || 0;
+
+    // Simulate
+    const simTotalVotes = currentTotalVotes + additionalVotes;
+    const simParticipation = Math.min(100, Math.round((simTotalVotes / totalProposals) * 100));
+    const simEffParticipation = Math.round(simParticipation * (drep.deliberation_modifier || 1));
+
+    const currentVotesWithRationale = Math.round((drep.rationale_rate / 100) * currentTotalVotes);
+    const simRationaleRaw = simTotalVotes > 0
+      ? Math.round(((currentVotesWithRationale + additionalRationales) / simTotalVotes) * 100)
+      : 0;
+    const simRationaleCurved = applyRationaleCurve(simRationaleRaw);
+
+    const currentCurvedRationale = applyRationaleCurve(drep.rationale_rate);
+    const currentScore = Math.round(
+      drep.effective_participation * 0.30 +
+      currentCurvedRationale * 0.35 +
+      drep.reliability_score * 0.20 +
+      drep.profile_completeness * 0.15
+    );
+
+    const simScore = Math.round(
+      simEffParticipation * 0.30 +
+      simRationaleCurved * 0.35 +
+      drep.reliability_score * 0.20 +
+      drep.profile_completeness * 0.15
+    );
+
+    // Calculate simulated rank
+    const allScores = (allDrepsResult.data || []).map((d: any) => d.score);
+    const currentRank = allScores.filter((s: number) => s > drep.score).length + 1;
+    const simRank = allScores.filter((s: number) => s > simScore).length + 1;
+
+    return NextResponse.json({
+      current: {
+        score: currentScore,
+        participation: drep.effective_participation,
+        rationale: currentCurvedRationale,
+        reliability: drep.reliability_score,
+        profile: drep.profile_completeness,
+        rank: currentRank,
+      },
+      simulated: {
+        score: Math.min(100, simScore),
+        participation: simEffParticipation,
+        rationale: simRationaleCurved,
+        reliability: drep.reliability_score,
+        profile: drep.profile_completeness,
+        rank: simRank,
+      },
+      pendingProposalCount: additionalVotes,
+    });
+  } catch (err) {
+    console.error('[Simulate API] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/drep/[drepId]/explanations/route.ts
+++ b/app/api/drep/[drepId]/explanations/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { parseSessionToken, isSessionExpired } from '@/lib/supabaseAuth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+  const supabase = getSupabaseAdmin();
+
+  const { data, error } = await supabase
+    .from('vote_explanations')
+    .select('*')
+    .eq('drep_id', drepId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('[Explanations GET] Error:', error);
+    return NextResponse.json({ error: 'Failed to fetch explanations' }, { status: 500 });
+  }
+
+  return NextResponse.json(data || []);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+
+  try {
+    const body = await request.json();
+    const { sessionToken, proposalTxHash, proposalIndex, explanationText, aiAssisted } = body;
+
+    if (!sessionToken || !proposalTxHash || proposalIndex == null || !explanationText) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const parsed = parseSessionToken(sessionToken);
+    if (!parsed || isSessionExpired(parsed)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: user } = await supabase
+      .from('users')
+      .select('claimed_drep_id')
+      .eq('wallet_address', parsed.walletAddress)
+      .single();
+
+    if (!user || user.claimed_drep_id !== drepId) {
+      return NextResponse.json({ error: 'Not authorized for this DRep' }, { status: 403 });
+    }
+
+    const { data, error } = await supabase
+      .from('vote_explanations')
+      .upsert(
+        {
+          drep_id: drepId,
+          proposal_tx_hash: proposalTxHash,
+          proposal_index: proposalIndex,
+          explanation_text: explanationText,
+          ai_assisted: aiAssisted || false,
+        },
+        { onConflict: 'drep_id,proposal_tx_hash,proposal_index' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[Explanations POST] Error:', error);
+      return NextResponse.json({ error: 'Failed to save explanation' }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[Explanations POST] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/drep/[drepId]/philosophy/route.ts
+++ b/app/api/drep/[drepId]/philosophy/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { parseSessionToken, isSessionExpired } from '@/lib/supabaseAuth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('governance_philosophy')
+    .select('philosophy_text, updated_at')
+    .eq('drep_id', drepId)
+    .single();
+
+  return NextResponse.json(data || { philosophy_text: null });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+  try {
+    const { sessionToken, philosophyText } = await request.json();
+    if (!sessionToken || !philosophyText) return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+
+    const parsed = parseSessionToken(sessionToken);
+    if (!parsed || isSessionExpired(parsed)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const supabase = getSupabaseAdmin();
+    const { data: user } = await supabase
+      .from('users')
+      .select('claimed_drep_id')
+      .eq('wallet_address', parsed.walletAddress)
+      .single();
+
+    if (!user || user.claimed_drep_id !== drepId) return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+
+    const { data, error } = await supabase
+      .from('governance_philosophy')
+      .upsert({ drep_id: drepId, philosophy_text: philosophyText }, { onConflict: 'drep_id' })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[Philosophy POST] Error:', error);
+      return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[Philosophy POST] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/drep/[drepId]/positions/route.ts
+++ b/app/api/drep/[drepId]/positions/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { parseSessionToken, isSessionExpired } from '@/lib/supabaseAuth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('position_statements')
+    .select('*')
+    .eq('drep_id', drepId)
+    .order('created_at', { ascending: false });
+
+  return NextResponse.json(data || []);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  const { drepId } = await params;
+  try {
+    const { sessionToken, proposalTxHash, proposalIndex, statementText } = await request.json();
+    if (!sessionToken || !proposalTxHash || proposalIndex == null || !statementText) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+
+    const parsed = parseSessionToken(sessionToken);
+    if (!parsed || isSessionExpired(parsed)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const supabase = getSupabaseAdmin();
+    const { data: user } = await supabase
+      .from('users')
+      .select('claimed_drep_id')
+      .eq('wallet_address', parsed.walletAddress)
+      .single();
+
+    if (!user || user.claimed_drep_id !== drepId) return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+
+    const { data, error } = await supabase
+      .from('position_statements')
+      .upsert(
+        { drep_id: drepId, proposal_tx_hash: proposalTxHash, proposal_index: proposalIndex, statement_text: statementText },
+        { onConflict: 'drep_id,proposal_tx_hash,proposal_index' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error('[Positions POST] Error:', error);
+      return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[Positions POST] Error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -8,6 +8,7 @@ import { syncSlow } from '@/inngest/functions/sync-slow';
 import { alertIntegrity } from '@/inngest/functions/alert-integrity';
 import { alertInbox } from '@/inngest/functions/alert-inbox';
 import { alertApiHealth } from '@/inngest/functions/alert-api-health';
+import { checkNotifications } from '@/inngest/functions/check-notifications';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -20,5 +21,6 @@ export const { GET, POST, PUT } = serve({
     alertIntegrity,
     alertInbox,
     alertApiHealth,
+    checkNotifications,
   ],
 });

--- a/app/claim/[drepId]/ClaimPageClient.tsx
+++ b/app/claim/[drepId]/ClaimPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useWallet } from '@/utils/wallet';
@@ -15,10 +15,15 @@ import {
   Inbox,
   TrendingUp,
   ArrowRight,
-  Check,
   Loader2,
   ExternalLink,
+  Users,
+  Trophy,
+  BarChart3,
+  Eye,
+  Lock,
 } from 'lucide-react';
+import { ClaimCelebration } from '@/components/ClaimCelebration';
 
 interface ClaimPageClientProps {
   drepId: string;
@@ -31,36 +36,36 @@ interface ClaimPageClientProps {
   isClaimed: boolean;
 }
 
-function ScoreRing({ score }: { score: number }) {
-  const size = 160;
-  const strokeWidth = 10;
+interface PulseData {
+  votesThisWeek: number;
+  activeDReps: number;
+  claimedDReps: number;
+  activeProposals: number;
+}
+
+interface TopDRep {
+  drepId: string;
+  name: string;
+  score: number;
+}
+
+function ScoreRing({ score, size = 140 }: { score: number; size?: number }) {
+  const strokeWidth = 8;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
   const progress = Math.min(100, Math.max(0, score)) / 100;
   const dashOffset = circumference * (1 - progress);
   const color = score >= 80 ? '#22c55e' : score >= 60 ? '#f59e0b' : '#ef4444';
-  const label = score >= 80 ? 'Strong' : score >= 60 ? 'Good' : 'Needs Work';
 
   return (
     <div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
       <svg width={size} height={size} className="absolute -rotate-90">
-        <circle
-          cx={size / 2} cy={size / 2} r={radius}
-          fill="none" stroke="currentColor" strokeWidth={strokeWidth}
-          className="text-muted/30"
-        />
-        <circle
-          cx={size / 2} cy={size / 2} r={radius}
-          fill="none" stroke={color} strokeWidth={strokeWidth}
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={dashOffset}
-          className="transition-all duration-1000 ease-out"
-        />
+        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke="currentColor" strokeWidth={strokeWidth} className="text-muted/30" />
+        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeDasharray={circumference} strokeDashoffset={dashOffset} className="transition-all duration-1000 ease-out" />
       </svg>
       <div className="flex flex-col items-center">
-        <span className="text-4xl font-bold tabular-nums" style={{ color }}>{score}</span>
-        <span className="text-xs text-muted-foreground">{label}</span>
+        <span className="text-3xl font-bold tabular-nums" style={{ color }}>{score}</span>
+        <span className="text-[10px] text-muted-foreground">/100</span>
       </div>
     </div>
   );
@@ -70,7 +75,6 @@ function PillarBar({ label, value, max }: { label: string; value: number; max: n
   const pct = Math.min(100, (value / 100) * 100);
   const color = pct >= 80 ? 'bg-green-500' : pct >= 50 ? 'bg-amber-500' : 'bg-red-500';
   const points = Math.round((value / 100) * max);
-
   return (
     <div className="flex items-center gap-3">
       <span className="text-xs text-muted-foreground w-24 shrink-0">{label}</span>
@@ -82,38 +86,46 @@ function PillarBar({ label, value, max }: { label: string; value: number; max: n
   );
 }
 
+function getLowestPillar(p: { participation: number; rationale: number; reliability: number; profile: number }) {
+  const pillars = [
+    { key: 'Participation', value: p.participation },
+    { key: 'Rationale', value: p.rationale },
+    { key: 'Reliability', value: p.reliability },
+    { key: 'Profile', value: p.profile },
+  ];
+  return pillars.reduce((min, curr) => curr.value < min.value ? curr : min);
+}
+
 export function ClaimPageClient({
-  drepId,
-  name,
-  score,
-  participation,
-  rationale,
-  reliability,
-  profile,
-  isClaimed,
+  drepId, name, score, participation, rationale, reliability, profile, isClaimed,
 }: ClaimPageClientProps) {
   const router = useRouter();
   const { isAuthenticated, ownDRepId, connecting, reconnecting } = useWallet();
-  const [claimedCount, setClaimedCount] = useState<number | null>(null);
+  const [pulse, setPulse] = useState<PulseData | null>(null);
+  const [topDreps, setTopDreps] = useState<TopDRep[]>([]);
   const [claiming, setClaiming] = useState(false);
-  const [claimSuccess, setClaimSuccess] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
+
+  const lowestPillar = useMemo(() => getLowestPillar({ participation, rationale, reliability, profile }), [participation, rationale, reliability, profile]);
 
   useEffect(() => {
     posthog.capture('claim_page_viewed', { drep_id: drepId, drep_score: score, is_claimed: isClaimed });
-    fetch('/api/stats/claimed')
+    fetch('/api/governance/pulse')
       .then(r => r.json())
-      .then(d => setClaimedCount(d.claimedCount))
+      .then(d => setPulse({ votesThisWeek: d.votesThisWeek, activeDReps: d.activeDReps, claimedDReps: d.claimedDReps, activeProposals: d.activeProposals }))
+      .catch(() => {});
+    fetch('/api/dreps?limit=3&sort=score&claimed=true')
+      .then(r => r.json())
+      .then(d => { if (Array.isArray(d)) setTopDreps(d.slice(0, 3).map((x: any) => ({ drepId: x.drepId, name: x.name || x.drepId.slice(0, 16), score: x.drepScore }))); })
       .catch(() => {});
   }, []);
 
-  // Auto-claim when wallet matches
   useEffect(() => {
-    if (!isAuthenticated || !ownDRepId || ownDRepId !== drepId || isClaimed || claiming || claimSuccess) return;
-
+    if (!isAuthenticated || !ownDRepId || ownDRepId !== drepId || isClaimed || claiming || showCelebration) return;
     const token = getStoredSession();
     if (!token) return;
-
     setClaiming(true);
+    posthog.capture('claim_initiated', { drep_id: drepId });
     fetch('/api/drep-claim', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -123,15 +135,15 @@ export function ClaimPageClient({
       .then(d => {
         if (d.claimed) {
           posthog.capture('claim_completed', { drep_id: drepId, drep_score: score, source: 'claim_page' });
-          setClaimSuccess(true);
-          setTimeout(() => router.push('/dashboard'), 1500);
+          setShowCelebration(true);
+          posthog.capture('claim_celebration_seen', { drep_id: drepId });
         }
       })
       .catch(() => {})
       .finally(() => setClaiming(false));
-  }, [isAuthenticated, ownDRepId, drepId, isClaimed, claiming, claimSuccess, router]);
+  }, [isAuthenticated, ownDRepId, drepId, isClaimed, claiming, showCelebration]);
 
-  if (claiming || (isAuthenticated && ownDRepId === drepId && !claimSuccess)) {
+  if (claiming || (isAuthenticated && ownDRepId === drepId && !showCelebration)) {
     return (
       <div className="container mx-auto px-4 py-24 max-w-lg text-center space-y-4">
         <Loader2 className="h-10 w-10 animate-spin mx-auto text-primary" />
@@ -140,15 +152,17 @@ export function ClaimPageClient({
     );
   }
 
-  if (claimSuccess) {
+  if (showCelebration) {
     return (
-      <div className="container mx-auto px-4 py-24 max-w-lg text-center space-y-6">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30">
-          <Check className="h-8 w-8 text-green-600 dark:text-green-400" />
-        </div>
-        <h1 className="text-2xl font-bold">Profile Claimed!</h1>
-        <p className="text-sm text-muted-foreground">Redirecting to your dashboard...</p>
-      </div>
+      <ClaimCelebration
+        name={name}
+        score={score}
+        participation={participation}
+        rationale={rationale}
+        reliability={reliability}
+        profile={profile}
+        onContinue={() => router.push('/dashboard')}
+      />
     );
   }
 
@@ -157,9 +171,7 @@ export function ClaimPageClient({
       <div className="container mx-auto px-4 py-24 max-w-lg text-center space-y-6">
         <Shield className="h-12 w-12 mx-auto text-muted-foreground" />
         <h1 className="text-2xl font-bold">Profile Already Claimed</h1>
-        <p className="text-sm text-muted-foreground">
-          This DRep profile has already been claimed by its owner.
-        </p>
+        <p className="text-sm text-muted-foreground">This DRep profile has been claimed by its owner.</p>
         <Link href={`/drep/${encodeURIComponent(drepId)}`}>
           <Button variant="outline" className="gap-2">
             View Public Profile <ExternalLink className="h-4 w-4" />
@@ -170,79 +182,104 @@ export function ClaimPageClient({
   }
 
   return (
-    <div className="container mx-auto px-4 py-12 max-w-2xl">
-      {/* Hero */}
-      <div className="text-center space-y-6 mb-10">
-        <Badge variant="secondary" className="text-xs">
-          Unclaimed Profile
-        </Badge>
+    <div className="container mx-auto px-4 py-10 max-w-2xl space-y-8">
+      {/* Outcome-driven hero */}
+      <div className="text-center space-y-4">
+        <Badge variant="secondary" className="text-xs">Unclaimed Profile</Badge>
+        <h1 className="text-3xl font-bold tracking-tight">{name}</h1>
+        {pulse && (
+          <p className="text-sm text-muted-foreground max-w-md mx-auto">
+            <span className="font-semibold text-foreground">{pulse.votesThisWeek.toLocaleString()}</span> votes cast this week across{' '}
+            <span className="font-semibold text-foreground">{pulse.activeDReps}</span> active DReps.
+            Your profile is live. <span className="font-medium text-primary">Own your reputation.</span>
+          </p>
+        )}
+      </div>
 
-        <h1 className="text-3xl font-bold tracking-tight">
-          {name}
-        </h1>
-
-        <div className="flex justify-center">
-          <ScoreRing score={score} />
-        </div>
-
-        <div className="space-y-2 max-w-md mx-auto">
+      {/* Score + biggest opportunity */}
+      <div className="flex flex-col items-center space-y-4">
+        <ScoreRing score={score} />
+        <div className="space-y-2 w-full max-w-md">
           <PillarBar label="Participation" value={participation} max={30} />
           <PillarBar label="Rationale" value={rationale} max={35} />
           <PillarBar label="Reliability" value={reliability} max={20} />
           <PillarBar label="Profile" value={profile} max={15} />
         </div>
+        <p className="text-xs text-muted-foreground">
+          Biggest opportunity: <span className="font-semibold text-foreground">{lowestPillar.key}</span> ({lowestPillar.value}%) — claim to get actionable steps
+        </p>
       </div>
 
-      {/* Value Props */}
-      <Card className="mb-8 border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
-        <CardContent className="pt-6 space-y-4">
-          <h2 className="text-lg font-semibold text-center">Claim your DRepScore profile</h2>
-          <div className="grid gap-3">
-            <ValueProp
-              icon={<Sparkles className="h-5 w-5 text-primary" />}
-              title="Personalized Dashboard"
-              desc="Track your score over time, see recommendations, and monitor your governance performance."
-            />
-            <ValueProp
-              icon={<Inbox className="h-5 w-5 text-primary" />}
-              title="Governance Inbox"
-              desc="Prioritized list of pending proposals with score impact estimates and deadlines."
-            />
-            <ValueProp
-              icon={<TrendingUp className="h-5 w-5 text-primary" />}
-              title="Score Tracking & Alerts"
-              desc="Get notified when your score changes, delegations shift, or deadlines approach."
-            />
+      {/* Blurred dashboard preview */}
+      <Card className="relative overflow-hidden border-primary/20">
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-background/80 backdrop-blur-sm">
+          <Lock className="h-6 w-6 text-primary mb-2" />
+          <p className="text-sm font-semibold">Unlock your command center</p>
+          <p className="text-xs text-muted-foreground">Governance Inbox, Score Simulator, Delegator Analytics</p>
+        </div>
+        <CardContent className="py-6 opacity-40 pointer-events-none select-none">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="h-20 rounded-lg bg-muted animate-pulse" />
+            <div className="h-20 rounded-lg bg-muted animate-pulse" />
+            <div className="h-32 rounded-lg bg-muted animate-pulse col-span-2" />
+            <div className="h-16 rounded-lg bg-muted animate-pulse" />
+            <div className="h-16 rounded-lg bg-muted animate-pulse" />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Social proof */}
+      {(pulse?.claimedDReps ?? 0) > 0 && (
+        <div className="text-center space-y-3">
+          <p className="text-xs text-muted-foreground">
+            <span className="font-semibold text-foreground">{pulse!.claimedDReps}</span> DReps have claimed their profile
+          </p>
+          {topDreps.length > 0 && (
+            <div className="flex justify-center gap-3">
+              {topDreps.map(d => (
+                <Link key={d.drepId} href={`/drep/${encodeURIComponent(d.drepId)}`} className="text-center group">
+                  <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mb-1 group-hover:bg-primary/20 transition-colors">
+                    <Trophy className="h-4 w-4 text-primary" />
+                  </div>
+                  <p className="text-[10px] font-medium truncate max-w-[80px]">{d.name}</p>
+                  <p className="text-[10px] text-muted-foreground">{d.score}/100</p>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* What you get */}
+      <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
+        <CardContent className="pt-6 space-y-3">
+          <h2 className="text-sm font-semibold text-center mb-4">What you unlock</h2>
+          <div className="grid gap-2">
+            <ValueProp icon={<BarChart3 className="h-4 w-4 text-primary" />} title="Score Simulator" desc="See exactly how your score changes with each vote and rationale" />
+            <ValueProp icon={<Inbox className="h-4 w-4 text-primary" />} title="Governance Inbox" desc="Prioritized proposals with deadlines, impact scores, and AI rationale drafting" />
+            <ValueProp icon={<Users className="h-4 w-4 text-primary" />} title="Delegator Analytics" desc="Track delegator growth, profile views, and representation alignment" />
+            <ValueProp icon={<TrendingUp className="h-4 w-4 text-primary" />} title="Competitive Context" desc="Your rank, nearby DReps, and a path to the top 10" />
+            <ValueProp icon={<Eye className="h-4 w-4 text-primary" />} title="Notifications" desc="Score changes, delegation shifts, proposal deadlines — push, Discord, or Telegram" />
+            <ValueProp icon={<Sparkles className="h-4 w-4 text-primary" />} title="Milestones & Report Cards" desc="Earn achievement badges and share branded score cards" />
           </div>
         </CardContent>
       </Card>
 
       {/* CTA */}
-      <div className="text-center space-y-4">
+      <div className="text-center space-y-4 pb-8">
         <Button
           size="lg"
           className="gap-2 text-base px-8"
           onClick={() => { posthog.capture('claim_wallet_connect_clicked', { drep_id: drepId }); window.dispatchEvent(new Event('openWalletConnect')); }}
           disabled={connecting || reconnecting}
         >
-          {connecting || reconnecting ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Shield className="h-5 w-5" />
-          )}
+          {connecting || reconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Shield className="h-5 w-5" />}
           Connect Wallet to Claim
           <ArrowRight className="h-4 w-4" />
         </Button>
-
         <p className="text-xs text-muted-foreground max-w-sm mx-auto">
           Read-only signature verification — we never request transactions or access to your funds.
         </p>
-
-        {claimedCount !== null && claimedCount > 0 && (
-          <p className="text-xs text-muted-foreground">
-            <span className="font-semibold text-foreground">{claimedCount}</span> DReps have already claimed their profile
-          </p>
-        )}
       </div>
     </div>
   );
@@ -250,7 +287,7 @@ export function ClaimPageClient({
 
 function ValueProp({ icon, title, desc }: { icon: React.ReactNode; title: string; desc: string }) {
   return (
-    <div className="flex items-start gap-3 p-3 rounded-lg bg-background/60">
+    <div className="flex items-start gap-3 p-2.5 rounded-lg bg-background/60">
       <div className="mt-0.5 shrink-0">{icon}</div>
       <div>
         <p className="text-sm font-medium">{title}</p>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -35,6 +35,15 @@ import { ScoreHistoryChart } from '@/components/ScoreHistoryChart';
 import { DRepDashboard } from '@/components/DRepDashboard';
 import { GovernanceInboxWidget } from '@/components/GovernanceInboxWidget';
 import { ProfileViewStats } from '@/components/ProfileViewStats';
+import { DelegatorTrendChart } from '@/components/DelegatorTrendChart';
+import { CompetitiveContext } from '@/components/CompetitiveContext';
+import { OnboardingChecklist } from '@/components/OnboardingChecklist';
+import { RepresentationScorecard } from '@/components/RepresentationScorecard';
+import { ScoreSimulator } from '@/components/ScoreSimulator';
+import { ActivityHeatmap } from '@/components/ActivityHeatmap';
+import { MilestoneBadges } from '@/components/MilestoneBadges';
+import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
+import { DRepReportCard } from '@/components/DRepReportCard';
 import { formatAda, getPillarStatus, applyRationaleCurve, getMissingProfileFields } from '@/utils/scoring';
 import type { ScoreSnapshot } from '@/lib/data';
 import type { VoteRecord } from '@/types/drep';
@@ -301,56 +310,43 @@ export default function MyDRepPage() {
         </CardContent>
       </Card>
 
+      {/* Onboarding Checklist (if incomplete) */}
+      {sessionAddress && (
+        <div className="mb-6">
+          <OnboardingChecklist
+            drepId={drep.drepId}
+            walletAddress={sessionAddress}
+            profileCompleteness={drep.profileCompleteness}
+          />
+        </div>
+      )}
+
       {/* Two-Column Layout */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Left Column — Main Content (2/3) */}
+        {/* Left Column — Action Center (2/3) */}
         <div className="lg:col-span-2 space-y-6">
-          {/* Recommendations + Missing Rationale — actionable first */}
+          {/* Recommendations + Explain Your Vote */}
           <DRepDashboard drep={drep} scoreHistory={scoreHistory} />
 
-          {/* Score Trend */}
+          {/* Score Simulator */}
+          <ScoreSimulator drepId={drep.drepId} pendingCount={0} />
+
+          {/* Score History */}
           <ScoreHistoryChart history={scoreHistory} />
         </div>
 
-        {/* Right Column — Sidebar (1/3) */}
+        {/* Right Column — Intelligence (1/3) */}
         <div className="space-y-6">
-          {/* Reliability Breakdown */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Activity className="h-4 w-4" />
-                Reliability Breakdown
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <ReliabilityStat
-                icon={<Zap className="h-3.5 w-3.5" />}
-                label="Active Streak"
-                value={`${drep.reliabilityStreak} epoch${drep.reliabilityStreak !== 1 ? 's' : ''}`}
-                detail="Consecutive epochs with votes"
-              />
-              <ReliabilityStat
-                icon={<Clock className="h-3.5 w-3.5" />}
-                label="Last Voted"
-                value={drep.reliabilityRecency === 0 ? 'This epoch' : `${drep.reliabilityRecency} epoch${drep.reliabilityRecency !== 1 ? 's' : ''} ago`}
-                detail="Recency of activity"
-              />
-              <ReliabilityStat
-                icon={<Activity className="h-3.5 w-3.5" />}
-                label="Longest Gap"
-                value={`${drep.reliabilityLongestGap} epoch${drep.reliabilityLongestGap !== 1 ? 's' : ''}`}
-                detail="Longest period without voting"
-              />
-              <ReliabilityStat
-                icon={<Award className="h-3.5 w-3.5" />}
-                label="Tenure"
-                value={`${drep.reliabilityTenure} epoch${drep.reliabilityTenure !== 1 ? 's' : ''}`}
-                detail="Time since first vote"
-              />
-            </CardContent>
-          </Card>
+          {/* Competitive Context */}
+          <CompetitiveContext drepId={drep.drepId} />
 
-          {/* Delegator Summary */}
+          {/* Representation Scorecard */}
+          <RepresentationScorecard drepId={drep.drepId} />
+
+          {/* Delegator Analytics */}
+          <DelegatorTrendChart drepId={drep.drepId} />
+
+          {/* At a Glance */}
           <Card>
             <CardHeader className="pb-3">
               <CardTitle className="text-sm flex items-center gap-2">
@@ -371,6 +367,12 @@ export default function MyDRepPage() {
               )}
             </CardContent>
           </Card>
+
+          {/* Activity Heatmap */}
+          <ActivityHeatmap drepId={drep.drepId} />
+
+          {/* Achievements */}
+          <MilestoneBadges drepId={drep.drepId} />
 
           {/* Profile Health Check */}
           <Card>
@@ -429,27 +431,6 @@ export default function MyDRepPage() {
             </CardContent>
           </Card>
 
-          {/* Coach's Note */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <BarChart3 className="h-4 w-4" />
-                Coach&apos;s Note
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                {percentile >= 90
-                  ? 'Excellent — you\'re among the top-performing DReps. Keep up the consistency and your delegators will notice.'
-                  : percentile >= 70
-                  ? 'Strong performance. Focus on your weakest pillar to break into the top tier. Small improvements compound fast.'
-                  : percentile >= 50
-                  ? 'Above average. Check your recommendations above for quick wins that can meaningfully boost your score.'
-                  : 'Room to grow. Your action plan above highlights the fastest path to improvement — start with rationale quality.'}
-              </p>
-            </CardContent>
-          </Card>
-
           {/* Public Profile Link */}
           <Card>
             <CardContent className="pt-6">
@@ -460,6 +441,22 @@ export default function MyDRepPage() {
             </CardContent>
           </Card>
         </div>
+      </div>
+
+      {/* Bottom Section — Full Width */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-6">
+        <GovernancePhilosophyEditor drepId={drep.drepId} />
+        <DRepReportCard
+          drepId={drep.drepId}
+          name={drep.name || drep.drepId.slice(0, 20)}
+          score={drep.drepScore}
+          rank={null}
+          delegators={drep.delegatorCount}
+          participation={drep.effectiveParticipation}
+          rationale={adjustedRationale}
+          reliability={drep.reliabilityScore}
+          profile={drep.profileCompleteness}
+        />
       </div>
     </div>
   );

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -32,6 +32,9 @@ import { AboutSection } from '@/components/AboutSection';
 import { SocialIconsLarge } from '@/components/SocialIconsLarge';
 import { CompareButton } from '@/components/CompareButton';
 import { ProfileViewTracker } from '@/components/ProfileViewTracker';
+import { MilestoneBadges } from '@/components/MilestoneBadges';
+import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
+import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import {
   getDRepById,
   getVotesByDRepId,
@@ -380,8 +383,17 @@ export default async function DRepDetailPage({ params }: DRepDetailPageProps) {
         profileHint={profileHint}
       />
 
+      {/* Milestone Badges */}
+      <MilestoneBadges drepId={drep.drepId} compact />
+
       {/* Score History Chart */}
       <ScoreHistoryChart history={scoreHistory} />
+
+      {/* Governance Philosophy */}
+      <GovernancePhilosophyEditor drepId={drep.drepId} readOnly />
+
+      {/* Activity Heatmap */}
+      <ActivityHeatmap drepId={drep.drepId} />
 
       {/* About Section */}
       <AboutSection 

--- a/components/ActivityHeatmap.tsx
+++ b/components/ActivityHeatmap.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useEffect, useState, useMemo } from 'react';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { Activity } from 'lucide-react';
+
+interface EpochActivity {
+  epoch: number;
+  votes: number;
+  totalProposals: number;
+  withRationale: number;
+}
+
+interface ActivityHeatmapProps {
+  drepId: string;
+}
+
+export function ActivityHeatmap({ drepId }: ActivityHeatmapProps) {
+  const [data, setData] = useState<EpochActivity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!drepId) return;
+    // Fetch vote data and build epoch activity from it
+    fetch(`/api/drep/${encodeURIComponent(drepId)}/votes`)
+      .then(r => r.json())
+      .then(votes => {
+        if (!Array.isArray(votes)) { setLoading(false); return; }
+        
+        // Group votes by epoch
+        const epochMap = new Map<number, { votes: number; withRationale: number }>();
+        for (const v of votes) {
+          const epoch = v.epochNo || v.epoch_no;
+          if (!epoch) continue;
+          if (!epochMap.has(epoch)) epochMap.set(epoch, { votes: 0, withRationale: 0 });
+          const entry = epochMap.get(epoch)!;
+          entry.votes++;
+          if (v.hasRationale || v.meta_url) entry.withRationale++;
+        }
+
+        const epochs = [...epochMap.entries()]
+          .map(([epoch, data]) => ({
+            epoch,
+            votes: data.votes,
+            totalProposals: 0, // We don't have per-epoch proposal counts here
+            withRationale: data.withRationale,
+          }))
+          .sort((a, b) => a.epoch - b.epoch)
+          .slice(-50);
+
+        setData(epochs);
+        posthog.capture('activity_heatmap_viewed', { drepId, epochCount: epochs.length });
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  const { minEpoch, maxEpoch, grid } = useMemo(() => {
+    if (data.length === 0) return { minEpoch: 0, maxEpoch: 0, grid: [] };
+    const min = data[0].epoch;
+    const max = data[data.length - 1].epoch;
+    const activityMap = new Map(data.map(d => [d.epoch, d]));
+    
+    const cells: (EpochActivity | null)[] = [];
+    for (let e = min; e <= max; e++) {
+      cells.push(activityMap.get(e) || null);
+    }
+    return { minEpoch: min, maxEpoch: max, grid: cells };
+  }, [data]);
+
+  function getColor(entry: EpochActivity | null): string {
+    if (!entry || entry.votes === 0) return 'bg-muted';
+    if (entry.votes >= 4) return 'bg-green-500';
+    if (entry.votes >= 2) return 'bg-green-400 dark:bg-green-600';
+    return 'bg-green-300 dark:bg-green-700';
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Activity className="h-4 w-4" />
+            Voting Activity
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-16 animate-pulse bg-muted rounded" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Activity className="h-4 w-4" />
+            Voting Activity
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">No voting activity data available yet.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Activity className="h-4 w-4" />
+            Voting Activity
+          </CardTitle>
+          <span className="text-[10px] text-muted-foreground">
+            Epochs {minEpoch}–{maxEpoch}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <div className="flex flex-wrap gap-1">
+            {grid.map((entry, i) => {
+              const epoch = minEpoch + i;
+              return (
+                <Tooltip key={epoch}>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={`w-3 h-3 rounded-sm ${getColor(entry)} transition-colors`}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs">
+                      <span className="font-medium">Epoch {epoch}</span>
+                      {entry ? (
+                        <>: {entry.votes} vote{entry.votes !== 1 ? 's' : ''}, {entry.withRationale} with rationale</>
+                      ) : (
+                        <>: No votes</>
+                      )}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        </TooltipProvider>
+        <div className="flex items-center gap-2 mt-2">
+          <span className="text-[10px] text-muted-foreground">Less</span>
+          <div className="flex gap-0.5">
+            <div className="w-2.5 h-2.5 rounded-sm bg-muted" />
+            <div className="w-2.5 h-2.5 rounded-sm bg-green-300 dark:bg-green-700" />
+            <div className="w-2.5 h-2.5 rounded-sm bg-green-400 dark:bg-green-600" />
+            <div className="w-2.5 h-2.5 rounded-sm bg-green-500" />
+          </div>
+          <span className="text-[10px] text-muted-foreground">More</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ClaimCelebration.tsx
+++ b/components/ClaimCelebration.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import confetti from 'canvas-confetti';
+import { Check, ArrowRight, Sparkles, FileText, Vote, Share2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface ClaimCelebrationProps {
+  name: string;
+  score: number;
+  participation: number;
+  rationale: number;
+  reliability: number;
+  profile: number;
+  onContinue: () => void;
+}
+
+const CHECKLIST_ITEMS = [
+  {
+    key: 'profile',
+    icon: Sparkles,
+    label: 'Complete your CIP-119 profile',
+    desc: 'Add objectives, motivations, and social links on GovTool',
+    href: 'https://gov.tools',
+  },
+  {
+    key: 'rationale',
+    icon: FileText,
+    label: 'Draft rationale for a pending proposal',
+    desc: 'Use the AI Rationale Assistant in your Governance Inbox',
+    href: null,
+  },
+  {
+    key: 'vote',
+    icon: Vote,
+    label: 'Vote on a pending proposal',
+    desc: 'Head to GovTool to cast your vote with rationale attached',
+    href: 'https://gov.tools',
+  },
+];
+
+function AnimatedScore({ target }: { target: number }) {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    let frame: number;
+    const start = performance.now();
+    const duration = 1200;
+
+    function tick(now: number) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setCurrent(Math.round(eased * target));
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    }
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target]);
+
+  const color = current >= 80 ? 'text-green-500' : current >= 60 ? 'text-amber-500' : 'text-red-500';
+
+  return <span className={`text-7xl font-bold tabular-nums ${color}`}>{current}</span>;
+}
+
+function PillarReveal({ label, value, max, delay }: { label: string; value: number; max: number; delay: number }) {
+  const [width, setWidth] = useState(0);
+  const pct = Math.min(100, (value / 100) * 100);
+  const color = pct >= 80 ? 'bg-green-500' : pct >= 50 ? 'bg-amber-500' : 'bg-red-500';
+  const points = Math.round((value / 100) * max);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setWidth(pct), delay);
+    return () => clearTimeout(timer);
+  }, [pct, delay]);
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs text-muted-foreground w-24 shrink-0">{label}</span>
+      <div className="flex-1 h-2.5 bg-muted rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ease-out ${color}`}
+          style={{ width: `${width}%` }}
+        />
+      </div>
+      <span className="text-xs font-semibold tabular-nums w-10 text-right">{points}/{max}</span>
+    </div>
+  );
+}
+
+export function ClaimCelebration({
+  name,
+  score,
+  participation,
+  rationale,
+  reliability,
+  profile,
+  onContinue,
+}: ClaimCelebrationProps) {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+
+    const duration = 2000;
+    const end = Date.now() + duration;
+
+    function frame() {
+      confetti({
+        particleCount: 3,
+        angle: 60,
+        spread: 55,
+        origin: { x: 0, y: 0.7 },
+        colors: ['#6366f1', '#22c55e', '#f59e0b'],
+      });
+      confetti({
+        particleCount: 3,
+        angle: 120,
+        spread: 55,
+        origin: { x: 1, y: 0.7 },
+        colors: ['#6366f1', '#22c55e', '#f59e0b'],
+      });
+      if (Date.now() < end) requestAnimationFrame(frame);
+    }
+    frame();
+  }, []);
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-lg text-center space-y-8">
+      <div className="space-y-2">
+        <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-green-100 dark:bg-green-900/30 mb-2">
+          <Check className="h-7 w-7 text-green-600 dark:text-green-400" />
+        </div>
+        <h1 className="text-2xl font-bold">Welcome, {name}!</h1>
+        <p className="text-sm text-muted-foreground">Your DRepScore command center is live.</p>
+      </div>
+
+      <div className="space-y-1">
+        <AnimatedScore target={score} />
+        <p className="text-sm text-muted-foreground">/100 DRepScore</p>
+      </div>
+
+      <div className="space-y-2 max-w-sm mx-auto">
+        <PillarReveal label="Participation" value={participation} max={30} delay={400} />
+        <PillarReveal label="Rationale" value={rationale} max={35} delay={600} />
+        <PillarReveal label="Reliability" value={reliability} max={20} delay={800} />
+        <PillarReveal label="Profile" value={profile} max={15} delay={1000} />
+      </div>
+
+      <Card className="text-left border-primary/20">
+        <CardContent className="pt-5 space-y-3">
+          <h3 className="text-sm font-semibold flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Your first 3 actions
+          </h3>
+          {CHECKLIST_ITEMS.map((item) => (
+            <div key={item.key} className="flex items-start gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors">
+              <item.icon className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium">{item.label}</p>
+                <p className="text-xs text-muted-foreground">{item.desc}</p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Button size="lg" className="gap-2" onClick={onContinue}>
+        Go to Dashboard
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/components/CompetitiveContext.tsx
+++ b/components/CompetitiveContext.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Trophy, ArrowUp, ArrowDown, Target } from 'lucide-react';
+
+interface NearbyDRep {
+  drepId: string;
+  name: string;
+  score: number;
+  rank: number;
+}
+
+interface CompetitiveData {
+  rank: number;
+  totalActive: number;
+  nearbyAbove: NearbyDRep[];
+  nearbyBelow: NearbyDRep[];
+  distanceToTop10: number;
+  top10FocusArea: { pillar: string; gap: number } | null;
+}
+
+export function CompetitiveContext({ drepId }: { drepId: string }) {
+  const [data, setData] = useState<CompetitiveData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!drepId) return;
+    fetch(`/api/dashboard/competitive?drepId=${encodeURIComponent(drepId)}`)
+      .then(r => r.json())
+      .then(d => { if (d.rank) setData(d); })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  useEffect(() => {
+    if (data) {
+      try { posthog?.capture('competitive_context_viewed', { drepId, rank: data.rank }); } catch {}
+    }
+  }, [data, drepId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Trophy className="h-4 w-4" />
+            Your Ranking
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-24 animate-pulse bg-muted rounded" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Trophy className="h-4 w-4" />
+          Your Ranking
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Rank display */}
+        <div className="text-center py-2">
+          <span className="text-3xl font-bold tabular-nums">#{data.rank}</span>
+          <span className="text-sm text-muted-foreground ml-1">of {data.totalActive} active DReps</span>
+        </div>
+
+        {/* Nearby DReps */}
+        <div className="space-y-1">
+          {data.nearbyAbove.map(d => (
+            <Link
+              key={d.drepId}
+              href={`/drep/${encodeURIComponent(d.drepId)}`}
+              className="flex items-center justify-between text-xs py-1.5 px-2 rounded hover:bg-muted/50 transition-colors"
+              onClick={() => { try { posthog?.capture('nearby_drep_clicked', { drepId: d.drepId }); } catch {} }}
+            >
+              <div className="flex items-center gap-2">
+                <ArrowUp className="h-3 w-3 text-green-500" />
+                <span className="text-muted-foreground">#{d.rank}</span>
+                <span className="font-medium truncate max-w-[120px]">{d.name}</span>
+              </div>
+              <span className="tabular-nums font-medium">{d.score}</span>
+            </Link>
+          ))}
+
+          <div className="flex items-center justify-between text-xs py-1.5 px-2 rounded bg-primary/5 border border-primary/20">
+            <div className="flex items-center gap-2">
+              <Target className="h-3 w-3 text-primary" />
+              <span className="font-semibold">You</span>
+            </div>
+          </div>
+
+          {data.nearbyBelow.map(d => (
+            <Link
+              key={d.drepId}
+              href={`/drep/${encodeURIComponent(d.drepId)}`}
+              className="flex items-center justify-between text-xs py-1.5 px-2 rounded hover:bg-muted/50 transition-colors"
+              onClick={() => { try { posthog?.capture('nearby_drep_clicked', { drepId: d.drepId }); } catch {} }}
+            >
+              <div className="flex items-center gap-2">
+                <ArrowDown className="h-3 w-3 text-red-500" />
+                <span className="text-muted-foreground">#{d.rank}</span>
+                <span className="font-medium truncate max-w-[120px]">{d.name}</span>
+              </div>
+              <span className="tabular-nums font-medium">{d.score}</span>
+            </Link>
+          ))}
+        </div>
+
+        {/* Top 10 path */}
+        {data.distanceToTop10 > 0 && data.top10FocusArea && (
+          <div className="bg-muted/40 rounded-lg p-3 space-y-1">
+            <p className="text-xs font-medium">
+              {data.distanceToTop10} points from top 10
+            </p>
+            <p className="text-[10px] text-muted-foreground">
+              Focus on <span className="font-semibold text-foreground">{data.top10FocusArea.pillar}</span> —
+              you're {data.top10FocusArea.gap} points below the top-10 average
+            </p>
+          </div>
+        )}
+
+        {data.rank <= 10 && (
+          <div className="bg-green-500/10 rounded-lg p-3">
+            <p className="text-xs font-medium text-green-700 dark:text-green-400">
+              You're in the top 10! Keep it up.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/DRepReportCard.tsx
+++ b/components/DRepReportCard.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Share2, Download, Copy, Check, Image, Loader2 } from 'lucide-react';
+
+interface DRepReportCardProps {
+  drepId: string;
+  name: string;
+  score: number;
+  rank: number | null;
+  delegators: number;
+  participation: number;
+  rationale: number;
+  reliability: number;
+  profile: number;
+}
+
+export function DRepReportCard({
+  drepId, name, score, rank, delegators, participation, rationale, reliability, profile,
+}: DRepReportCardProps) {
+  const [generating, setGenerating] = useState(false);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const generateCard = useCallback(async () => {
+    setGenerating(true);
+    try {
+      // Use the OG image route which already generates DRep cards
+      const url = `/api/og/drep/${encodeURIComponent(drepId)}`;
+      setImageUrl(url);
+      posthog.capture('report_card_generated', { drep_id: drepId, score });
+    } finally {
+      setGenerating(false);
+    }
+  }, [drepId, score]);
+
+  const shareOnX = useCallback(() => {
+    const text = `My DRepScore: ${score}/100\n\nParticipation: ${participation}%\nRationale: ${rationale}%\nReliability: ${reliability}%\n${rank ? `Ranked #${rank}` : ''}\n\n${delegators} delegators trust my governance.\n\nCheck your DRep's score:`;
+    const shareUrl = `https://drepscore.io/drep/${encodeURIComponent(drepId)}`;
+    window.open(`https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`, '_blank');
+    posthog.capture('report_card_shared', { drep_id: drepId, platform: 'x' });
+  }, [drepId, score, rank, delegators, participation, rationale, reliability]);
+
+  const copyLink = useCallback(async () => {
+    await navigator.clipboard.writeText(`https://drepscore.io/drep/${encodeURIComponent(drepId)}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+    posthog.capture('report_card_shared', { drep_id: drepId, platform: 'copy' });
+  }, [drepId]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Share2 className="h-4 w-4" />
+          Share Your Score
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Preview card */}
+        <div className="bg-gradient-to-br from-primary/10 to-primary/5 rounded-lg p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold">{name}</p>
+              <p className="text-xs text-muted-foreground">DRepScore</p>
+            </div>
+            <div className="text-right">
+              <span className={`text-2xl font-bold tabular-nums ${score >= 80 ? 'text-green-600 dark:text-green-400' : score >= 60 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'}`}>
+                {score}
+              </span>
+              <span className="text-xs text-muted-foreground">/100</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-[10px]">
+            <div>Participation: <span className="font-medium">{participation}%</span></div>
+            <div>Rationale: <span className="font-medium">{rationale}%</span></div>
+            <div>Reliability: <span className="font-medium">{reliability}%</span></div>
+            <div>Profile: <span className="font-medium">{profile}%</span></div>
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+            {rank && <Badge variant="secondary" className="text-[10px]">#{rank}</Badge>}
+            <span>{delegators} delegators</span>
+          </div>
+        </div>
+
+        {/* Share buttons */}
+        <div className="flex gap-2">
+          <Button variant="default" size="sm" className="flex-1 gap-1.5 text-xs" onClick={shareOnX}>
+            Share on X
+          </Button>
+          <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={copyLink}>
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            {copied ? 'Copied!' : 'Copy Link'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/DelegatorTrendChart.tsx
+++ b/components/DelegatorTrendChart.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
+  Tooltip as RechartsTooltip, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Users, TrendingUp, TrendingDown } from 'lucide-react';
+
+interface Snapshot {
+  epoch: number;
+  votingPowerAda: number;
+  delegatorCount: number | null;
+}
+
+interface DelegatorTrendChartProps {
+  drepId: string;
+}
+
+export function DelegatorTrendChart({ drepId }: DelegatorTrendChartProps) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [currentDelegators, setCurrentDelegators] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!drepId) return;
+    fetch(`/api/dashboard/delegator-trends?drepId=${encodeURIComponent(drepId)}`)
+      .then(r => r.json())
+      .then(d => {
+        setSnapshots(d.snapshots || []);
+        setCurrentDelegators(d.currentDelegators);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="h-4 w-4" />
+            Delegator Analytics
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[180px] animate-pulse bg-muted rounded" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (snapshots.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="h-4 w-4" />
+            Delegator Analytics
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Power tracking data will appear here as snapshots are collected.
+          </p>
+          {currentDelegators !== null && (
+            <div className="mt-3 flex items-center gap-2">
+              <span className="text-2xl font-bold tabular-nums">{currentDelegators}</span>
+              <span className="text-sm text-muted-foreground">current delegators</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartData = snapshots.map(s => ({
+    epoch: `E${s.epoch}`,
+    'Voting Power (ADA)': s.votingPowerAda,
+  }));
+
+  const first = snapshots[0];
+  const last = snapshots[snapshots.length - 1];
+  const powerChange = last.votingPowerAda - first.votingPowerAda;
+  const powerChangeFormatted = powerChange >= 1_000_000
+    ? `${(powerChange / 1_000_000).toFixed(1)}M`
+    : powerChange >= 1_000
+      ? `${(powerChange / 1_000).toFixed(0)}K`
+      : powerChange.toLocaleString();
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="h-4 w-4" />
+            Delegator Analytics
+          </CardTitle>
+          <div className="flex items-center gap-3">
+            {currentDelegators !== null && (
+              <span className="text-xs text-muted-foreground">
+                <span className="font-semibold text-foreground tabular-nums">{currentDelegators}</span> delegators
+              </span>
+            )}
+            {snapshots.length > 1 && (
+              <span className={`text-xs font-medium flex items-center gap-1 ${powerChange > 0 ? 'text-green-600 dark:text-green-400' : powerChange < 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'}`}>
+                {powerChange > 0 ? <TrendingUp className="h-3 w-3" /> : powerChange < 0 ? <TrendingDown className="h-3 w-3" /> : null}
+                {powerChange > 0 ? '+' : ''}{powerChangeFormatted} ADA
+              </span>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[180px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 5, right: 10, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis dataKey="epoch" tick={{ fontSize: 11 }} className="fill-muted-foreground" />
+              <YAxis tick={{ fontSize: 11 }} className="fill-muted-foreground" tickFormatter={(v) => v >= 1_000_000 ? `${(v/1_000_000).toFixed(0)}M` : v >= 1_000 ? `${(v/1_000).toFixed(0)}K` : v} />
+              <RechartsTooltip
+                contentStyle={{ fontSize: '12px', borderRadius: '8px' }}
+                formatter={(value: number) => [`${value.toLocaleString()} ADA`, 'Voting Power']}
+              />
+              <Line type="monotone" dataKey="Voting Power (ADA)" stroke="hsl(var(--chart-2))" strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/GovernanceInboxWidget.tsx
+++ b/components/GovernanceInboxWidget.tsx
@@ -14,6 +14,7 @@ import {
   TrendingUp,
   Clock,
   Vote,
+  FileText,
 } from 'lucide-react';
 
 interface PendingProposal {
@@ -126,6 +127,14 @@ export function GovernanceInboxWidget({ drepId }: { drepId: string }) {
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        {/* Draft rationale banner */}
+        <div className="flex items-center gap-2 text-xs bg-primary/5 border border-primary/20 rounded-md px-3 py-2">
+          <FileText className="h-3.5 w-3.5 text-primary shrink-0" />
+          <span className="text-muted-foreground">
+            <span className="font-medium text-foreground">Draft rationale before voting</span> — proposals with rationale boost your score by up to 35%
+          </span>
+        </div>
+
         {/* Urgency callout */}
         {hasUrgent && (
           <div className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-md px-3 py-2">
@@ -153,6 +162,12 @@ export function GovernanceInboxWidget({ drepId }: { drepId: string }) {
                     {p.epochsRemaining}ep
                   </span>
                 )}
+                <Link href={`/dashboard/inbox?drepId=${encodeURIComponent(drepId)}&proposal=${p.txHash}`}>
+                  <Button variant="ghost" size="sm" className="h-6 px-2 text-[10px] gap-1">
+                    <FileText className="h-3 w-3" />
+                    Draft
+                  </Button>
+                </Link>
               </div>
             </div>
           ))}

--- a/components/GovernancePhilosophyEditor.tsx
+++ b/components/GovernancePhilosophyEditor.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BookOpen, Save, Loader2, PenLine } from 'lucide-react';
+
+interface GovernancePhilosophyEditorProps {
+  drepId: string;
+  readOnly?: boolean;
+}
+
+export function GovernancePhilosophyEditor({ drepId, readOnly = false }: GovernancePhilosophyEditorProps) {
+  const [text, setText] = useState('');
+  const [savedText, setSavedText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/drep/${encodeURIComponent(drepId)}/philosophy`)
+      .then(r => r.json())
+      .then(d => {
+        const t = d?.philosophy_text || '';
+        setText(t);
+        setSavedText(t);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  const handleSave = useCallback(async () => {
+    const token = getStoredSession();
+    if (!token || !text.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/philosophy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionToken: token, philosophyText: text.trim() }),
+      });
+      if (res.ok) {
+        setSavedText(text.trim());
+        setEditing(false);
+        posthog.capture('philosophy_saved', { drep_id: drepId, length: text.trim().length });
+      }
+    } catch {}
+    finally { setSaving(false); }
+  }, [text, drepId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base"><BookOpen className="h-4 w-4" />Governance Philosophy</CardTitle>
+        </CardHeader>
+        <CardContent><div className="h-16 animate-pulse bg-muted rounded" /></CardContent>
+      </Card>
+    );
+  }
+
+  if (readOnly) {
+    if (!savedText) return null;
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base"><BookOpen className="h-4 w-4" />Governance Philosophy</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">{savedText}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base"><BookOpen className="h-4 w-4" />Governance Philosophy</CardTitle>
+          {!editing && savedText && (
+            <Button variant="ghost" size="sm" className="h-6 px-2 text-xs gap-1" onClick={() => setEditing(true)}>
+              <PenLine className="h-3 w-3" /> Edit
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {!savedText && !editing ? (
+          <div className="text-center py-3 space-y-2">
+            <p className="text-xs text-muted-foreground">Tell delegators what you stand for.</p>
+            <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={() => setEditing(true)}>
+              <PenLine className="h-3 w-3" /> Write Philosophy
+            </Button>
+          </div>
+        ) : editing ? (
+          <div className="space-y-3">
+            <textarea
+              className="w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Describe your governance values, priorities, and approach..."
+              value={text}
+              onChange={e => setText(e.target.value)}
+            />
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={() => { setText(savedText); setEditing(false); }}>Cancel</Button>
+              <Button size="sm" className="gap-1.5" onClick={handleSave} disabled={saving || !text.trim()}>
+                {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />} Save
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap">{savedText}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/MilestoneBadges.tsx
+++ b/components/MilestoneBadges.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  Award,
+  Shield,
+  Users,
+  Star,
+  Target,
+  FileText,
+  CheckCircle2,
+  Lock,
+} from 'lucide-react';
+
+const ICON_MAP: Record<string, React.ElementType> = {
+  Shield, Users, Star, Target, FileText, CheckCircle2,
+};
+
+interface Milestone {
+  key: string;
+  label: string;
+  description: string;
+  icon: string;
+  category: string;
+  achieved: boolean;
+  achievedAt: string | null;
+}
+
+interface MilestoneBadgesProps {
+  drepId: string;
+  compact?: boolean;
+}
+
+export function MilestoneBadges({ drepId, compact = false }: MilestoneBadgesProps) {
+  const [milestones, setMilestones] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!drepId) return;
+    // Check for new milestones first, then fetch
+    fetch('/api/dashboard/milestones', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ drepId }),
+    })
+      .then(() => fetch(`/api/dashboard/milestones?drepId=${encodeURIComponent(drepId)}`))
+      .then(r => r.json())
+      .then(d => {
+        if (d.milestones) setMilestones(d.milestones);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  useEffect(() => {
+    const achieved = milestones.filter(m => m.achieved);
+    if (achieved.length > 0) {
+      posthog.capture('milestone_achieved', { drepId, count: achieved.length, keys: achieved.map(m => m.key) });
+    }
+  }, [milestones, drepId]);
+
+  if (loading) {
+    return compact ? null : (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Award className="h-4 w-4" />
+            Achievements
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-16 animate-pulse bg-muted rounded" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const achieved = milestones.filter(m => m.achieved);
+  const unachieved = milestones.filter(m => !m.achieved);
+
+  if (compact) {
+    if (achieved.length === 0) return null;
+    return (
+      <TooltipProvider>
+        <div className="flex flex-wrap gap-1.5">
+          {achieved.map(m => {
+            const Icon = ICON_MAP[m.icon] || Award;
+            return (
+              <Tooltip key={m.key}>
+                <TooltipTrigger asChild>
+                  <Badge variant="secondary" className="gap-1 text-[10px]">
+                    <Icon className="h-3 w-3" />
+                    {m.label}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="text-xs">{m.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Award className="h-4 w-4" />
+          Achievements
+          <Badge variant="secondary" className="text-[10px]">{achieved.length}/{milestones.length}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <div className="grid grid-cols-3 gap-2">
+            {achieved.map(m => {
+              const Icon = ICON_MAP[m.icon] || Award;
+              return (
+                <Tooltip key={m.key}>
+                  <TooltipTrigger asChild>
+                    <div className="flex flex-col items-center gap-1 p-2 rounded-lg bg-primary/5 border border-primary/20 text-center">
+                      <Icon className="h-5 w-5 text-primary" />
+                      <span className="text-[10px] font-medium leading-tight">{m.label}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs">{m.description}</p>
+                    {m.achievedAt && <p className="text-[10px] text-muted-foreground mt-0.5">Achieved {new Date(m.achievedAt).toLocaleDateString()}</p>}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+            {unachieved.slice(0, 6 - achieved.length).map(m => {
+              const Icon = ICON_MAP[m.icon] || Award;
+              return (
+                <Tooltip key={m.key}>
+                  <TooltipTrigger asChild>
+                    <div className="flex flex-col items-center gap-1 p-2 rounded-lg bg-muted/40 text-center opacity-40">
+                      <Lock className="h-5 w-5" />
+                      <span className="text-[10px] font-medium leading-tight">{m.label}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs">{m.description}</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/OnboardingChecklist.tsx
+++ b/components/OnboardingChecklist.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { CheckCircle2, Circle, Sparkles, ExternalLink, FileText, Share2, X } from 'lucide-react';
+
+interface OnboardingChecklistProps {
+  drepId: string;
+  walletAddress: string;
+  profileCompleteness: number;
+}
+
+const ITEMS = [
+  { key: 'profile', label: 'Complete your profile', desc: 'Add objectives, motivations, and social links via GovTool', icon: Sparkles, href: 'https://gov.tools' },
+  { key: 'rationale', label: 'Write your first rationale', desc: 'Use the AI Rationale Assistant in your Governance Inbox', icon: FileText, href: null },
+  { key: 'vote', label: 'Vote on a pending proposal', desc: 'Head to GovTool to cast your vote', icon: ExternalLink, href: 'https://gov.tools' },
+  { key: 'share', label: 'Share your score', desc: 'Let delegators know you are active on DRepScore', icon: Share2, href: null },
+];
+
+export function OnboardingChecklist({ drepId, walletAddress, profileCompleteness }: OnboardingChecklistProps) {
+  const [checklist, setChecklist] = useState<Record<string, boolean>>({});
+  const [dismissed, setDismissed] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/dashboard/onboarding?wallet=${encodeURIComponent(walletAddress)}`)
+      .then(r => r.json())
+      .then(d => {
+        const cl = d.checklist || {};
+        if (cl._dismissed) setDismissed(true);
+        if (profileCompleteness >= 80 && !cl.profile) cl.profile = true;
+        setChecklist(cl);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [walletAddress, profileCompleteness]);
+
+  const toggleItem = useCallback(async (key: string) => {
+    const token = getStoredSession();
+    if (!token) return;
+    const newVal = !checklist[key];
+    setChecklist(prev => ({ ...prev, [key]: newVal }));
+    posthog.capture('onboarding_checklist_item_completed', { drep_id: drepId, item: key, completed: newVal });
+    await fetch('/api/dashboard/onboarding', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionToken: token, item: key, completed: newVal }),
+    }).catch(() => {});
+  }, [checklist, drepId]);
+
+  const handleDismiss = useCallback(async () => {
+    const token = getStoredSession();
+    if (!token) return;
+    setDismissed(true);
+    posthog.capture('onboarding_checklist_dismissed', { drep_id: drepId });
+    await fetch('/api/dashboard/onboarding', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionToken: token, item: '_dismissed', completed: true }),
+    }).catch(() => {});
+  }, [drepId]);
+
+  if (loading || dismissed) return null;
+
+  const completedCount = ITEMS.filter(i => checklist[i.key]).length;
+  const allDone = completedCount === ITEMS.length;
+
+  return (
+    <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Getting Started ({completedCount}/{ITEMS.length})
+          </CardTitle>
+          {allDone && (
+            <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={handleDismiss}>
+              <X className="h-3 w-3 mr-1" /> Dismiss
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {ITEMS.map(item => {
+          const done = !!checklist[item.key];
+          return (
+            <button
+              key={item.key}
+              className={`w-full flex items-start gap-3 p-2 rounded-lg text-left transition-colors ${done ? 'opacity-60' : 'hover:bg-muted/50'}`}
+              onClick={() => {
+                if (item.href && !done) {
+                  window.open(item.href, '_blank');
+                }
+                toggleItem(item.key);
+              }}
+            >
+              {done ? (
+                <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+              ) : (
+                <Circle className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+              )}
+              <div>
+                <p className={`text-xs font-medium ${done ? 'line-through' : ''}`}>{item.label}</p>
+                <p className="text-[10px] text-muted-foreground">{item.desc}</p>
+              </div>
+            </button>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/PositionStatementEditor.tsx
+++ b/components/PositionStatementEditor.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { MessageSquare, Save, Loader2 } from 'lucide-react';
+
+interface PositionStatementEditorProps {
+  drepId: string;
+  proposalTxHash: string;
+  proposalIndex: number;
+  proposalTitle: string;
+  existingStatement?: string;
+  onSaved?: (text: string) => void;
+}
+
+export function PositionStatementEditor({
+  drepId, proposalTxHash, proposalIndex, proposalTitle, existingStatement, onSaved,
+}: PositionStatementEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState(existingStatement || '');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (!text.trim()) return;
+    setSaving(true);
+    try {
+      const token = getStoredSession();
+      if (!token) return;
+      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/positions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionToken: token, proposalTxHash, proposalIndex, statementText: text.trim() }),
+      });
+      if (res.ok) {
+        posthog.capture('position_statement_saved', { drep_id: drepId, proposal_tx_hash: proposalTxHash });
+        onSaved?.(text.trim());
+        setOpen(false);
+      }
+    } catch {}
+    finally { setSaving(false); }
+  }, [text, drepId, proposalTxHash, proposalIndex, onSaved]);
+
+  return (
+    <>
+      <Button variant="ghost" size="sm" className="h-6 px-2 text-[10px] gap-1" onClick={() => setOpen(true)}>
+        <MessageSquare className="h-3 w-3" />
+        Position
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <MessageSquare className="h-4 w-4" />
+              State Your Position
+            </DialogTitle>
+            <DialogDescription className="text-xs">{proposalTitle}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <textarea
+              className="w-full min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Share your stance and reasoning on this proposal..."
+              value={text}
+              onChange={e => setText(e.target.value)}
+            />
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={() => setOpen(false)}>Cancel</Button>
+              <Button size="sm" className="gap-1.5" onClick={handleSave} disabled={saving || !text.trim()}>
+                {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />} Publish
+              </Button>
+            </div>
+            <p className="text-[10px] text-muted-foreground">Visible to delegators on the proposal page.</p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/RepresentationScorecard.tsx
+++ b/components/RepresentationScorecard.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Users, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
+
+interface ProposalAlignment {
+  key: string;
+  title: string;
+  drepVote: string;
+  delegatorMajority: string;
+  delegatorMajorityPct: number;
+  totalResponses: number;
+  aligned: boolean;
+}
+
+interface RepresentationData {
+  alignment: number | null;
+  totalCompared: number;
+  proposals: ProposalAlignment[];
+}
+
+export function RepresentationScorecard({ drepId }: { drepId: string }) {
+  const [data, setData] = useState<RepresentationData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!drepId) return;
+    fetch(`/api/dashboard/representation?drepId=${encodeURIComponent(drepId)}`)
+      .then(r => r.json())
+      .then(d => setData(d))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [drepId]);
+
+  useEffect(() => {
+    if (data?.alignment !== null && data?.alignment !== undefined) {
+      try { posthog?.capture('representation_scorecard_viewed', { drepId, alignment: data.alignment }); } catch {}
+    }
+  }, [data, drepId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="h-4 w-4" />
+            Delegator Representation
+          </CardTitle>
+        </CardHeader>
+        <CardContent><div className="h-20 animate-pulse bg-muted rounded" /></CardContent>
+      </Card>
+    );
+  }
+
+  if (!data || data.alignment === null) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="h-4 w-4" />
+            Delegator Representation
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">
+            Not enough delegator poll data yet. As your delegators vote in sentiment polls, representation alignment will appear here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const color = data.alignment >= 75 ? 'text-green-600 dark:text-green-400'
+    : data.alignment >= 50 ? 'text-amber-600 dark:text-amber-400'
+    : 'text-red-600 dark:text-red-400';
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Users className="h-4 w-4" />
+          Delegator Representation
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="text-center py-1">
+          <span className={`text-3xl font-bold tabular-nums ${color}`}>{data.alignment}%</span>
+          <p className="text-xs text-muted-foreground mt-1">
+            aligned with your delegators on {data.totalCompared} proposal{data.totalCompared !== 1 ? 's' : ''}
+          </p>
+        </div>
+
+        {data.proposals.length > 0 && (
+          <div className="space-y-1.5 max-h-[200px] overflow-y-auto">
+            {data.proposals.slice(0, 8).map(p => (
+              <div
+                key={p.key}
+                className="flex items-center justify-between gap-2 text-xs py-1.5 px-2 rounded hover:bg-muted/50"
+                onClick={() => { try { posthog?.capture('representation_divergence_clicked', { drepId, proposal: p.key }); } catch {} }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {p.aligned ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />
+                  ) : (
+                    <XCircle className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                  )}
+                  <span className="truncate">{p.title}</span>
+                </div>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <Badge variant="outline" className="text-[10px]">You: {p.drepVote}</Badge>
+                  <Badge variant={p.aligned ? 'secondary' : 'destructive'} className="text-[10px]">
+                    {p.delegatorMajorityPct}% {p.delegatorMajority}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {data.proposals.filter(p => !p.aligned && p.delegatorMajorityPct >= 60).length > 0 && (
+          <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-2.5 flex items-start gap-2">
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0" />
+            <p className="text-[10px] text-muted-foreground">
+              {data.proposals.filter(p => !p.aligned && p.delegatorMajorityPct >= 60).length} vote{data.proposals.filter(p => !p.aligned && p.delegatorMajorityPct >= 60).length !== 1 ? 's' : ''} diverged significantly from delegator sentiment. Consider explaining your reasoning.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ScoreSimulator.tsx
+++ b/components/ScoreSimulator.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Calculator, ArrowRight, TrendingUp } from 'lucide-react';
+
+interface SimulationResult {
+  current: { score: number; participation: number; rationale: number; rank: number };
+  simulated: { score: number; participation: number; rationale: number; rank: number };
+}
+
+export function ScoreSimulator({ drepId, pendingCount }: { drepId: string; pendingCount: number }) {
+  const [votes, setVotes] = useState(0);
+  const [rationales, setRationales] = useState(0);
+  const [result, setResult] = useState<SimulationResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const maxVotes = Math.max(pendingCount, 10);
+
+  const simulate = useCallback(async () => {
+    if (votes === 0) { setResult(null); return; }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/dashboard/simulate?drepId=${encodeURIComponent(drepId)}&votes=${votes}&rationales=${rationales}`);
+      const data = await res.json();
+      if (data.current) setResult(data);
+      posthog.capture('score_simulator_adjusted', { drepId, votes, rationales });
+    } catch {}
+    finally { setLoading(false); }
+  }, [drepId, votes, rationales]);
+
+  useEffect(() => {
+    const timer = setTimeout(simulate, 300);
+    return () => clearTimeout(timer);
+  }, [simulate]);
+
+  useEffect(() => {
+    posthog.capture('score_simulator_viewed', { drepId });
+  }, [drepId]);
+
+  const presets = [
+    { label: 'All + rationale', v: pendingCount, r: pendingCount },
+    { label: 'All, no rationale', v: pendingCount, r: 0 },
+    { label: 'Half + rationale', v: Math.ceil(pendingCount / 2), r: Math.ceil(pendingCount / 2) },
+  ];
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Calculator className="h-4 w-4" />
+          Score Simulator
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Presets */}
+        {pendingCount > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {presets.map(p => (
+              <Button
+                key={p.label}
+                variant={votes === p.v && rationales === p.r ? 'default' : 'outline'}
+                size="sm"
+                className="h-6 text-[10px] px-2"
+                onClick={() => { setVotes(p.v); setRationales(p.r); }}
+              >
+                {p.label}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {/* Sliders */}
+        <div className="space-y-3">
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-muted-foreground">Votes to cast</span>
+              <span className="font-medium tabular-nums">{votes}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={maxVotes}
+              value={votes}
+              onChange={e => {
+                const v = parseInt(e.target.value);
+                setVotes(v);
+                if (rationales > v) setRationales(v);
+              }}
+              className="w-full accent-primary h-1.5"
+            />
+          </div>
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-muted-foreground">With rationale</span>
+              <span className="font-medium tabular-nums">{rationales}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={votes}
+              value={rationales}
+              onChange={e => setRationales(parseInt(e.target.value))}
+              className="w-full accent-primary h-1.5"
+            />
+          </div>
+        </div>
+
+        {/* Result */}
+        {result && (
+          <div className="bg-muted/40 rounded-lg p-3 space-y-2">
+            <div className="flex items-center justify-center gap-3">
+              <div className="text-center">
+                <span className="text-xl font-bold tabular-nums">{result.current.score}</span>
+                <p className="text-[10px] text-muted-foreground">Current</p>
+              </div>
+              <ArrowRight className="h-4 w-4 text-muted-foreground" />
+              <div className="text-center">
+                <span className={`text-xl font-bold tabular-nums ${result.simulated.score > result.current.score ? 'text-green-600 dark:text-green-400' : ''}`}>
+                  {result.simulated.score}
+                </span>
+                <p className="text-[10px] text-muted-foreground">Projected</p>
+              </div>
+              {result.simulated.score > result.current.score && (
+                <Badge variant="secondary" className="text-[10px]">
+                  <TrendingUp className="h-3 w-3 mr-1" />
+                  +{result.simulated.score - result.current.score}
+                </Badge>
+              )}
+            </div>
+
+            {result.simulated.rank < result.current.rank && (
+              <p className="text-[10px] text-center text-muted-foreground">
+                Rank: #{result.current.rank} → <span className="font-semibold text-foreground">#{result.simulated.rank}</span>
+              </p>
+            )}
+
+            <div className="grid grid-cols-2 gap-2 text-[10px]">
+              <div>
+                <span className="text-muted-foreground">Participation:</span>{' '}
+                <span className="font-medium">{result.current.participation}% → {result.simulated.participation}%</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Rationale:</span>{' '}
+                <span className="font-medium">{result.current.rationale}% → {result.simulated.rationale}%</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!result && votes === 0 && (
+          <p className="text-xs text-muted-foreground text-center py-2">
+            Adjust the sliders to see how your score would change.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/VoteExplanationEditor.tsx
+++ b/components/VoteExplanationEditor.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { posthog } from '@/lib/posthog';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Sparkles, Save, Loader2, PenLine, Info } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface VoteExplanationEditorProps {
+  drepId: string;
+  proposalTxHash: string;
+  proposalIndex: number;
+  proposalTitle: string;
+  vote: string;
+  existingExplanation?: string;
+  onSaved?: (explanation: string) => void;
+}
+
+export function VoteExplanationEditor({
+  drepId,
+  proposalTxHash,
+  proposalIndex,
+  proposalTitle,
+  vote,
+  existingExplanation,
+  onSaved,
+}: VoteExplanationEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState(existingExplanation || '');
+  const [saving, setSaving] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [aiAssisted, setAiAssisted] = useState(false);
+
+  const handleAiGenerate = useCallback(async () => {
+    setGenerating(true);
+    try {
+      const res = await fetch('/api/rationale/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drepId,
+          proposalTitle,
+          proposalAbstract: null,
+          proposalType: 'Governance',
+          aiSummary: null,
+        }),
+      });
+      const data = await res.json();
+      if (data.draft) {
+        setText(data.draft);
+        setAiAssisted(true);
+        posthog.capture('vote_explanation_ai_generated', { drep_id: drepId, proposal_tx_hash: proposalTxHash });
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setGenerating(false);
+    }
+  }, [drepId, proposalTitle, proposalTxHash]);
+
+  const handleSave = useCallback(async () => {
+    if (!text.trim()) return;
+    setSaving(true);
+    try {
+      const token = getStoredSession();
+      if (!token) return;
+
+      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/explanations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionToken: token,
+          proposalTxHash,
+          proposalIndex,
+          explanationText: text.trim(),
+          aiAssisted,
+        }),
+      });
+
+      if (res.ok) {
+        posthog.capture('vote_explanation_saved', {
+          drep_id: drepId,
+          proposal_tx_hash: proposalTxHash,
+          ai_assisted: aiAssisted,
+          length: text.trim().length,
+        });
+        onSaved?.(text.trim());
+        setOpen(false);
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setSaving(false);
+    }
+  }, [text, drepId, proposalTxHash, proposalIndex, aiAssisted, onSaved]);
+
+  return (
+    <>
+      <Button variant="outline" size="sm" className="gap-1.5 text-xs h-7" onClick={() => setOpen(true)}>
+        <PenLine className="h-3 w-3" />
+        {existingExplanation ? 'Edit' : 'Explain'}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <PenLine className="h-4 w-4" />
+              Explain Your Vote
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {proposalTitle}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                You voted: {vote}
+              </Badge>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-[280px]">
+                    <p className="text-xs">This explanation is stored on DRepScore and visible to your delegators. It does not affect your on-chain rationale score.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+
+            <textarea
+              className="w-full min-h-[120px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Explain your reasoning for this vote..."
+              value={text}
+              onChange={e => setText(e.target.value)}
+            />
+
+            <div className="flex items-center justify-between">
+              <Button variant="ghost" size="sm" className="gap-1.5 text-xs" onClick={handleAiGenerate} disabled={generating}>
+                {generating ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
+                AI Draft
+              </Button>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => setOpen(false)}>Cancel</Button>
+                <Button size="sm" className="gap-1.5" onClick={handleSave} disabled={saving || !text.trim()}>
+                  {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                  Save
+                </Button>
+              </div>
+            </div>
+
+            {aiAssisted && (
+              <p className="text-[10px] text-muted-foreground">AI-assisted draft — edit before saving to add your personal perspective.</p>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/inngest/functions/check-notifications.ts
+++ b/inngest/functions/check-notifications.ts
@@ -1,0 +1,220 @@
+/**
+ * Notification Checker — runs after every DRep sync to fire notifications.
+ * Wires the 5 previously-untriggered types + 5 new DRep-specific types.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { notifyUser, broadcastEvent, type NotificationEvent } from '@/lib/notifications';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { checkAndAwardMilestones, MILESTONES } from '@/lib/milestones';
+import { errMsg } from '@/lib/sync-utils';
+
+const SCORE_CHANGE_THRESHOLD = 3;
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://drepscore.io';
+
+export const checkNotifications = inngest.createFunction(
+  {
+    id: 'check-notifications',
+    retries: 1,
+    concurrency: { limit: 1, scope: 'env', key: '"notifications"' },
+  },
+  { cron: '15 */6 * * *' },
+  async ({ step }) => {
+    const stats = { scoreChange: 0, delegation: 0, pending: 0, urgent: 0, milestone: 0, rank: 0, opportunity: 0 };
+
+    // Step 1: Gather claimed DReps and their data
+    const context = await step.run('gather-claimed-dreps', async () => {
+      const supabase = getSupabaseAdmin();
+
+      const { data: users } = await supabase
+        .from('users')
+        .select('wallet_address, claimed_drep_id')
+        .not('claimed_drep_id', 'is', null);
+
+      if (!users || users.length === 0) return { users: [] as any[], dreps: [] as any[], proposals: [] as any[], allDreps: [] as any[] };
+
+      const drepIds = users.map(u => u.claimed_drep_id).filter(Boolean);
+
+      const [drepsResult, proposalsResult] = await Promise.all([
+        supabase.from('dreps').select('id, score, info, effective_participation, rationale_rate, reliability_score, profile_completeness').in('id', drepIds),
+        supabase.from('proposals').select('tx_hash, proposal_index, proposal_type, title, expiration_epoch').is('ratified_epoch', null).is('enacted_epoch', null).is('dropped_epoch', null).is('expired_epoch', null),
+      ]);
+
+      // Get all dreps for ranking
+      const { data: allDreps } = await supabase
+        .from('dreps')
+        .select('id, score')
+        .not('info->isActive', 'eq', false)
+        .order('score', { ascending: false });
+
+      return {
+        users: users || [],
+        dreps: drepsResult.data || [],
+        proposals: proposalsResult.data || [],
+        allDreps: allDreps || [],
+      };
+    });
+
+    if (context.users.length === 0) return { stats };
+
+    // Step 2: Check score changes and delegation changes
+    await step.run('check-score-and-delegation', async () => {
+      const supabase = getSupabaseAdmin();
+
+      for (const user of context.users) {
+        const drep = context.dreps.find((d: any) => d.id === user.claimed_drep_id);
+        if (!drep) continue;
+
+        // Score change: check last score history entry
+        const { data: history } = await supabase
+          .from('drep_score_history')
+          .select('score')
+          .eq('drep_id', drep.id)
+          .order('snapshot_date', { ascending: false })
+          .limit(2);
+
+        if (history && history.length >= 2) {
+          const delta = history[0].score - history[1].score;
+          if (Math.abs(delta) >= SCORE_CHANGE_THRESHOLD) {
+            await notifyUser(user.wallet_address, {
+              eventType: 'score-change',
+              title: `Score ${delta > 0 ? 'increased' : 'decreased'} by ${Math.abs(delta)} points`,
+              body: `Your DRepScore is now ${history[0].score}/100.`,
+              url: `${BASE_URL}/dashboard`,
+            });
+            stats.scoreChange++;
+          }
+        }
+
+        // Delegation change
+        const { data: snapshots } = await supabase
+          .from('drep_power_snapshots')
+          .select('delegator_count')
+          .eq('drep_id', drep.id)
+          .order('epoch_no', { ascending: false })
+          .limit(2);
+
+        if (snapshots && snapshots.length >= 2 && snapshots[0].delegator_count != null && snapshots[1].delegator_count != null) {
+          const delegatorDelta = snapshots[0].delegator_count - snapshots[1].delegator_count;
+          if (delegatorDelta !== 0) {
+            await notifyUser(user.wallet_address, {
+              eventType: 'delegation-change',
+              title: `${delegatorDelta > 0 ? '+' : ''}${delegatorDelta} delegator${Math.abs(delegatorDelta) !== 1 ? 's' : ''}`,
+              body: `You now have ${snapshots[0].delegator_count} delegators.`,
+              url: `${BASE_URL}/dashboard`,
+            });
+            stats.delegation++;
+
+            if (delegatorDelta > 0) {
+              await notifyUser(user.wallet_address, {
+                eventType: 'delegator-growth',
+                title: `You gained ${delegatorDelta} delegator${delegatorDelta !== 1 ? 's' : ''}`,
+                body: `Your delegation is growing — ${snapshots[0].delegator_count} total delegators.`,
+                url: `${BASE_URL}/dashboard`,
+              });
+            }
+          }
+        }
+      }
+    });
+
+    // Step 3: Check pending proposals and deadlines
+    await step.run('check-proposals', async () => {
+      const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+      const openProposals = context.proposals;
+
+      if (openProposals.length > 0) {
+        await broadcastEvent({
+          eventType: 'pending-proposals',
+          title: `${openProposals.length} proposals awaiting votes`,
+          body: `There are ${openProposals.length} open governance proposals.`,
+          url: `${BASE_URL}/dashboard/inbox`,
+        });
+        stats.pending++;
+      }
+
+      const urgentProposals = openProposals.filter((p: any) => {
+        if (!p.expiration_epoch) return false;
+        return p.expiration_epoch - currentEpoch <= 2;
+      });
+
+      if (urgentProposals.length > 0) {
+        await broadcastEvent({
+          eventType: 'urgent-deadline',
+          title: `${urgentProposals.length} proposal${urgentProposals.length !== 1 ? 's' : ''} expiring soon`,
+          body: `These proposals expire within 2 epochs. Vote now.`,
+          url: `${BASE_URL}/dashboard/inbox`,
+        });
+
+        for (const user of context.users) {
+          await notifyUser(user.wallet_address, {
+            eventType: 'proposal-deadline',
+            title: `${urgentProposals.length} proposal${urgentProposals.length !== 1 ? 's' : ''} expire in 2 epochs`,
+            body: 'Vote now to maintain your participation rate.',
+            url: `${BASE_URL}/dashboard/inbox`,
+          });
+        }
+        stats.urgent++;
+      }
+    });
+
+    // Step 4: Check rank changes and score opportunities
+    await step.run('check-rank-and-opportunities', async () => {
+      const allDreps = context.allDreps || [];
+
+      for (const user of context.users) {
+        const drep = context.dreps.find((d: any) => d.id === user.claimed_drep_id);
+        if (!drep) continue;
+
+        const rank = allDreps.findIndex((d: any) => d.id === drep.id) + 1;
+        if (rank <= 0) continue;
+
+        // Near top 10 opportunity
+        if (rank > 10 && rank <= 15 && allDreps.length >= 10) {
+          const distance = allDreps[9].score - drep.score;
+          if (distance <= 5) {
+            await notifyUser(user.wallet_address, {
+              eventType: 'score-opportunity',
+              title: `You're ${distance} point${distance !== 1 ? 's' : ''} from the top 10`,
+              body: `Ranked #${rank} — a few more rationales could push you into the top 10.`,
+              url: `${BASE_URL}/dashboard`,
+            });
+            stats.opportunity++;
+          }
+        }
+      }
+    });
+
+    // Step 5: Check milestones for near-milestone notifications
+    await step.run('check-near-milestones', async () => {
+      const supabase = getSupabaseAdmin();
+
+      for (const user of context.users) {
+        const drep = context.dreps.find((d: any) => d.id === user.claimed_drep_id);
+        if (!drep) continue;
+
+        try {
+          const newMilestones = await checkAndAwardMilestones(drep.id);
+
+          for (const key of newMilestones) {
+            const def = MILESTONES.find(m => m.key === key);
+            if (def) {
+              await notifyUser(user.wallet_address, {
+                eventType: 'near-milestone',
+                title: `Achievement unlocked: ${def.label}`,
+                body: def.description,
+                url: `${BASE_URL}/dashboard`,
+              });
+              stats.milestone++;
+            }
+          }
+        } catch (e) {
+          console.warn(`[notifications] Milestone check failed for ${drep.id}:`, errMsg(e));
+        }
+      }
+    });
+
+    return { stats };
+  }
+);

--- a/lib/milestones.ts
+++ b/lib/milestones.ts
@@ -1,0 +1,130 @@
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export interface MilestoneDefinition {
+  key: string;
+  label: string;
+  description: string;
+  icon: string; // lucide icon name
+  category: 'delegators' | 'score' | 'rationale' | 'participation' | 'profile';
+}
+
+export const MILESTONES: MilestoneDefinition[] = [
+  { key: 'claimed-profile', label: 'Profile Claimed', description: 'Claimed your DRepScore profile', icon: 'Shield', category: 'profile' },
+  { key: 'first-10-delegators', label: 'First 10 Delegators', description: 'Reached 10 delegators', icon: 'Users', category: 'delegators' },
+  { key: 'first-100-delegators', label: 'First 100 Delegators', description: 'Reached 100 delegators', icon: 'Users', category: 'delegators' },
+  { key: 'first-1000-delegators', label: 'First 1000 Delegators', description: 'Reached 1,000 delegators', icon: 'Users', category: 'delegators' },
+  { key: 'score-above-80-30d', label: 'Consistent Excellence', description: 'Score above 80 for 30+ days', icon: 'Star', category: 'score' },
+  { key: 'all-pillars-strong', label: 'Well-Rounded', description: 'All pillars above 70', icon: 'Target', category: 'score' },
+  { key: 'rationale-streak-5', label: 'Rationale Streak 5', description: '5 consecutive votes with rationale', icon: 'FileText', category: 'rationale' },
+  { key: 'rationale-streak-10', label: 'Rationale Streak 10', description: '10 consecutive votes with rationale', icon: 'FileText', category: 'rationale' },
+  { key: 'perfect-participation-epoch', label: 'Perfect Epoch', description: 'Voted on all proposals in an epoch', icon: 'CheckCircle2', category: 'participation' },
+];
+
+export interface AchievedMilestone {
+  milestoneKey: string;
+  achievedAt: string;
+}
+
+export async function getAchievedMilestones(drepId: string): Promise<AchievedMilestone[]> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('drep_milestones')
+    .select('milestone_key, achieved_at')
+    .eq('drep_id', drepId);
+  return (data || []).map((d: { milestone_key: string; achieved_at: string }) => ({ milestoneKey: d.milestone_key, achievedAt: d.achieved_at }));
+}
+
+export async function checkAndAwardMilestones(drepId: string): Promise<string[]> {
+  const supabase = getSupabaseAdmin();
+
+  const [achieved, drepResult, votesResult, scoreHistoryResult] = await Promise.all([
+    getAchievedMilestones(drepId),
+    supabase.from('dreps').select('score, info, effective_participation, rationale_rate, reliability_score, profile_completeness').eq('id', drepId).single(),
+    supabase.from('drep_votes').select('epoch_no, meta_url').eq('drep_id', drepId).order('block_time', { ascending: false }),
+    supabase.from('drep_score_history').select('score, snapshot_date').eq('drep_id', drepId).order('snapshot_date', { ascending: false }).limit(60),
+  ]);
+
+  const drep = drepResult.data;
+  const votes = votesResult.data || [];
+  const scoreHistory = scoreHistoryResult.data || [];
+  if (!drep) return [];
+
+  const existing = new Set(achieved.map(a => a.milestoneKey));
+  const newMilestones: string[] = [];
+
+  function award(key: string) {
+    if (existing.has(key)) return;
+    newMilestones.push(key);
+  }
+
+  // Claimed profile — awarded elsewhere but check
+  const { data: claimedUser } = await supabase
+    .from('users')
+    .select('wallet_address')
+    .eq('claimed_drep_id', drepId)
+    .limit(1);
+  if (claimedUser && claimedUser.length > 0) award('claimed-profile');
+
+  // Delegator milestones
+  const delegators = (drep.info as { delegatorCount?: number })?.delegatorCount || 0;
+  if (delegators >= 10) award('first-10-delegators');
+  if (delegators >= 100) award('first-100-delegators');
+  if (delegators >= 1000) award('first-1000-delegators');
+
+  // Score milestones
+  if (drep.effective_participation >= 70 && drep.rationale_rate >= 70 && drep.reliability_score >= 70 && drep.profile_completeness >= 70) {
+    award('all-pillars-strong');
+  }
+
+  // Score above 80 for 30 days
+  if (scoreHistory.length >= 30) {
+    const last30 = scoreHistory.slice(0, 30);
+    if (last30.every((s: { score: number }) => s.score >= 80)) award('score-above-80-30d');
+  }
+
+  // Rationale streaks — check consecutive votes with rationale
+  let streak = 0;
+  let maxStreak = 0;
+  for (const v of votes) {
+    if (v.meta_url) { streak++; maxStreak = Math.max(maxStreak, streak); }
+    else streak = 0;
+  }
+  if (maxStreak >= 5) award('rationale-streak-5');
+  if (maxStreak >= 10) award('rationale-streak-10');
+
+  // Perfect participation epoch — check if any epoch has votes on all proposals
+  // Simplified: check if voted on 5+ proposals in any single epoch
+  const epochCounts = new Map<number, number>();
+  for (const v of votes) {
+    if (!v.epoch_no) continue;
+    epochCounts.set(v.epoch_no, (epochCounts.get(v.epoch_no) || 0) + 1);
+  }
+  // Get total proposals per epoch from proposals table
+  const { data: proposals } = await supabase
+    .from('proposals')
+    .select('proposed_epoch')
+    .not('proposed_epoch', 'is', null);
+  const proposalsPerEpoch = new Map<number, number>();
+  for (const p of (proposals || [])) {
+    if (!(p as { proposed_epoch?: number }).proposed_epoch) continue;
+    const epoch = (p as { proposed_epoch: number }).proposed_epoch;
+    proposalsPerEpoch.set(epoch, (proposalsPerEpoch.get(epoch) || 0) + 1);
+  }
+  for (const [epoch, count] of epochCounts.entries()) {
+    const total = proposalsPerEpoch.get(epoch) || 0;
+    if (total > 0 && count >= total) {
+      award('perfect-participation-epoch');
+      break;
+    }
+  }
+
+  // Persist new milestones
+  if (newMilestones.length > 0) {
+    await supabase.from('drep_milestones').upsert(
+      newMilestones.map(key => ({ drep_id: drepId, milestone_key: key })),
+      { onConflict: 'drep_id,milestone_key' }
+    );
+  }
+
+  return newMilestones;
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -13,7 +13,12 @@ export type EventType =
   | 'delegation-change'
   | 'critical-proposal-open'
   | 'profile-view'
-  | 'api-health-alert';
+  | 'api-health-alert'
+  | 'delegator-growth'
+  | 'rank-change'
+  | 'near-milestone'
+  | 'proposal-deadline'
+  | 'score-opportunity';
 
 export type Channel = 'push' | 'discord' | 'telegram';
 
@@ -39,11 +44,11 @@ async function sendDiscordWebhook(
   event: NotificationEvent
 ): Promise<boolean> {
   try {
-    const color = event.eventType === 'urgent-deadline' || event.eventType === 'critical-proposal-open'
+    const color = event.eventType === 'urgent-deadline' || event.eventType === 'critical-proposal-open' || event.eventType === 'proposal-deadline'
       ? 0xff4444
-      : event.eventType === 'api-health-alert'
+      : event.eventType === 'api-health-alert' || event.eventType === 'near-milestone'
       ? 0xf59e0b
-      : event.eventType === 'score-change'
+      : event.eventType === 'score-change' || event.eventType === 'delegator-growth' || event.eventType === 'rank-change' || event.eventType === 'score-opportunity'
       ? 0x22c55e
       : 0x3b82f6;
 

--- a/supabase/migrations/023_drep_command_center.sql
+++ b/supabase/migrations/023_drep_command_center.sql
@@ -1,0 +1,109 @@
+-- Session 3: DRep Command Center
+-- New tables for milestones, positioning tools, vote explanations
+-- Column additions to users and drep_power_snapshots
+
+BEGIN;
+
+-- =============================================
+-- 1. New tables
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS drep_milestones (
+  drep_id TEXT NOT NULL,
+  milestone_key TEXT NOT NULL,
+  achieved_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (drep_id, milestone_key)
+);
+
+CREATE TABLE IF NOT EXISTS position_statements (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  drep_id TEXT NOT NULL,
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INT NOT NULL,
+  statement_text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS vote_explanations (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  drep_id TEXT NOT NULL,
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INT NOT NULL,
+  explanation_text TEXT NOT NULL,
+  ai_assisted BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS governance_philosophy (
+  drep_id TEXT PRIMARY KEY,
+  philosophy_text TEXT NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- =============================================
+-- 2. Indexes
+-- =============================================
+
+CREATE INDEX IF NOT EXISTS idx_drep_milestones_drep ON drep_milestones(drep_id);
+CREATE INDEX IF NOT EXISTS idx_position_statements_drep ON position_statements(drep_id);
+CREATE INDEX IF NOT EXISTS idx_position_statements_proposal ON position_statements(proposal_tx_hash, proposal_index);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_position_statements_unique ON position_statements(drep_id, proposal_tx_hash, proposal_index);
+CREATE INDEX IF NOT EXISTS idx_vote_explanations_drep ON vote_explanations(drep_id);
+CREATE INDEX IF NOT EXISTS idx_vote_explanations_proposal ON vote_explanations(proposal_tx_hash, proposal_index);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vote_explanations_unique ON vote_explanations(drep_id, proposal_tx_hash, proposal_index);
+
+-- =============================================
+-- 3. Column additions
+-- =============================================
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS onboarding_checklist JSONB DEFAULT '{}';
+ALTER TABLE drep_power_snapshots ADD COLUMN IF NOT EXISTS delegator_count INT;
+
+-- =============================================
+-- 4. Updated_at triggers
+-- =============================================
+
+CREATE TRIGGER set_position_statements_updated_at
+  BEFORE UPDATE ON position_statements
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_vote_explanations_updated_at
+  BEFORE UPDATE ON vote_explanations
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TRIGGER set_governance_philosophy_updated_at
+  BEFORE UPDATE ON governance_philosophy
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- =============================================
+-- 5. RLS policies (public read, service-role write)
+-- =============================================
+
+ALTER TABLE drep_milestones ENABLE ROW LEVEL SECURITY;
+ALTER TABLE position_statements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE vote_explanations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE governance_philosophy ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read access" ON drep_milestones FOR SELECT USING (true);
+CREATE POLICY "Service role only" ON drep_milestones FOR INSERT WITH CHECK (false);
+CREATE POLICY "Service role only update" ON drep_milestones FOR UPDATE USING (false);
+CREATE POLICY "Service role only delete" ON drep_milestones FOR DELETE USING (false);
+
+CREATE POLICY "Public read access" ON position_statements FOR SELECT USING (true);
+CREATE POLICY "Service role only" ON position_statements FOR INSERT WITH CHECK (false);
+CREATE POLICY "Service role only update" ON position_statements FOR UPDATE USING (false);
+CREATE POLICY "Service role only delete" ON position_statements FOR DELETE USING (false);
+
+CREATE POLICY "Public read access" ON vote_explanations FOR SELECT USING (true);
+CREATE POLICY "Service role only" ON vote_explanations FOR INSERT WITH CHECK (false);
+CREATE POLICY "Service role only update" ON vote_explanations FOR UPDATE USING (false);
+CREATE POLICY "Service role only delete" ON vote_explanations FOR DELETE USING (false);
+
+CREATE POLICY "Public read access" ON governance_philosophy FOR SELECT USING (true);
+CREATE POLICY "Service role only" ON governance_philosophy FOR INSERT WITH CHECK (false);
+CREATE POLICY "Service role only update" ON governance_philosophy FOR UPDATE USING (false);
+CREATE POLICY "Service role only delete" ON governance_philosophy FOR DELETE USING (false);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Transform the DRep experience from a read-only report card into an actionable command center.

- **Phase 1 — Data Foundation + Claim Funnel**: Migration 023 (4 new tables + column additions + RLS), claim page overhaul with FOMO-driven design, post-claim celebration with confetti
- **Phase 2 — Dashboard Action Center**: Rationale dual-flow (pre-vote drafting + post-vote explanations), delegator analytics, competitive context with rank/gap analysis, onboarding checklist, representation scorecard, score simulator, activity heatmap
- **Phase 3 — Gamification + Positioning**: 9-milestone badge system, governance philosophy editor, position statement editor, shareable report card with X integration
- **Phase 4 — Notifications + Dashboard Layout**: 10 notification types wired via Inngest cron, full dashboard layout overhaul (score hero + two-column + bottom section), public profile enhanced with badges/philosophy/heatmap
- **Docs**: Updated product-wow-plan.md with Session 3 details + added Session 7 strategic roadmap

### New Components (12)
ClaimCelebration, VoteExplanationEditor, DelegatorTrendChart, CompetitiveContext, OnboardingChecklist, RepresentationScorecard, ScoreSimulator, ActivityHeatmap, MilestoneBadges, GovernancePhilosophyEditor, PositionStatementEditor, DRepReportCard

### New API Routes (9)
delegator-trends, competitive, onboarding, milestones, representation, simulate, explanations, philosophy, positions

### New Tables (4)
drep_milestones, position_statements, vote_explanations, governance_philosophy

## Test plan
- [x] TypeScript type-check passes (pre-commit hook)
- [x] All 211 tests pass (pre-push hook)
- [x] Production build succeeds (pre-push hook)
- [ ] Railway deployment succeeds
- [ ] Supabase migration 023 applies cleanly
- [ ] Claim page renders with new FOMO design
- [ ] Dashboard renders all new widgets without errors
- [ ] API routes return valid responses for claimed DReps


Made with [Cursor](https://cursor.com)