### PR TITLE
fix: hero section visual cleanup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -325,6 +325,10 @@ button:not(:disabled):active,
 .animation-delay-400 { animation-delay: 0.4s; }
 .animation-delay-500 { animation-delay: 0.5s; }
 
+.hero-text-shadow {
+  text-shadow: 0 0 20px rgba(10, 11, 20, 0.8), 0 2px 8px rgba(10, 11, 20, 0.6);
+}
+
 /* Pillar bar stagger animation */
 @keyframes grow {
   from { transform: scaleY(0); }

--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -216,21 +216,21 @@ export function ConstellationHero({ stats, ssrHolderData, ssrWalletAddress, onPe
 
       {/* Text Overlay */}
       {!showPersonalCard && (
-        <div className="absolute inset-0 flex flex-col items-center justify-start pt-[14vh] md:justify-center md:pt-0 z-10 pointer-events-none px-4">
+        <div className={`absolute inset-0 flex flex-col items-center justify-start pt-[14vh] md:justify-center md:pt-0 z-10 pointer-events-none px-4 transition-opacity duration-700 ${constellationReady ? 'opacity-100' : 'opacity-0'}`}>
           <h1
-            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-center max-w-4xl leading-tight animate-fade-in-up"
+            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-center max-w-4xl leading-tight animate-fade-in-up hero-text-shadow"
           >
             <span className="text-white">
               This is what decentralized governance looks like.
             </span>
           </h1>
 
-          <p className="mt-4 text-sm sm:text-base md:text-lg text-white/60 text-center max-w-2xl animate-fade-in-up animation-delay-200">
+          <p className="mt-4 text-sm sm:text-base md:text-lg text-white/60 text-center max-w-2xl animate-fade-in-up animation-delay-200 hero-text-shadow">
             {stats.activeDReps.toLocaleString()} representatives. {stats.totalAdaGoverned} ADA. Every vote shapes Cardano&apos;s future.
           </p>
 
           {/* Live stats strip */}
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs sm:text-sm text-white/40 animate-fade-in-up animation-delay-200">
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs sm:text-sm text-white/40 animate-fade-in-up animation-delay-200 hero-text-shadow">
             <span>{stats.activeDReps.toLocaleString()} Active DReps</span>
             <span className="hidden sm:inline text-white/20">|</span>
             <span>{stats.totalAdaGoverned} ADA Governed</span>

--- a/components/GovernanceConstellation.tsx
+++ b/components/GovernanceConstellation.tsx
@@ -444,7 +444,7 @@ function ShootingStars() {
     <group ref={groupRef}>
       {Array.from({ length: METEOR_POOL }, (_, i) => (
         <mesh key={i} visible={false}>
-          <cylinderGeometry args={[0.03, 0.003, 1.5, 4]} />
+          <cylinderGeometry args={[0.03, 0.003, 1.5, 8]} />
           <meshBasicMaterial
             color="#e8dcc8"
             transparent


### PR DESCRIPTION
## Summary

- **Square artifact fix**: Shooting star meshes used a 4-segment cylinder (square cross-section) that bloom amplified into visible rectangular streaks. Bumped to 8 radial segments.
- **Mobile text readability**: Added `hero-text-shadow` utility using the hero background color (`#0a0b14`) as a multi-layer text shadow on the headline, subtitle, and stats strip. Improves contrast over the bright governance core without opaque overlays.
- **Desktop copy flash**: Text overlay now gates on `constellationReady` — starts at `opacity-0` and fades in with the constellation for a single cohesive reveal instead of a two-step load.

## Test plan

- [x] Type-check passes (`tsc --noEmit`)
- [x] All 241 tests pass
- [ ] Visual: verify no square artifacts on shooting stars (desktop with bloom)
- [ ] Visual: verify hero text is readable on mobile over the bright core
- [ ] Visual: verify hero loads as single reveal (gradient → constellation + text together)
