### PR TITLE
feat: Hero constellation visual polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ analytics/src/.observablehq/cache
 analytics/dist
 analytics/.env
 
+# Vercel (legacy, no longer used)
+.vercel/
+
 # Cursor plans
 .cursor/plans/
 

--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -216,7 +216,7 @@ export function ConstellationHero({ stats, ssrHolderData, ssrWalletAddress, onPe
 
       {/* Text Overlay */}
       {!showPersonalCard && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center z-10 pointer-events-none px-4">
+        <div className="absolute inset-0 flex flex-col items-center justify-start pt-[14vh] md:justify-center md:pt-0 z-10 pointer-events-none px-4">
           <h1
             className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-center max-w-4xl leading-tight animate-fade-in-up"
           >

--- a/components/GovernanceConstellation.tsx
+++ b/components/GovernanceConstellation.tsx
@@ -162,6 +162,7 @@ export const GovernanceConstellation = forwardRef<ConstellationRef, Constellatio
               pulseId={sceneState.pulseId}
             />
             <ConstellationEdges edges={sceneState.edges} dimmed={sceneState.dimmed} />
+            <ShootingStars />
 
             {quality !== 'low' && (
               <EffectComposer>
@@ -200,14 +201,20 @@ function ConstellationNodes({
   dimmed: boolean;
   pulseId: string | null;
 }) {
-  if (nodes.length === 0) return null;
+  const [frameReady, setFrameReady] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setFrameReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  if (nodes.length === 0 || !frameReady) return null;
 
   const regularNodes = nodes.filter(n => !n.isAnchor);
   const anchorNodes = nodes.filter(n => n.isAnchor);
 
   return (
     <>
-      {/* Regular DRep nodes */}
       <Instances limit={regularNodes.length + 10} frustumCulled={false}>
         <sphereGeometry args={[1, 10, 10]} />
         <meshStandardMaterial
@@ -233,7 +240,6 @@ function ConstellationNodes({
         })}
       </Instances>
 
-      {/* Anchor nodes — brighter emissive for inner hexagonal ring */}
       <Instances limit={anchorNodes.length + 2} frustumCulled={false}>
         <sphereGeometry args={[1, 12, 12]} />
         <meshStandardMaterial
@@ -340,7 +346,6 @@ function AmbientStarfield({ count }: { count: number }) {
 
 function GovernanceCore() {
   const coreRef = useRef<THREE.Mesh>(null);
-  const discRef = useRef<THREE.Mesh>(null);
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime();
@@ -348,35 +353,108 @@ function GovernanceCore() {
       const breath = 0.95 + 0.05 * Math.sin(t * 1.57);
       coreRef.current.scale.setScalar(breath);
     }
-    if (discRef.current) {
-      discRef.current.rotation.z = -t * 0.08;
-    }
   });
 
   return (
     <group>
-      {/* Luminous governance sun */}
       <mesh ref={coreRef}>
-        <sphereGeometry args={[0.6, 24, 24]} />
+        <sphereGeometry args={[1.1, 32, 32]} />
         <meshStandardMaterial
           emissive="#ffd280"
-          emissiveIntensity={4}
+          emissiveIntensity={3.5}
           color="#ffd280"
           toneMapped={false}
         />
       </mesh>
-      {/* Accretion disc */}
-      <mesh ref={discRef} rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[1.8, 0.02, 8, 64]} />
-        <meshStandardMaterial
-          emissive="#ffd280"
-          emissiveIntensity={2}
-          color="#ffd280"
-          transparent
-          opacity={0.15}
-          toneMapped={false}
-        />
-      </mesh>
+      <pointLight color="#ffd280" intensity={8} distance={18} decay={2} />
+    </group>
+  );
+}
+
+const METEOR_POOL = 4;
+const SPAWN_MIN_S = 4;
+const SPAWN_MAX_S = 10;
+
+function ShootingStars() {
+  const groupRef = useRef<THREE.Group>(null);
+  const stateRef = useRef({
+    meteors: Array.from({ length: METEOR_POOL }, () => ({
+      active: false,
+      start: new THREE.Vector3(),
+      end: new THREE.Vector3(),
+      progress: 0,
+      speed: 0,
+    })),
+    timer: SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S),
+  });
+
+  const _pos = useRef(new THREE.Vector3());
+  const _dir = useRef(new THREE.Vector3());
+  const _up = useRef(new THREE.Vector3(0, 1, 0));
+
+  useFrame((_, delta) => {
+    const group = groupRef.current;
+    if (!group) return;
+    const { meteors } = stateRef.current;
+
+    stateRef.current.timer -= delta;
+    if (stateRef.current.timer <= 0) {
+      stateRef.current.timer = SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S);
+      const slot = meteors.find(m => !m.active);
+      if (slot) {
+        const angle = Math.random() * Math.PI * 2;
+        const r = 13 + Math.random() * 5;
+        slot.start.set(Math.cos(angle) * r, Math.sin(angle) * r, (Math.random() - 0.5) * 8);
+        const endAngle = angle + Math.PI + (Math.random() - 0.5) * 0.8;
+        const endR = 1 + Math.random() * 6;
+        slot.end.set(Math.cos(endAngle) * endR, Math.sin(endAngle) * endR, (Math.random() - 0.5) * 6);
+        slot.progress = 0;
+        slot.speed = 0.5 + Math.random() * 0.4;
+        slot.active = true;
+      }
+    }
+
+    for (let i = 0; i < METEOR_POOL; i++) {
+      const m = meteors[i];
+      const mesh = group.children[i] as THREE.Mesh;
+      if (!mesh) continue;
+
+      if (!m.active) { mesh.visible = false; continue; }
+
+      m.progress += delta * m.speed;
+      if (m.progress >= 1) { m.active = false; mesh.visible = false; continue; }
+
+      _pos.current.lerpVectors(m.start, m.end, m.progress);
+      mesh.position.copy(_pos.current);
+
+      _dir.current.subVectors(m.end, m.start).normalize();
+      mesh.quaternion.setFromUnitVectors(_up.current, _dir.current);
+
+      const fadeIn = Math.min(1, m.progress * 8);
+      const fadeOut = 1 - m.progress * m.progress;
+      const opacity = fadeIn * fadeOut * 0.8;
+      mesh.scale.set(1, 0.4 + opacity * 0.8, 1);
+
+      (mesh.material as THREE.MeshBasicMaterial).opacity = opacity;
+      mesh.visible = true;
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      {Array.from({ length: METEOR_POOL }, (_, i) => (
+        <mesh key={i} visible={false}>
+          <cylinderGeometry args={[0.03, 0.003, 1.5, 4]} />
+          <meshBasicMaterial
+            color="#e8dcc8"
+            transparent
+            opacity={0}
+            blending={THREE.AdditiveBlending}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </mesh>
+      ))}
     </group>
   );
 }

--- a/lib/constellation/layout.ts
+++ b/lib/constellation/layout.ts
@@ -22,7 +22,7 @@ const ARM_ANGLES: Record<AlignmentDimension, number> = (() => {
 })();
 
 const ARM_PITCH = [0.26, -0.26, 0.26, -0.26, 0.26, -0.26]; // ~15° alternating tilt
-const ARM_FAN_ARC = Math.PI / 4;
+const ARM_FAN_ARC = Math.PI / 3;
 const MAX_RADIUS = 12;
 const ANCHOR_RADIUS = MAX_RADIUS * 0.3;
 const MIN_VISIBLE_SCALE = 0.06;
@@ -65,7 +65,7 @@ export function computeLayout(
       dominant: dim,
       alignments: [50, 50, 50, 50, 50, 50],
       position: [x, y, z],
-      scale: MAX_VISIBLE_SCALE * 1.5,
+      scale: MAX_VISIBLE_SCALE * 1.2,
       isAnchor: true,
     };
     anchorNodes.push(anchor);
@@ -84,6 +84,9 @@ export function computeLayout(
     nodes.push(node);
     nodeMap.set(node.id, node);
   }
+
+  rebalanceAngular(nodes);
+  repulse(nodes);
 
   const edges = computeEdges(nodes, anchorNodes);
   return { nodes, edges, nodeMap };
@@ -106,9 +109,10 @@ function computeNodePosition(input: LayoutInput): [number, number, number] {
   const hashNorm = (hash % 10000) / 10000;
 
   if (totalWeight < 1) {
-    const r = 0.5 + hashNorm * 1.5;
-    const a = hashNorm * Math.PI * 2;
-    return [Math.cos(a) * r, Math.sin(a) * r, (hashNorm - 0.5) * 2];
+    const hashAngle = ((hash >> 8) % 10000) / 10000;
+    const r = 0.8 + hashNorm * 1.8;
+    const a = hashAngle * Math.PI * 2;
+    return [Math.cos(a) * r, Math.sin(a) * r, (hashAngle - 0.5) * 2.5];
   }
 
   const dirAngle = Math.atan2(wy, wx);
@@ -139,14 +143,8 @@ function computeEdges(
   anchorNodes: ConstellationNode3D[]
 ): ConstellationEdge3D[] {
   const edges: ConstellationEdge3D[] = [];
-  const origin: [number, number, number] = [0, 0, 0];
 
-  // H3: Hub-spoke edges — core to each anchor
-  for (const anchor of anchorNodes) {
-    edges.push({ from: origin, to: anchor.position });
-  }
-
-  // H2: Anchor ring — connect each anchor to its neighbors (hexagonal ring)
+  // Anchor ring — connect each anchor to its neighbors (hexagonal ring)
   for (let i = 0; i < anchorNodes.length; i++) {
     const next = anchorNodes[(i + 1) % anchorNodes.length];
     edges.push({ from: anchorNodes[i].position, to: next.position });
@@ -185,6 +183,90 @@ function dist3D(a: [number, number, number], b: [number, number, number]): numbe
   const dy = a[1] - b[1];
   const dz = a[2] - b[2];
   return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function rebalanceAngular(nodes: ConstellationNode3D[]): void {
+  const realNodes = nodes.filter(n => !n.isAnchor);
+  if (realNodes.length < 2) return;
+
+  const NUM_SECTORS = 12;
+  const sectorArc = (Math.PI * 2) / NUM_SECTORS;
+
+  const sectors: ConstellationNode3D[][] = Array.from({ length: NUM_SECTORS }, () => []);
+  for (const node of realNodes) {
+    let angle = Math.atan2(node.position[1], node.position[0]);
+    if (angle < 0) angle += Math.PI * 2;
+    const sector = Math.min(NUM_SECTORS - 1, Math.floor(angle / sectorArc));
+    sectors[sector].push(node);
+  }
+
+  const avgPerSector = realNodes.length / NUM_SECTORS;
+  const cap = Math.ceil(avgPerSector * 1.8);
+
+  for (let s = 0; s < NUM_SECTORS; s++) {
+    if (sectors[s].length <= cap) continue;
+
+    sectors[s].sort((a, b) => {
+      const dA = a.position[0] ** 2 + a.position[1] ** 2;
+      const dB = b.position[0] ** 2 + b.position[1] ** 2;
+      return dB - dA;
+    });
+
+    const overflow = sectors[s].length - cap;
+    for (let i = 0; i < overflow; i++) {
+      const node = sectors[s][i];
+      const left = (s - 1 + NUM_SECTORS) % NUM_SECTORS;
+      const right = (s + 1) % NUM_SECTORS;
+      const target = sectors[left].length <= sectors[right].length ? left : right;
+
+      const currentAngle = Math.atan2(node.position[1], node.position[0]);
+      const targetCenter = (target + 0.5) * sectorArc;
+
+      let delta = targetCenter - currentAngle;
+      while (delta > Math.PI) delta -= Math.PI * 2;
+      while (delta < -Math.PI) delta += Math.PI * 2;
+
+      const shift = delta * 0.4;
+      const r = Math.sqrt(node.position[0] ** 2 + node.position[1] ** 2);
+      const newAngle = currentAngle + shift;
+
+      node.position[0] = Math.cos(newAngle) * r;
+      node.position[1] = Math.sin(newAngle) * r;
+
+      sectors[target].push(node);
+    }
+    sectors[s].splice(0, overflow);
+  }
+}
+
+function repulse(nodes: ConstellationNode3D[]): void {
+  const realNodes = nodes.filter(n => !n.isAnchor);
+  const MIN_DIST = 0.8;
+  const STRENGTH = 0.4;
+
+  for (let iter = 0; iter < 3; iter++) {
+    for (let i = 0; i < realNodes.length; i++) {
+      for (let j = i + 1; j < realNodes.length; j++) {
+        const a = realNodes[i].position;
+        const b = realNodes[j].position;
+        const dx = b[0] - a[0];
+        const dy = b[1] - a[1];
+        const dz = b[2] - a[2];
+        const distSq = dx * dx + dy * dy + dz * dz;
+
+        if (distSq < MIN_DIST * MIN_DIST && distSq > 0.0001) {
+          const dist = Math.sqrt(distSq);
+          const force = (MIN_DIST - dist) / dist * STRENGTH;
+          a[0] -= dx * force;
+          a[1] -= dy * force;
+          a[2] -= dz * force;
+          b[0] += dx * force;
+          b[1] += dy * force;
+          b[2] += dz * force;
+        }
+      }
+    }
+  }
 }
 
 function simpleHash(str: string): number {


### PR DESCRIPTION
## Summary

- **Even node distribution**: Widened arm fan arc (PI/4 to PI/3), added angular rebalancing across 12 sectors with overflow redistribution, plus 3-pass repulsion to prevent node overlap
- **Removed cheap horizontal lines**: Deleted hub-spoke edges and accretion disc torus that were cheapening the sun
- **Enlarged governance sun**: Sphere radius 0.6 to 1.1 with point light radial glow; reduced anchor node scale so large DReps don't rival the sun
- **Shooting stars**: New ShootingStars component with pooled tapered meteor meshes, additive blending, sporadic 4-10s spawns (symbolize governance events in motion)
- **Fixed square artifacts**: Frame-ready gate on Instances prevents geometry flash on first render
- **Mobile text fix**: Text overlay shifts upward on small screens so sun bloom doesn't obscure stats
- **Cleanup**: Added .vercel/ to gitignore (migrated to Railway)

## Test plan

- [x] TypeScript compiles clean (tsc --noEmit)
- [x] All 241 tests pass (vitest run)
- [ ] Visual check: nodes distributed more evenly around the sun
- [ ] Visual check: no horizontal spoke lines through the sun
- [ ] Visual check: sun is clearly larger than largest DRep nodes
- [ ] Visual check: shooting stars appear every 4-10s with smooth fade
- [ ] Visual check: no random square artifacts on load
- [ ] Mobile check: stats text readable above the sun on small screens