### PR TITLE
feat: Session 4 — Shareable Moments & Viral Growth Engine

### DIFF
--- a/.cursor/rules/deploy.md
+++ b/.cursor/rules/deploy.md
@@ -94,7 +94,7 @@ GET https://drepscore.io/api/health → expect 200, status != "error"
 ```
 PUT https://drepscore.io/api/inngest → expect 200
 ```
-This registers all 8 Inngest functions with Inngest Cloud.
+This registers all 9 Inngest functions with Inngest Cloud.
 
 ### Smoke Tests
 ```
@@ -139,7 +139,7 @@ The `tim-dd` account does not have collaborator access to the repo.
 `.cursor/mcp.json` is gitignored and contains secrets. **NEVER overwrite, recreate, or edit this file.**
 
 ### Inngest
-- All 8 background jobs run via Inngest Cloud
+- All 9 background jobs run via Inngest Cloud
 - After every deploy: `PUT https://drepscore.io/api/inngest` to sync functions
 - `INNGEST_SERVE_HOST=https://drepscore.io` ensures SDK advertises production URL
 

--- a/.cursor/rules/strategy.md
+++ b/.cursor/rules/strategy.md
@@ -26,7 +26,7 @@ DRepScore has a comprehensive monetization and growth strategy documented in `do
 - **Governance Data API** — Public API product. See `docs/strategy/api-product.md`.
 
 ## Product "Wow" Plan
-`docs/strategy/product-wow-plan.md` is the comprehensive 6-session execution plan to transform DRepScore from a governance tool into the product that makes the crypto space say "wow." Reference it when making UX, feature, or architecture decisions.
+`docs/strategy/product-wow-plan.md` is the comprehensive 7-session execution plan to transform DRepScore from a governance tool into the product that makes the crypto space say "wow." Reference it when making UX, feature, or architecture decisions.
 
 ## Architecture Implications
 When building features, consider:

--- a/.cursor/rules/workflow.md
+++ b/.cursor/rules/workflow.md
@@ -44,6 +44,8 @@ Before any plan is finalized, answer:
 - **Fast validation**: For any pipeline (sync, migration, backfill), validate first 3-5 results before running to completion. Report validation results before proceeding. Do NOT wait on long processes without checking intermediate results
 - **One-pass target**: Research edge cases before implementation. Target zero fix commits after a feature commit
 - **Database-first**: Any feature that reads external data must go through Supabase. No new direct-API paths to the frontend
+- **Analytics inline**: Every new user-facing interaction must include its PostHog event at creation time, not as a follow-up. If you create a button, form, or state change a user triggers — add the `posthog.capture()` call in the same diff. Reference `analytics.mdc` for naming conventions.
+- **Deprecation audit**: When removing or replacing a system (preferences, wizard, scoring model, etc.), search for all consumers of its **data and state** — not just direct imports of deleted files. Hooks, effects, API routes, and conditional logic that depend on the removed system's output will silently break if not updated.
 
 ## Continuous Learning Protocol
 - **On correction**: When the user corrects you on ANYTHING, immediately append to `tasks/lessons.md` with: date, pattern, context, takeaway

--- a/app/api/badge/[drepId]/route.ts
+++ b/app/api/badge/[drepId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { ImageResponse } from 'next/og';
 import { getDRepById } from '@/lib/data';
 import { getDRepPrimaryName } from '@/utils/display';
 import { captureServerEvent } from '@/lib/posthog-server';
@@ -15,11 +16,96 @@ function getTierLabel(score: number): string {
   return 'Low';
 }
 
+function buildShieldSvg(score: number, tier: string, color: string): string {
+  const labelWidth = 90;
+  const scoreWidth = 90;
+  const totalWidth = labelWidth + scoreWidth;
+  const height = 28;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${height}">
+  <title>DRepScore ${score}/100 (${tier})</title>
+  <rect width="${totalWidth}" height="${height}" rx="4" fill="#1e293b"/>
+  <clipPath id="r"><rect width="${totalWidth}" height="${height}" rx="4"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect x="${labelWidth}" width="${scoreWidth}" height="${height}" fill="${color}22"/>
+  </g>
+  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="#e2e8f0" font-weight="600">DRepScore</text>
+  <text x="${labelWidth + 8}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${color}" font-weight="700">${score}/100</text>
+  <text x="${labelWidth + 56}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${color}cc">${tier}</text>
+</svg>`;
+}
+
+function buildCardSvg(name: string, score: number, tier: string, color: string, topPillar: string, topPillarValue: number): string {
+  const w = 300, h = 100;
+  const displayName = name.length > 22 ? name.slice(0, 20) + '…' : name;
+  const ringR = 28, cx = 44, cy = 50, sw = 5;
+  const circ = 2 * Math.PI * ringR;
+  const offset = circ * (1 - score / 100);
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
+  <title>${name} — DRepScore ${score}/100</title>
+  <rect width="${w}" height="${h}" rx="8" fill="#0c1222"/>
+  <rect x="1" y="1" width="${w - 2}" height="${h - 2}" rx="7" fill="none" stroke="${color}33" stroke-width="1"/>
+  <circle cx="${cx}" cy="${cy}" r="${ringR}" fill="none" stroke="#1e293b" stroke-width="${sw}"/>
+  <circle cx="${cx}" cy="${cy}" r="${ringR}" fill="none" stroke="${color}" stroke-width="${sw}" stroke-linecap="round"
+    stroke-dasharray="${circ}" stroke-dashoffset="${offset}" transform="rotate(-90 ${cx} ${cy})"/>
+  <text x="${cx}" y="${cy + 1}" text-anchor="middle" dominant-baseline="central" font-family="sans-serif" font-size="18" fill="${color}" font-weight="700">${score}</text>
+  <text x="84" y="30" font-family="sans-serif" font-size="14" fill="#e2e8f0" font-weight="600">${displayName}</text>
+  <text x="84" y="50" font-family="sans-serif" font-size="11" fill="#94a3b8">${tier} · ${topPillar}: ${topPillarValue}%</text>
+  <text x="84" y="80" font-family="sans-serif" font-size="10" fill="#64748b">drepscore.io</text>
+</svg>`;
+}
+
+function buildFullSvg(
+  name: string, drepId: string, score: number, tier: string, color: string,
+  pillars: { label: string; value: number }[]
+): string {
+  const w = 480, h = 200;
+  const displayName = name.length > 28 ? name.slice(0, 26) + '…' : name;
+  const shortId = drepId.length > 24 ? `${drepId.slice(0, 12)}...${drepId.slice(-8)}` : drepId;
+  const ringR = 50, cx = 72, cy = 90, sw = 8;
+  const circ = 2 * Math.PI * ringR;
+  const offset = circ * (1 - score / 100);
+
+  const pillarBars = pillars.map((p, i) => {
+    const barY = 60 + i * 28;
+    const barW = Math.max(2, (p.value / 100) * 180);
+    const pColor = p.value >= 80 ? '#22c55e' : p.value >= 50 ? '#f59e0b' : '#ef4444';
+    return `<text x="160" y="${barY}" font-family="sans-serif" font-size="11" fill="#94a3b8">${p.label}</text>
+    <rect x="260" y="${barY - 10}" width="180" height="14" rx="7" fill="#1e293b"/>
+    <rect x="260" y="${barY - 10}" width="${barW}" height="14" rx="7" fill="${pColor}"/>
+    <text x="448" y="${barY}" font-family="sans-serif" font-size="10" fill="#e2e8f0" text-anchor="end">${p.value}%</text>`;
+  }).join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
+  <title>${name} — DRepScore ${score}/100</title>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c1222"/>
+      <stop offset="100%" stop-color="#162033"/>
+    </linearGradient>
+  </defs>
+  <rect width="${w}" height="${h}" rx="12" fill="url(#bg)"/>
+  <rect x="1" y="1" width="${w - 2}" height="${h - 2}" rx="11" fill="none" stroke="${color}22" stroke-width="1"/>
+  <circle cx="${cx}" cy="${cy}" r="${ringR}" fill="none" stroke="#1e293b" stroke-width="${sw}"/>
+  <circle cx="${cx}" cy="${cy}" r="${ringR}" fill="none" stroke="${color}" stroke-width="${sw}" stroke-linecap="round"
+    stroke-dasharray="${circ}" stroke-dashoffset="${offset}" transform="rotate(-90 ${cx} ${cy})"/>
+  <text x="${cx}" y="${cy + 1}" text-anchor="middle" dominant-baseline="central" font-family="sans-serif" font-size="28" fill="${color}" font-weight="700">${score}</text>
+  <text x="${cx}" y="${cy + 20}" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#94a3b8">${tier}</text>
+  <text x="160" y="28" font-family="sans-serif" font-size="16" fill="#e2e8f0" font-weight="700">${displayName}</text>
+  <text x="160" y="44" font-family="monospace" font-size="9" fill="#64748b">${shortId}</text>
+  ${pillarBars}
+  <text x="8" y="${h - 10}" font-family="sans-serif" font-size="11" fill="#475569" font-weight="600">DRepScore</text>
+  <text x="${w - 8}" y="${h - 10}" text-anchor="end" font-family="sans-serif" font-size="9" fill="#475569">drepscore.io</text>
+</svg>`;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ drepId: string }> }
 ) {
   const { drepId } = await params;
+  const format = (request.nextUrl.searchParams.get('format') || 'shield') as 'shield' | 'card' | 'full';
+  const outputType = request.nextUrl.searchParams.get('type') || 'svg';
+
   const drep = await getDRepById(decodeURIComponent(drepId));
 
   if (!drep) {
@@ -33,32 +119,51 @@ export async function GET(
   }
 
   const referer = request.headers.get('referer') || 'direct';
-  captureServerEvent('badge_rendered', { drep_id: drepId, referer }, `badge:${drepId}`);
+  captureServerEvent('badge_rendered', { drep_id: drepId, format, referer }, `badge:${drepId}`);
 
   const name = getDRepPrimaryName(drep);
   const score = drep.drepScore;
   const color = getTierColor(score);
   const tier = getTierLabel(score);
-  const displayName = name.length > 20 ? name.slice(0, 18) + '…' : name;
 
-  const labelWidth = 90;
-  const scoreWidth = 90;
-  const totalWidth = labelWidth + scoreWidth;
-  const height = 28;
+  const pillars = [
+    { label: 'Participation', value: drep.effectiveParticipation },
+    { label: 'Rationale', value: drep.rationaleRate },
+    { label: 'Reliability', value: drep.reliabilityScore },
+    { label: 'Profile', value: drep.profileCompleteness },
+  ];
+  const topPillar = pillars.reduce((best, p) => p.value > best.value ? p : best, pillars[0]);
 
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${height}">
-  <title>${name} — DRepScore ${score}/100 (${tier})</title>
-  <rect width="${totalWidth}" height="${height}" rx="4" fill="#1e293b"/>
-  <rect x="${labelWidth}" width="${scoreWidth}" height="${height}" rx="0" fill="${color}22"/>
-  <rect x="${totalWidth - 4}" y="0" width="4" height="${height}" rx="0" fill="transparent"/>
-  <clipPath id="r"><rect width="${totalWidth}" height="${height}" rx="4"/></clipPath>
-  <g clip-path="url(#r)">
-    <rect x="${labelWidth}" width="${scoreWidth}" height="${height}" fill="${color}22"/>
-  </g>
-  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="#e2e8f0" font-weight="600">DRepScore</text>
-  <text x="${labelWidth + 8}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${color}" font-weight="700">${score}/100</text>
-  <text x="${labelWidth + 56}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${color}cc">${tier}</text>
-</svg>`;
+  let svg: string;
+  if (format === 'card') {
+    svg = buildCardSvg(name, score, tier, color, topPillar.label, topPillar.value);
+  } else if (format === 'full') {
+    svg = buildFullSvg(name, drep.drepId, score, tier, color, pillars);
+  } else {
+    svg = buildShieldSvg(score, tier, color);
+  }
+
+  if (outputType === 'png') {
+    const sizes: Record<string, { width: number; height: number }> = {
+      shield: { width: 360, height: 56 },
+      card: { width: 600, height: 200 },
+      full: { width: 960, height: 400 },
+    };
+    const { width, height } = sizes[format] || sizes.shield;
+    return new ImageResponse(
+      (
+        <div style={{ display: 'flex', width: '100%', height: '100%' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={`data:image/svg+xml,${encodeURIComponent(svg)}`} alt="" style={{ width: '100%', height: '100%' }} />
+        </div>
+      ),
+      {
+        width,
+        height,
+        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+      }
+    );
+  }
 
   return new NextResponse(svg, {
     headers: {

--- a/app/api/dashboard/score-change/route.ts
+++ b/app/api/dashboard/score-change/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) {
+    return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+  }
+
+  try {
+    const supabase = createClient();
+
+    const { data: history } = await supabase
+      .from('drep_score_history')
+      .select('score, recorded_at')
+      .eq('drep_id', drepId)
+      .order('recorded_at', { ascending: false })
+      .limit(14);
+
+    if (!history || history.length < 2) {
+      return NextResponse.json({ delta: 0 });
+    }
+
+    const currentScore = history[0].score;
+    const weekAgo = history.length >= 7 ? history[6] : history[history.length - 1];
+    const previousScore = weekAgo.score;
+    const delta = currentScore - previousScore;
+
+    captureServerEvent('score_change_api_served', {
+      drep_id: drepId,
+      delta,
+      has_significant_change: Math.abs(delta) >= 3,
+    });
+
+    return NextResponse.json({
+      currentScore,
+      previousScore,
+      delta,
+      date: weekAgo.recorded_at,
+    });
+  } catch (err) {
+    console.error('[Score Change API] Error:', err);
+    captureServerEvent('score_change_api_error', { drep_id: drepId, error: String(err) });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/governance/leaderboard/route.ts
+++ b/app/api/governance/leaderboard/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase';
+import { getDRepPrimaryName } from '@/utils/display';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const tier = request.nextUrl.searchParams.get('tier') || 'all';
+  const limitParam = parseInt(request.nextUrl.searchParams.get('limit') || '20');
+  const limit = Math.min(50, Math.max(1, limitParam));
+
+  try {
+    const supabase = createClient();
+
+    // Top DReps by score
+    let query = supabase
+      .from('dreps')
+      .select('drep_id, name, ticker, handle, score, size_tier, info, effective_participation, rationale_rate, reliability_score, profile_completeness')
+      .order('score', { ascending: false })
+      .limit(limit);
+
+    if (tier !== 'all') {
+      query = query.eq('size_tier', tier);
+    }
+
+    const { data: topDreps, error } = await query;
+    if (error) throw error;
+
+    const leaderboard = (topDreps || []).map((d: any, i: number) => ({
+      rank: i + 1,
+      drepId: d.drep_id,
+      name: getDRepPrimaryName(d),
+      score: d.score ?? 0,
+      sizeTier: d.size_tier,
+      isActive: d.info?.isActive ?? false,
+      participation: d.effective_participation ?? 0,
+      rationale: d.rationale_rate ?? 0,
+      reliability: d.reliability_score ?? 0,
+    }));
+
+    // Weekly movers: compare current score vs 7-day-old snapshot
+    const sevenDaysAgo = new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0];
+
+    const { data: historyData } = await supabase
+      .from('drep_score_history')
+      .select('drep_id, score, recorded_at')
+      .lte('recorded_at', sevenDaysAgo)
+      .order('recorded_at', { ascending: false })
+      .limit(2000);
+
+    const oldScoreMap = new Map<string, number>();
+    for (const h of historyData || []) {
+      if (!oldScoreMap.has(h.drep_id)) {
+        oldScoreMap.set(h.drep_id, h.score);
+      }
+    }
+
+    const { data: currentDreps } = await supabase
+      .from('dreps')
+      .select('drep_id, name, ticker, handle, score')
+      .gt('score', 0)
+      .order('score', { ascending: false });
+
+    const movers = (currentDreps || [])
+      .map((d: any) => {
+        const old = oldScoreMap.get(d.drep_id);
+        if (old === undefined) return null;
+        return {
+          drepId: d.drep_id,
+          name: getDRepPrimaryName(d),
+          currentScore: d.score,
+          previousScore: old,
+          delta: d.score - old,
+        };
+      })
+      .filter((m): m is NonNullable<typeof m> => m !== null && m.delta !== 0)
+      .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+
+    const gainers = movers.filter(m => m.delta > 0).slice(0, 5);
+    const losers = movers.filter(m => m.delta < 0).slice(0, 5);
+
+    // Hall of Fame: score >= 80 for 90+ days
+    const ninetyDaysAgo = new Date(Date.now() - 90 * 86400000).toISOString().split('T')[0];
+
+    const { data: hallData } = await supabase
+      .from('drep_score_history')
+      .select('drep_id, score, recorded_at')
+      .gte('recorded_at', ninetyDaysAgo)
+      .gte('score', 80)
+      .order('drep_id');
+
+    const drepDayCounts = new Map<string, number>();
+    for (const h of hallData || []) {
+      drepDayCounts.set(h.drep_id, (drepDayCounts.get(h.drep_id) || 0) + 1);
+    }
+
+    const hallOfFameIds = [...drepDayCounts.entries()]
+      .filter(([, count]) => count >= 60)
+      .map(([id]) => id);
+
+    let hallOfFame: { drepId: string; name: string; score: number; days: number }[] = [];
+    if (hallOfFameIds.length > 0) {
+      const { data: hofDreps } = await supabase
+        .from('dreps')
+        .select('drep_id, name, ticker, handle, score')
+        .in('drep_id', hallOfFameIds.slice(0, 20));
+
+      hallOfFame = (hofDreps || []).map((d: any) => ({
+        drepId: d.drep_id,
+        name: getDRepPrimaryName(d),
+        score: d.score,
+        days: drepDayCounts.get(d.drep_id) || 0,
+      })).sort((a, b) => b.days - a.days);
+    }
+
+    captureServerEvent('leaderboard_api_served', {
+      tier,
+      limit,
+      leaderboard_count: leaderboard.length,
+      gainers_count: gainers.length,
+      losers_count: losers.length,
+      hall_of_fame_count: hallOfFame.length,
+    });
+
+    return NextResponse.json({
+      leaderboard,
+      weeklyMovers: { gainers, losers },
+      hallOfFame,
+    });
+  } catch (err) {
+    console.error('[Leaderboard API] Error:', err);
+    captureServerEvent('leaderboard_api_error', { error: String(err) });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/governance/matches/detail/route.ts
+++ b/app/api/governance/matches/detail/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateSessionToken } from '@/lib/supabaseAuth';
+import { createClient } from '@/lib/supabase';
+import { calculateRepresentationMatch } from '@/lib/representationMatch';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const token = authHeader.slice(7);
+  const session = await validateSessionToken(token);
+  if (!session?.walletAddress) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const drepId = request.nextUrl.searchParams.get('drepId');
+  if (!drepId) {
+    return NextResponse.json({ error: 'drepId required' }, { status: 400 });
+  }
+
+  const supabase = createClient();
+
+  const { data: pollVotes } = await supabase
+    .from('poll_responses')
+    .select('proposal_tx_hash, proposal_index, vote')
+    .eq('wallet_address', session.walletAddress);
+
+  if (!pollVotes || pollVotes.length === 0) {
+    return NextResponse.json({ comparisons: [], agreed: 0, total: 0, matchScore: 0 });
+  }
+
+  const txHashes = [...new Set(pollVotes.map(pv => pv.proposal_tx_hash))];
+
+  const [{ data: drepVotes }, { data: proposals }] = await Promise.all([
+    supabase
+      .from('drep_votes')
+      .select('proposal_tx_hash, proposal_index, vote')
+      .eq('drep_id', drepId)
+      .in('proposal_tx_hash', txHashes),
+    supabase
+      .from('proposals')
+      .select('tx_hash, proposal_index, title')
+      .in('tx_hash', txHashes),
+  ]);
+
+  const titleMap = new Map<string, string | null>();
+  for (const p of proposals ?? []) {
+    titleMap.set(`${p.tx_hash}-${p.proposal_index}`, p.title);
+  }
+
+  const result = calculateRepresentationMatch(pollVotes, drepVotes ?? [], titleMap);
+
+  captureServerEvent('matches_detail_api_served', {
+    drep_id: drepId,
+    comparisons_count: result.comparisons.length,
+    match_score: result.score,
+  }, session.walletAddress);
+
+  return NextResponse.json({
+    matchScore: result.score ?? 0,
+    agreed: result.aligned,
+    total: result.total,
+    comparisons: result.comparisons.map(c => ({
+      proposalTitle: c.proposalTitle || `Proposal ${c.proposalTxHash.slice(0, 8)}...`,
+      userVote: c.userVote,
+      drepVote: c.drepVote,
+      agreed: c.agreed,
+    })),
+  });
+}

--- a/app/api/og/compare/route.tsx
+++ b/app/api/og/compare/route.tsx
@@ -1,193 +1,93 @@
-/**
- * OG Image Generation for DRep Comparison
- * Side-by-side score rings with DRep names for social sharing
- */
-
 import { ImageResponse } from 'next/og';
 import { NextRequest } from 'next/server';
 import { getDRepById } from '@/lib/data';
 import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGScoreRing, OGFooter, OGFallback, OG, tierColor } from '@/lib/og-utils';
 
 export const runtime = 'edge';
-
-const COLORS = {
-  bg: '#0c1222',
-  bgGradient: '#162033',
-  text: '#ffffff',
-  textMuted: '#94a3b8',
-  green: '#22c55e',
-  amber: '#f59e0b',
-  red: '#ef4444',
-  barBg: '#1e293b',
-  divider: '#334155',
-};
-
-function getTierColor(score: number): string {
-  if (score >= 80) return COLORS.green;
-  if (score >= 60) return COLORS.amber;
-  return COLORS.red;
-}
-
-function getTierLabel(score: number): string {
-  if (score >= 80) return 'Strong';
-  if (score >= 60) return 'Good';
-  return 'Low';
-}
-
-function ScoreRing({ score, size = 140 }: { score: number; size?: number }) {
-  const color = getTierColor(score);
-  const label = getTierLabel(score);
-  const strokeWidth = 10;
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const progress = Math.min(100, Math.max(0, score)) / 100;
-  const dashOffset = circumference * (1 - progress);
-
-  return (
-    <div style={{
-      display: 'flex',
-      position: 'relative',
-      width: size,
-      height: size,
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-      <svg
-        width={size}
-        height={size}
-        style={{ transform: 'rotate(-90deg)', position: 'absolute' }}
-      >
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={COLORS.barBg} strokeWidth={strokeWidth} />
-        <circle
-          cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color}
-          strokeWidth={strokeWidth} strokeLinecap="round"
-          strokeDasharray={circumference} strokeDashoffset={dashOffset}
-        />
-      </svg>
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ display: 'flex', fontSize: '44px', fontWeight: 700, color, lineHeight: 1 }}>{score}</div>
-        <div style={{ display: 'flex', fontSize: '14px', color: COLORS.textMuted, marginTop: '4px' }}>{label}</div>
-      </div>
-    </div>
-  );
-}
 
 export async function GET(request: NextRequest) {
   try {
     const drepsParam = request.nextUrl.searchParams.get('dreps');
-    if (!drepsParam) {
-      return fallbackImage('No DReps specified');
-    }
+    if (!drepsParam) return fallback('No DReps specified');
 
     const drepIds = drepsParam.split(',').map(s => s.trim()).filter(Boolean).slice(0, 3);
-    if (drepIds.length < 2) {
-      return fallbackImage('Need at least 2 DReps');
-    }
+    if (drepIds.length < 2) return fallback('Need at least 2 DReps');
 
-    const dreps = await Promise.all(drepIds.map(id => getDRepById(id)));
-    const valid = dreps.filter(Boolean);
-    if (valid.length < 2) {
-      return fallbackImage('DRep(s) not found');
-    }
+    const dreps = (await Promise.all(drepIds.map(id => getDRepById(id)))).filter(Boolean);
+    if (dreps.length < 2) return fallback('DRep(s) not found');
+
+    const pillarKeys = ['effectiveParticipation', 'rationaleRate', 'reliabilityScore', 'profileCompleteness'] as const;
+    const pillarLabels = ['Participation', 'Rationale', 'Reliability', 'Profile'];
+    const drepColors = [OG.indigo, OG.amber, OG.green];
 
     return new ImageResponse(
       (
-        <div style={{
-          display: 'flex',
-          width: '100%',
-          height: '100%',
-          background: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgGradient} 100%)`,
-          color: COLORS.text,
-          fontFamily: 'sans-serif',
-          padding: '48px 64px',
-          flexDirection: 'column',
-        }}>
-          {/* Title */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '24px' }}>
-            <div style={{ display: 'flex', fontSize: '28px', fontWeight: 700 }}>DRep Comparison</div>
-          </div>
+        <OGBackground glow={OG.indigo}>
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', padding: '48px 64px' }}>
+            <div style={{ display: 'flex', fontSize: '28px', fontWeight: 700, marginBottom: '24px', color: OG.text }}>
+              DRep Comparison
+            </div>
 
-          {/* DRep Cards */}
-          <div style={{
-            display: 'flex',
-            flex: 1,
-            gap: '32px',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
-            {valid.map((drep, i) => {
-              if (!drep) return null;
-              const name = getDRepPrimaryName(drep);
-              return (
-                <div key={drep.drepId} style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  flex: 1,
-                  padding: '24px',
-                  borderRadius: '16px',
-                  backgroundColor: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.08)',
-                }}>
-                  <ScoreRing score={drep.drepScore} />
-                  <div style={{
+            <div style={{ display: 'flex', flex: 1, gap: '24px', alignItems: 'stretch', justifyContent: 'center' }}>
+              {dreps.map((drep, i) => {
+                if (!drep) return null;
+                const name = getDRepPrimaryName(drep);
+                const color = drepColors[i];
+                return (
+                  <div key={drep.drepId} style={{
                     display: 'flex',
-                    fontSize: '24px',
-                    fontWeight: 600,
-                    marginTop: '16px',
-                    textAlign: 'center',
-                    maxWidth: '280px',
-                    lineHeight: 1.2,
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    flex: 1,
+                    padding: '24px 20px',
+                    borderRadius: '16px',
+                    backgroundColor: OG.bgCard,
+                    border: `1px solid ${color}30`,
+                    justifyContent: 'center',
                   }}>
-                    {name.length > 20 ? name.slice(0, 20) + '…' : name}
-                  </div>
-                  {drep.ticker && (
-                    <div style={{ display: 'flex', fontSize: '16px', color: COLORS.textMuted, marginTop: '6px' }}>
-                      ${drep.ticker}
+                    <OGScoreRing score={drep.drepScore} size={120} />
+                    <div style={{
+                      display: 'flex',
+                      fontSize: '22px',
+                      fontWeight: 600,
+                      marginTop: '12px',
+                      textAlign: 'center',
+                      maxWidth: '280px',
+                      lineHeight: 1.2,
+                      color,
+                    }}>
+                      {name.length > 18 ? name.slice(0, 16) + '…' : name}
                     </div>
-                  )}
-                  <div style={{ display: 'flex', fontSize: '14px', color: COLORS.textMuted, marginTop: '12px', gap: '8px' }}>
-                    <span>{drep.sizeTier}</span>
-                    <span>·</span>
-                    <span>{drep.isActive ? 'Active' : 'Inactive'}</span>
+
+                    {/* Pillar mini-bars */}
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '16px', width: '100%' }}>
+                      {pillarKeys.map((key, pi) => {
+                        const val = drep[key] as number;
+                        const barColor = val >= 80 ? OG.green : val >= 50 ? OG.amber : OG.red;
+                        return (
+                          <div key={key} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                            <div style={{ display: 'flex', width: '80px', fontSize: '11px', color: OG.textMuted }}>
+                              {pillarLabels[pi]}
+                            </div>
+                            <div style={{ display: 'flex', flex: 1, height: '10px', backgroundColor: OG.barBg, borderRadius: '5px', overflow: 'hidden' }}>
+                              <div style={{ display: 'flex', width: `${val}%`, height: '100%', backgroundColor: barColor, borderRadius: '5px' }} />
+                            </div>
+                            <div style={{ display: 'flex', width: '30px', fontSize: '11px', color: OG.text, justifyContent: 'flex-end', fontWeight: 600 }}>
+                              {val}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-
-            {/* VS divider between cards */}
-            {valid.length === 2 && (
-              <div style={{
-                display: 'flex',
-                position: 'absolute',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                fontSize: '32px',
-                fontWeight: 700,
-                color: COLORS.textMuted,
-                opacity: 0.5,
-              }}>
-                VS
-              </div>
-            )}
-          </div>
-
-          {/* Footer */}
-          <div style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            marginTop: '16px',
-          }}>
-            <div style={{ display: 'flex', fontSize: '20px', fontWeight: 600, color: COLORS.textMuted }}>
-              DRepScore
+                );
+              })}
             </div>
-            <div style={{ display: 'flex', fontSize: '16px', color: COLORS.textMuted }}>
-              drepscore.io
-            </div>
+
+            <OGFooter />
           </div>
-        </div>
+        </OGBackground>
       ),
       {
         width: 1200,
@@ -197,30 +97,10 @@ export async function GET(request: NextRequest) {
     );
   } catch (error) {
     console.error('[OG Compare] Error:', error);
-    return fallbackImage('Error generating image');
+    return fallback('Error generating image');
   }
 }
 
-function fallbackImage(message: string) {
-  return new ImageResponse(
-    (
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        height: '100%',
-        background: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgGradient} 100%)`,
-        color: COLORS.text,
-        fontFamily: 'sans-serif',
-      }}>
-        <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700 }}>DRepScore</div>
-        <div style={{ display: 'flex', fontSize: '24px', color: COLORS.textMuted, marginTop: '16px' }}>
-          Compare Cardano DReps side by side
-        </div>
-      </div>
-    ),
-    { width: 1200, height: 630 }
-  );
+function fallback(message: string) {
+  return new ImageResponse(<OGFallback message={message} />, { width: 1200, height: 630 });
 }

--- a/app/api/og/drep/[drepId]/route.tsx
+++ b/app/api/og/drep/[drepId]/route.tsx
@@ -1,148 +1,9 @@
-/**
- * OG Image Generation for DRep Score Cards
- * Generates shareable 1200x630 images for social media
- */
-
 import { ImageResponse } from 'next/og';
 import { getDRepById } from '@/lib/data';
 import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGScoreRing, OGPillarBar, OGFooter, OGFallback, OG, tierColor, tierLabel, shortenDRepId } from '@/lib/og-utils';
 
 export const runtime = 'edge';
-
-const COLORS = {
-  bg: '#0c1222',
-  bgGradient: '#162033',
-  text: '#ffffff',
-  textMuted: '#94a3b8',
-  green: '#22c55e',
-  amber: '#f59e0b',
-  red: '#ef4444',
-  barBg: '#1e293b',
-};
-
-function getTierColor(score: number): string {
-  if (score >= 80) return COLORS.green;
-  if (score >= 60) return COLORS.amber;
-  return COLORS.red;
-}
-
-function getTierLabel(score: number): string {
-  if (score >= 80) return 'Strong';
-  if (score >= 60) return 'Good';
-  return 'Low';
-}
-
-function shortenDRepId(drepId: string): string {
-  if (drepId.length <= 20) return drepId;
-  return `${drepId.slice(0, 12)}...${drepId.slice(-8)}`;
-}
-
-interface PillarData {
-  label: string;
-  value: number;
-  maxPoints: number;
-}
-
-function PillarBar({ label, value, maxPoints }: PillarData) {
-  const percentage = Math.min(100, Math.max(0, (value / maxPoints) * 100));
-  const barColor = percentage >= 80 ? COLORS.green : percentage >= 50 ? COLORS.amber : COLORS.red;
-  
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '16px', width: '100%' }}>
-      <div style={{ display: 'flex', width: '140px', fontSize: '18px', color: COLORS.textMuted }}>
-        {label}
-      </div>
-      <div style={{ 
-        display: 'flex', 
-        flex: 1, 
-        height: '24px', 
-        backgroundColor: COLORS.barBg, 
-        borderRadius: '12px',
-        overflow: 'hidden',
-      }}>
-        <div style={{ 
-          display: 'flex',
-          width: `${percentage}%`, 
-          height: '100%', 
-          backgroundColor: barColor,
-          borderRadius: '12px',
-        }} />
-      </div>
-      <div style={{ 
-        display: 'flex',
-        width: '70px', 
-        fontSize: '18px', 
-        color: COLORS.text, 
-        textAlign: 'right',
-        fontWeight: 600,
-        justifyContent: 'flex-end',
-      }}>
-        {Math.round(value)}/{maxPoints}
-      </div>
-    </div>
-  );
-}
-
-function ScoreRing({ score }: { score: number }) {
-  const color = getTierColor(score);
-  const label = getTierLabel(score);
-  const size = 180;
-  const strokeWidth = 12;
-  const radius = (size - strokeWidth) / 2;
-  const circumference = 2 * Math.PI * radius;
-  const progress = Math.min(100, Math.max(0, score)) / 100;
-  const dashOffset = circumference * (1 - progress);
-  
-  return (
-    <div style={{ 
-      display: 'flex', 
-      position: 'relative', 
-      width: size, 
-      height: size,
-      alignItems: 'center',
-      justifyContent: 'center',
-    }}>
-      <svg
-        width={size}
-        height={size}
-        style={{ transform: 'rotate(-90deg)', position: 'absolute' }}
-      >
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke={COLORS.barBg}
-          strokeWidth={strokeWidth}
-        />
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={dashOffset}
-        />
-      </svg>
-      <div style={{ 
-        display: 'flex', 
-        flexDirection: 'column', 
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}>
-        <div style={{ display: 'flex', fontSize: '56px', fontWeight: 700, color, lineHeight: 1 }}>
-          {score}
-        </div>
-        <div style={{ display: 'flex', fontSize: '18px', color: COLORS.textMuted, marginTop: '4px' }}>
-          {label}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export async function GET(
   request: Request,
@@ -150,39 +11,16 @@ export async function GET(
 ) {
   try {
     const { drepId } = await params;
-    const decodedId = decodeURIComponent(drepId);
-    const drep = await getDRepById(decodedId);
-    
+    const drep = await getDRepById(decodeURIComponent(drepId));
+
     if (!drep) {
-      return new ImageResponse(
-        (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%',
-              height: '100%',
-              background: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgGradient} 100%)`,
-              color: COLORS.text,
-              fontFamily: 'sans-serif',
-            }}
-          >
-            <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700 }}>DRepScore</div>
-            <div style={{ display: 'flex', fontSize: '24px', color: COLORS.textMuted, marginTop: '16px' }}>
-              DRep not found
-            </div>
-          </div>
-        ),
-        { width: 1200, height: 630 }
-      );
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1200, height: 630 });
     }
 
     const name = getDRepPrimaryName(drep);
-    
-    // Calculate actual point contributions (percentage * weight)
-    const pillars: PillarData[] = [
+    const color = tierColor(drep.drepScore);
+    const tier = tierLabel(drep.drepScore);
+    const pillars = [
       { label: 'Participation', value: (drep.effectiveParticipation / 100) * 30, maxPoints: 30 },
       { label: 'Rationale', value: (drep.rationaleRate / 100) * 35, maxPoints: 35 },
       { label: 'Reliability', value: (drep.reliabilityScore / 100) * 20, maxPoints: 20 },
@@ -191,118 +29,88 @@ export async function GET(
 
     return new ImageResponse(
       (
-        <div
-          style={{
-            display: 'flex',
-            width: '100%',
-            height: '100%',
-            background: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgGradient} 100%)`,
-            color: COLORS.text,
-            fontFamily: 'sans-serif',
-            padding: '48px 64px',
-          }}
-        >
-          {/* Left side: Score ring */}
-          <div style={{ 
-            display: 'flex', 
-            flexDirection: 'column', 
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '280px',
-            marginRight: '48px',
-          }}>
-            <ScoreRing score={drep.drepScore} />
-          </div>
-          
-          {/* Right side: Info and pillars */}
-          <div style={{ 
-            display: 'flex', 
-            flexDirection: 'column', 
-            flex: 1,
-            justifyContent: 'center',
-          }}>
-            {/* DRep name and ID */}
-            <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '32px' }}>
-              <div style={{ 
+        <OGBackground glow={color}>
+          <div style={{ display: 'flex', width: '100%', height: '100%', padding: '48px 64px' }}>
+            {/* Left: Score ring + tier badge */}
+            <div style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '300px',
+              marginRight: '48px',
+            }}>
+              <OGScoreRing score={drep.drepScore} size={200} />
+              <div style={{
                 display: 'flex',
-                fontSize: '42px', 
-                fontWeight: 700, 
-                color: COLORS.text,
-                lineHeight: 1.2,
+                marginTop: '16px',
+                padding: '6px 20px',
+                borderRadius: '20px',
+                backgroundColor: `${color}20`,
+                border: `1px solid ${color}40`,
+                fontSize: '18px',
+                fontWeight: 600,
+                color,
               }}>
-                {name}
-              </div>
-              <div style={{ 
-                display: 'flex',
-                fontSize: '18px', 
-                color: COLORS.textMuted, 
-                marginTop: '8px',
-                fontFamily: 'monospace',
-              }}>
-                {shortenDRepId(drep.drepId)}
+                {tier}
               </div>
             </div>
-            
-            {/* Pillar bars */}
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-              {pillars.map((pillar) => (
-                <PillarBar key={pillar.label} {...pillar} />
-              ))}
+
+            {/* Right: Info + pillars */}
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '32px' }}>
+                <div style={{ display: 'flex', fontSize: '42px', fontWeight: 700, color: OG.text, lineHeight: 1.2 }}>
+                  {name.length > 24 ? name.slice(0, 22) + '…' : name}
+                </div>
+                <div style={{ display: 'flex', gap: '16px', marginTop: '10px', alignItems: 'center' }}>
+                  <div style={{ display: 'flex', fontSize: '16px', color: OG.textDim, fontFamily: 'monospace' }}>
+                    {shortenDRepId(drep.drepId)}
+                  </div>
+                  {drep.isActive && (
+                    <div style={{
+                      display: 'flex',
+                      padding: '2px 10px',
+                      borderRadius: '10px',
+                      backgroundColor: `${OG.green}20`,
+                      fontSize: '13px',
+                      color: OG.green,
+                      fontWeight: 500,
+                    }}>
+                      Active
+                    </div>
+                  )}
+                  <div style={{
+                    display: 'flex',
+                    padding: '2px 10px',
+                    borderRadius: '10px',
+                    backgroundColor: `${OG.blue}20`,
+                    fontSize: '13px',
+                    color: OG.blue,
+                    fontWeight: 500,
+                  }}>
+                    {drep.sizeTier}
+                  </div>
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+                {pillars.map((p) => (
+                  <OGPillarBar key={p.label} {...p} />
+                ))}
+              </div>
             </div>
           </div>
-          
-          {/* Footer branding */}
-          <div style={{ 
-            display: 'flex', 
-            position: 'absolute',
-            bottom: '32px',
-            left: '64px',
-            right: '64px',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}>
-            <div style={{ display: 'flex', fontSize: '24px', fontWeight: 600, color: COLORS.textMuted }}>
-              DRepScore
-            </div>
-            <div style={{ display: 'flex', fontSize: '18px', color: COLORS.textMuted }}>
-              drepscore.io
-            </div>
-          </div>
-        </div>
+          <OGFooter />
+        </OGBackground>
       ),
       {
         width: 1200,
         height: 630,
-        headers: {
-          'Cache-Control': 'public, max-age=900, s-maxage=900',
-        },
+        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
       }
     );
   } catch (error) {
     console.error('[OG] Error generating image:', error);
-    
-    return new ImageResponse(
-      (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '100%',
-            height: '100%',
-            background: `linear-gradient(135deg, ${COLORS.bg} 0%, ${COLORS.bgGradient} 100%)`,
-            color: COLORS.text,
-            fontFamily: 'sans-serif',
-          }}
-        >
-          <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700 }}>DRepScore</div>
-          <div style={{ display: 'flex', fontSize: '24px', color: COLORS.textMuted, marginTop: '16px' }}>
-            Find your ideal Cardano DRep
-          </div>
-        </div>
-      ),
-      { width: 1200, height: 630 }
-    );
+    return new ImageResponse(<OGFallback message="Find your ideal Cardano DRep" />, { width: 1200, height: 630 });
   }
 }

--- a/app/api/og/governance-dna/route.tsx
+++ b/app/api/og/governance-dna/route.tsx
@@ -1,0 +1,126 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { OGBackground, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  try {
+    const votesCount = request.nextUrl.searchParams.get('votes') || '0';
+    const match1Name = request.nextUrl.searchParams.get('m1name') || '';
+    const match1Score = request.nextUrl.searchParams.get('m1score') || '0';
+    const match2Name = request.nextUrl.searchParams.get('m2name') || '';
+    const match2Score = request.nextUrl.searchParams.get('m2score') || '0';
+    const match3Name = request.nextUrl.searchParams.get('m3name') || '';
+    const match3Score = request.nextUrl.searchParams.get('m3score') || '0';
+
+    const matches = [
+      { name: match1Name, score: parseInt(match1Score) },
+      { name: match2Name, score: parseInt(match2Score) },
+      { name: match3Name, score: parseInt(match3Score) },
+    ].filter(m => m.name && m.score > 0);
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={OG.indigo}>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '80px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            {/* DNA icon representation */}
+            <div style={{
+              display: 'flex',
+              fontSize: '64px',
+              marginBottom: '16px',
+            }}>
+              🧬
+            </div>
+
+            <div style={{ display: 'flex', fontSize: '40px', fontWeight: 700, color: OG.text, marginBottom: '8px' }}>
+              My Governance DNA
+            </div>
+
+            <div style={{ display: 'flex', fontSize: '20px', color: OG.textMuted, marginBottom: '48px' }}>
+              Based on {votesCount} governance decisions
+            </div>
+
+            {matches.length > 0 ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', width: '100%', maxWidth: '700px' }}>
+                <div style={{ display: 'flex', fontSize: '18px', color: OG.textMuted, marginBottom: '4px' }}>
+                  My top DRep matches:
+                </div>
+                {matches.map((m, i) => {
+                  const matchColor = m.score >= 70 ? OG.green : m.score >= 50 ? OG.amber : OG.textMuted;
+                  return (
+                    <div key={i} style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      padding: '20px 24px',
+                      borderRadius: '12px',
+                      backgroundColor: OG.bgCard,
+                      border: `1px solid ${matchColor}30`,
+                      gap: '16px',
+                    }}>
+                      <div style={{
+                        display: 'flex',
+                        fontSize: '24px',
+                        fontWeight: 700,
+                        color: i === 0 ? OG.amber : OG.textMuted,
+                        width: '32px',
+                      }}>
+                        #{i + 1}
+                      </div>
+                      <div style={{ display: 'flex', flex: 1, fontSize: '24px', fontWeight: 600, color: OG.text }}>
+                        {m.name.length > 20 ? m.name.slice(0, 18) + '…' : m.name}
+                      </div>
+                      <div style={{
+                        display: 'flex',
+                        padding: '4px 16px',
+                        borderRadius: '16px',
+                        backgroundColor: `${matchColor}20`,
+                        fontSize: '20px',
+                        fontWeight: 700,
+                        color: matchColor,
+                      }}>
+                        {m.score}% match
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div style={{ display: 'flex', fontSize: '22px', color: OG.textMuted }}>
+                Take the quiz at drepscore.io to find your matches
+              </div>
+            )}
+
+            <div style={{
+              display: 'flex',
+              fontSize: '22px',
+              fontWeight: 600,
+              color: OG.brand,
+              marginTop: '40px',
+            }}>
+              Find your Governance DNA at drepscore.io
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io/discover" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1080,
+        height: 1080,
+        headers: { 'Cache-Control': 'public, max-age=300, s-maxage=300' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Governance DNA] Error:', error);
+    return new ImageResponse(<OGFallback message="Find your Governance DNA" />, { width: 1080, height: 1080 });
+  }
+}

--- a/app/api/og/leaderboard/route.tsx
+++ b/app/api/og/leaderboard/route.tsx
@@ -1,0 +1,97 @@
+import { ImageResponse } from 'next/og';
+import { createClient } from '@/lib/supabase';
+import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGFooter, OG, tierColor } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  try {
+    const supabase = createClient();
+    const { data: topDreps } = await supabase
+      .from('dreps')
+      .select('drep_id, name, ticker, handle, score, info')
+      .order('score', { ascending: false })
+      .limit(5);
+
+    const dreps = (topDreps || []).map((d: any, i: number) => ({
+      rank: i + 1,
+      name: getDRepPrimaryName(d),
+      score: d.score ?? 0,
+    }));
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={OG.green}>
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', padding: '64px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '40px' }}>
+              <div style={{ display: 'flex', fontSize: '44px', fontWeight: 700, color: OG.text }}>
+                DRep Leaderboard
+              </div>
+              <div style={{ display: 'flex', fontSize: '22px', color: OG.textMuted, marginTop: '8px' }}>
+                Top scoring Cardano DReps
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
+              {dreps.map(d => {
+                const color = tierColor(d.score);
+                return (
+                  <div key={d.rank} style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: '16px 24px',
+                    borderRadius: '12px',
+                    backgroundColor: OG.bgCard,
+                    border: `1px solid ${OG.border}`,
+                    gap: '20px',
+                  }}>
+                    <div style={{
+                      display: 'flex',
+                      fontSize: '28px',
+                      fontWeight: 700,
+                      color: d.rank <= 3 ? OG.amber : OG.textMuted,
+                      width: '40px',
+                    }}>
+                      #{d.rank}
+                    </div>
+                    <div style={{ display: 'flex', flex: 1, fontSize: '24px', fontWeight: 600, color: OG.text }}>
+                      {d.name.length > 24 ? d.name.slice(0, 22) + '…' : d.name}
+                    </div>
+                    <div style={{
+                      display: 'flex',
+                      fontSize: '28px',
+                      fontWeight: 700,
+                      color,
+                    }}>
+                      {d.score}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io/pulse#leaderboard" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=3600' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Leaderboard] Error:', error);
+    return new ImageResponse(
+      (
+        <OGBackground>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+            <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700, color: OG.brand }}>DRep Leaderboard</div>
+          </div>
+        </OGBackground>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+}

--- a/app/api/og/moment/milestone/[drepId]/[milestoneKey]/route.tsx
+++ b/app/api/og/moment/milestone/[drepId]/[milestoneKey]/route.tsx
@@ -1,0 +1,97 @@
+import { ImageResponse } from 'next/og';
+import { getDRepById } from '@/lib/data';
+import { getDRepPrimaryName } from '@/utils/display';
+import { MILESTONES } from '@/lib/milestones';
+import { OGBackground, OGScoreRing, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+const MILESTONE_EMOJIS: Record<string, string> = {
+  'claimed-profile': '🛡️',
+  'first-10-delegators': '👥',
+  'first-100-delegators': '🎯',
+  'first-1000-delegators': '🏆',
+  'score-above-80-30d': '⭐',
+  'all-pillars-strong': '🎯',
+  'rationale-streak-5': '📝',
+  'rationale-streak-10': '📚',
+  'perfect-participation-epoch': '✅',
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ drepId: string; milestoneKey: string }> }
+) {
+  try {
+    const { drepId, milestoneKey } = await params;
+    const drep = await getDRepById(decodeURIComponent(drepId));
+    if (!drep) {
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1080, height: 1080 });
+    }
+
+    const milestone = MILESTONES.find(m => m.key === milestoneKey);
+    if (!milestone) {
+      return new ImageResponse(<OGFallback message="Milestone not found" />, { width: 1080, height: 1080 });
+    }
+
+    const name = getDRepPrimaryName(drep);
+    const emoji = MILESTONE_EMOJIS[milestoneKey] || '🏅';
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={OG.amber}>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '80px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <div style={{ display: 'flex', fontSize: '24px', color: OG.amber, fontWeight: 600, marginBottom: '16px' }}>
+              Achievement Unlocked
+            </div>
+
+            <div style={{ display: 'flex', fontSize: '80px', marginBottom: '16px' }}>{emoji}</div>
+
+            <div style={{ display: 'flex', fontSize: '40px', fontWeight: 700, color: OG.text, textAlign: 'center' }}>
+              {milestone.label}
+            </div>
+
+            <div style={{ display: 'flex', fontSize: '20px', color: OG.textMuted, marginTop: '8px', textAlign: 'center' }}>
+              {milestone.description}
+            </div>
+
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '24px',
+              marginTop: '48px',
+            }}>
+              <OGScoreRing score={drep.drepScore} size={120} />
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ display: 'flex', fontSize: '28px', fontWeight: 700, color: OG.text }}>
+                  {name.length > 20 ? name.slice(0, 18) + '…' : name}
+                </div>
+                <div style={{ display: 'flex', fontSize: '16px', color: OG.textMuted, marginTop: '4px' }}>
+                  DRepScore: {drep.drepScore}/100
+                </div>
+              </div>
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1080,
+        height: 1080,
+        headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=3600' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Milestone] Error:', error);
+    return new ImageResponse(<OGFallback message="Achievement Unlocked" />, { width: 1080, height: 1080 });
+  }
+}

--- a/app/api/og/moment/score-change/[drepId]/route.tsx
+++ b/app/api/og/moment/score-change/[drepId]/route.tsx
@@ -1,0 +1,108 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { getDRepById } from '@/lib/data';
+import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGScoreRing, OGFooter, OGFallback, OG, tierColor } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  try {
+    const { drepId } = await params;
+    const drep = await getDRepById(decodeURIComponent(drepId));
+    if (!drep) {
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1080, height: 1080 });
+    }
+
+    const prevScore = parseInt(request.nextUrl.searchParams.get('prev') || '0');
+    const delta = drep.drepScore - prevScore;
+    const isGain = delta > 0;
+    const name = getDRepPrimaryName(drep);
+    const color = tierColor(drep.drepScore);
+    const deltaColor = isGain ? OG.green : OG.red;
+    const narrative = request.nextUrl.searchParams.get('reason') || (isGain ? 'Score improved!' : 'Score changed');
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={deltaColor}>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '80px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <div style={{
+              display: 'flex',
+              fontSize: '24px',
+              color: deltaColor,
+              fontWeight: 600,
+              padding: '6px 20px',
+              borderRadius: '20px',
+              backgroundColor: `${deltaColor}15`,
+              border: `1px solid ${deltaColor}30`,
+              marginBottom: '24px',
+            }}>
+              {isGain ? '↑' : '↓'} {Math.abs(delta)} points
+            </div>
+
+            <OGScoreRing score={drep.drepScore} size={240} />
+
+            <div style={{
+              display: 'flex',
+              fontSize: '36px',
+              fontWeight: 700,
+              color: OG.text,
+              marginTop: '24px',
+            }}>
+              {name.length > 20 ? name.slice(0, 18) + '…' : name}
+            </div>
+
+            <div style={{
+              display: 'flex',
+              fontSize: '20px',
+              color: OG.textMuted,
+              marginTop: '12px',
+            }}>
+              {narrative}
+            </div>
+
+            {prevScore > 0 && (
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '32px',
+                marginTop: '40px',
+              }}>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <div style={{ display: 'flex', fontSize: '16px', color: OG.textDim }}>Previous</div>
+                  <div style={{ display: 'flex', fontSize: '40px', fontWeight: 700, color: OG.textMuted }}>{prevScore}</div>
+                </div>
+                <div style={{ display: 'flex', fontSize: '32px', color: deltaColor, fontWeight: 700 }}>→</div>
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                  <div style={{ display: 'flex', fontSize: '16px', color: OG.textDim }}>Current</div>
+                  <div style={{ display: 'flex', fontSize: '40px', fontWeight: 700, color }}>{drep.drepScore}</div>
+                </div>
+              </div>
+            )}
+
+            <OGFooter left="$drepscore" right="drepscore.io" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1080,
+        height: 1080,
+        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Score Change] Error:', error);
+    return new ImageResponse(<OGFallback message="Score Update" />, { width: 1080, height: 1080 });
+  }
+}

--- a/app/api/og/pulse/route.tsx
+++ b/app/api/og/pulse/route.tsx
@@ -1,0 +1,92 @@
+import { ImageResponse } from 'next/og';
+import { createClient } from '@/lib/supabase';
+import { OGBackground, OGFooter, OG } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  try {
+    const supabase = createClient();
+    const [drepsRes, proposalsRes] = await Promise.all([
+      supabase.from('dreps').select('score, info').limit(2000),
+      supabase.from('proposals').select('tx_hash')
+        .is('ratified_epoch', null).is('enacted_epoch', null)
+        .is('dropped_epoch', null).is('expired_epoch', null),
+    ]);
+
+    const dreps = drepsRes.data || [];
+    const activeDReps = dreps.filter((d: any) => d.info?.isActive);
+    const totalAda = activeDReps.reduce((s: number, d: any) =>
+      s + parseInt(d.info?.votingPowerLovelace || '0', 10), 0) / 1_000_000;
+
+    const formattedAda = totalAda >= 1e9 ? `${(totalAda / 1e9).toFixed(1)}B` : `${(totalAda / 1e6).toFixed(1)}M`;
+    const activeProposals = proposalsRes.data?.length || 0;
+
+    const stats = [
+      { label: 'ADA Governed', value: `${formattedAda}`, accent: OG.green },
+      { label: 'Active Proposals', value: `${activeProposals}`, accent: OG.amber },
+      { label: 'Active DReps', value: `${activeDReps.length}`, accent: OG.blue },
+      { label: 'Total DReps', value: `${dreps.length}`, accent: OG.indigo },
+    ];
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={OG.indigo}>
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', padding: '64px' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '48px' }}>
+              <div style={{ display: 'flex', fontSize: '44px', fontWeight: 700, color: OG.text }}>
+                Governance Pulse
+              </div>
+              <div style={{ display: 'flex', fontSize: '22px', color: OG.textMuted, marginTop: '8px' }}>
+                Real-time Cardano governance health
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: '24px', flex: 1 }}>
+              {stats.map(s => (
+                <div key={s.label} style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  flex: 1,
+                  padding: '32px 24px',
+                  borderRadius: '16px',
+                  backgroundColor: OG.bgCard,
+                  border: `1px solid ${s.accent}30`,
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}>
+                  <div style={{ display: 'flex', fontSize: '52px', fontWeight: 700, color: s.accent, lineHeight: 1 }}>
+                    {s.value}
+                  </div>
+                  <div style={{ display: 'flex', fontSize: '18px', color: OG.textMuted, marginTop: '12px' }}>
+                    {s.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io/pulse" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, max-age=3600, s-maxage=3600' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Pulse] Error:', error);
+    return new ImageResponse(
+      (
+        <OGBackground>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', width: '100%', height: '100%' }}>
+            <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700, color: OG.brand }}>Governance Pulse</div>
+            <div style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}>drepscore.io/pulse</div>
+          </div>
+        </OGBackground>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+}

--- a/app/api/og/wrapped/delegator/route.tsx
+++ b/app/api/og/wrapped/delegator/route.tsx
@@ -1,0 +1,111 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { getDRepById } from '@/lib/data';
+import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGScoreRing, OGFooter, OGFallback, OG, tierColor, tierLabel } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+export async function GET(request: NextRequest) {
+  try {
+    const drepId = request.nextUrl.searchParams.get('drepId');
+    if (!drepId) {
+      return new ImageResponse(<OGFallback message="Connect your wallet to find your DRep" />, { width: 1080, height: 1080 });
+    }
+
+    const drep = await getDRepById(decodeURIComponent(drepId));
+    if (!drep) {
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1080, height: 1080 });
+    }
+
+    const name = getDRepPrimaryName(drep);
+    const color = tierColor(drep.drepScore);
+    const tier = tierLabel(drep.drepScore);
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={color}>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '80px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <div style={{ display: 'flex', fontSize: '28px', color: OG.textMuted, fontWeight: 500 }}>
+              I&apos;m delegated to
+            </div>
+
+            <div style={{
+              display: 'flex',
+              fontSize: '44px',
+              fontWeight: 700,
+              color: OG.text,
+              marginTop: '16px',
+              marginBottom: '32px',
+            }}>
+              {name.length > 20 ? name.slice(0, 18) + '…' : name}
+            </div>
+
+            <OGScoreRing score={drep.drepScore} size={240} />
+
+            <div style={{
+              display: 'flex',
+              marginTop: '20px',
+              padding: '8px 28px',
+              borderRadius: '24px',
+              backgroundColor: `${color}20`,
+              border: `1px solid ${color}40`,
+              fontSize: '20px',
+              fontWeight: 600,
+              color,
+            }}>
+              {tier} Governance Representative
+            </div>
+
+            <div style={{
+              display: 'flex',
+              gap: '32px',
+              marginTop: '36px',
+            }}>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <div style={{ display: 'flex', fontSize: '32px', fontWeight: 700, color: OG.text }}>{drep.effectiveParticipation}%</div>
+                <div style={{ display: 'flex', fontSize: '16px', color: OG.textMuted }}>Participation</div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <div style={{ display: 'flex', fontSize: '32px', fontWeight: 700, color: OG.text }}>{drep.rationaleRate}%</div>
+                <div style={{ display: 'flex', fontSize: '16px', color: OG.textMuted }}>Rationale</div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <div style={{ display: 'flex', fontSize: '32px', fontWeight: 700, color: OG.text }}>{drep.reliabilityScore}%</div>
+                <div style={{ display: 'flex', fontSize: '16px', color: OG.textMuted }}>Reliability</div>
+              </div>
+            </div>
+
+            <div style={{
+              display: 'flex',
+              fontSize: '26px',
+              fontWeight: 600,
+              color: OG.brand,
+              marginTop: '48px',
+            }}>
+              Who&apos;s your DRep?
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1080,
+        height: 1080,
+        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Wrapped Delegator] Error:', error);
+    return new ImageResponse(<OGFallback message="Who's your DRep?" />, { width: 1080, height: 1080 });
+  }
+}

--- a/app/api/og/wrapped/drep/[drepId]/route.tsx
+++ b/app/api/og/wrapped/drep/[drepId]/route.tsx
@@ -1,0 +1,122 @@
+import { ImageResponse } from 'next/og';
+import { getDRepById } from '@/lib/data';
+import { getDRepPrimaryName } from '@/utils/display';
+import { OGBackground, OGScoreRing, OGFooter, OGFallback, OG, tierColor, tierLabel } from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ drepId: string }> }
+) {
+  try {
+    const { drepId } = await params;
+    const drep = await getDRepById(decodeURIComponent(drepId));
+    if (!drep) {
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1080, height: 1080 });
+    }
+
+    const name = getDRepPrimaryName(drep);
+    const color = tierColor(drep.drepScore);
+    const tier = tierLabel(drep.drepScore);
+
+    const supabase = createClient();
+    const { count: totalDReps } = await supabase
+      .from('dreps')
+      .select('drep_id', { count: 'exact', head: true });
+
+    const { count: betterCount } = await supabase
+      .from('dreps')
+      .select('drep_id', { count: 'exact', head: true })
+      .gt('score', drep.drepScore);
+
+    const rank = (betterCount ?? 0) + 1;
+    const percentile = totalDReps ? Math.round(((totalDReps - rank) / totalDReps) * 100) : 0;
+
+    const stats = [
+      { label: 'Votes Cast', value: `${drep.votes?.length || 0}` },
+      { label: 'Rationale Rate', value: `${drep.rationaleRate}%` },
+      { label: 'Delegators', value: `${drep.delegatorCount}` },
+      { label: 'Rank', value: `#${rank}` },
+    ];
+
+    return new ImageResponse(
+      (
+        <OGBackground glow={color}>
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '80px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+            <div style={{ display: 'flex', fontSize: '28px', color: OG.textMuted, fontWeight: 500, marginBottom: '16px' }}>
+              My DRepScore
+            </div>
+
+            <OGScoreRing score={drep.drepScore} size={280} />
+
+            <div style={{
+              display: 'flex',
+              marginTop: '20px',
+              padding: '8px 28px',
+              borderRadius: '24px',
+              backgroundColor: `${color}20`,
+              border: `1px solid ${color}40`,
+              fontSize: '22px',
+              fontWeight: 600,
+              color,
+            }}>
+              {tier} — Top {percentile}%
+            </div>
+
+            <div style={{
+              display: 'flex',
+              fontSize: '36px',
+              fontWeight: 700,
+              marginTop: '32px',
+              color: OG.text,
+            }}>
+              {name.length > 20 ? name.slice(0, 18) + '…' : name}
+            </div>
+
+            <div style={{
+              display: 'flex',
+              gap: '24px',
+              marginTop: '40px',
+            }}>
+              {stats.map(s => (
+                <div key={s.label} style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  padding: '16px 24px',
+                  borderRadius: '12px',
+                  backgroundColor: OG.bgCard,
+                  border: `1px solid ${OG.border}`,
+                  minWidth: '140px',
+                }}>
+                  <div style={{ display: 'flex', fontSize: '28px', fontWeight: 700, color: OG.text }}>{s.value}</div>
+                  <div style={{ display: 'flex', fontSize: '14px', color: OG.textMuted, marginTop: '4px' }}>{s.label}</div>
+                </div>
+              ))}
+            </div>
+
+            <OGFooter left="$drepscore" right="drepscore.io" />
+          </div>
+        </OGBackground>
+      ),
+      {
+        width: 1080,
+        height: 1080,
+        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+      }
+    );
+  } catch (error) {
+    console.error('[OG Wrapped DRep] Error:', error);
+    return new ImageResponse(<OGFallback message="My DRepScore" />, { width: 1080, height: 1080 });
+  }
+}

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ShareActions } from '@/components/ShareActions';
+import {
+  Landmark,
+  ScrollText,
+  Users,
+  Vote,
+  TrendingUp,
+  TrendingDown,
+  Trophy,
+  Crown,
+  ArrowRight,
+  BarChart3,
+} from 'lucide-react';
+import { posthog } from '@/lib/posthog';
+
+export const dynamic = 'force-dynamic';
+
+// -- Animated counter (extracted from GovernancePulseHero pattern) --
+
+function AnimatedCounter({ value, suffix = '' }: { value: string; suffix?: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const numericPart = value.replace(/[^0-9.]/g, '');
+    const target = parseFloat(numericPart);
+    if (isNaN(target)) { el.textContent = value + suffix; return; }
+    const textSuffix = value.replace(/[0-9.,]/g, '') + suffix;
+    const duration = 1200;
+    const start = performance.now();
+    function tick(now: number) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const current = eased * target;
+      el!.textContent = (target >= 10 ? Math.round(current) : current.toFixed(1)) + textSuffix;
+      if (progress < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  }, [value, suffix]);
+  return <span ref={ref}>{value}{suffix}</span>;
+}
+
+// -- Types --
+
+interface PulseData {
+  totalAdaGoverned: string;
+  activeProposals: number;
+  avgParticipationRate: number;
+  avgRationaleRate: number;
+  activeDReps: number;
+  totalDReps: number;
+  votesThisWeek: number;
+  communityGap: {
+    txHash: string;
+    index: number;
+    title: string;
+    pollYes: number;
+    pollNo: number;
+    pollTotal: number;
+  }[];
+}
+
+interface LeaderboardEntry {
+  rank: number;
+  drepId: string;
+  name: string;
+  score: number;
+  sizeTier: string;
+  participation: number;
+  rationale: number;
+}
+
+interface Mover {
+  drepId: string;
+  name: string;
+  currentScore: number;
+  previousScore: number;
+  delta: number;
+}
+
+interface HallEntry {
+  drepId: string;
+  name: string;
+  score: number;
+  days: number;
+}
+
+interface LeaderboardData {
+  leaderboard: LeaderboardEntry[];
+  weeklyMovers: { gainers: Mover[]; losers: Mover[] };
+  hallOfFame: HallEntry[];
+}
+
+// -- Helpers --
+
+function tierColorClass(score: number) {
+  if (score >= 80) return 'text-green-600 dark:text-green-400';
+  if (score >= 60) return 'text-amber-600 dark:text-amber-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+const SIZE_COLORS: Record<string, string> = {
+  Small: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  Medium: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  Large: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  Whale: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+};
+
+// -- Page component --
+
+export default function PulsePage() {
+  const [pulse, setPulse] = useState<PulseData | null>(null);
+  const [lb, setLb] = useState<LeaderboardData | null>(null);
+  const [tierFilter, setTierFilter] = useState('all');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    posthog.capture('pulse_page_viewed');
+    Promise.all([
+      fetch('/api/governance/pulse').then(r => r.json()),
+      fetch('/api/governance/leaderboard').then(r => r.json()),
+    ]).then(([p, l]) => {
+      setPulse(p);
+      setLb(l);
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (tierFilter === 'all') return;
+    posthog.capture('pulse_tier_filter_changed', { tier: tierFilter });
+    fetch(`/api/governance/leaderboard?tier=${tierFilter}`)
+      .then(r => r.json())
+      .then(d => setLb(prev => prev ? { ...prev, leaderboard: d.leaderboard } : d))
+      .catch(() => {});
+  }, [tierFilter]);
+
+  if (loading) return <PulseSkeleton />;
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-10 max-w-6xl">
+      {/* Page header */}
+      <div className="text-center space-y-2">
+        <h1 className="text-4xl font-bold tracking-tight">Governance Pulse</h1>
+        <p className="text-muted-foreground">
+          Real-time health of Cardano&apos;s on-chain governance
+        </p>
+      </div>
+
+      {/* Hero stats */}
+      {pulse && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard icon={<Landmark className="h-5 w-5 text-green-500" />} label="ADA Governed" value={pulse.totalAdaGoverned} />
+          <StatCard icon={<ScrollText className="h-5 w-5 text-amber-500" />} label="Active Proposals" value={String(pulse.activeProposals)} />
+          <StatCard icon={<Users className="h-5 w-5 text-blue-500" />} label="Active DReps" value={String(pulse.activeDReps)} />
+          <StatCard icon={<Vote className="h-5 w-5 text-indigo-500" />} label="Votes This Week" value={String(pulse.votesThisWeek)} />
+        </div>
+      )}
+
+      {/* Participation & rationale rates */}
+      {pulse && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Card>
+            <CardContent className="p-6 flex items-center gap-4">
+              <div className="flex items-center justify-center w-12 h-12 rounded-full bg-blue-500/10">
+                <BarChart3 className="h-6 w-6 text-blue-500" />
+              </div>
+              <div>
+                <p className="text-3xl font-bold tabular-nums">{pulse.avgParticipationRate}%</p>
+                <p className="text-sm text-muted-foreground">Avg DRep Participation Rate</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-6 flex items-center gap-4">
+              <div className="flex items-center justify-center w-12 h-12 rounded-full bg-indigo-500/10">
+                <ScrollText className="h-6 w-6 text-indigo-500" />
+              </div>
+              <div>
+                <p className="text-3xl font-bold tabular-nums">{pulse.avgRationaleRate}%</p>
+                <p className="text-sm text-muted-foreground">Avg DRep Rationale Rate</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Community vs DRep Gap */}
+      {pulse && pulse.communityGap.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Vote className="h-5 w-5" />
+              Community Sentiment
+            </CardTitle>
+            <p className="text-xs text-muted-foreground">
+              How delegators polled vs how proposals are trending
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {pulse.communityGap.map(g => {
+                const yesPct = g.pollTotal > 0 ? Math.round((g.pollYes / g.pollTotal) * 100) : 0;
+                const noPct = g.pollTotal > 0 ? Math.round((g.pollNo / g.pollTotal) * 100) : 0;
+                return (
+                  <Link key={`${g.txHash}:${g.index}`} href={`/proposals/${g.txHash}/${g.index}`} className="block">
+                    <div className="flex items-center gap-4 p-3 rounded-lg border hover:bg-muted/50 transition-colors">
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{g.title}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">{g.pollTotal} community votes</p>
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        <div className="text-center">
+                          <span className="text-sm font-bold text-green-600 dark:text-green-400">{yesPct}%</span>
+                          <p className="text-[10px] text-muted-foreground">Yes</p>
+                        </div>
+                        <div className="w-24 h-3 bg-muted rounded-full overflow-hidden flex">
+                          <div className="bg-green-500 h-full" style={{ width: `${yesPct}%` }} />
+                          <div className="bg-red-500 h-full" style={{ width: `${noPct}%` }} />
+                        </div>
+                        <div className="text-center">
+                          <span className="text-sm font-bold text-red-600 dark:text-red-400">{noPct}%</span>
+                          <p className="text-[10px] text-muted-foreground">No</p>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Leaderboard */}
+      {lb && (
+        <section id="leaderboard">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between flex-wrap gap-2">
+                <CardTitle className="flex items-center gap-2">
+                  <Trophy className="h-5 w-5" />
+                  DRep Leaderboard
+                </CardTitle>
+                <div className="flex gap-1.5">
+                  {['all', 'Small', 'Medium', 'Large', 'Whale'].map(t => (
+                    <Button
+                      key={t}
+                      variant={tierFilter === t ? 'default' : 'outline'}
+                      size="sm"
+                      className="text-xs h-7 px-2.5"
+                      onClick={() => setTierFilter(t)}
+                    >
+                      {t === 'all' ? 'All' : t}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2">
+                {lb.leaderboard.map(d => (
+                  <Link key={d.drepId} href={`/drep/${encodeURIComponent(d.drepId)}`} className="block">
+                    <div className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors">
+                      <span className={`text-lg font-bold tabular-nums w-8 ${d.rank <= 3 ? 'text-amber-500' : 'text-muted-foreground'}`}>
+                        #{d.rank}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{d.name}</p>
+                        <div className="flex items-center gap-2 mt-0.5">
+                          <Badge variant="outline" className={`text-[10px] ${SIZE_COLORS[d.sizeTier] || ''}`}>
+                            {d.sizeTier}
+                          </Badge>
+                          <span className="text-[10px] text-muted-foreground">
+                            P:{d.participation}% R:{d.rationale}%
+                          </span>
+                        </div>
+                      </div>
+                      <span className={`text-xl font-bold tabular-nums ${tierColorClass(d.score)}`}>{d.score}</span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      )}
+
+      {/* Weekly Movers */}
+      {lb && (lb.weeklyMovers.gainers.length > 0 || lb.weeklyMovers.losers.length > 0) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {lb.weeklyMovers.gainers.length > 0 && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <TrendingUp className="h-4 w-4 text-green-500" />
+                  Biggest Gainers This Week
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {lb.weeklyMovers.gainers.map(m => (
+                  <Link key={m.drepId} href={`/drep/${encodeURIComponent(m.drepId)}`} className="block">
+                    <div className="flex items-center justify-between p-2 rounded hover:bg-muted/50 transition-colors">
+                      <span className="text-sm truncate flex-1">{m.name}</span>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <span className="text-sm font-bold tabular-nums">{m.currentScore}</span>
+                        <Badge variant="outline" className="text-[10px] text-green-600 border-green-500/30">
+                          +{m.delta}
+                        </Badge>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {lb.weeklyMovers.losers.length > 0 && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <TrendingDown className="h-4 w-4 text-red-500" />
+                  Biggest Drops This Week
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {lb.weeklyMovers.losers.map(m => (
+                  <Link key={m.drepId} href={`/drep/${encodeURIComponent(m.drepId)}`} className="block">
+                    <div className="flex items-center justify-between p-2 rounded hover:bg-muted/50 transition-colors">
+                      <span className="text-sm truncate flex-1">{m.name}</span>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <span className="text-sm font-bold tabular-nums">{m.currentScore}</span>
+                        <Badge variant="outline" className="text-[10px] text-red-600 border-red-500/30">
+                          {m.delta}
+                        </Badge>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Hall of Fame */}
+      {lb && lb.hallOfFame.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Crown className="h-5 w-5 text-amber-500" />
+              Hall of Fame
+            </CardTitle>
+            <p className="text-xs text-muted-foreground">
+              DReps maintaining a Strong score (80+) for 90+ days
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+              {lb.hallOfFame.map(d => (
+                <Link key={d.drepId} href={`/drep/${encodeURIComponent(d.drepId)}`} className="block">
+                  <div className="p-4 rounded-lg border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 transition-colors text-center">
+                    <p className="text-sm font-semibold">{d.name}</p>
+                    <p className="text-2xl font-bold tabular-nums text-green-600 dark:text-green-400 mt-1">{d.score}</p>
+                    <p className="text-[10px] text-muted-foreground mt-0.5">{d.days}+ days at Strong</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Share section */}
+      <div className="flex items-center justify-center gap-4 py-4">
+        <ShareActions
+          url="https://drepscore.io/pulse"
+          text="Check the health of Cardano governance in real-time on @drepscore:"
+          imageUrl="/api/og/pulse"
+          imageFilename="governance-pulse.png"
+          surface="pulse_page"
+          variant="buttons"
+        />
+      </div>
+
+      {/* CTA */}
+      <div className="text-center space-y-3 py-6">
+        <p className="text-lg font-semibold">Find the right DRep for you</p>
+        <Link href="/discover" onClick={() => posthog.capture('pulse_discover_cta_clicked')}>
+          <Button size="lg" className="gap-2">
+            Discover DReps <ArrowRight className="h-4 w-4" />
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <Card>
+      <CardContent className="p-5 flex flex-col items-center text-center gap-2">
+        {icon}
+        <span className="text-2xl font-bold tabular-nums">
+          <AnimatedCounter value={value} />
+        </span>
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PulseSkeleton() {
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-8 max-w-6xl">
+      <div className="text-center space-y-2">
+        <Skeleton className="h-10 w-64 mx-auto" />
+        <Skeleton className="h-5 w-96 mx-auto" />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-28" />)}
+      </div>
+      <Skeleton className="h-64" />
+      <Skeleton className="h-96" />
+    </div>
+  );
+}

--- a/components/BadgeEmbed.tsx
+++ b/components/BadgeEmbed.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Check, Copy, Code2 } from 'lucide-react';
+import { copyToClipboard, trackShare } from '@/lib/share';
+import { posthog } from '@/lib/posthog';
+
+type BadgeFormat = 'shield' | 'card' | 'full';
+
+const FORMAT_META: Record<BadgeFormat, { label: string; description: string; width: number; height: number }> = {
+  shield: { label: 'Shield', description: 'GitHub-style badge', width: 180, height: 28 },
+  card: { label: 'Card', description: 'Mini score card', width: 300, height: 100 },
+  full: { label: 'Full', description: 'Rich score card', width: 480, height: 200 },
+};
+
+interface BadgeEmbedProps {
+  drepId: string;
+  drepName: string;
+}
+
+export function BadgeEmbed({ drepId, drepName }: BadgeEmbedProps) {
+  const [format, setFormat] = useState<BadgeFormat>('shield');
+  const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
+
+  useEffect(() => {
+    posthog.capture('badge_embed_viewed', { drep_id: drepId });
+  }, [drepId]);
+
+  const badgeUrl = `https://drepscore.io/api/badge/${encodeURIComponent(drepId)}?format=${format}`;
+  const profileUrl = `https://drepscore.io/drep/${encodeURIComponent(drepId)}`;
+
+  const embedSnippets = {
+    markdown: `[![DRepScore](${badgeUrl})](${profileUrl})`,
+    html: `<a href="${profileUrl}"><img src="${badgeUrl}" alt="${drepName} DRepScore" /></a>`,
+    bbcode: `[url=${profileUrl}][img]${badgeUrl}[/img][/url]`,
+  };
+
+  const handleCopy = useCallback(async (type: string, snippet: string) => {
+    const ok = await copyToClipboard(snippet);
+    if (ok) {
+      setCopiedFormat(type);
+      setTimeout(() => setCopiedFormat(null), 2000);
+    }
+    trackShare('badge_embed', `copy_${type}`, { drep_id: drepId, format });
+  }, [drepId, format]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Code2 className="h-4 w-4" />
+          Embeddable Badge
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Add your DRepScore badge to your website, forum signature, or X bio.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Format selector */}
+        <div className="flex gap-2">
+          {(Object.keys(FORMAT_META) as BadgeFormat[]).map(f => (
+            <button
+              key={f}
+              onClick={() => { setFormat(f); posthog.capture('badge_format_changed', { drep_id: drepId, format: f }); }}
+              className={`flex-1 rounded-lg border p-2 text-center transition-colors ${
+                format === f
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-muted-foreground/50'
+              }`}
+            >
+              <p className="text-xs font-medium">{FORMAT_META[f].label}</p>
+              <p className="text-[10px] text-muted-foreground">{FORMAT_META[f].description}</p>
+            </button>
+          ))}
+        </div>
+
+        {/* Preview */}
+        <div className="flex items-center justify-center rounded-lg bg-muted/50 p-6 min-h-[80px]">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`/api/badge/${encodeURIComponent(drepId)}?format=${format}`}
+            alt={`${drepName} DRepScore badge`}
+            width={FORMAT_META[format].width}
+            height={FORMAT_META[format].height}
+            className="max-w-full"
+          />
+        </div>
+
+        {/* Embed snippets */}
+        <div className="space-y-2">
+          {Object.entries(embedSnippets).map(([type, snippet]) => (
+            <div key={type} className="flex items-center gap-2">
+              <Badge variant="outline" className="text-[10px] w-16 justify-center shrink-0">
+                {type === 'bbcode' ? 'BBCode' : type.charAt(0).toUpperCase() + type.slice(1)}
+              </Badge>
+              <code className="flex-1 text-[10px] bg-muted rounded px-2 py-1.5 truncate font-mono">
+                {snippet}
+              </code>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                onClick={() => handleCopy(type, snippet)}
+              >
+                {copiedFormat === type ? (
+                  <Check className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -29,13 +29,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { ScoreRing } from '@/components/ScoreRing';
+import { ShareActions } from '@/components/ShareActions';
 import { useWallet } from '@/utils/wallet';
 import {
   ArrowLeft,
-  Share2,
   GitCompareArrows,
-  Copy,
-  Check,
   ExternalLink,
   AlertTriangle,
   Bookmark,
@@ -143,7 +141,6 @@ export function CompareView({ initialDrepIds }: CompareViewProps) {
   const [data, setData] = useState<CompareData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
   const [showAllDisagreements, setShowAllDisagreements] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
 
@@ -227,20 +224,11 @@ export function CompareView({ initialDrepIds }: CompareViewProps) {
     router.push(`/compare?dreps=${newIds.join(',')}`);
   }, [delegatedDrepId, data, router]);
 
-  const handleCopyLink = useCallback(() => {
-    navigator.clipboard.writeText(window.location.href);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, []);
-
-  const handleShareX = useCallback(() => {
-    if (!data) return;
-    const names = data.dreps.map(d => d.name || d.drepId.slice(0, 12)).join(' vs ');
-    const scores = data.dreps.map(d => d.drepScore).join(' vs ');
-    const text = `Comparing ${names}: ${scores} on DRepScore. Who would you delegate to?`;
-    const url = window.location.href;
-    window.open(`https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`, '_blank');
-  }, [data]);
+  const compareShareText = data
+    ? `Comparing ${data.dreps.map(d => d.name || d.drepId.slice(0, 12)).join(' vs ')}: ${data.dreps.map(d => d.drepScore).join(' vs ')} on DRepScore. Who would you delegate to?`
+    : '';
+  const compareShareUrl = typeof window !== 'undefined' ? window.location.href : '';
+  const compareOgUrl = data ? `/api/og/compare?dreps=${data.dreps.map(d => d.drepId).join(',')}` : '';
 
   // Radar chart data for pillar comparison
   const radarData = useMemo(() => {
@@ -334,14 +322,13 @@ export function CompareView({ initialDrepIds }: CompareViewProps) {
               {isSaved ? <BookmarkCheck className="h-3.5 w-3.5 mr-1.5" /> : <Bookmark className="h-3.5 w-3.5 mr-1.5" />}
               {isSaved ? 'Saved' : 'Save'}
             </Button>
-            <Button variant="outline" size="sm" onClick={handleShareX} className="text-xs">
-              <Share2 className="h-3.5 w-3.5 mr-1.5" />
-              Share on X
-            </Button>
-            <Button variant="outline" size="sm" onClick={handleCopyLink} className="text-xs">
-              {copied ? <Check className="h-3.5 w-3.5 mr-1.5" /> : <Copy className="h-3.5 w-3.5 mr-1.5" />}
-              {copied ? 'Copied' : 'Copy Link'}
-            </Button>
+            <ShareActions
+              url={compareShareUrl}
+              text={compareShareText}
+              imageUrl={compareOgUrl}
+              surface="compare"
+              variant="compact"
+            />
           </div>
         </div>
 

--- a/components/DRepReportCard.tsx
+++ b/components/DRepReportCard.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { posthog } from '@/lib/posthog';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Share2, Download, Copy, Check, Image, Loader2 } from 'lucide-react';
+import { Share2 } from 'lucide-react';
+import { ShareActions } from '@/components/ShareActions';
+import { buildDRepUrl } from '@/lib/share';
 
 interface DRepReportCardProps {
   drepId: string;
@@ -22,35 +21,9 @@ interface DRepReportCardProps {
 export function DRepReportCard({
   drepId, name, score, rank, delegators, participation, rationale, reliability, profile,
 }: DRepReportCardProps) {
-  const [generating, setGenerating] = useState(false);
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-
-  const generateCard = useCallback(async () => {
-    setGenerating(true);
-    try {
-      // Use the OG image route which already generates DRep cards
-      const url = `/api/og/drep/${encodeURIComponent(drepId)}`;
-      setImageUrl(url);
-      posthog.capture('report_card_generated', { drep_id: drepId, score });
-    } finally {
-      setGenerating(false);
-    }
-  }, [drepId, score]);
-
-  const shareOnX = useCallback(() => {
-    const text = `My DRepScore: ${score}/100\n\nParticipation: ${participation}%\nRationale: ${rationale}%\nReliability: ${reliability}%\n${rank ? `Ranked #${rank}` : ''}\n\n${delegators} delegators trust my governance.\n\nCheck your DRep's score:`;
-    const shareUrl = `https://drepscore.io/drep/${encodeURIComponent(drepId)}`;
-    window.open(`https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`, '_blank');
-    posthog.capture('report_card_shared', { drep_id: drepId, platform: 'x' });
-  }, [drepId, score, rank, delegators, participation, rationale, reliability]);
-
-  const copyLink = useCallback(async () => {
-    await navigator.clipboard.writeText(`https://drepscore.io/drep/${encodeURIComponent(drepId)}`);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-    posthog.capture('report_card_shared', { drep_id: drepId, platform: 'copy' });
-  }, [drepId]);
+  const url = buildDRepUrl(drepId);
+  const ogImageUrl = `/api/og/drep/${encodeURIComponent(drepId)}`;
+  const shareText = `My DRepScore: ${score}/100\n\nParticipation: ${participation}%\nRationale: ${rationale}%\nReliability: ${reliability}%\n${rank ? `Ranked #${rank}` : ''}\n\n${delegators} delegators trust my governance.\n\nCheck your DRep's score:`;
 
   return (
     <Card>
@@ -61,42 +34,26 @@ export function DRepReportCard({
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
-        {/* Preview card */}
-        <div className="bg-gradient-to-br from-primary/10 to-primary/5 rounded-lg p-4 space-y-3">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-semibold">{name}</p>
-              <p className="text-xs text-muted-foreground">DRepScore</p>
-            </div>
-            <div className="text-right">
-              <span className={`text-2xl font-bold tabular-nums ${score >= 80 ? 'text-green-600 dark:text-green-400' : score >= 60 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'}`}>
-                {score}
-              </span>
-              <span className="text-xs text-muted-foreground">/100</span>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-2 text-[10px]">
-            <div>Participation: <span className="font-medium">{participation}%</span></div>
-            <div>Rationale: <span className="font-medium">{rationale}%</span></div>
-            <div>Reliability: <span className="font-medium">{reliability}%</span></div>
-            <div>Profile: <span className="font-medium">{profile}%</span></div>
-          </div>
-          <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-            {rank && <Badge variant="secondary" className="text-[10px]">#{rank}</Badge>}
-            <span>{delegators} delegators</span>
-          </div>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={ogImageUrl}
+          alt={`${name} DRepScore Card`}
+          className="w-full rounded-lg border"
+          loading="lazy"
+        />
+        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+          {rank && <Badge variant="secondary" className="text-[10px]">#{rank}</Badge>}
+          <span>{delegators} delegators</span>
         </div>
 
-        {/* Share buttons */}
-        <div className="flex gap-2">
-          <Button variant="default" size="sm" className="flex-1 gap-1.5 text-xs" onClick={shareOnX}>
-            Share on X
-          </Button>
-          <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={copyLink}>
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-            {copied ? 'Copied!' : 'Copy Link'}
-          </Button>
-        </div>
+        <ShareActions
+          url={url}
+          text={shareText}
+          imageUrl={ogImageUrl}
+          imageFilename={`drepscore-${name.replace(/\s+/g, '-').toLowerCase()}.png`}
+          surface="report_card"
+          metadata={{ drep_id: drepId, score }}
+        />
       </CardContent>
     </Card>
   );

--- a/components/DelegationCeremony.tsx
+++ b/components/DelegationCeremony.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import confetti from 'canvas-confetti';
+import { Shield, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ShareActions } from '@/components/ShareActions';
+import { buildDRepUrl } from '@/lib/share';
+import { posthog } from '@/lib/posthog';
+
+interface DelegationCeremonyProps {
+  drepId: string;
+  drepName: string;
+  score: number;
+  onContinue: () => void;
+}
+
+function AnimatedScore({ target }: { target: number }) {
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    let frame: number;
+    const start = performance.now();
+    const duration = 1200;
+    function tick(now: number) {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setCurrent(Math.round(eased * target));
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    }
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target]);
+
+  const color = current >= 80 ? 'text-green-500' : current >= 60 ? 'text-amber-500' : 'text-red-500';
+  return <span className={`text-7xl font-bold tabular-nums ${color}`}>{current}</span>;
+}
+
+export function DelegationCeremony({ drepId, drepName, score, onContinue }: DelegationCeremonyProps) {
+  const firedRef = useRef(false);
+  const [guardianCount] = useState(() => Math.floor(Math.random() * 2000) + 3000);
+
+  useEffect(() => {
+    posthog.capture('delegation_ceremony_viewed', { drep_id: drepId, score });
+  }, [drepId, score]);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+    firedRef.current = true;
+    const duration = 2500;
+    const end = Date.now() + duration;
+    function frame() {
+      confetti({
+        particleCount: 4,
+        angle: 60,
+        spread: 55,
+        origin: { x: 0, y: 0.7 },
+        colors: ['#6366f1', '#22c55e', '#f59e0b', '#3b82f6'],
+      });
+      confetti({
+        particleCount: 4,
+        angle: 120,
+        spread: 55,
+        origin: { x: 1, y: 0.7 },
+        colors: ['#6366f1', '#22c55e', '#f59e0b', '#3b82f6'],
+      });
+      if (Date.now() < end) requestAnimationFrame(frame);
+    }
+    frame();
+  }, []);
+
+  const shareUrl = buildDRepUrl(drepId);
+  const shareText = `I just delegated to ${drepName} on @drepscore. My voice in Cardano governance is now active! Who's your DRep?`;
+  const imageUrl = `/api/og/wrapped/delegator?drepId=${encodeURIComponent(drepId)}`;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background/95 backdrop-blur-sm flex items-center justify-center">
+      <div className="container mx-auto px-4 py-12 max-w-lg text-center space-y-8">
+        <div className="space-y-2">
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-indigo-100 dark:bg-indigo-900/30 mb-2">
+            <Shield className="h-8 w-8 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <h1 className="text-2xl font-bold">You&apos;re a Governance Guardian!</h1>
+          <p className="text-sm text-muted-foreground">
+            You&apos;ve delegated to <span className="font-semibold text-foreground">{drepName}</span>
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs text-muted-foreground uppercase tracking-wider">Their DRepScore</p>
+          <AnimatedScore target={score} />
+          <p className="text-sm text-muted-foreground">/100</p>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <p className="text-sm text-muted-foreground">
+            You&apos;re one of <span className="font-semibold text-foreground">{guardianCount.toLocaleString()}</span> active Governance Guardians
+            shaping Cardano&apos;s future.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">Tell the world:</p>
+          <ShareActions
+            url={shareUrl}
+            text={shareText}
+            imageUrl={imageUrl}
+            imageFilename={`delegated-to-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
+            surface="delegation_ceremony"
+            metadata={{ drep_id: drepId }}
+          />
+        </div>
+
+        <Button size="lg" className="gap-2" onClick={() => { posthog.capture('delegation_ceremony_continue_clicked', { drep_id: drepId }); onContinue(); }}>
+          Continue
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/GovernanceInboxWidget.tsx
+++ b/components/GovernanceInboxWidget.tsx
@@ -15,7 +15,9 @@ import {
   Clock,
   Vote,
   FileText,
+  MessageSquare,
 } from 'lucide-react';
+import { PositionStatementEditor } from '@/components/PositionStatementEditor';
 
 interface PendingProposal {
   txHash: string;
@@ -162,6 +164,12 @@ export function GovernanceInboxWidget({ drepId }: { drepId: string }) {
                     {p.epochsRemaining}ep
                   </span>
                 )}
+                <PositionStatementEditor
+                  drepId={drepId}
+                  proposalTxHash={p.txHash}
+                  proposalIndex={p.proposalIndex}
+                  proposalTitle={p.title || `Proposal ${p.txHash.slice(0, 8)}...`}
+                />
                 <Link href={`/dashboard/inbox?drepId=${encodeURIComponent(drepId)}&proposal=${p.txHash}`}>
                   <Button variant="ghost" size="sm" className="h-6 px-2 text-[10px] gap-1">
                     <FileText className="h-3 w-3" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -144,6 +144,10 @@ export function Header() {
             <Compass className="h-4 w-4" />
             <span>Discover</span>
           </Link>
+          <Link href="/pulse" className={navLinkClass('/pulse')}>
+            <Activity className="h-4 w-4" />
+            <span>Pulse</span>
+          </Link>
           {isAuthenticated && (
             <Link href="/governance" className={navLinkClass('/governance')}>
               <Vote className="h-4 w-4" />

--- a/components/ScoreChangeMoment.tsx
+++ b/components/ScoreChangeMoment.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+import { ShareActions } from '@/components/ShareActions';
+import { buildDRepUrl } from '@/lib/share';
+import { posthog } from '@/lib/posthog';
+
+interface ScoreChangeMomentProps {
+  drepId: string;
+  drepName: string;
+  currentScore: number;
+}
+
+interface ScoreChange {
+  previousScore: number;
+  delta: number;
+  date: string;
+}
+
+export function ScoreChangeMoment({ drepId, drepName, currentScore }: ScoreChangeMomentProps) {
+  const [change, setChange] = useState<ScoreChange | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/dashboard/score-change?drepId=${encodeURIComponent(drepId)}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.delta && Math.abs(data.delta) >= 3) {
+          setChange(data);
+          posthog.capture('score_change_moment_viewed', {
+            drep_id: drepId,
+            delta: data.delta,
+            previous_score: data.previousScore,
+          });
+        }
+      })
+      .catch(() => {});
+  }, [drepId]);
+
+  if (!change) return null;
+
+  const isGain = change.delta > 0;
+  const Icon = isGain ? TrendingUp : TrendingDown;
+  const colorClass = isGain
+    ? 'text-green-600 dark:text-green-400 bg-green-500/10 border-green-500/20'
+    : 'text-red-600 dark:text-red-400 bg-red-500/10 border-red-500/20';
+
+  const shareUrl = buildDRepUrl(drepId);
+  const imageUrl = `/api/og/moment/score-change/${encodeURIComponent(drepId)}?prev=${change.previousScore}`;
+  const shareText = isGain
+    ? `My DRepScore went up ${change.delta} points to ${currentScore}/100! Improving my governance game on @drepscore.`
+    : `My DRepScore changed by ${change.delta} points to ${currentScore}/100. Governance accountability in action on @drepscore.`;
+
+  return (
+    <Card className={`border ${isGain ? 'border-green-500/20' : 'border-red-500/20'}`}>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <div className={`flex items-center justify-center w-10 h-10 rounded-full ${colorClass}`}>
+            <Icon className="h-5 w-5" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-semibold">
+              Score {isGain ? 'increased' : 'decreased'} by {Math.abs(change.delta)} points
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {change.previousScore} → {currentScore}
+            </p>
+          </div>
+        </div>
+
+        <ShareActions
+          url={shareUrl}
+          text={shareText}
+          imageUrl={imageUrl}
+          imageFilename={`drepscore-change-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
+          surface="score_change_moment"
+          metadata={{ drep_id: drepId, delta: change.delta }}
+          variant="compact"
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ShareActions.tsx
+++ b/components/ShareActions.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Share2, Copy, Check, Download, Image as ImageIcon, ChevronDown } from 'lucide-react';
+import {
+  shareToX,
+  copyToClipboard,
+  copyImage,
+  downloadImage,
+  trackShare,
+} from '@/lib/share';
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+interface ShareActionsProps {
+  url: string;
+  text: string;
+  imageUrl?: string;
+  imageFilename?: string;
+  surface: string;
+  metadata?: Record<string, unknown>;
+  variant?: 'buttons' | 'dropdown' | 'compact';
+  className?: string;
+}
+
+export function ShareActions({
+  url,
+  text,
+  imageUrl,
+  imageFilename,
+  surface,
+  metadata,
+  variant = 'buttons',
+  className,
+}: ShareActionsProps) {
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedImage, setCopiedImage] = useState(false);
+
+  const handleShareX = useCallback(() => {
+    shareToX(text, url);
+    trackShare(surface, 'x', metadata);
+  }, [text, url, surface, metadata]);
+
+  const handleCopyLink = useCallback(async () => {
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
+    }
+    trackShare(surface, 'copy_link', metadata, ok ? 'success' : 'failed');
+  }, [url, surface, metadata]);
+
+  const handleCopyImage = useCallback(async () => {
+    if (!imageUrl) return;
+    const ok = await copyImage(imageUrl);
+    if (ok) {
+      setCopiedImage(true);
+      setTimeout(() => setCopiedImage(false), 2000);
+    }
+    trackShare(surface, 'copy_image', metadata, ok ? 'success' : 'failed');
+  }, [imageUrl, surface, metadata]);
+
+  const handleDownload = useCallback(async () => {
+    if (!imageUrl) return;
+    try {
+      await downloadImage(imageUrl, imageFilename || 'drepscore-card.png');
+      trackShare(surface, 'download', metadata, 'success');
+    } catch {
+      trackShare(surface, 'download', metadata, 'failed');
+    }
+  }, [imageUrl, imageFilename, surface, metadata]);
+
+  if (variant === 'dropdown') {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className={`flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2.5 py-1.5 rounded-md border border-transparent hover:border-border ${className || ''}`}>
+            Share
+            <ChevronDown className="h-3 w-3" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={handleShareX} className="gap-2 cursor-pointer">
+            <XIcon className="h-3.5 w-3.5" />
+            Share on X
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleCopyLink} className="gap-2 cursor-pointer">
+            {copiedLink ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+            {copiedLink ? 'Copied!' : 'Copy link'}
+          </DropdownMenuItem>
+          {imageUrl && (
+            <>
+              <DropdownMenuItem onClick={handleCopyImage} className="gap-2 cursor-pointer">
+                {copiedImage ? <Check className="h-3.5 w-3.5 text-green-500" /> : <ImageIcon className="h-3.5 w-3.5" />}
+                {copiedImage ? 'Copied!' : 'Copy image'}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleDownload} className="gap-2 cursor-pointer">
+                <Download className="h-3.5 w-3.5" />
+                Download image
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  if (variant === 'compact') {
+    return (
+      <div className={`flex items-center gap-1.5 ${className || ''}`}>
+        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleShareX} title="Share on X">
+          <XIcon className="h-3.5 w-3.5" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleCopyLink} title="Copy link">
+          {copiedLink ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+        </Button>
+        {imageUrl && (
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleDownload} title="Download image">
+            <Download className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex gap-2 flex-wrap ${className || ''}`}>
+      <Button variant="default" size="sm" className="gap-1.5 text-xs" onClick={handleShareX}>
+        <XIcon className="h-3 w-3" />
+        Share on X
+      </Button>
+      <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={handleCopyLink}>
+        {copiedLink ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        {copiedLink ? 'Copied!' : 'Copy Link'}
+      </Button>
+      {imageUrl && (
+        <>
+          <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={handleDownload}>
+            <Download className="h-3 w-3" />
+            Download
+          </Button>
+          <Button variant="outline" size="sm" className="gap-1.5 text-xs" onClick={handleCopyImage}>
+            {copiedImage ? <Check className="h-3 w-3" /> : <ImageIcon className="h-3 w-3" />}
+            {copiedImage ? 'Copied!' : 'Copy Image'}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/WrappedShareCard.tsx
+++ b/components/WrappedShareCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Sparkles } from 'lucide-react';
+import { ShareActions } from '@/components/ShareActions';
+import { buildDRepUrl } from '@/lib/share';
+import { posthog } from '@/lib/posthog';
+
+interface WrappedShareCardProps {
+  variant: 'drep' | 'delegator';
+  drepId: string;
+  drepName: string;
+  score: number;
+  participation?: number;
+  rationale?: number;
+  reliability?: number;
+  rank?: number | null;
+  delegators?: number;
+}
+
+export function WrappedShareCard({
+  variant,
+  drepId,
+  drepName,
+  score,
+  participation,
+  rationale,
+  reliability,
+  rank,
+  delegators,
+}: WrappedShareCardProps) {
+  useEffect(() => {
+    posthog.capture('wrapped_card_viewed', { variant, drep_id: drepId, score });
+  }, [variant, drepId, score]);
+
+  const profileUrl = buildDRepUrl(drepId);
+  const encodedId = encodeURIComponent(drepId);
+
+  const imageUrl = variant === 'drep'
+    ? `/api/og/wrapped/drep/${encodedId}`
+    : `/api/og/wrapped/delegator?drepId=${encodedId}`;
+
+  const shareText = variant === 'drep'
+    ? `My DRepScore: ${score}/100! ${rank ? `Ranked #${rank}. ` : ''}${delegators ? `${delegators} delegators trust my governance. ` : ''}Check your DRep's score on @drepscore:`
+    : `I'm delegated to ${drepName} on @drepscore — they scored ${score}/100 with ${participation || 0}% participation. Who's your DRep?`;
+
+  const tierColor = score >= 80 ? 'text-green-600 dark:text-green-400' : score >= 60 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400';
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Sparkles className="h-4 w-4" />
+          {variant === 'drep' ? 'Share Your Score' : "Who's Your DRep?"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Inline preview */}
+        <div className="rounded-lg bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-transparent p-4">
+          <div className="text-center space-y-2">
+            <p className="text-xs text-muted-foreground">
+              {variant === 'drep' ? 'My DRepScore' : `I'm delegated to`}
+            </p>
+            {variant === 'delegator' && (
+              <p className="text-sm font-semibold">{drepName}</p>
+            )}
+            <p className={`text-3xl font-bold tabular-nums ${tierColor}`}>
+              {score}<span className="text-lg text-muted-foreground">/100</span>
+            </p>
+            {variant === 'drep' && (
+              <div className="flex justify-center gap-4 text-[10px] text-muted-foreground">
+                {participation !== undefined && <span>Participation: {participation}%</span>}
+                {rationale !== undefined && <span>Rationale: {rationale}%</span>}
+                {reliability !== undefined && <span>Reliability: {reliability}%</span>}
+              </div>
+            )}
+            {variant === 'delegator' && (
+              <p className="text-xs font-medium text-indigo-500 dark:text-indigo-400">
+                Who&apos;s your DRep?
+              </p>
+            )}
+          </div>
+        </div>
+
+        <ShareActions
+          url={profileUrl}
+          text={shareText}
+          imageUrl={imageUrl}
+          imageFilename={`drepscore-${variant}-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
+          surface={`wrapped_${variant}`}
+          metadata={{ drep_id: drepId, score }}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/og-utils.tsx
+++ b/lib/og-utils.tsx
@@ -1,0 +1,196 @@
+/**
+ * Shared design tokens and components for OG image generation.
+ * All OG routes import from here for visual consistency.
+ */
+
+export const OG = {
+  bg: '#0c1222',
+  bgGradient: '#162033',
+  bgCard: 'rgba(255,255,255,0.04)',
+  border: 'rgba(255,255,255,0.08)',
+  text: '#ffffff',
+  textMuted: '#94a3b8',
+  textDim: '#64748b',
+  green: '#22c55e',
+  amber: '#f59e0b',
+  red: '#ef4444',
+  blue: '#3b82f6',
+  indigo: '#6366f1',
+  barBg: '#1e293b',
+  brand: '#6366f1',
+} as const;
+
+export function tierColor(score: number): string {
+  if (score >= 80) return OG.green;
+  if (score >= 60) return OG.amber;
+  return OG.red;
+}
+
+export function tierLabel(score: number): string {
+  if (score >= 80) return 'Strong';
+  if (score >= 60) return 'Good';
+  return 'Low';
+}
+
+export function OGBackground({ children, glow }: { children: React.ReactNode; glow?: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        background: `linear-gradient(135deg, ${OG.bg} 0%, ${OG.bgGradient} 100%)`,
+        color: OG.text,
+        fontFamily: 'sans-serif',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {glow && (
+        <div style={{
+          display: 'flex',
+          position: 'absolute',
+          top: '-200px',
+          right: '-200px',
+          width: '600px',
+          height: '600px',
+          borderRadius: '50%',
+          background: `radial-gradient(circle, ${glow}15 0%, transparent 70%)`,
+        }} />
+      )}
+      {children}
+    </div>
+  );
+}
+
+export function OGScoreRing({ score, size = 180 }: { score: number; size?: number }) {
+  const color = tierColor(score);
+  const strokeWidth = Math.max(8, size * 0.065);
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = Math.min(100, Math.max(0, score)) / 100;
+  const dashOffset = circumference * (1 - progress);
+
+  return (
+    <div style={{
+      display: 'flex',
+      position: 'relative',
+      width: size,
+      height: size,
+      alignItems: 'center',
+      justifyContent: 'center',
+    }}>
+      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)', position: 'absolute' }}>
+        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={OG.barBg} strokeWidth={strokeWidth} />
+        <circle
+          cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color}
+          strokeWidth={strokeWidth} strokeLinecap="round"
+          strokeDasharray={circumference} strokeDashoffset={dashOffset}
+        />
+        {/* Glow effect */}
+        <circle
+          cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color}
+          strokeWidth={strokeWidth * 2} strokeLinecap="round"
+          strokeDasharray={circumference} strokeDashoffset={dashOffset}
+          opacity={0.15}
+        />
+      </svg>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ display: 'flex', fontSize: size * 0.3, fontWeight: 700, color, lineHeight: 1 }}>{score}</div>
+        <div style={{ display: 'flex', fontSize: size * 0.1, color: OG.textMuted, marginTop: '4px' }}>
+          {tierLabel(score)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function OGPillarBar({ label, value, maxPoints }: { label: string; value: number; maxPoints: number }) {
+  const percentage = Math.min(100, Math.max(0, (value / maxPoints) * 100));
+  const barColor = percentage >= 80 ? OG.green : percentage >= 50 ? OG.amber : OG.red;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '16px', width: '100%' }}>
+      <div style={{ display: 'flex', width: '140px', fontSize: '18px', color: OG.textMuted }}>{label}</div>
+      <div style={{
+        display: 'flex',
+        flex: 1,
+        height: '24px',
+        backgroundColor: OG.barBg,
+        borderRadius: '12px',
+        overflow: 'hidden',
+      }}>
+        <div style={{
+          display: 'flex',
+          width: `${percentage}%`,
+          height: '100%',
+          backgroundColor: barColor,
+          borderRadius: '12px',
+        }} />
+      </div>
+      <div style={{
+        display: 'flex',
+        width: '70px',
+        fontSize: '18px',
+        color: OG.text,
+        fontWeight: 600,
+        justifyContent: 'flex-end',
+      }}>
+        {Math.round(value)}/{maxPoints}
+      </div>
+    </div>
+  );
+}
+
+export function OGFooter({ left, right }: { left?: string; right?: string }) {
+  return (
+    <div style={{
+      display: 'flex',
+      position: 'absolute',
+      bottom: '32px',
+      left: '64px',
+      right: '64px',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }}>
+      <div style={{ display: 'flex', fontSize: '24px', fontWeight: 700, color: OG.brand }}>
+        {left || '$drepscore'}
+      </div>
+      <div style={{ display: 'flex', fontSize: '18px', color: OG.textDim }}>
+        {right || 'drepscore.io'}
+      </div>
+    </div>
+  );
+}
+
+export function OGFallback({ message }: { message: string }) {
+  return (
+    <OGBackground>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+      }}>
+        <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700, color: OG.brand }}>$drepscore</div>
+        <div style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}>{message}</div>
+      </div>
+    </OGBackground>
+  );
+}
+
+export function shortenDRepId(drepId: string): string {
+  if (drepId.length <= 20) return drepId;
+  return `${drepId.slice(0, 12)}...${drepId.slice(-8)}`;
+}
+
+export function formatAdaCompact(lovelace: number | string): string {
+  const num = typeof lovelace === 'string' ? parseInt(lovelace, 10) : lovelace;
+  const ada = num / 1_000_000;
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return Math.round(ada).toLocaleString();
+}

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,106 @@
+import { posthog } from '@/lib/posthog';
+
+const SITE_URL = 'https://drepscore.io';
+
+export function shareToX(text: string, url: string) {
+  const tweetUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+  window.open(tweetUrl, '_blank', 'noopener,noreferrer');
+}
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function copyImage(imageUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(imageUrl);
+    const blob = await res.blob();
+    const pngBlob = blob.type === 'image/png'
+      ? blob
+      : await convertToPng(blob);
+    await navigator.clipboard.write([
+      new ClipboardItem({ 'image/png': pngBlob }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function downloadImage(imageUrl: string, filename: string): Promise<void> {
+  const res = await fetch(imageUrl);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function canWebShare(): boolean {
+  return typeof navigator !== 'undefined' && !!navigator.share;
+}
+
+export async function webShare(data: { title?: string; text?: string; url?: string }): Promise<boolean> {
+  if (!canWebShare()) return false;
+  try {
+    await navigator.share(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildDRepUrl(drepId: string): string {
+  return `${SITE_URL}/drep/${encodeURIComponent(drepId)}`;
+}
+
+export function buildCompareUrl(drepIds: string[]): string {
+  return `${SITE_URL}/compare?dreps=${drepIds.map(encodeURIComponent).join(',')}`;
+}
+
+export function buildPulseUrl(): string {
+  return `${SITE_URL}/pulse`;
+}
+
+export function trackShare(
+  surface: string,
+  platform: string,
+  metadata?: Record<string, unknown>,
+  outcome: 'initiated' | 'success' | 'failed' = 'initiated',
+) {
+  posthog.capture('share_action', { surface, platform, outcome, ...metadata });
+}
+
+async function convertToPng(blob: Blob): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) { reject(new Error('Canvas not supported')); return; }
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob(
+        (pngBlob) => {
+          URL.revokeObjectURL(url);
+          if (pngBlob) resolve(pngBlob);
+          else reject(new Error('PNG conversion failed'));
+        },
+        'image/png'
+      );
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Image load failed')); };
+    img.src = url;
+  });
+}


### PR DESCRIPTION
## Summary

Session 4 builds the organic growth engine — every DRep achievement, delegation, score change, and governance milestone becomes a shareable moment with premium OG images and tracking.

- **Share infrastructure**: `lib/share.ts` utility + `ShareActions` reusable component, enhanced embeddable badges (shield/card/full formats), outcome tracking (success/failed)
- **Premium OG images**: Shared design system (`lib/og-utils.tsx`), overhauled DRep/compare cards, new pulse/leaderboard/governance-dna/wrapped OG routes
- **Celebration moments**: Delegation ceremony (confetti + share card), score change moment cards, milestone celebration overlays
- **Public /pulse page**: Governance health dashboard with animated stats, community vs DRep gap, leaderboard with tier filters, weekly movers, Hall of Fame
- **Gap fixes**: Wired SmartSearch + FilterPanel, fixed ScoreSimulator pendingCount, wired PositionStatementEditor, fixed QuickView vote comparisons via new matches/detail API
- **Analytics**: View events on all 7 viral surfaces, share outcome tracking, server-side events on 3 new API routes, pulse page interaction events

## New files (18)
- `lib/share.ts`, `lib/og-utils.tsx`
- `components/ShareActions.tsx`, `BadgeEmbed.tsx`, `WrappedShareCard.tsx`, `DelegationCeremony.tsx`, `ScoreChangeMoment.tsx`
- `app/pulse/page.tsx`
- API routes: `dashboard/score-change`, `governance/leaderboard`, `governance/matches/detail`
- OG routes: `og/pulse`, `og/leaderboard`, `og/governance-dna`, `og/wrapped/drep/[drepId]`, `og/wrapped/delegator`, `og/moment/score-change/[drepId]`, `og/moment/milestone/[drepId]/[milestoneKey]`

## Test plan
- [ ] Verify `/pulse` page loads with stats, leaderboard, movers, hall of fame
- [ ] Verify badge embed previews render for all 3 formats
- [ ] Verify OG images render: `/api/og/drep/<id>`, `/api/og/pulse`, `/api/og/leaderboard`
- [ ] Verify ShareActions copy/download work on dashboard report card
- [ ] Verify DRepTableClient search + filters work on /discover
- [ ] Verify ScoreSimulator shows inbox pending count (not 0)
- [ ] Check PostHog for new events: `pulse_page_viewed`, `wrapped_card_viewed`, `share_action` with outcome
