### PR TITLE
feat: Session 15 — The Narrative & Feel Layer

### DIFF
--- a/app/api/governance/health-index/route.ts
+++ b/app/api/governance/health-index/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { computeGHI } from '@/lib/ghi';
+
+let cachedResult: { data: Awaited<ReturnType<typeof computeGHI>>; ts: number } | null = null;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export async function GET() {
+  try {
+    if (cachedResult && Date.now() - cachedResult.ts < CACHE_TTL_MS) {
+      return NextResponse.json(cachedResult.data, {
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600' },
+      });
+    }
+
+    const result = await computeGHI();
+    cachedResult = { data: result, ts: Date.now() };
+
+    return NextResponse.json(result, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600' },
+    });
+  } catch (error) {
+    console.error('[GHI] Failed to compute:', error);
+    return NextResponse.json({ error: 'Failed to compute GHI' }, { status: 500 });
+  }
+}

--- a/app/api/governance/insights/route.ts
+++ b/app/api/governance/insights/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { computeInsights } from '@/lib/proposalInsights';
+
+let cachedResult: { data: Awaited<ReturnType<typeof computeInsights>>; ts: number } | null = null;
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+export async function GET() {
+  try {
+    if (cachedResult && Date.now() - cachedResult.ts < CACHE_TTL_MS) {
+      return NextResponse.json(cachedResult.data, {
+        headers: { 'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=3600' },
+      });
+    }
+
+    const result = await computeInsights();
+    cachedResult = { data: result, ts: Date.now() };
+
+    return NextResponse.json(result, {
+      headers: { 'Cache-Control': 'public, s-maxage=21600, stale-while-revalidate=3600' },
+    });
+  } catch (error) {
+    console.error('[Insights] API error:', error);
+    return NextResponse.json([], { status: 500 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -43,6 +43,8 @@ import { ScoreChangeMoment } from '@/components/ScoreChangeMoment';
 import { DashboardUrgentBar } from '@/components/DashboardUrgentBar';
 import { AnimatedTabs, type TabDefinition } from '@/components/AnimatedTabs';
 import { applyRationaleCurve, getMissingProfileFields } from '@/utils/scoring';
+import { generateDashboardNarrative } from '@/lib/narratives';
+import { NarrativeSummary } from '@/components/NarrativeSummary';
 import type { ScoreSnapshot } from '@/lib/data';
 import type { VoteRecord } from '@/types/drep';
 
@@ -267,6 +269,18 @@ export default function MyDRepPage() {
             </Badge>
           )}
         </div>
+
+        <NarrativeSummary
+          text={generateDashboardNarrative({
+            pendingCount: inboxPendingCount,
+            drepScore: drep.drepScore,
+            scoreChange,
+            percentile,
+            delegatorCount: drep.delegatorCount,
+            drepName: drep.name || drep.drepId.slice(0, 16),
+          })}
+          className="mb-3"
+        />
 
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2 py-3 px-4 rounded-lg border border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
           <div className="flex items-center gap-2">
@@ -504,9 +518,9 @@ function ConnectWalletCTA() {
       <Card className="border-2 border-dashed">
         <CardContent className="pt-8 pb-8 space-y-4">
           <Wallet className="h-12 w-12 mx-auto text-muted-foreground" />
-          <h2 className="text-xl font-bold">Connect Your Wallet</h2>
+          <h2 className="text-xl font-bold">Enter Governance</h2>
           <p className="text-sm text-muted-foreground max-w-sm mx-auto">
-            Connect a Cardano wallet that holds your DRep credentials to access your personalized dashboard.
+            Connect your Cardano wallet to access your personalized governance command center.
           </p>
           <p className="text-xs text-muted-foreground">
             Use the wallet button in the header to connect.
@@ -525,13 +539,11 @@ function NotADRepCTA() {
           <Shield className="h-12 w-12 mx-auto text-muted-foreground" />
           <h2 className="text-xl font-bold">No DRep Profile Found</h2>
           <p className="text-sm text-muted-foreground max-w-sm mx-auto">
-            We couldn&apos;t find a DRep profile for your wallet. If you&apos;ve registered as a DRep,
-            it may take up to 30 minutes to sync. Make sure you&apos;re using the wallet associated
-            with your DRep registration.
+            No DRep profile linked to this wallet yet. If you&apos;ve recently registered, it may take up to 30 minutes to sync.
           </p>
           <Link href="/">
             <Button variant="outline" className="gap-2 mt-2">
-              Browse DReps <ArrowRight className="h-4 w-4" />
+              Explore DReps <ArrowRight className="h-4 w-4" />
             </Button>
           </Link>
         </CardContent>
@@ -545,9 +557,9 @@ function ErrorState({ message }: { message: string | null }) {
     <div className="container mx-auto px-4 py-16 max-w-lg text-center">
       <Card className="border-2 border-destructive/30">
         <CardContent className="pt-8 pb-8 space-y-4">
-          <h2 className="text-xl font-bold">Something Went Wrong</h2>
+          <h2 className="text-xl font-bold">Something went sideways</h2>
           <p className="text-sm text-muted-foreground">
-            {message || 'Failed to load your dashboard. Please try again.'}
+            {message || 'The chain threw us a curveball. Try refreshing.'}
           </p>
           <Button onClick={() => window.location.reload()} variant="outline">
             Try Again

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -32,13 +32,16 @@ import { AboutSection } from '@/components/AboutSection';
 import { SocialIconsLarge } from '@/components/SocialIconsLarge';
 import { CompareButton } from '@/components/CompareButton';
 import { ProfileViewTracker } from '@/components/ProfileViewTracker';
+import { ProfileViewStats } from '@/components/ProfileViewStats';
 import { MilestoneBadges } from '@/components/MilestoneBadges';
 import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
 import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
-import { extractAlignments } from '@/lib/drepIdentity';
+import { extractAlignments, getIdentityColor, getDominantDimension } from '@/lib/drepIdentity';
 import { getDRepTraitTags } from '@/lib/alignment';
+import { generateDRepNarrative } from '@/lib/narratives';
+import { NarrativeSummary } from '@/components/NarrativeSummary';
 import {
   getDRepById,
   getVotesByDRepId,
@@ -286,6 +289,24 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <CompareButton currentDrepId={drep.drepId} currentDrepName={drepName} />
       </DRepProfileHero>
 
+      {/* Narrative summary */}
+      <NarrativeSummary
+        text={generateDRepNarrative({
+          name: drepName,
+          participationRate: drep.effectiveParticipation,
+          rationaleRate: drep.rationaleRate,
+          drepScore: drep.drepScore,
+          rank: null,
+          delegatorCount: drep.delegatorCount,
+          votingPower: drep.votingPower,
+          alignments,
+          isActive: drep.isActive,
+          totalVotes: drep.totalVotes,
+          sizeTier: drep.sizeTier,
+        })}
+        accentColor={getIdentityColor(getDominantDimension(alignments)).hex}
+      />
+
       {/* Identity metadata row */}
       <div className="flex items-center gap-3 flex-wrap text-sm text-muted-foreground">
         {drep.ticker && (
@@ -336,6 +357,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         )}
         <SocialIconsLarge metadata={drep.metadata} brokenLinks={brokenLinks} />
         <CopyableAddress address={drep.drepId} className="text-xs" />
+        <ProfileViewStats drepId={drep.drepId} />
       </div>
 
       {/* Tabbed content — 4 tabs replacing 8 stacked sections */}

--- a/app/proposals/page.tsx
+++ b/app/proposals/page.tsx
@@ -1,8 +1,10 @@
 import { getAllProposalsWithVoteSummary } from '@/lib/data';
 import { blockTimeToEpoch } from '@/lib/koios';
 import { ProposalsPageClient } from '@/components/ProposalsPageClient';
+import { ProposalsHero } from '@/components/ProposalsHero';
 import { GovernanceSubNav } from '@/components/GovernanceSubNav';
 import { PageViewTracker } from '@/components/PageViewTracker';
+import { generateProposalsNarrative } from '@/lib/narratives';
 
 export const revalidate = 900; // 15 min cache
 
@@ -10,15 +12,40 @@ export default async function ProposalsPage() {
   const proposals = await getAllProposalsWithVoteSummary();
   const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
 
+  const openProposals = proposals.filter(
+    p => !p.ratifiedEpoch && !p.enactedEpoch && !p.droppedEpoch && !p.expiredEpoch
+  );
+  const expiringProposals = openProposals.filter(
+    p => p.expirationEpoch != null && p.expirationEpoch <= currentEpoch + 2
+  );
+  const totalAdaAtStake = openProposals.reduce(
+    (sum, p) => sum + (p.withdrawalAmount ? p.withdrawalAmount / 1_000_000 : 0), 0
+  );
+  const totalVotesCast = openProposals.reduce((sum, p) => sum + p.totalVotes, 0);
+
+  const narrativeText = generateProposalsNarrative({
+    openCount: openProposals.length,
+    expiringCount: expiringProposals.length,
+    totalAdaAtStake,
+    totalVotesCast,
+    currentEpoch,
+  });
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="space-y-2 mb-6">
         <h1 className="text-3xl font-bold">Governance Proposals</h1>
         <p className="text-muted-foreground">
-          All Cardano governance proposals with DRep vote breakdowns. Click any proposal to see how DReps voted.
+          Track Cardano governance proposals, DRep votes, and treasury decisions in real time.
         </p>
       </div>
       <GovernanceSubNav />
+      <ProposalsHero
+        openCount={openProposals.length}
+        expiringCount={expiringProposals.length}
+        totalAdaAtStake={totalAdaAtStake}
+        narrativeText={narrativeText}
+      />
       <PageViewTracker event="proposals_page_viewed" />
       <ProposalsPageClient proposals={proposals} currentEpoch={currentEpoch} />
     </div>

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -7,7 +7,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ShareActions } from '@/components/ShareActions';
 import { TreasuryHealthWidget } from '@/components/TreasuryHealthWidget';
 import { GovernanceSubNav } from '@/components/GovernanceSubNav';
+import { GovernanceHealthIndex } from '@/components/GovernanceHealthIndex';
+import { NarrativeSummary } from '@/components/NarrativeSummary';
+import { ActivityFeed } from '@/components/ActivityFeed';
+import { CrossProposalInsights } from '@/components/CrossProposalInsights';
 import { PulseLeaderboardClient } from '@/components/PulseLeaderboardClient';
+import { generatePulseNarrative } from '@/lib/narratives';
 import {
   Landmark,
   ScrollText,
@@ -161,6 +166,14 @@ async function LeaderboardSection() {
 export default async function PulsePage() {
   const pulse = await fetchPulseData();
 
+  const pulseNarrative = pulse ? generatePulseNarrative({
+    votesThisWeek: pulse.votesThisWeek,
+    activeProposals: pulse.activeProposals,
+    activeDReps: pulse.activeDReps,
+    totalAdaGoverned: pulse.totalAdaGoverned,
+    avgParticipationRate: pulse.avgParticipationRate,
+  }) : null;
+
   return (
     <div className="container mx-auto px-4 py-8 space-y-10 max-w-6xl">
       <div className="text-center space-y-2">
@@ -171,6 +184,18 @@ export default async function PulsePage() {
       </div>
 
       <GovernanceSubNav />
+
+      {/* GHI Hero + Narrative */}
+      <div className="flex flex-col md:flex-row items-center gap-8 py-4">
+        <GovernanceHealthIndex size="hero" />
+        <div className="flex-1 space-y-3">
+          <h2 className="text-lg font-semibold">Governance Health Index</h2>
+          <NarrativeSummary text={pulseNarrative} />
+          <p className="text-xs text-muted-foreground">
+            A composite score measuring participation, rationale quality, delegation spread, and DRep diversity.
+          </p>
+        </div>
+      </div>
 
       <TreasuryHealthWidget />
 
@@ -209,6 +234,9 @@ export default async function PulsePage() {
           </Card>
         </div>
       )}
+
+      {/* Live Activity Feed */}
+      <ActivityFeed limit={10} />
 
       {/* Community Sentiment */}
       {pulse && pulse.communityGap.length > 0 && (
@@ -258,6 +286,9 @@ export default async function PulsePage() {
           </CardContent>
         </Card>
       )}
+
+      {/* Cross-Proposal Insights */}
+      <CrossProposalInsights />
 
       {/* Leaderboard + Movers + Hall of Fame (with Suspense) */}
       <Suspense fallback={<LeaderboardSkeleton />}>

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { spring } from '@/lib/animations';
+
+export default function Template({ children }: { children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={spring.smooth}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Vote, FileText, Users, ScrollText } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Activity } from 'lucide-react';
+
+interface ActivityEvent {
+  type: 'vote' | 'rationale' | 'proposal';
+  drepId: string;
+  drepName: string | null;
+  detail: string | null;
+  vote?: 'Yes' | 'No' | 'Abstain';
+  timestamp: number;
+}
+
+const EVENT_ICONS: Record<string, { icon: typeof Vote; color: string; bg: string }> = {
+  vote: { icon: Vote, color: 'text-green-400', bg: 'bg-green-500/10' },
+  rationale: { icon: ScrollText, color: 'text-blue-400', bg: 'bg-blue-500/10' },
+  proposal: { icon: FileText, color: 'text-amber-400', bg: 'bg-amber-500/10' },
+  delegation: { icon: Users, color: 'text-purple-400', bg: 'bg-purple-500/10' },
+};
+
+function formatRelativeTime(timestamp: number): string {
+  const seconds = Math.floor(Date.now() / 1000 - timestamp);
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+function formatEventText(event: ActivityEvent): string {
+  const name = event.drepName || (event.drepId ? `${event.drepId.slice(0, 8)}...` : '');
+
+  switch (event.type) {
+    case 'vote': {
+      const proposal = event.detail ? ` on ${event.detail}` : '';
+      return `${name} voted ${event.vote}${proposal}`;
+    }
+    case 'rationale':
+      return `${name} published rationale`;
+    case 'proposal':
+      return event.detail ? `New: ${event.detail}` : 'New proposal submitted';
+    default:
+      return '';
+  }
+}
+
+export function ActivityFeed({ limit = 10 }: { limit?: number }) {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/governance/activity?limit=${limit}`);
+      if (!res.ok) return;
+      const data: ActivityEvent[] = await res.json();
+      setEvents(data);
+    } catch {}
+  }, [limit]);
+
+  useEffect(() => {
+    fetchEvents();
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') fetchEvents();
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchEvents]);
+
+  if (events.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Activity className="h-4 w-4 text-primary" />
+          Live Governance Activity
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3" aria-label="Recent governance activity">
+          {events.map((event, i) => {
+            const config = EVENT_ICONS[event.type] || EVENT_ICONS.vote;
+            const Icon = config.icon;
+            return (
+              <li key={`${event.timestamp}-${i}`} className="flex items-start gap-3">
+                <div className={`flex items-center justify-center w-7 h-7 rounded-full ${config.bg} shrink-0 mt-0.5`}>
+                  <Icon className={`h-3.5 w-3.5 ${config.color}`} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm leading-snug">{formatEventText(event)}</p>
+                  <span className="text-xs text-muted-foreground">{formatRelativeTime(event.timestamp)}</span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/CardanoGovernanceExplainer.tsx
+++ b/components/CardanoGovernanceExplainer.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { spring, fadeInUp, staggerContainer } from '@/lib/animations';
+import { Button } from '@/components/ui/button';
+import { ArrowRight, Users, ScrollText, Landmark } from 'lucide-react';
+
+interface ExplainerProps {
+  activeDReps?: number;
+  activeProposals?: number;
+  totalAdaGoverned?: string;
+}
+
+export function CardanoGovernanceExplainer({
+  activeDReps,
+  activeProposals,
+  totalAdaGoverned,
+}: ExplainerProps) {
+  return (
+    <section className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-slate-900 to-blue-950/50 border border-white/5">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-blue-500/5 via-transparent to-transparent" />
+
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, margin: '-50px' }}
+        className="relative px-6 py-10 md:px-12 md:py-14 max-w-4xl mx-auto"
+      >
+        <motion.h2
+          variants={fadeInUp}
+          className="text-2xl md:text-3xl font-bold text-white mb-4"
+        >
+          What is Cardano Governance?
+        </motion.h2>
+
+        <motion.p variants={fadeInUp} className="text-base text-white/70 leading-relaxed mb-6 max-w-2xl">
+          Cardano is the only major blockchain where every token holder has a direct voice in
+          treasury decisions worth billions. Through CIP-1694, ADA holders delegate their voting
+          power to <strong className="text-white/90">DReps</strong> (Delegated Representatives) — a
+          liquid democracy model where you can change your representative at any time.
+        </motion.p>
+
+        <motion.p variants={fadeInUp} className="text-sm text-white/50 leading-relaxed mb-8 max-w-2xl">
+          Unlike Ethereum&apos;s multisig-heavy governance or Polkadot&apos;s council system,
+          Cardano&apos;s model is fully on-chain, permissionless, and transparent. Every vote,
+          every rationale, every delegation is recorded on the blockchain.
+        </motion.p>
+
+        {/* Live stats */}
+        {(activeDReps || activeProposals || totalAdaGoverned) && (
+          <motion.div
+            variants={fadeInUp}
+            className="grid grid-cols-3 gap-4 mb-8 max-w-lg"
+          >
+            {totalAdaGoverned && (
+              <div className="text-center">
+                <Landmark className="h-5 w-5 text-emerald-400 mx-auto mb-1" />
+                <p className="text-xl font-bold text-white tabular-nums">{totalAdaGoverned}</p>
+                <p className="text-[10px] text-white/40 uppercase tracking-wider">ADA Governed</p>
+              </div>
+            )}
+            {activeDReps != null && (
+              <div className="text-center">
+                <Users className="h-5 w-5 text-purple-400 mx-auto mb-1" />
+                <p className="text-xl font-bold text-white tabular-nums">{activeDReps}</p>
+                <p className="text-[10px] text-white/40 uppercase tracking-wider">Active DReps</p>
+              </div>
+            )}
+            {activeProposals != null && (
+              <div className="text-center">
+                <ScrollText className="h-5 w-5 text-amber-400 mx-auto mb-1" />
+                <p className="text-xl font-bold text-white tabular-nums">{activeProposals}</p>
+                <p className="text-[10px] text-white/40 uppercase tracking-wider">Open Proposals</p>
+              </div>
+            )}
+          </motion.div>
+        )}
+
+        <motion.div variants={fadeInUp} className="flex flex-wrap gap-3">
+          <Link href="/discover">
+            <Button size="lg" className="gap-2">
+              Explore DReps <ArrowRight className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/proposals">
+            <Button variant="outline" size="lg" className="gap-2 border-white/10 text-white hover:bg-white/5">
+              See Live Proposals
+            </Button>
+          </Link>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+}

--- a/components/CrossProposalInsights.tsx
+++ b/components/CrossProposalInsights.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ShareActions } from '@/components/ShareActions';
+import { spring, fadeInUp, staggerContainer } from '@/lib/animations';
+import { Lightbulb, Vote, Landmark, Users } from 'lucide-react';
+import type { GovernanceInsight } from '@/lib/proposalInsights';
+
+const CATEGORY_ICONS: Record<string, typeof Vote> = {
+  voting: Vote,
+  treasury: Landmark,
+  behavior: Users,
+};
+
+export function CrossProposalInsights() {
+  const [insights, setInsights] = useState<GovernanceInsight[]>([]);
+
+  useEffect(() => {
+    fetch('/api/governance/insights')
+      .then(r => r.ok ? r.json() : [])
+      .then(setInsights)
+      .catch(() => {});
+  }, []);
+
+  if (insights.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Lightbulb className="h-5 w-5 text-amber-500" />
+          Governance Insights
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">
+          Patterns emerging from how DReps vote, reason, and govern.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+          className="grid grid-cols-1 md:grid-cols-3 gap-4"
+        >
+          {insights.map(insight => {
+            const Icon = CATEGORY_ICONS[insight.category] || Lightbulb;
+            return (
+              <motion.div
+                key={insight.id}
+                variants={fadeInUp}
+                className="rounded-lg border bg-card/50 p-4 space-y-2"
+              >
+                <div className="flex items-center gap-2">
+                  <Icon className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    {insight.category}
+                  </span>
+                </div>
+                <p className="text-3xl font-bold tabular-nums">{insight.stat}</p>
+                <p className="text-sm font-semibold">{insight.headline}</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">{insight.description}</p>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/DRepTableClient.tsx
+++ b/components/DRepTableClient.tsx
@@ -396,7 +396,7 @@ export function DRepTableClient({
           message={
             searchQuery
               ? `No results matching "${searchQuery}"`
-              : "Try adjusting your filters."
+              : "No DReps match. Try adjusting your filters — there are hundreds of active representatives to explore."
           }
           icon="search"
           action={

--- a/components/DRepTreasuryStance.tsx
+++ b/components/DRepTreasuryStance.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
+import { StanceSkeleton } from '@/components/ui/content-skeletons';
 import { Landmark, ThumbsUp, ThumbsDown, Scale, Award } from 'lucide-react';
 import { formatAda, type DRepTreasuryRecord } from '@/lib/treasury';
 import { posthog } from '@/lib/posthog';
@@ -35,7 +35,7 @@ export function DRepTreasuryStance({ drepId, compact = false }: Props) {
     });
   }, [drepId]);
 
-  if (loading) return compact ? null : <Skeleton className="h-24 w-full" />;
+  if (loading) return compact ? null : <StanceSkeleton />;
   if (!record || record.totalProposals === 0) return null;
 
   const stance = record.approvedAda > record.opposedAda * 2 ? 'Growth'

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -16,6 +16,8 @@ interface EmptyStateProps {
   icon?: LucideIcon | 'search' | 'database';
   compact?: boolean;
   component?: string;
+  /** Optional accent color for a subtle gradient background */
+  accentColor?: string;
 }
 
 export function EmptyState({
@@ -25,6 +27,7 @@ export function EmptyState({
   icon = Search,
   compact = false,
   component,
+  accentColor,
 }: EmptyStateProps) {
   const Icon = icon === 'search' ? Search : icon === 'database' ? Database : icon;
 
@@ -52,9 +55,16 @@ export function EmptyState({
     )
   ) : null;
 
+  const gradientStyle = accentColor
+    ? { background: `radial-gradient(ellipse at center, ${accentColor}08 0%, transparent 70%)` }
+    : undefined;
+
   if (compact) {
     return (
-      <div className="flex flex-col items-center justify-center py-6 px-4 text-center">
+      <div
+        className="flex flex-col items-center justify-center py-6 px-4 text-center rounded-lg"
+        style={gradientStyle}
+      >
         <Icon className="h-8 w-8 text-muted-foreground mb-2" />
         <p className="text-sm font-medium mb-1">{title}</p>
         <p className="text-xs text-muted-foreground max-w-sm mb-3">{message}</p>
@@ -64,9 +74,17 @@ export function EmptyState({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-      <div className="rounded-full bg-muted p-6 mb-4">
-        <Icon className="h-12 w-12 text-muted-foreground" />
+    <div
+      className="flex flex-col items-center justify-center py-16 px-4 text-center rounded-xl"
+      style={gradientStyle}
+    >
+      <div
+        className="rounded-full p-6 mb-4"
+        style={accentColor
+          ? { background: `${accentColor}10` }
+          : undefined}
+      >
+        <Icon className="h-12 w-12 text-muted-foreground" style={accentColor ? { color: `${accentColor}80` } : undefined} />
       </div>
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <p className="text-muted-foreground max-w-md mb-6">{message}</p>

--- a/components/GovernanceHealthIndex.tsx
+++ b/components/GovernanceHealthIndex.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion, useSpring, useTransform } from 'framer-motion';
+import { GHI_BAND_COLORS, GHI_BAND_LABELS, type GHIBand, type GHIComponent } from '@/lib/ghi';
+import { spring } from '@/lib/animations';
+
+interface GHIData {
+  score: number;
+  band: GHIBand;
+  components: GHIComponent[];
+}
+
+interface GovernanceHealthIndexProps {
+  size?: 'hero' | 'compact';
+  className?: string;
+}
+
+export function GovernanceHealthIndex({ size = 'hero', className = '' }: GovernanceHealthIndexProps) {
+  const [data, setData] = useState<GHIData | null>(null);
+
+  useEffect(() => {
+    fetch('/api/governance/health-index')
+      .then(r => r.ok ? r.json() : null)
+      .then(setData)
+      .catch(() => {});
+  }, []);
+
+  if (!data) return <GHISkeleton size={size} />;
+
+  return size === 'hero'
+    ? <GHIHero data={data} className={className} />
+    : <GHICompact data={data} className={className} />;
+}
+
+function GHISkeleton({ size }: { size: 'hero' | 'compact' }) {
+  const dim = size === 'hero' ? 'h-48 w-48' : 'h-20 w-20';
+  return (
+    <div className={`${dim} rounded-full bg-muted/30 animate-pulse`} />
+  );
+}
+
+function GHIHero({ data, className }: { data: GHIData; className: string }) {
+  const color = GHI_BAND_COLORS[data.band];
+  const label = GHI_BAND_LABELS[data.band];
+
+  const svgSize = 192;
+  const strokeWidth = 8;
+  const radius = (svgSize - strokeWidth) / 2 - 4;
+  const circumference = Math.PI * radius; // half-circle arc
+  const arcStart = Math.PI;
+  const scoreRatio = data.score / 100;
+
+  const springVal = useSpring(0, { stiffness: 80, damping: 20 });
+  const displayScore = useTransform(springVal, v => Math.round(v));
+  const dashOffset = useTransform(springVal, v => circumference * (1 - v / 100));
+
+  useEffect(() => {
+    springVal.set(data.score);
+  }, [data.score, springVal]);
+
+  const cx = svgSize / 2;
+  const cy = svgSize / 2 + 16;
+
+  const arcPath = describeArc(cx, cy, radius, 180, 360);
+  const trackPath = arcPath;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={spring.smooth}
+      className={`flex flex-col items-center gap-3 ${className}`}
+    >
+      <div className="relative" style={{ width: svgSize, height: svgSize / 2 + 40 }}>
+        <svg
+          width={svgSize}
+          height={svgSize / 2 + 40}
+          viewBox={`0 0 ${svgSize} ${svgSize / 2 + 40}`}
+          className="overflow-visible"
+        >
+          <defs>
+            <filter id="ghi-glow">
+              <feGaussianBlur stdDeviation="6" result="blur" />
+              <feComposite in="SourceGraphic" in2="blur" operator="over" />
+            </filter>
+          </defs>
+
+          {/* Track */}
+          <path
+            d={trackPath}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            className="text-muted/20"
+          />
+
+          {/* Active arc */}
+          <motion.path
+            d={trackPath}
+            fill="none"
+            stroke={color}
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            style={{ strokeDashoffset: dashOffset }}
+            filter="url(#ghi-glow)"
+          />
+
+          {/* Component segment markers */}
+          {data.components.map((comp, i) => {
+            const angle = 180 + (comp.contribution / data.score) * 180 * (i / data.components.length);
+            return null; // segment markers intentionally omitted for cleanliness
+          })}
+        </svg>
+
+        {/* Score number */}
+        <div className="absolute inset-0 flex flex-col items-center justify-end pb-3">
+          <motion.span
+            className="text-5xl font-bold tabular-nums"
+            style={{ color }}
+          >
+            {displayScore}
+          </motion.span>
+          <span className="text-xs font-medium uppercase tracking-wider mt-0.5" style={{ color }}>
+            {label}
+          </span>
+        </div>
+      </div>
+
+      {/* Component breakdown */}
+      <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-center">
+        {data.components.map(comp => (
+          <div key={comp.name} className="flex flex-col items-center">
+            <span className="text-xs text-muted-foreground">{comp.name}</span>
+            <span className="text-sm font-semibold tabular-nums">{comp.value}</span>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+
+function GHICompact({ data, className }: { data: GHIData; className: string }) {
+  const color = GHI_BAND_COLORS[data.band];
+  const label = GHI_BAND_LABELS[data.band];
+
+  const springVal = useSpring(0, { stiffness: 80, damping: 20 });
+  const displayScore = useTransform(springVal, v => Math.round(v));
+
+  useEffect(() => {
+    springVal.set(data.score);
+  }, [data.score, springVal]);
+
+  const svgSize = 64;
+  const strokeWidth = 4;
+  const radius = (svgSize - strokeWidth) / 2 - 2;
+  const circumference = Math.PI * radius;
+  const cx = svgSize / 2;
+  const cy = svgSize / 2 + 8;
+  const trackPath = describeArc(cx, cy, radius, 180, 360);
+  const dashOffset = useTransform(springVal, v => circumference * (1 - v / 100));
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className={`flex items-center gap-2 ${className}`}
+    >
+      <div className="relative" style={{ width: svgSize, height: svgSize / 2 + 12 }}>
+        <svg
+          width={svgSize}
+          height={svgSize / 2 + 12}
+          viewBox={`0 0 ${svgSize} ${svgSize / 2 + 12}`}
+          className="overflow-visible"
+        >
+          <path d={trackPath} fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" className="text-muted/20" />
+          <motion.path d={trackPath} fill="none" stroke={color} strokeWidth={strokeWidth} strokeLinecap="round" strokeDasharray={circumference} style={{ strokeDashoffset: dashOffset }} />
+        </svg>
+        <div className="absolute inset-0 flex items-end justify-center pb-0.5">
+          <motion.span className="text-lg font-bold tabular-nums" style={{ color }}>{displayScore}</motion.span>
+        </div>
+      </div>
+      <div className="flex flex-col">
+        <span className="text-xs font-medium" style={{ color }}>{label}</span>
+        <span className="text-[10px] text-muted-foreground">Health Index</span>
+      </div>
+    </motion.div>
+  );
+}
+
+function describeArc(cx: number, cy: number, r: number, startAngle: number, endAngle: number): string {
+  const startRad = (startAngle * Math.PI) / 180;
+  const endRad = (endAngle * Math.PI) / 180;
+  const x1 = cx + r * Math.cos(startRad);
+  const y1 = cy + r * Math.sin(startRad);
+  const x2 = cx + r * Math.cos(endRad);
+  const y2 = cy + r * Math.sin(endRad);
+  const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+  return `M ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2}`;
+}

--- a/components/GovernanceHeartbeat.tsx
+++ b/components/GovernanceHeartbeat.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type ActivityLevel = 'quiet' | 'active' | 'busy';
+
+export function GovernanceHeartbeat() {
+  const [level, setLevel] = useState<ActivityLevel>('quiet');
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const res = await fetch('/api/governance/activity?limit=5');
+        if (!res.ok) return;
+        const events = await res.json();
+        const recentCount = Array.isArray(events) ? events.length : 0;
+        setCount(recentCount);
+
+        if (recentCount >= 10) setLevel('busy');
+        else if (recentCount >= 3) setLevel('active');
+        else setLevel('quiet');
+      } catch {}
+    }
+
+    check();
+    const interval = setInterval(check, 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const colors: Record<ActivityLevel, string> = {
+    quiet: 'bg-muted-foreground/30',
+    active: 'bg-cyan-400',
+    busy: 'bg-emerald-400',
+  };
+
+  const labels: Record<ActivityLevel, string> = {
+    quiet: 'Governance is quiet right now',
+    active: `${count} recent governance actions`,
+    busy: `${count} governance actions — governance is active!`,
+  };
+
+  const animationClass = level === 'quiet' ? '' : 'animate-pulse';
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href="/pulse"
+            className="relative flex items-center justify-center w-5 h-5"
+            aria-label={labels[level]}
+          >
+            <span className={`absolute inline-flex h-2.5 w-2.5 rounded-full ${colors[level]} ${animationClass}`} />
+            {level !== 'quiet' && (
+              <span className={`absolute inline-flex h-2.5 w-2.5 rounded-full ${colors[level]} opacity-30 animate-ping`} />
+            )}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">{labels[level]}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,6 +44,7 @@ import {
   Inbox,
 } from 'lucide-react';
 import { MobileNav } from './MobileNav';
+import { GovernanceHeartbeat } from './GovernanceHeartbeat';
 
 const ALERT_ICONS: Record<AlertType, typeof TrendingDown> = {
   'representation-shift': TrendingDown,
@@ -139,9 +140,12 @@ export function Header() {
   return (
     <header className="sticky top-0 z-50 w-full bg-background/80 backdrop-blur-xl supports-[backdrop-filter]:bg-background/50 dark:border-b-0 dark:shadow-[inset_0_-1px_0_0_rgba(255,255,255,0.06)] border-b">
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
-        <Link href="/" className="flex items-center space-x-2">
-          <span className="text-2xl font-bold text-primary dark:drop-shadow-[0_0_12px_rgba(var(--primary-rgb),0.3)]">$drepscore</span>
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link href="/" className="flex items-center space-x-2">
+            <span className="text-2xl font-bold text-primary dark:drop-shadow-[0_0_12px_rgba(var(--primary-rgb),0.3)]">$drepscore</span>
+          </Link>
+          <GovernanceHeartbeat />
+        </div>
 
         <nav className="flex items-center space-x-2 sm:space-x-4">
           <Link href="/discover" className={navLinkClass('/discover')}>

--- a/components/HomepageDualMode.tsx
+++ b/components/HomepageDualMode.tsx
@@ -5,6 +5,7 @@ import { ConstellationHero } from '@/components/ConstellationHero';
 import { PersonalGovernanceCard } from '@/components/PersonalGovernanceCard';
 import { HowItWorksV2 } from '@/components/HowItWorksV2';
 import { DRepDiscoveryPreview } from '@/components/DRepDiscoveryPreview';
+import { CardanoGovernanceExplainer } from '@/components/CardanoGovernanceExplainer';
 
 interface PreviewDRep {
   drepId: string;
@@ -66,11 +67,20 @@ export function HomepageDualMode({ pulseData, topDReps, ssrHolderData, ssrWallet
 
       <div className="container mx-auto px-4 space-y-12 py-8">
         <HowItWorksV2 />
+
+        {!personalCard && (
+          <CardanoGovernanceExplainer
+            activeDReps={pulseData.activeDReps}
+            activeProposals={pulseData.activeProposals}
+            totalAdaGoverned={pulseData.totalAdaGoverned}
+          />
+        )}
+
         <DRepDiscoveryPreview dreps={topDReps} />
 
         <footer className="text-center py-8 space-y-2">
           <p className="text-sm font-medium text-muted-foreground">
-            Governance intelligence for Cardano.
+            Governance intelligence for Cardano
           </p>
           <a
             href="https://www.cardano.org/governance/"
@@ -78,7 +88,7 @@ export function HomepageDualMode({ pulseData, topDReps, ssrHolderData, ssrWallet
             rel="noopener noreferrer"
             className="text-xs text-muted-foreground/60 hover:text-primary transition-colors"
           >
-            New to Cardano?
+            New to Cardano governance?
           </a>
         </footer>
       </div>

--- a/components/NarrativeSummary.tsx
+++ b/components/NarrativeSummary.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { spring } from '@/lib/animations';
+
+interface NarrativeSummaryProps {
+  text: string | null;
+  accentColor?: string;
+  className?: string;
+}
+
+export function NarrativeSummary({ text, accentColor, className = '' }: NarrativeSummaryProps) {
+  if (!text) return null;
+
+  return (
+    <motion.p
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={spring.smooth}
+      className={`text-sm text-muted-foreground leading-relaxed ${className}`}
+      style={accentColor ? {
+        borderLeft: `2px solid ${accentColor}`,
+        paddingLeft: '0.75rem',
+      } : undefined}
+    >
+      {text}
+    </motion.p>
+  );
+}

--- a/components/ProposalDrawer.tsx
+++ b/components/ProposalDrawer.tsx
@@ -102,9 +102,19 @@ export function ProposalDrawer({ open, onOpenChange, proposal, drepId }: Proposa
               {TYPE_LABELS[proposal.proposalType] || proposal.proposalType}
             </Badge>
             {proposal.epochsRemaining != null && (
-              <Badge variant="outline" className="text-[10px] gap-1">
+              <Badge
+                variant="outline"
+                className={`text-[10px] gap-1 ${
+                  proposal.epochsRemaining <= 2
+                    ? 'border-red-500/50 text-red-600 dark:text-red-400 bg-red-500/5 animate-pulse'
+                    : ''
+                }`}
+              >
                 <Clock className="h-2.5 w-2.5" />
-                {proposal.epochsRemaining} epoch{proposal.epochsRemaining !== 1 ? 's' : ''} left
+                {proposal.epochsRemaining <= 2
+                  ? `Voting closes in ~${proposal.epochsRemaining * 5} days`
+                  : `${proposal.epochsRemaining} epoch${proposal.epochsRemaining !== 1 ? 's' : ''} left`
+                }
               </Badge>
             )}
           </div>

--- a/components/ProposalVotersClient.tsx
+++ b/components/ProposalVotersClient.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { CopyableAddress } from '@/components/CopyableAddress';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
 
 interface ProposalVotersClientProps {
   votes: ProposalVoteDetail[];
@@ -142,6 +143,19 @@ export function ProposalVotersClient({
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1 min-w-0 space-y-1">
                     <div className="flex items-center gap-2 flex-wrap">
+                      {v.alignments && (
+                        <GovernanceRadar
+                          alignments={{
+                            treasuryConservative: v.alignments.treasuryConservative,
+                            treasuryGrowth: v.alignments.treasuryGrowth,
+                            decentralization: v.alignments.decentralization,
+                            security: v.alignments.security,
+                            innovation: v.alignments.innovation,
+                            transparency: v.alignments.transparency,
+                          }}
+                          size="mini"
+                        />
+                      )}
                       <Badge
                         variant={v.vote === 'Yes' ? 'default' : v.vote === 'No' ? 'destructive' : 'secondary'}
                         className="shrink-0"
@@ -238,8 +252,8 @@ export function ProposalVotersClient({
         {filtered.length === 0 && (
           <EmptyState
             icon="search"
-            title="No Votes Match"
-            message="No votes match the current filter. Try selecting a different vote type."
+            title="No votes here yet"
+            message="No votes match the current filter. Try selecting a different vote type to see how DReps weighed in."
             action={filter !== 'all' ? { label: 'Show All Votes', onClick: () => setFilter('all') } : undefined}
             compact
             component="ProposalVotersClient"

--- a/components/ProposalsHero.tsx
+++ b/components/ProposalsHero.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { motion, useSpring, useTransform } from 'framer-motion';
+import { useEffect } from 'react';
+import { spring } from '@/lib/animations';
+import { NarrativeSummary } from './NarrativeSummary';
+import { AlertTriangle, Clock, Landmark } from 'lucide-react';
+
+interface ProposalsHeroProps {
+  openCount: number;
+  expiringCount: number;
+  totalAdaAtStake: number;
+  narrativeText: string | null;
+}
+
+function AnimatedCounter({ value, className }: { value: number; className?: string }) {
+  const springVal = useSpring(0, { stiffness: 100, damping: 20 });
+  const display = useTransform(springVal, v => Math.round(v));
+
+  useEffect(() => {
+    springVal.set(value);
+  }, [value, springVal]);
+
+  return <motion.span className={className}>{display}</motion.span>;
+}
+
+export function ProposalsHero({ openCount, expiringCount, totalAdaAtStake, narrativeText }: ProposalsHeroProps) {
+  const hasUrgent = expiringCount > 0;
+  const adaFormatted = totalAdaAtStake >= 1_000_000
+    ? `${(totalAdaAtStake / 1_000_000).toFixed(1)}M`
+    : totalAdaAtStake >= 1_000
+      ? `${(totalAdaAtStake / 1_000).toFixed(0)}K`
+      : totalAdaAtStake.toLocaleString();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={spring.smooth}
+      className={`rounded-lg border p-5 mb-6 ${
+        hasUrgent
+          ? 'border-amber-500/30 bg-gradient-to-r from-amber-500/5 to-transparent'
+          : 'border-border bg-card/50'
+      }`}
+    >
+      <div className="flex flex-wrap items-center gap-6 mb-3">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center justify-center w-8 h-8 rounded-full bg-primary/10">
+            <Landmark className="h-4 w-4 text-primary" />
+          </div>
+          <div>
+            <AnimatedCounter value={openCount} className="text-2xl font-bold tabular-nums" />
+            <p className="text-xs text-muted-foreground">Open</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className={`flex items-center justify-center w-8 h-8 rounded-full ${
+            hasUrgent ? 'bg-amber-500/10' : 'bg-muted/50'
+          }`}>
+            <Clock className={`h-4 w-4 ${hasUrgent ? 'text-amber-500' : 'text-muted-foreground'}`} />
+          </div>
+          <div>
+            <AnimatedCounter
+              value={expiringCount}
+              className={`text-2xl font-bold tabular-nums ${hasUrgent ? 'text-amber-500' : ''}`}
+            />
+            <p className="text-xs text-muted-foreground">Expiring Soon</p>
+          </div>
+        </div>
+
+        {totalAdaAtStake > 0 && (
+          <div className="flex items-center gap-2">
+            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-500/10">
+              <Landmark className="h-4 w-4 text-emerald-500" />
+            </div>
+            <div>
+              <span className="text-2xl font-bold tabular-nums">{adaFormatted}</span>
+              <p className="text-xs text-muted-foreground">ADA at Stake</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <NarrativeSummary text={narrativeText} />
+    </motion.div>
+  );
+}

--- a/components/ProposalsListClient.tsx
+++ b/components/ProposalsListClient.tsx
@@ -325,7 +325,7 @@ export function ProposalsListClient({ proposals, watchlist = [], currentEpoch }:
               key={voteKey}
               href={`/proposals/${p.txHash}/${p.proposalIndex}`}
             >
-              <Card className={`hover:bg-muted/30 transition-colors cursor-pointer group mb-3 border-l-4 ${isUrgent ? 'border-l-red-500 bg-red-500/5' : (config?.borderColor || 'border-l-primary')}`}>
+              <Card className={`hover:bg-muted/30 transition-colors cursor-pointer group mb-3 border-l-4 ${isUrgent ? 'border-l-red-500 bg-gradient-to-r from-red-500/5 to-transparent ring-1 ring-red-500/20' : (config?.borderColor || 'border-l-primary')}`}>
                 <CardContent className="p-4">
                   <div className="flex items-start gap-3">
                     {TypeIcon && (
@@ -343,8 +343,8 @@ export function ProposalsListClient({ proposals, watchlist = [], currentEpoch }:
                           expiredEpoch={p.expiredEpoch}
                         />
                         {isUrgent && (
-                          <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-4">
-                            Urgent
+                          <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-4 animate-pulse">
+                            {epochsLeft <= 1 ? 'Expiring This Epoch' : 'Expiring Soon'}
                           </Badge>
                         )}
                         <PriorityBadge proposalType={p.proposalType} />
@@ -401,11 +401,11 @@ export function ProposalsListClient({ proposals, watchlist = [], currentEpoch }:
       {filtered.length === 0 && (
         <EmptyState
           icon="search"
-          title="No Proposals Match"
-          message="No proposals match your filters. Try broadening your search or view all proposals."
+          title="The pipeline is quiet"
+          message="No proposals match your filters. The governance pipeline has quiet moments — try broadening your search or check back soon."
           action={{ label: 'Clear Filters', onClick: () => { setTypeFilter('all'); setSearchQuery(''); } }}
           compact
-          component="ProposalsListClient"
+          component="proposals_list"
         />
       )}
     </div>

--- a/components/SentimentPoll.tsx
+++ b/components/SentimentPoll.tsx
@@ -182,6 +182,11 @@ export function SentimentPoll({ txHash, proposalIndex, isOpen }: SentimentPollPr
       </CardHeader>
 
       <CardContent className="space-y-4">
+        {community.total > 0 && (
+          <p className="text-sm font-semibold text-foreground">
+            {community.total} {community.total === 1 ? 'person has' : 'people have'} shared their opinion
+          </p>
+        )}
         {revealed && hasVoted ? (
           <ResultsView
             community={community}
@@ -190,13 +195,9 @@ export function SentimentPoll({ txHash, proposalIndex, isOpen }: SentimentPollPr
             onChangeVote={() => setChangingVote(true)}
           />
         ) : (
-          <div className="text-sm text-muted-foreground">
-            {community.total > 0 ? (
-              <p>{community.total} holder{community.total !== 1 ? 's have' : ' has'} weighed in</p>
-            ) : (
-              <p>Be the first to share your opinion</p>
-            )}
-          </div>
+          community.total === 0 && (
+            <p className="text-sm text-muted-foreground">Be the first to share your opinion</p>
+          )
         )}
 
         {showButtons && connected && (

--- a/components/TreasuryAccountabilitySection.tsx
+++ b/components/TreasuryAccountabilitySection.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
+import { PollSkeleton } from '@/components/ui/content-skeletons';
 import { CheckCircle2, AlertCircle, Clock, XCircle, Scale, TrendingUp } from 'lucide-react';
 import { formatAda } from '@/lib/treasury';
 import { posthog } from '@/lib/posthog';
@@ -88,7 +88,7 @@ export function TreasuryAccountabilitySection() {
       }));
   }, [data]);
 
-  if (loading) return <Skeleton className="h-64 w-full" />;
+  if (loading) return <PollSkeleton />;
 
   if (!data || data.totalEnacted === 0) {
     return (

--- a/components/TreasuryCharts.tsx
+++ b/components/TreasuryCharts.tsx
@@ -5,7 +5,7 @@ import { scaleLinear } from 'd3-scale';
 import { area as d3area, line as d3line, curveMonotoneX } from 'd3-shape';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
+import { ChartSkeleton } from '@/components/ui/content-skeletons';
 import { TrendingUp, BarChart3 } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
 import { useChartDimensions } from '@/lib/charts/useChartDimensions';
@@ -206,7 +206,7 @@ export function TreasuryCharts() {
       .catch(() => setLoading(false));
   }, [range]);
 
-  if (loading) return <Skeleton className="h-80 w-full" />;
+  if (loading) return <ChartSkeleton height="h-80" />;
   if (!data || !data.snapshots.length) return null;
 
   return (

--- a/components/TreasuryHistoryTimeline.tsx
+++ b/components/TreasuryHistoryTimeline.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
+import { TimelineSkeleton } from '@/components/ui/content-skeletons';
 import { History, ArrowDown, CheckCircle2 } from 'lucide-react';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase';
@@ -41,7 +41,7 @@ export function TreasuryHistoryTimeline() {
       });
   }, []);
 
-  if (loading) return <Skeleton className="h-48 w-full" />;
+  if (loading) return <TimelineSkeleton count={4} />;
   if (!proposals.length) {
     return (
       <Card>

--- a/components/TreasuryPendingProposals.tsx
+++ b/components/TreasuryPendingProposals.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
+import { CardListSkeleton } from '@/components/ui/content-skeletons';
 import { Scale, ExternalLink, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { formatAda } from '@/lib/treasury';
@@ -52,7 +52,7 @@ export function TreasuryPendingProposals({ treasuryBalanceAda, runwayMonths }: P
       .catch(() => setLoading(false));
   }, []);
 
-  if (loading) return <Skeleton className="h-48 w-full" />;
+  if (loading) return <CardListSkeleton count={3} />;
   if (!data || !data.proposals.length) {
     return (
       <Card>

--- a/components/VotingHistoryChart.tsx
+++ b/components/VotingHistoryChart.tsx
@@ -561,8 +561,8 @@ export function VotingHistoryChart({ votes, userPrefs = [] }: VotingHistoryChart
           {filteredVotes.length === 0 && (
             <EmptyState
               icon="search"
-              title="No Votes Found"
-              message="No votes in this time period. Adjust the filter to see more history."
+              title="No votes in this period"
+              message="This DRep may be new or taking a break from governance. Adjust the time filter to see more history."
               compact
               component="VotingHistoryChart"
             />

--- a/components/ui/content-skeletons.tsx
+++ b/components/ui/content-skeletons.tsx
@@ -1,0 +1,121 @@
+import { Skeleton } from './skeleton';
+
+export function ChartSkeleton({ height = 'h-64' }: { height?: string }) {
+  return (
+    <div className={`${height} w-full rounded-lg border bg-card/50 p-4 space-y-3`}>
+      {/* Y-axis labels */}
+      <div className="flex gap-4 h-full">
+        <div className="flex flex-col justify-between py-2 w-8">
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-6" />
+        </div>
+        {/* Chart area */}
+        <div className="flex-1 relative">
+          <div className="absolute inset-0 flex flex-col justify-between">
+            <Skeleton className="h-px w-full opacity-30" />
+            <Skeleton className="h-px w-full opacity-30" />
+            <Skeleton className="h-px w-full opacity-30" />
+            <Skeleton className="h-px w-full opacity-30" />
+          </div>
+          <svg className="w-full h-full opacity-10" viewBox="0 0 100 50" preserveAspectRatio="none">
+            <path d="M0 40 Q25 10 50 30 T100 20" fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground" />
+          </svg>
+        </div>
+      </div>
+      {/* X-axis labels */}
+      <div className="flex justify-between pl-12">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-3 w-12" />
+      </div>
+    </div>
+  );
+}
+
+export function CardListSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="rounded-lg border bg-card/50 p-4 flex items-center gap-4">
+          <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function StatPodSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className={`grid grid-cols-2 md:grid-cols-${count} gap-4`}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="rounded-lg border bg-card/50 p-4 flex flex-col items-center gap-2">
+          <Skeleton className="h-5 w-5 rounded-full" />
+          <Skeleton className="h-6 w-16" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TimelineSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="space-y-4 pl-4 border-l-2 border-muted">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 relative">
+          <Skeleton className="h-3 w-3 rounded-full absolute -left-[23px] top-1" />
+          <div className="space-y-1.5 flex-1">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PollSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card/50 p-5 space-y-4">
+      <Skeleton className="h-5 w-48" />
+      <Skeleton className="h-3 w-64" />
+      <div className="space-y-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="flex items-center gap-3">
+            <Skeleton className="h-10 w-10 rounded-lg" />
+            <div className="flex-1">
+              <Skeleton className="h-3 w-full rounded-full" />
+            </div>
+            <Skeleton className="h-4 w-8" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function StanceSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card/50 p-5 space-y-4">
+      <Skeleton className="h-5 w-40" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="rounded-lg border bg-card/30 p-4 space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-3/4" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/strategy/product-wow-plan-v2.md
+++ b/docs/strategy/product-wow-plan-v2.md
@@ -451,9 +451,14 @@ DRepScore has all the data to generate insights nobody else in crypto can create
 - No cross-chain data exists currently (Koios is Cardano-only)
 - v1 API route `/api/v1/governance/health` returns aggregate stats already
 
+**8. GHI historical trend + epoch-over-epoch comparison.** Not just "the number" but "the number over time." A sparkline showing GHI across epochs makes it a trackable metric that people check back on. Store epoch-level GHI snapshots in a new `ghi_snapshots` table.
+
+**9. AI-narrated DRep profiles.** Upgrade from the template-based narrative system (built in Session 15) to AI-generated richer, more nuanced DRep summaries. Cached, not real-time — regenerate weekly per DRep. Uses the template narrative as a fallback when AI cache is stale.
+
 ### Success Criteria
 
 - GHI gets shared on X/Twitter as "the number" for Cardano governance health
+- GHI trend sparkline becomes the most-checked element on Pulse page
 - "State of Governance" report becomes the most-linked DRepScore URL within 2 months
 - Cross-proposal insights generate social media discussion
 - At least one media outlet or researcher cites DRepScore data within 3 months
@@ -486,7 +491,9 @@ DRepScore is a read-only analytical tool where all communication is one-directio
 
 **5. Developer experience for v1 API.** New `/developers` page: interactive API explorer, code examples (JS, Python, cURL), embed widget generator, use cases. API keys for Pro tier (manual approval initially). Rate limits: 100/min public, 1000/min Pro. Every Cardano dApp that integrates becomes a distribution channel.
 
-**6. Governance achievement NFTs (stretch goal).** Milestone badges as on-chain CIP-25 NFTs: mint when DRep achieves a milestone, NFT image features the milestone badge with governance identity radar. Builds minting transaction via MeshSDK. Only build if Sessions 12-16 ship cleanly.
+**6. "Governance Wrapped" — periodic summary cards.** Monthly/epoch-level summary for delegators showing their governance participation: proposals their DRep voted on, how their delegation influenced outcomes, governance level progress. Shareable card format optimized for X/Twitter. Uses existing data from `drep_votes`, `poll_responses`, `governance_events`.
+
+**7. Governance achievement NFTs (stretch goal).** Milestone badges as on-chain CIP-25 NFTs: mint when DRep achieves a milestone, NFT image features the milestone badge with governance identity radar. Builds minting transaction via MeshSDK. Only build if Sessions 12-16 ship cleanly.
 
 ### Current State (for agent context)
 
@@ -514,6 +521,41 @@ DRepScore is a read-only analytical tool where all communication is one-directio
 
 ---
 
+## Session 18 — Sensory Polish & Performance
+
+### Thesis
+
+After Sessions 15-17 deliver narrative, intelligence, and social features, Session 18 is a dedicated polish pass to push from 95 to 97+ on the wow scale. Pure quality — no new features, just refinement of everything already built.
+
+### What Changes
+
+**1. Sound design (optional, off by default).** Subtle audio cues for delegation, milestone achievement, score reveal. Think Stripe's checkout chime — so subtle you almost miss it, but it registers emotionally. Global toggle in user preferences. Uses Web Audio API for minimal bundle impact.
+
+**2. Scroll-driven storytelling on DRep profiles.** Apple-style progressive reveals — as you scroll through profile tabs, each section has a mini narrative transition. Not just fade-in but contextual (e.g., voting record section opens with a timeline animation). Uses Framer Motion `useScroll` + `useTransform`.
+
+**3. Performance audit.** Sub-100ms interactions, optimistic UI for all mutations, Core Web Vitals green across all pages. The fastest governance app in crypto. Specific targets: LCP < 2.5s, FID < 100ms, CLS < 0.1, TTI < 3.5s.
+
+**4. Haptic feedback on mobile.** `navigator.vibrate()` for key actions (delegation, vote submission, milestone achievement) on supported devices. Subtle 10-20ms pulses, never distracting.
+
+**5. Community showcase.** Curated "DRep of the Epoch" spotlight, community-submitted governance stories. This is the content flywheel that makes the platform self-sustaining. New section on Pulse page with editorial curation.
+
+**6. Advanced OG image system.** Dynamic OG images that update in real-time (e.g., DRep OG image shows current score, not cached score). Makes shared links always current. Upgrade existing OG routes to use ISR with shorter revalidation.
+
+### Success Criteria
+
+- Core Web Vitals green on all pages
+- "DRep of the Epoch" generates community engagement and repeat visits
+- Sound design, when enabled, creates memorable "moments" without being annoying
+- Scroll-driven storytelling makes DRep profiles feel like premium product pages
+
+### Risks
+
+- Sound design requires careful taste — bad audio is worse than no audio. Start with 1-2 sounds, test extensively.
+- Performance optimization may require architectural changes (RSC boundaries, streaming).
+- Community showcase requires editorial process — plan for content moderation.
+
+---
+
 ## Execution Order and Dependencies
 
 ```mermaid
@@ -522,7 +564,9 @@ graph LR
     S13 --> S14[Session 14: Architecture]
     S14 --> S15[Session 15: Narrative & Feel]
     S15 --> S16[Session 16: Intelligence]
-    S16 --> S17[Session 17: Social Layer]
+    S15 --> S17[Session 17: Social Layer]
+    S16 --> S18[Session 18: Sensory Polish]
+    S17 --> S18
 ```
 
 - **Session 12** ships first — it's the front door. Everything else is less impactful if the first impression doesn't convert.
@@ -531,6 +575,17 @@ graph LR
 - **Session 15** adds the narrative and emotional layer that makes the architecture feel alive.
 - **Session 16** builds on Session 15's narrative infrastructure with full intelligence capabilities.
 - **Sessions 16 and 17** can be parallelized once Session 15 ships.
+- **Session 18** follows both 16 and 17 — it's a polish pass that refines everything built in prior sessions.
+
+### Target Score Projections
+
+| Session | Estimated Score | Delta |
+|---------|----------------|-------|
+| Post S12-14 | ~62/100 | — |
+| Post S15 | ~83-86/100 | +21-24 |
+| Post S16 | ~88-91/100 | +5 |
+| Post S17 | ~93-95/100 | +4 |
+| Post S18 | ~97-98/100 | +3 |
 
 Each session gets its own worktree (`drepscore-<session-name>`) and detailed implementation plan (`.cursor/plans/<session>.plan.md`) before building begins.
 
@@ -561,5 +616,5 @@ In addition to all anti-patterns from v1 and v1.5:
 | Custom iconography | Lucide is high quality and consistent. Custom icons require a designer. |
 | Route-level URL restructuring for governance pages | Sub-nav achieves the same UX benefit without SEO/redirect risk. |
 | Floating compare tray while browsing DReps | Complex interaction design. Revisit post-S17. |
-| Sound design | Potential polish item after Sessions 12-16 ship. |
+| Sound design | Moved to Session 18 — Sensory Polish & Performance. |
 | Internationalization | Important but separate workstream — doesn't affect the "wow" factor for English-speaking crypto audience. |

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -557,6 +557,14 @@ export interface ProposalVoteDetail {
   rationaleAiSummary: string | null;
   hashVerified: boolean | null;
   metaUrl: string | null;
+  alignments?: {
+    treasuryConservative: number | null;
+    treasuryGrowth: number | null;
+    decentralization: number | null;
+    security: number | null;
+    innovation: number | null;
+    transparency: number | null;
+  } | null;
 }
 
 /**
@@ -644,17 +652,26 @@ export async function getVotesByProposal(
 
     if (error || !votes) return [];
 
-    // Fetch DRep names
+    // Fetch DRep names and alignment data
     const drepIds = [...new Set(votes.map(v => v.drep_id))];
     const { data: dreps } = await supabase
       .from('dreps')
-      .select('id, info')
+      .select('id, info, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency')
       .in('id', drepIds);
 
     const drepNameMap = new Map<string, string | null>();
+    const drepAlignmentMap = new Map<string, ProposalVoteDetail['alignments']>();
     if (dreps) {
       for (const d of dreps) {
         drepNameMap.set(d.id, (d.info as any)?.name || null);
+        drepAlignmentMap.set(d.id, {
+          treasuryConservative: d.alignment_treasury_conservative,
+          treasuryGrowth: d.alignment_treasury_growth,
+          decentralization: d.alignment_decentralization,
+          security: d.alignment_security,
+          innovation: d.alignment_innovation,
+          transparency: d.alignment_transparency,
+        });
       }
     }
 
@@ -688,6 +705,7 @@ export async function getVotesByProposal(
         rationaleAiSummary: rat?.summary || null,
         hashVerified: rat?.verified ?? null,
         metaUrl: v.meta_url,
+        alignments: drepAlignmentMap.get(v.drep_id) || null,
       };
     });
   } catch (err) {

--- a/lib/ghi.ts
+++ b/lib/ghi.ts
@@ -1,0 +1,156 @@
+/**
+ * Governance Health Index (GHI) — a single 0-100 number for Cardano ecosystem health.
+ * The crypto equivalent of the Fear & Greed Index.
+ *
+ * Components:
+ *   Participation Rate    (25%) — avg effective participation of active DReps
+ *   Rationale Rate        (20%) — avg rationale rate of active DReps
+ *   Delegation Spread     (15%) — inverse Gini of voting power (more spread = healthier)
+ *   Proposal Throughput   (15%) — ratio of proposals with votes to total proposals
+ *   DRep Diversity        (10%) — variety of alignment profiles among active DReps
+ *   DRep Activity         (15%) — ratio of active DReps to total registered
+ */
+
+import { createClient } from './supabase';
+
+export type GHIBand = 'critical' | 'fair' | 'good' | 'strong';
+
+export interface GHIComponent {
+  name: string;
+  value: number;
+  weight: number;
+  contribution: number;
+}
+
+export interface GHIResult {
+  score: number;
+  band: GHIBand;
+  components: GHIComponent[];
+}
+
+function getBand(score: number): GHIBand {
+  if (score >= 76) return 'strong';
+  if (score >= 51) return 'good';
+  if (score >= 26) return 'fair';
+  return 'critical';
+}
+
+export const GHI_BAND_COLORS: Record<GHIBand, string> = {
+  critical: '#ef4444',
+  fair: '#f59e0b',
+  good: '#06b6d4',
+  strong: '#10b981',
+};
+
+export const GHI_BAND_LABELS: Record<GHIBand, string> = {
+  critical: 'Critical',
+  fair: 'Fair',
+  good: 'Good',
+  strong: 'Strong',
+};
+
+function computeGini(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const total = sorted.reduce((s, v) => s + v, 0);
+  if (total === 0) return 0;
+
+  let sumOfAbsDiffs = 0;
+  for (let i = 0; i < n; i++) {
+    sumOfAbsDiffs += (2 * (i + 1) - n - 1) * sorted[i];
+  }
+  return sumOfAbsDiffs / (n * total);
+}
+
+export async function computeGHI(): Promise<GHIResult> {
+  const supabase = createClient();
+
+  const [drepsRes, proposalsRes, votesRes] = await Promise.all([
+    supabase.from('dreps').select(
+      'id, effective_participation, rationale_rate, info, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency'
+    ),
+    supabase.from('proposals').select('tx_hash, proposal_index, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch'),
+    supabase.from('drep_votes').select('proposal_tx_hash, proposal_index', { count: 'exact', head: false }),
+  ]);
+
+  const allDreps = drepsRes.data || [];
+  const activeDreps = allDreps.filter((d: any) => d.info?.isActive);
+  const proposals = proposalsRes.data || [];
+  const votes = votesRes.data || [];
+
+  // 1. Participation Rate (25%)
+  const participationRates = activeDreps.map((d: any) => d.effective_participation || 0);
+  const avgParticipation = participationRates.length > 0
+    ? participationRates.reduce((a: number, b: number) => a + b, 0) / participationRates.length
+    : 0;
+
+  // 2. Rationale Rate (20%)
+  const rationaleRates = activeDreps.map((d: any) => d.rationale_rate || 0);
+  const avgRationale = rationaleRates.length > 0
+    ? rationaleRates.reduce((a: number, b: number) => a + b, 0) / rationaleRates.length
+    : 0;
+
+  // 3. Delegation Spread (15%) — inverse Gini
+  const votingPowers = activeDreps
+    .map((d: any) => parseInt(d.info?.votingPowerLovelace || '0', 10))
+    .filter((v: number) => v > 0);
+  const gini = computeGini(votingPowers);
+  const delegationSpread = Math.round((1 - gini) * 100);
+
+  // 4. Proposal Throughput (15%) — proposals that received at least one vote
+  const votedProposalKeys = new Set(votes.map((v: any) => `${v.proposal_tx_hash}-${v.proposal_index}`));
+  const totalProposals = proposals.length;
+  const proposalThroughput = totalProposals > 0
+    ? Math.min(100, Math.round((votedProposalKeys.size / totalProposals) * 100))
+    : 0;
+
+  // 5. DRep Diversity (10%) — unique alignment profiles
+  const profiles = activeDreps.map((d: any) => {
+    const dims = [
+      d.alignment_treasury_conservative,
+      d.alignment_treasury_growth,
+      d.alignment_decentralization,
+      d.alignment_security,
+      d.alignment_innovation,
+      d.alignment_transparency,
+    ];
+    return dims.map(v => {
+      if (v == null) return 'M';
+      if (v >= 70) return 'H';
+      if (v <= 30) return 'L';
+      return 'M';
+    }).join('');
+  });
+  const uniqueProfiles = new Set(profiles).size;
+  const maxPossible = Math.min(activeDreps.length, 729); // 3^6
+  const diversityScore = maxPossible > 0
+    ? Math.min(100, Math.round((uniqueProfiles / Math.min(maxPossible, 50)) * 100))
+    : 0;
+
+  // 6. DRep Activity (15%) — active / total
+  const activityRatio = allDreps.length > 0
+    ? Math.min(100, Math.round((activeDreps.length / allDreps.length) * 100))
+    : 0;
+
+  const components: GHIComponent[] = [
+    { name: 'Participation', value: Math.round(avgParticipation), weight: 0.25, contribution: 0 },
+    { name: 'Rationale', value: Math.round(avgRationale), weight: 0.20, contribution: 0 },
+    { name: 'Delegation Spread', value: delegationSpread, weight: 0.15, contribution: 0 },
+    { name: 'Proposal Throughput', value: proposalThroughput, weight: 0.15, contribution: 0 },
+    { name: 'DRep Diversity', value: diversityScore, weight: 0.10, contribution: 0 },
+    { name: 'DRep Activity', value: activityRatio, weight: 0.15, contribution: 0 },
+  ];
+
+  components.forEach(c => {
+    c.contribution = Math.round(c.value * c.weight);
+  });
+
+  const score = Math.min(100, Math.max(0, components.reduce((s, c) => s + c.contribution, 0)));
+
+  return {
+    score,
+    band: getBand(score),
+    components,
+  };
+}

--- a/lib/microcopy.ts
+++ b/lib/microcopy.ts
@@ -1,0 +1,70 @@
+/**
+ * Micro-Copy System — centralized copy bank for UI micro-moments.
+ * The difference between a shadcn template and a product with personality.
+ */
+
+export const LOADING_MESSAGES = {
+  proposals: 'Counting votes...',
+  discover: 'Mapping the constellation...',
+  dashboard: 'Checking the chain...',
+  pulse: 'Reading the governance pulse...',
+  treasury: 'Tallying the treasury...',
+  profile: 'Loading your governance journey...',
+  drep: 'Building their governance portrait...',
+  default: 'Loading...',
+} as const;
+
+export const ERROR_MESSAGES = {
+  generic: 'The chain threw us a curveball. Try refreshing.',
+  network: 'Lost connection to the governance layer. Check your network and try again.',
+  notFound: "We looked everywhere in the constellation — this page doesn't exist.",
+  rateLimit: 'Too many requests. Governance moves at its own pace — try again in a moment.',
+} as const;
+
+export const SCORE_BAND_LABELS: Record<string, string> = {
+  strong: 'Governance powerhouse',
+  good: 'Solid contributor',
+  fair: 'Getting started',
+  low: 'Room to grow',
+};
+
+export const CTA_LABELS = {
+  connectWallet: 'Enter Governance',
+  connectWalletShort: 'Connect',
+  exploreDreps: 'Explore DReps',
+  seeProposals: 'See Live Proposals',
+  delegate: 'Delegate Your Voice',
+  findDrep: 'Find Your Representative',
+  viewProfile: 'View Full Profile',
+  compare: 'Compare DReps',
+  claimProfile: 'Claim Your Profile',
+} as const;
+
+export const PAGE_DESCRIPTIONS = {
+  discover: 'Find the representative that matches your governance values.',
+  proposals: 'Track Cardano governance proposals, DRep votes, and treasury decisions in real time.',
+  pulse: 'Real-time health of Cardano\'s on-chain governance.',
+  treasury: 'How Cardano\'s treasury is being spent — and whether it should be.',
+  governance: 'Your personal governance hub. Track your delegation and participation.',
+  dashboard: 'Your command center for governance.',
+  compare: 'See how DReps stack up against each other.',
+} as const;
+
+export const EMPTY_STATE_MESSAGES = {
+  noProposals: 'The governance pipeline has quiet moments — check back soon or broaden your search.',
+  noDreps: 'No DReps match. Try adjusting your filters — there are hundreds of active representatives to explore.',
+  noVotes: 'This DRep may be new or taking a break from governance.',
+  noWatchlist: 'Your watchlist is empty. Star DReps you want to track — you\'ll see their activity here.',
+  noInbox: 'All caught up! No pending actions right now.',
+} as const;
+
+export function getLoadingMessage(page: keyof typeof LOADING_MESSAGES): string {
+  return LOADING_MESSAGES[page] || LOADING_MESSAGES.default;
+}
+
+export function getScoreBandLabel(score: number): string {
+  if (score >= 80) return SCORE_BAND_LABELS.strong;
+  if (score >= 60) return SCORE_BAND_LABELS.good;
+  if (score >= 40) return SCORE_BAND_LABELS.fair;
+  return SCORE_BAND_LABELS.low;
+}

--- a/lib/narratives.ts
+++ b/lib/narratives.ts
@@ -1,0 +1,226 @@
+/**
+ * Narrative Template Engine — generates contextual prose from existing data.
+ * Template-based (not AI) — smart string interpolation with personality.
+ *
+ * Voice: warm, knowledgeable, slightly opinionated. Like a governance-passionate
+ * friend who speaks plainly. Never corporate, never academic.
+ */
+
+import { getDimensionLabel, type AlignmentScores, getDominantDimension } from './drepIdentity';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function pct(n: number | null | undefined): string {
+  return `${Math.round(n ?? 0)}%`;
+}
+
+function formatAdaCompact(amount: number): string {
+  if (amount >= 1_000_000_000) return `${(amount / 1_000_000_000).toFixed(1)}B`;
+  if (amount >= 1_000_000) return `${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `${(amount / 1_000).toFixed(1)}K`;
+  return Math.round(amount).toLocaleString();
+}
+
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function participationWord(rate: number): string {
+  if (rate >= 90) return 'nearly everything';
+  if (rate >= 75) return 'most proposals';
+  if (rate >= 50) return 'the majority of proposals';
+  if (rate >= 25) return 'some proposals';
+  return 'relatively few proposals';
+}
+
+function rationaleWord(rate: number): string {
+  if (rate >= 90) return 'always explains their reasoning';
+  if (rate >= 70) return 'regularly provides reasoning';
+  if (rate >= 40) return 'sometimes explains their votes';
+  if (rate > 0) return 'occasionally provides reasoning';
+  return 'has not yet published vote rationale';
+}
+
+function trendWord(delta: number): string {
+  if (delta > 10) return 'surging';
+  if (delta > 3) return 'climbing';
+  if (delta > 0) return 'up';
+  if (delta < -10) return 'dropping sharply';
+  if (delta < -3) return 'declining';
+  if (delta < 0) return 'down';
+  return 'holding steady';
+}
+
+// ---------------------------------------------------------------------------
+// DRep Profile Narrative
+// ---------------------------------------------------------------------------
+
+export interface DRepNarrativeData {
+  name: string;
+  participationRate: number;
+  rationaleRate: number;
+  drepScore: number;
+  rank: number | null;
+  delegatorCount: number;
+  votingPower: number;
+  alignments: AlignmentScores;
+  isActive: boolean;
+  totalVotes: number;
+  sizeTier: string;
+}
+
+export function generateDRepNarrative(data: DRepNarrativeData): string | null {
+  if (!data.isActive && data.totalVotes === 0) {
+    return `${data.name} is registered but hasn't participated in governance yet — their story is just beginning.`;
+  }
+
+  if (!data.isActive) {
+    return `${data.name} is currently inactive in governance. They previously voted on ${data.totalVotes} proposal${data.totalVotes !== 1 ? 's' : ''} and have ${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''} representing ${formatAdaCompact(data.votingPower)} ADA.`;
+  }
+
+  const dominant = getDominantDimension(data.alignments);
+  const dominantLabel = getDimensionLabel(dominant).toLowerCase();
+  const parts: string[] = [];
+
+  const focusIntro = pick([
+    `A ${dominantLabel}-focused DRep who votes on ${participationWord(data.participationRate)}`,
+    `With a focus on ${dominantLabel}, ${data.name} votes on ${participationWord(data.participationRate)}`,
+    `${data.name} brings a ${dominantLabel} perspective and votes on ${participationWord(data.participationRate)}`,
+  ]);
+
+  parts.push(`${focusIntro} and ${rationaleWord(data.rationaleRate)}.`);
+
+  const contextParts: string[] = [];
+  if (data.rank && data.rank <= 20) {
+    contextParts.push(`Ranked #${data.rank}`);
+  }
+  if (data.delegatorCount > 0) {
+    contextParts.push(`${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''}`);
+  }
+  if (data.votingPower > 0) {
+    contextParts.push(`${formatAdaCompact(data.votingPower)} ADA delegated`);
+  }
+
+  if (contextParts.length > 0) {
+    const sizeComment = data.sizeTier === 'Whale' ? ' — one of the largest voices in governance'
+      : data.sizeTier === 'Large' ? ' — a significant voice in governance'
+      : '';
+    parts.push(`${contextParts.join(' · ')}${sizeComment}.`);
+  }
+
+  return parts.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Proposals Page Narrative
+// ---------------------------------------------------------------------------
+
+export interface ProposalsNarrativeData {
+  openCount: number;
+  expiringCount: number;
+  totalAdaAtStake: number;
+  totalVotesCast: number;
+  currentEpoch: number;
+}
+
+export function generateProposalsNarrative(data: ProposalsNarrativeData): string | null {
+  if (data.openCount === 0) {
+    return pick([
+      'No proposals are open right now. The governance pipeline has quiet moments — a good time to review past decisions.',
+      'All proposals have been resolved. Check back soon or review how past proposals were decided.',
+    ]);
+  }
+
+  const parts: string[] = [];
+
+  if (data.expiringCount > 0) {
+    parts.push(`${data.openCount} proposal${data.openCount !== 1 ? 's are' : ' is'} live. ${data.expiringCount} expire${data.expiringCount === 1 ? 's' : ''} this epoch`);
+    if (data.totalAdaAtStake > 0) {
+      parts[0] += `, requesting ${formatAdaCompact(data.totalAdaAtStake)} ADA from the treasury`;
+    }
+    parts[0] += '.';
+  } else {
+    parts.push(`${data.openCount} proposal${data.openCount !== 1 ? 's are' : ' is'} open for voting.`);
+    if (data.totalAdaAtStake > 0) {
+      parts.push(`${formatAdaCompact(data.totalAdaAtStake)} ADA in treasury requests are on the table.`);
+    }
+  }
+
+  if (data.totalVotesCast > 100) {
+    parts.push(`${data.totalVotesCast.toLocaleString()} votes cast so far.`);
+  }
+
+  return parts.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard Narrative
+// ---------------------------------------------------------------------------
+
+export interface DashboardNarrativeData {
+  pendingCount: number;
+  drepScore: number;
+  scoreChange: number | null;
+  percentile: number;
+  delegatorCount: number;
+  drepName: string;
+}
+
+export function generateDashboardNarrative(data: DashboardNarrativeData): string | null {
+  const parts: string[] = [];
+
+  if (data.pendingCount > 0) {
+    parts.push(`${data.pendingCount} proposal${data.pendingCount !== 1 ? 's are' : ' is'} waiting for your vote.`);
+  } else {
+    parts.push("You're all caught up — no proposals need your attention right now.");
+  }
+
+  if (data.scoreChange !== null && data.scoreChange !== 0) {
+    const topPct = Math.max(1, Math.round(100 - data.percentile));
+    parts.push(`Your score is ${trendWord(data.scoreChange)} ${Math.abs(data.scoreChange)} point${Math.abs(data.scoreChange) !== 1 ? 's' : ''} — you're in the top ${topPct}% of active DReps.`);
+  } else {
+    const topPct = Math.max(1, Math.round(100 - data.percentile));
+    parts.push(`Score holding at ${data.drepScore} — top ${topPct}% of active DReps.`);
+  }
+
+  return parts.join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Pulse Page Narrative
+// ---------------------------------------------------------------------------
+
+export interface PulseNarrativeData {
+  votesThisWeek: number;
+  votesLastWeek?: number;
+  activeProposals: number;
+  activeDReps: number;
+  avgParticipationRate?: number;
+  totalAdaGoverned: string;
+}
+
+export function generatePulseNarrative(data: PulseNarrativeData): string | null {
+  const parts: string[] = [];
+
+  if (data.votesLastWeek && data.votesLastWeek > 0) {
+    const delta = data.votesThisWeek - data.votesLastWeek;
+    const pctChange = Math.round(Math.abs(delta) / data.votesLastWeek * 100);
+    if (delta > 0) {
+      parts.push(`Governance is heating up: ${data.votesThisWeek.toLocaleString()} votes this week, up ${pctChange}% from last week.`);
+    } else if (delta < 0) {
+      parts.push(`${data.votesThisWeek.toLocaleString()} votes this week, cooling off ${pctChange}% from last week.`);
+    } else {
+      parts.push(`${data.votesThisWeek.toLocaleString()} votes this week, holding steady.`);
+    }
+  } else if (data.votesThisWeek > 0) {
+    parts.push(`${data.votesThisWeek.toLocaleString()} votes cast this week across ${data.activeProposals} active proposal${data.activeProposals !== 1 ? 's' : ''}.`);
+  }
+
+  if (data.activeDReps > 0) {
+    parts.push(`${data.activeDReps} DReps are actively governing ${data.totalAdaGoverned} ADA.`);
+  }
+
+  return parts.length > 0 ? parts.join(' ') : null;
+}

--- a/lib/proposalInsights.ts
+++ b/lib/proposalInsights.ts
@@ -1,0 +1,158 @@
+/**
+ * Cross-Proposal Insights — computed governance patterns from existing data.
+ * 2-3 genuinely surprising insights that surface macro-level patterns.
+ */
+
+import { createClient } from './supabase';
+
+export interface GovernanceInsight {
+  id: string;
+  headline: string;
+  description: string;
+  stat: string;
+  category: 'voting' | 'treasury' | 'behavior';
+}
+
+export async function computeInsights(): Promise<GovernanceInsight[]> {
+  const supabase = createClient();
+  const insights: GovernanceInsight[] = [];
+
+  try {
+    // Insight 1: Rationale correlates with dissent
+    const [votesWithRat, votesWithoutRat] = await Promise.all([
+      supabase.rpc('count_votes_with_rationale_by_vote', undefined as any).then(r => r.data),
+      supabase.from('drep_votes')
+        .select('vote', { count: 'exact', head: false })
+        .then(r => r.data),
+    ]);
+
+    // Fallback: compute from raw data
+    const { data: allVotes } = await supabase
+      .from('drep_votes')
+      .select('vote_tx_hash, vote');
+    const { data: allRationales } = await supabase
+      .from('vote_rationales')
+      .select('vote_tx_hash');
+
+    if (allVotes && allRationales) {
+      const rationaleSet = new Set(allRationales.map(r => r.vote_tx_hash));
+      const withRationale = allVotes.filter(v => rationaleSet.has(v.vote_tx_hash));
+      const withoutRationale = allVotes.filter(v => !rationaleSet.has(v.vote_tx_hash));
+
+      const noWithRat = withRationale.filter(v => v.vote === 'No').length;
+      const noWithoutRat = withoutRationale.filter(v => v.vote === 'No').length;
+      const noRateWith = withRationale.length > 0 ? noWithRat / withRationale.length : 0;
+      const noRateWithout = withoutRationale.length > 0 ? noWithoutRat / withoutRationale.length : 0;
+
+      if (noRateWithout > 0) {
+        const ratio = noRateWith / noRateWithout;
+        if (ratio > 1.2) {
+          insights.push({
+            id: 'rationale-dissent',
+            headline: 'Rationale correlates with dissent',
+            description: `DReps who provide reasoning are ${ratio.toFixed(1)}x more likely to vote No. Explanation often accompanies opposition.`,
+            stat: `${ratio.toFixed(1)}x`,
+            category: 'behavior',
+          });
+        }
+      }
+    }
+
+    // Insight 2: Treasury proposals pass rate vs others
+    const { data: proposals } = await supabase
+      .from('proposals')
+      .select('proposal_type, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch');
+
+    if (proposals && proposals.length > 0) {
+      const treasury = proposals.filter(p => p.proposal_type === 'TreasuryWithdrawals');
+      const resolved = (ps: typeof proposals) => ps.filter(
+        p => p.ratified_epoch || p.enacted_epoch || p.dropped_epoch || p.expired_epoch
+      );
+      const passed = (ps: typeof proposals) => ps.filter(
+        p => p.ratified_epoch || p.enacted_epoch
+      );
+
+      const treasuryResolved = resolved(treasury);
+      const otherResolved = resolved(proposals.filter(p => p.proposal_type !== 'TreasuryWithdrawals'));
+
+      const treasuryPassRate = treasuryResolved.length > 0
+        ? Math.round((passed(treasury).length / treasuryResolved.length) * 100)
+        : null;
+      const otherPassRate = otherResolved.length > 0
+        ? Math.round((passed(proposals.filter(p => p.proposal_type !== 'TreasuryWithdrawals')).length / otherResolved.length) * 100)
+        : null;
+
+      if (treasuryPassRate !== null && otherPassRate !== null && treasuryResolved.length >= 3) {
+        insights.push({
+          id: 'treasury-contested',
+          headline: 'Treasury proposals face more scrutiny',
+          description: `Treasury withdrawals pass at ${treasuryPassRate}% vs ${otherPassRate}% for other proposal types. Money decisions get the most debate.`,
+          stat: `${treasuryPassRate}%`,
+          category: 'treasury',
+        });
+      }
+    }
+
+    // Insight 3: Top DRep agreement rate
+    const { data: topDreps } = await supabase
+      .from('dreps')
+      .select('id')
+      .eq('info->>isActive', 'true')
+      .order('score', { ascending: false })
+      .limit(10);
+
+    if (topDreps && topDreps.length >= 5) {
+      const topIds = topDreps.map(d => d.id);
+      const { data: topVotes } = await supabase
+        .from('drep_votes')
+        .select('drep_id, proposal_tx_hash, proposal_index, vote')
+        .in('drep_id', topIds);
+
+      if (topVotes && topVotes.length > 0) {
+        const proposalVoteMap = new Map<string, Map<string, string>>();
+        for (const v of topVotes) {
+          const key = `${v.proposal_tx_hash}-${v.proposal_index}`;
+          if (!proposalVoteMap.has(key)) proposalVoteMap.set(key, new Map());
+          proposalVoteMap.get(key)!.set(v.drep_id, v.vote);
+        }
+
+        let agreements = 0;
+        let comparisons = 0;
+
+        for (const [, voters] of proposalVoteMap) {
+          const entries = [...voters.entries()];
+          for (let i = 0; i < entries.length; i++) {
+            for (let j = i + 1; j < entries.length; j++) {
+              comparisons++;
+              if (entries[i][1] === entries[j][1]) agreements++;
+            }
+          }
+        }
+
+        const agreementRate = comparisons > 0 ? Math.round((agreements / comparisons) * 100) : 0;
+
+        if (comparisons > 10) {
+          const descriptor = agreementRate > 80 ? 'form a strong consensus'
+            : agreementRate > 60 ? 'mostly agree'
+            : 'show real ideological diversity';
+
+          insights.push({
+            id: 'top-agreement',
+            headline: `Top DReps ${descriptor}`,
+            description: `The 10 highest-scoring DReps agree on ${agreementRate}% of votes. ${
+              agreementRate > 70
+                ? 'Quality governance is converging around shared principles.'
+                : 'The best DReps bring genuinely different perspectives.'
+            }`,
+            stat: `${agreementRate}%`,
+            category: 'voting',
+          });
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[Insights] Computation error:', err);
+  }
+
+  return insights;
+}


### PR DESCRIPTION
## Summary

- **Narrative engine** (lib/narratives.ts): contextual prose across DRep profiles, Proposals, Dashboard, and Pulse pages
- **Governance Health Index**: composite 0-100 score with signature arc gauge, API route with 1hr cache
- **Page transitions**: Framer Motion entrance animations via app/template.tsx
- **Proposals command-center hero**: animated stat pods, urgency indicators for expiring proposals
- **Cross-proposal insights**: macro-level governance pattern detection displayed on Pulse
- **Cardano Governance explainer**: onboarding section for anonymous/non-Cardano visitors
- **Content-aware skeletons**: chart, card list, timeline, stat pod, poll, stance variants
- **Micro-copy system**: centralized copy bank (lib/microcopy.ts) for consistent brand voice
- **Governance heartbeat**: ambient activity indicator in Header linked to real-time data
- **Mini GovernanceRadar badges**: alignment data joins for proposal voter lists
- **Enhanced EmptyState**: accent gradients and contextual warm copy
- **ProfileViewStats + SentimentPoll social proof** activated
- **ActivityFeed vertical variant** on Pulse page
- **Strategy doc updated**: S16/S17 additions, new Session 18 for sensory polish

## Test plan

- [x] All 241 existing tests pass (vitest)
- [x] TypeScript compiles clean (tsc --noEmit)
- [ ] Visual QA: homepage (anon + authed), DRep profile, Proposals, Pulse, Dashboard
- [ ] GHI arc gauge renders correctly across viewport sizes
- [ ] Page transitions feel smooth, no layout shift
- [ ] Urgency theatrics display for proposals expiring within 2 epochs
- [ ] Heartbeat indicator pulses at correct cadence

Made with [Cursor](https://cursor.com)