### PR TITLE
feat: Session 18 — Cross-Chain Governance Intelligence Hub

### DIFF
--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { FeatureFlagAdmin } from '@/components/admin/FeatureFlagAdmin';
+
+export const metadata: Metadata = {
+  title: 'Feature Flags — Admin',
+};
+
+export default function FlagsPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Feature Flags</h1>
+        <p className="text-sm text-muted-foreground">
+          Toggle features on/off instantly. Changes take effect within 60 seconds (cache TTL).
+        </p>
+      </div>
+      <FeatureFlagAdmin />
+    </div>
+  );
+}

--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllFlags, setFeatureFlag, invalidateFlagCache } from '@/lib/featureFlags';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const allFlags = await getAllFlags();
+    const flags: Record<string, boolean> = {};
+    for (const f of allFlags) {
+      flags[f.key] = f.enabled;
+    }
+    return NextResponse.json({ flags, details: allFlags }, {
+      headers: { 'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60' },
+    });
+  } catch (err) {
+    return NextResponse.json({ error: 'Failed to load flags' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { key, enabled } = body;
+
+    if (typeof key !== 'string' || typeof enabled !== 'boolean') {
+      return NextResponse.json({ error: 'Invalid body: { key: string, enabled: boolean }' }, { status: 400 });
+    }
+
+    const success = await setFeatureFlag(key, enabled);
+    if (!success) {
+      return NextResponse.json({ error: 'Failed to update flag' }, { status: 500 });
+    }
+
+    invalidateFlagCache();
+
+    return NextResponse.json({ key, enabled });
+  } catch (err) {
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/governance/benchmarks/route.ts
+++ b/app/api/governance/benchmarks/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+
+export const dynamic = 'force-dynamic';
+
+interface BenchmarkRow {
+  chain: string;
+  period_label: string;
+  participation_rate: number | null;
+  delegate_count: number | null;
+  proposal_count: number | null;
+  proposal_throughput: number | null;
+  avg_rationale_rate: number | null;
+  governance_score: number | null;
+  grade: string | null;
+  fetched_at: string;
+}
+
+export async function GET() {
+  try {
+    const enabled = await getFeatureFlag('cross_chain_observatory');
+    if (!enabled) {
+      return NextResponse.json({ latest: {}, history: [], disabled: true }, { status: 200 });
+    }
+
+    const supabase = createClient();
+
+    const { data: latest, error: latestErr } = await supabase
+      .from('governance_benchmarks')
+      .select('chain, period_label, participation_rate, delegate_count, proposal_count, proposal_throughput, avg_rationale_rate, governance_score, grade, fetched_at')
+      .order('fetched_at', { ascending: false })
+      .limit(3);
+
+    if (latestErr) {
+      console.error('[benchmarks] Latest fetch error:', latestErr.message);
+      return NextResponse.json({ error: 'Failed to fetch benchmarks' }, { status: 500 });
+    }
+
+    const chains = ['cardano', 'ethereum', 'polkadot'] as const;
+    const latestByChain: Record<string, BenchmarkRow | null> = {};
+    for (const chain of chains) {
+      latestByChain[chain] = (latest as BenchmarkRow[])?.find(r => r.chain === chain) ?? null;
+    }
+
+    const { data: history, error: historyErr } = await supabase
+      .from('governance_benchmarks')
+      .select('chain, period_label, governance_score, grade, fetched_at')
+      .order('fetched_at', { ascending: true })
+      .limit(60);
+
+    if (historyErr) {
+      console.error('[benchmarks] History fetch error:', historyErr.message);
+    }
+
+    const historyByChain: Record<string, { periodLabel: string; score: number | null; grade: string | null }[]> = {
+      cardano: [],
+      ethereum: [],
+      polkadot: [],
+    };
+
+    if (history) {
+      for (const row of history as { chain: string; period_label: string; governance_score: number | null; grade: string | null }[]) {
+        if (historyByChain[row.chain]) {
+          historyByChain[row.chain].push({
+            periodLabel: row.period_label,
+            score: row.governance_score,
+            grade: row.grade,
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({
+      benchmarks: latestByChain,
+      history: historyByChain,
+      updatedAt: latest?.[0]?.fetched_at ?? null,
+    }, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (err) {
+    console.error('[benchmarks] Unexpected error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -16,6 +16,7 @@ import { generateGovernanceBrief } from '@/inngest/functions/generate-governance
 import { syncFreshnessGuard } from '@/inngest/functions/sync-freshness-guard';
 import { snapshotGhi } from '@/inngest/functions/snapshot-ghi';
 import { generateStateOfGovernance } from '@/inngest/functions/generate-state-of-governance';
+import { syncGovernanceBenchmarks } from '@/inngest/functions/sync-governance-benchmarks';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -36,5 +37,6 @@ export const { GET, POST, PUT } = serve({
     syncFreshnessGuard,
     snapshotGhi,
     generateStateOfGovernance,
+    syncGovernanceBenchmarks,
   ],
 });

--- a/app/api/og/cross-chain/route.tsx
+++ b/app/api/og/cross-chain/route.tsx
@@ -1,0 +1,125 @@
+import { ImageResponse } from 'next/og';
+import { createClient } from '@/lib/supabase';
+import { getGradeColor, CHAIN_IDENTITIES, type Chain } from '@/lib/crossChain';
+import { getFeatureFlag } from '@/lib/featureFlags';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const enabled = await getFeatureFlag('cross_chain_embed');
+    if (!enabled) {
+      return new Response('Feature disabled', { status: 404 });
+    }
+
+    const supabase = createClient();
+
+    const { data: rows } = await supabase
+      .from('governance_benchmarks')
+      .select('chain, governance_score, grade, participation_rate, delegate_count')
+      .order('fetched_at', { ascending: false })
+      .limit(3);
+
+    const chains: Chain[] = ['cardano', 'ethereum', 'polkadot'];
+    const byChain: Record<string, { score: number; grade: string; participation: number | null; delegates: number | null }> = {};
+
+    for (const chain of chains) {
+      const row = (rows ?? []).find((r: { chain: string }) => r.chain === chain);
+      if (row) {
+        byChain[chain] = {
+          score: row.governance_score ?? 0,
+          grade: row.grade ?? '—',
+          participation: row.participation_rate,
+          delegates: row.delegate_count,
+        };
+      }
+    }
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '1200',
+            height: '630',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#0a0b14',
+            fontFamily: 'system-ui, sans-serif',
+            padding: '60px',
+          }}
+        >
+          {/* Title */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              marginBottom: '16px',
+            }}
+          >
+            <span style={{ fontSize: '32px', fontWeight: 800, color: '#fff' }}>
+              Governance Health Across Chains
+            </span>
+          </div>
+          <span style={{ fontSize: '16px', color: '#9ca3af', marginBottom: '40px' }}>
+            How do major blockchain governance systems compare?
+          </span>
+
+          {/* Cards */}
+          <div style={{ display: 'flex', gap: '32px' }}>
+            {chains.map(chain => {
+              const d = byChain[chain];
+              const identity = CHAIN_IDENTITIES[chain];
+              const gradeColor = d ? getGradeColor(d.grade) : '#6b7280';
+
+              return (
+                <div
+                  key={chain}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    padding: '32px 40px',
+                    borderRadius: '16px',
+                    border: `1px solid ${identity.color}30`,
+                    backgroundColor: `${identity.color}08`,
+                    minWidth: '280px',
+                  }}
+                >
+                  <span style={{ fontSize: '20px', fontWeight: 700, color: '#fff', marginBottom: '4px' }}>
+                    {identity.name}
+                  </span>
+                  <span style={{ fontSize: '72px', fontWeight: 900, color: gradeColor, lineHeight: 1 }}>
+                    {d?.grade ?? '—'}
+                  </span>
+                  <span style={{ fontSize: '18px', color: '#9ca3af', marginTop: '8px' }}>
+                    {d ? `${d.score}/100` : 'No data'}
+                  </span>
+                  {d?.participation != null && (
+                    <span style={{ fontSize: '14px', color: '#6b7280', marginTop: '4px' }}>
+                      {d.participation}% participation
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Branding */}
+          <span style={{ fontSize: '14px', color: '#4b5563', marginTop: '32px' }}>
+            drepscore.io — Governance Intelligence for Crypto
+          </span>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (err) {
+    console.error('[og/cross-chain] Error:', err);
+    return new Response('OG image generation failed', { status: 500 });
+  }
+}

--- a/app/api/og/governance-identity/route.tsx
+++ b/app/api/og/governance-identity/route.tsx
@@ -1,0 +1,146 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const wallet = request.nextUrl.searchParams.get('wallet');
+
+    let drepName = 'Your DRep';
+    let drepScore = '—';
+    let epochsActive = '—';
+    let citizenSince = '';
+
+    if (wallet) {
+      const supabase = createClient();
+
+      const { data: user } = await supabase
+        .from('users')
+        .select('delegated_drep_id, created_at')
+        .eq('wallet_address', wallet)
+        .single();
+
+      if (user?.delegated_drep_id) {
+        const { data: drep } = await supabase
+          .from('dreps')
+          .select('id, score, info')
+          .eq('id', user.delegated_drep_id)
+          .single();
+
+        if (drep) {
+          const info = drep.info as Record<string, unknown> | null;
+          drepName = (info?.name as string) || (info?.ticker as string) || 'DRep';
+          drepScore = String(drep.score ?? '—');
+        }
+      }
+
+      if (user?.created_at) {
+        const created = new Date(user.created_at);
+        const daysSince = Math.floor((Date.now() - created.getTime()) / (1000 * 60 * 60 * 24));
+        const approxEpochs = Math.floor(daysSince / 5);
+        epochsActive = String(approxEpochs);
+      }
+    }
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '1200',
+            height: '630',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#0a0b14',
+            fontFamily: 'system-ui, sans-serif',
+            padding: '60px',
+          }}
+        >
+          {/* Top accent */}
+          <div style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: '3px',
+            background: 'linear-gradient(90deg, transparent, #06b6d4, transparent)',
+          }} />
+
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            marginBottom: '32px',
+          }}>
+            <div style={{
+              width: '48px',
+              height: '48px',
+              borderRadius: '50%',
+              backgroundColor: '#06b6d415',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '20px',
+              color: '#06b6d4',
+              fontWeight: 800,
+            }}>
+              G
+            </div>
+            <span style={{ fontSize: '28px', fontWeight: 800, color: '#fff' }}>
+              Governance Identity
+            </span>
+          </div>
+
+          {/* Stats */}
+          <div style={{ display: 'flex', gap: '40px', marginBottom: '40px' }}>
+            <StatBlock label="Delegated To" value={drepName} />
+            <StatBlock label="DRep Score" value={`${drepScore}/100`} />
+            <StatBlock label="Epochs Active" value={epochsActive} />
+          </div>
+
+          {citizenSince && (
+            <span style={{ fontSize: '16px', color: '#06b6d4', fontWeight: 600 }}>
+              {citizenSince}
+            </span>
+          )}
+
+          <span style={{
+            fontSize: '14px',
+            color: '#4b5563',
+            marginTop: 'auto',
+          }}>
+            drepscore.io — Governance Intelligence for Cardano
+          </span>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 630,
+      },
+    );
+  } catch (err) {
+    console.error('[og/governance-identity] Error:', err);
+    return new Response('OG image generation failed', { status: 500 });
+  }
+}
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      padding: '24px 32px',
+      borderRadius: '12px',
+      border: '1px solid rgba(6, 182, 212, 0.15)',
+      backgroundColor: 'rgba(6, 182, 212, 0.05)',
+      minWidth: '200px',
+    }}>
+      <span style={{ fontSize: '14px', color: '#6b7280', marginBottom: '8px' }}>{label}</span>
+      <span style={{ fontSize: '28px', fontWeight: 800, color: '#fff' }}>{value}</span>
+    </div>
+  );
+}

--- a/app/developers/page.tsx
+++ b/app/developers/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import { DeveloperPage } from '@/components/DeveloperPage';
+
+export const metadata: Metadata = {
+  title: 'Developers — DRepScore API',
+  description: 'Build on governance intelligence. Interactive API explorer, embeddable widgets, and documentation for the DRepScore v1 API.',
+  openGraph: {
+    title: 'DRepScore Developer Platform',
+    description: 'Build on governance intelligence. API explorer, embeddable widgets, and documentation.',
+  },
+};
+
+export default function DevelopersPage() {
+  return <DeveloperPage />;
+}

--- a/app/embed/cross-chain/page.tsx
+++ b/app/embed/cross-chain/page.tsx
@@ -1,0 +1,27 @@
+import { EmbedCrossChain } from '@/components/EmbedCrossChain';
+import { getFeatureFlag } from '@/lib/featureFlags';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  searchParams: Promise<{ theme?: string }>;
+}
+
+export default async function EmbedCrossChainPage({ searchParams }: Props) {
+  const [{ theme }, enabled] = await Promise.all([
+    searchParams,
+    getFeatureFlag('cross_chain_embed'),
+  ]);
+
+  if (!enabled) {
+    return <div style={{ padding: 16, fontSize: 12, color: '#888' }}>Widget unavailable</div>;
+  }
+
+  const isDark = theme !== 'light';
+
+  return (
+    <div className={isDark ? 'dark' : ''}>
+      <EmbedCrossChain theme={isDark ? 'dark' : 'light'} />
+    </div>
+  );
+}

--- a/app/embed/drep/[drepId]/page.tsx
+++ b/app/embed/drep/[drepId]/page.tsx
@@ -1,0 +1,32 @@
+import { getDRepById } from '@/lib/data';
+import { EmbedDRepCard } from '@/components/EmbedDRepCard';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ drepId: string }>;
+  searchParams: Promise<{ theme?: string }>;
+}
+
+export default async function EmbedDRepPage({ params, searchParams }: Props) {
+  const { drepId } = await params;
+  const { theme } = await searchParams;
+  const isDark = theme !== 'light';
+  const decodedId = decodeURIComponent(drepId);
+
+  const drep = await getDRepById(decodedId);
+
+  if (!drep) {
+    return (
+      <div className={`flex items-center justify-center p-6 text-sm ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
+        DRep not found
+      </div>
+    );
+  }
+
+  return (
+    <div className={isDark ? 'dark' : ''}>
+      <EmbedDRepCard drep={drep} theme={isDark ? 'dark' : 'light'} />
+    </div>
+  );
+}

--- a/app/embed/ghi/page.tsx
+++ b/app/embed/ghi/page.tsx
@@ -1,0 +1,18 @@
+import { EmbedGHI } from '@/components/EmbedGHI';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  searchParams: Promise<{ theme?: string }>;
+}
+
+export default async function EmbedGHIPage({ searchParams }: Props) {
+  const { theme } = await searchParams;
+  const isDark = theme !== 'light';
+
+  return (
+    <div className={isDark ? 'dark' : ''}>
+      <EmbedGHI theme={isDark ? 'dark' : 'light'} />
+    </div>
+  );
+}

--- a/app/embed/layout.tsx
+++ b/app/embed/layout.tsx
@@ -1,0 +1,15 @@
+import '@/app/globals.css';
+
+/**
+ * Embed layout — no header, footer, or nav.
+ * These pages are designed to be rendered inside iframes.
+ */
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="dark" suppressHydrationWarning>
+      <body className="bg-transparent min-h-0">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/governance/page.tsx
+++ b/app/governance/page.tsx
@@ -4,6 +4,7 @@ import { GovernanceCitizenSection } from '@/components/GovernanceCitizenSection'
 import { GovernanceCalendar } from '@/components/GovernanceCalendar';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { ActivityFeed } from '@/components/ActivityFeed';
+import { DelegatorGovernanceCard } from '@/components/DelegatorGovernanceCard';
 
 export const metadata: Metadata = {
   title: 'My Governance — DRepScore',
@@ -15,6 +16,7 @@ export default function GovernancePage() {
     <div className="container mx-auto px-4 py-8 space-y-8">
       <PageViewTracker event="governance_page_viewed" />
       <GovernanceDashboard />
+      <DelegatorGovernanceCard />
       <GovernanceCalendar />
       <GovernanceCitizenSection />
       <ActivityFeed limit={8} />

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -11,8 +11,10 @@ import { GovernanceHealthIndex } from '@/components/GovernanceHealthIndex';
 import { NarrativeSummary } from '@/components/NarrativeSummary';
 import { ActivityFeed } from '@/components/ActivityFeed';
 import { CrossProposalInsights } from '@/components/CrossProposalInsights';
+import { GovernanceObservatory } from '@/components/GovernanceObservatory';
 import { PulseLeaderboardClient } from '@/components/PulseLeaderboardClient';
 import { generatePulseNarrative } from '@/lib/narratives';
+import { getFeatureFlag } from '@/lib/featureFlags';
 import {
   Landmark,
   ScrollText,
@@ -164,7 +166,10 @@ async function LeaderboardSection() {
 }
 
 export default async function PulsePage() {
-  const pulse = await fetchPulseData();
+  const [pulse, showCrossChain] = await Promise.all([
+    fetchPulseData(),
+    getFeatureFlag('cross_chain_observatory'),
+  ]);
 
   const pulseNarrative = pulse ? generatePulseNarrative({
     votesThisWeek: pulse.votesThisWeek,
@@ -307,6 +312,9 @@ export default async function PulsePage() {
 
       {/* Cross-Proposal Insights */}
       <CrossProposalInsights />
+
+      {/* Cross-Chain Governance Observatory (feature-flagged) */}
+      {showCrossChain && <GovernanceObservatory />}
 
       {/* Leaderboard + Movers + Hall of Fame (with Suspense) */}
       <Suspense fallback={<LeaderboardSkeleton />}>

--- a/components/ApiExplorer.tsx
+++ b/components/ApiExplorer.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Play, Loader2, ChevronRight } from 'lucide-react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { CodeExample } from './CodeExample';
+import { fadeInUp, spring } from '@/lib/animations';
+
+interface EndpointDef {
+  id: string;
+  method: string;
+  path: string;
+  title: string;
+  description: string;
+  tier: 'public' | 'pro';
+  params: { name: string; type: string; default?: string; description: string }[];
+  examplePath: string;
+}
+
+const ENDPOINTS: EndpointDef[] = [
+  {
+    id: 'list-dreps',
+    method: 'GET',
+    path: '/api/v1/dreps',
+    title: 'List DReps',
+    description: 'Search and list all scored DReps with filtering and pagination.',
+    tier: 'public',
+    params: [
+      { name: 'search', type: 'string', description: 'Search by name, ticker, or ID' },
+      { name: 'sort', type: 'string', default: 'score', description: 'Sort field: score, name, voting_power' },
+      { name: 'limit', type: 'number', default: '20', description: 'Results per page (max 100)' },
+      { name: 'offset', type: 'number', default: '0', description: 'Pagination offset' },
+    ],
+    examplePath: '/api/v1/dreps?limit=3&sort=score',
+  },
+  {
+    id: 'get-drep',
+    method: 'GET',
+    path: '/api/v1/dreps/:drepId',
+    title: 'Get DRep',
+    description: 'Get detailed profile, score breakdown, and alignment data for a specific DRep.',
+    tier: 'public',
+    params: [
+      { name: 'drepId', type: 'string', description: 'DRep bech32 ID (drep1...)' },
+    ],
+    examplePath: '/api/v1/dreps/drep1...',
+  },
+  {
+    id: 'drep-votes',
+    method: 'GET',
+    path: '/api/v1/dreps/:drepId/votes',
+    title: 'DRep Votes',
+    description: 'Voting history for a DRep with rationale content.',
+    tier: 'pro',
+    params: [
+      { name: 'limit', type: 'number', default: '20', description: 'Results per page' },
+      { name: 'offset', type: 'number', default: '0', description: 'Pagination offset' },
+      { name: 'epoch', type: 'number', description: 'Filter by epoch' },
+    ],
+    examplePath: '/api/v1/dreps/drep1.../votes?limit=5',
+  },
+  {
+    id: 'drep-history',
+    method: 'GET',
+    path: '/api/v1/dreps/:drepId/history',
+    title: 'Score History',
+    description: 'Historical score data for trend analysis.',
+    tier: 'pro',
+    params: [
+      { name: 'days', type: 'number', default: '30', description: 'Lookback period (1-365)' },
+    ],
+    examplePath: '/api/v1/dreps/drep1.../history?days=30',
+  },
+  {
+    id: 'list-proposals',
+    method: 'GET',
+    path: '/api/v1/proposals',
+    title: 'List Proposals',
+    description: 'Governance proposals with status filtering and AI summaries.',
+    tier: 'public',
+    params: [
+      { name: 'status', type: 'string', description: 'Filter: open, ratified, enacted, dropped, expired' },
+      { name: 'type', type: 'string', description: 'Proposal type filter' },
+      { name: 'limit', type: 'number', default: '20', description: 'Results per page' },
+    ],
+    examplePath: '/api/v1/proposals?status=open&limit=5',
+  },
+  {
+    id: 'governance-health',
+    method: 'GET',
+    path: '/api/v1/governance/health',
+    title: 'Governance Health',
+    description: 'Ecosystem-wide governance statistics and health metrics.',
+    tier: 'public',
+    params: [],
+    examplePath: '/api/v1/governance/health',
+  },
+  {
+    id: 'drep-embed',
+    method: 'GET',
+    path: '/api/v1/embed/:drepId',
+    title: 'DRep Embed',
+    description: 'Embeddable DRep card in SVG, HTML, or JSON format.',
+    tier: 'public',
+    params: [
+      { name: 'format', type: 'string', default: 'svg', description: 'Output: svg, html, json' },
+      { name: 'style', type: 'string', default: 'card', description: 'SVG style: badge, card, minimal' },
+      { name: 'theme', type: 'string', default: 'dark', description: 'Theme: dark, light' },
+    ],
+    examplePath: '/api/v1/embed/drep1...?format=json',
+  },
+];
+
+function generateCodeExamples(endpoint: EndpointDef, baseUrl: string): Record<string, string> {
+  const url = `${baseUrl}${endpoint.examplePath}`;
+  return {
+    curl: `curl "${url}"`,
+    javascript: `const response = await fetch("${url}", {
+  headers: {
+    "Authorization": "Bearer ds_live_YOUR_API_KEY"
+  }
+});
+const data = await response.json();
+console.log(data);`,
+    python: `import requests
+
+response = requests.get(
+    "${url}",
+    headers={"Authorization": "Bearer ds_live_YOUR_API_KEY"}
+)
+data = response.json()
+print(data)`,
+  };
+}
+
+export function ApiExplorer() {
+  const [selected, setSelected] = useState<string>(ENDPOINTS[0].id);
+  const [response, setResponse] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const endpoint = ENDPOINTS.find(e => e.id === selected) ?? ENDPOINTS[0];
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io';
+  const codeExamples = generateCodeExamples(endpoint, baseUrl);
+
+  const tryEndpoint = useCallback(async () => {
+    if (endpoint.examplePath.includes('drep1...')) {
+      setResponse(JSON.stringify({ hint: 'Replace drep1... with a real DRep ID to try this endpoint.' }, null, 2));
+      return;
+    }
+    setLoading(true);
+    setResponse(null);
+    try {
+      const res = await fetch(endpoint.examplePath);
+      const data = await res.json();
+      setResponse(JSON.stringify(data, null, 2));
+    } catch (err) {
+      setResponse(JSON.stringify({ error: 'Request failed. The endpoint may require authentication.' }, null, 2));
+    } finally {
+      setLoading(false);
+    }
+  }, [endpoint]);
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
+      {/* Endpoint list */}
+      <div className="space-y-1">
+        <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Endpoints</h3>
+        {ENDPOINTS.map(ep => (
+          <button
+            key={ep.id}
+            onClick={() => { setSelected(ep.id); setResponse(null); }}
+            className={`flex w-full items-center gap-2 rounded-lg px-3 py-2.5 text-left text-sm transition-colors ${
+              selected === ep.id
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
+            }`}
+          >
+            <span className={`inline-flex w-10 justify-center rounded-md px-1.5 py-0.5 text-[10px] font-bold ${
+              ep.method === 'GET' ? 'bg-emerald-500/15 text-emerald-400' : 'bg-blue-500/15 text-blue-400'
+            }`}>
+              {ep.method}
+            </span>
+            <span className="flex-1 truncate">{ep.title}</span>
+            {ep.tier === 'pro' && (
+              <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-bold text-amber-400">PRO</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Detail panel */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={endpoint.id}
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+          className="space-y-5"
+        >
+          <div>
+            <div className="flex items-center gap-3 mb-2">
+              <span className="rounded-md bg-emerald-500/15 px-2 py-0.5 text-xs font-bold text-emerald-400">
+                {endpoint.method}
+              </span>
+              <code className="text-sm font-mono text-foreground">{endpoint.path}</code>
+              {endpoint.tier === 'pro' && (
+                <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-bold text-amber-400">Pro Tier</span>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground">{endpoint.description}</p>
+          </div>
+
+          {/* Parameters */}
+          {endpoint.params.length > 0 && (
+            <div>
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Parameters</h4>
+              <div className="overflow-hidden rounded-lg border border-border/40">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border/40 bg-muted/20">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">Name</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">Type</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {endpoint.params.map(p => (
+                      <tr key={p.name} className="border-b border-border/20 last:border-0">
+                        <td className="px-3 py-2 font-mono text-xs text-primary">{p.name}</td>
+                        <td className="px-3 py-2 text-xs text-muted-foreground">{p.type}</td>
+                        <td className="px-3 py-2 text-xs text-muted-foreground">
+                          {p.description}
+                          {p.default && <span className="ml-1 text-muted-foreground/60">(default: {p.default})</span>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Code examples */}
+          <div>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Example</h4>
+            <CodeExample code={codeExamples} />
+          </div>
+
+          {/* Try it */}
+          <div className="flex items-center gap-3">
+            <Button onClick={tryEndpoint} disabled={loading} className="gap-2">
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+              Try it
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              Makes a real API call — no key needed for public endpoints
+            </span>
+          </div>
+
+          {/* Response */}
+          {response && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              transition={{ ...spring.snappy }}
+            >
+              <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Response</h4>
+              <pre className="max-h-[400px] overflow-auto rounded-lg border border-border/40 bg-[#0d0e1a] p-4 text-xs leading-relaxed text-emerald-300/80 font-mono">
+                {response}
+              </pre>
+            </motion.div>
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/CodeExample.tsx
+++ b/components/CodeExample.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { Button } from './ui/button';
+
+interface CodeExampleProps {
+  code: Record<string, string>;
+  className?: string;
+}
+
+const LANG_LABELS: Record<string, string> = {
+  curl: 'cURL',
+  javascript: 'JavaScript',
+  python: 'Python',
+};
+
+export function CodeExample({ code, className = '' }: CodeExampleProps) {
+  const languages = Object.keys(code);
+  const [activeLang, setActiveLang] = useState(languages[0] ?? 'curl');
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code[activeLang] ?? '');
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={`overflow-hidden rounded-lg border border-border/60 bg-[#0d0e1a] ${className}`}>
+      <div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
+        <div className="flex gap-1">
+          {languages.map(lang => (
+            <button
+              key={lang}
+              onClick={() => setActiveLang(lang)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                activeLang === lang
+                  ? 'bg-primary/15 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {LANG_LABELS[lang] ?? lang}
+            </button>
+          ))}
+        </div>
+        <Button variant="ghost" size="sm" className="h-7 gap-1 text-xs" onClick={handleCopy}>
+          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto p-4 text-[13px] leading-relaxed">
+        <code className="text-emerald-300/90 font-mono">{code[activeLang]}</code>
+      </pre>
+    </div>
+  );
+}

--- a/components/CrossChainReportCard.tsx
+++ b/components/CrossChainReportCard.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { fadeInUp, spring } from '@/lib/animations';
+import { TrendingUp, TrendingDown, Minus, ExternalLink } from 'lucide-react';
+import { CHAIN_IDENTITIES, getGradeColor, type Chain } from '@/lib/crossChain';
+
+interface ChainData {
+  chain: Chain;
+  participationRate: number | null;
+  delegateCount: number | null;
+  proposalCount: number | null;
+  governanceScore: number | null;
+  grade: string | null;
+  fetchedAt: string | null;
+}
+
+interface HistoryPoint {
+  periodLabel: string;
+  score: number | null;
+  grade: string | null;
+}
+
+interface CrossChainReportCardProps {
+  data: ChainData;
+  history?: HistoryPoint[];
+  className?: string;
+}
+
+export function CrossChainReportCard({ data, history = [], className = '' }: CrossChainReportCardProps) {
+  const identity = CHAIN_IDENTITIES[data.chain];
+  const grade = data.grade ?? '—';
+  const gradeColor = data.grade ? getGradeColor(data.grade) : '#6b7280';
+  const score = data.governanceScore ?? 0;
+
+  const prevScore = history.length >= 2 ? history[history.length - 2]?.score : null;
+  const trend = prevScore != null && data.governanceScore != null
+    ? data.governanceScore > prevScore ? 'up' : data.governanceScore < prevScore ? 'down' : 'flat'
+    : null;
+
+  return (
+    <motion.div
+      variants={fadeInUp}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: '-50px' }}
+      className={`relative overflow-hidden rounded-xl border bg-card/50 p-5 transition-all hover:bg-card/80 ${className}`}
+      style={{
+        borderColor: `${identity.color}20`,
+        boxShadow: `0 0 20px ${identity.color}08, inset 0 1px 0 ${identity.color}10`,
+      }}
+    >
+      {/* Top glow line */}
+      <div
+        className="absolute inset-x-0 top-0 h-px"
+        style={{ background: `linear-gradient(90deg, transparent, ${identity.color}40, transparent)` }}
+      />
+
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        <div
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-sm font-bold"
+          style={{ backgroundColor: `${identity.color}15`, color: identity.color }}
+        >
+          {identity.name[0]}
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold">{identity.name}</h3>
+          <p className="text-xs text-muted-foreground">Governance Health</p>
+        </div>
+      </div>
+
+      {/* Grade */}
+      <div className="mb-4 flex items-end gap-3">
+        <motion.span
+          className="text-5xl font-black tracking-tight"
+          style={{ color: gradeColor }}
+          initial={{ opacity: 0, scale: 0.8 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          viewport={{ once: true }}
+          transition={{ ...spring.bouncy, delay: 0.1 }}
+        >
+          {grade}
+        </motion.span>
+        <div className="mb-1 flex flex-col gap-1">
+          <span className="text-lg font-semibold tabular-nums text-muted-foreground">{score}/100</span>
+          {trend && (
+            <span className={`flex items-center gap-0.5 text-xs font-medium ${
+              trend === 'up' ? 'text-green-500' : trend === 'down' ? 'text-red-500' : 'text-muted-foreground'
+            }`}>
+              {trend === 'up' ? <TrendingUp className="h-3 w-3" /> : trend === 'down' ? <TrendingDown className="h-3 w-3" /> : <Minus className="h-3 w-3" />}
+              {trend === 'up' ? 'Improving' : trend === 'down' ? 'Declining' : 'Stable'}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Mini sparkline */}
+      {history.length > 1 && (
+        <div className="mb-4">
+          <MiniSparkline
+            data={history.map(h => h.score ?? 0)}
+            color={identity.color}
+            height={28}
+          />
+        </div>
+      )}
+
+      {/* Metrics */}
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <MetricCell label="Participation" value={data.participationRate != null ? `${data.participationRate}%` : '—'} />
+        <MetricCell label="Delegates" value={data.delegateCount != null ? formatNumber(data.delegateCount) : '—'} />
+        <MetricCell label="Proposals" value={data.proposalCount != null ? formatNumber(data.proposalCount) : '—'} />
+      </div>
+
+      {data.chain !== 'cardano' && (
+        <div className="mt-3 flex justify-end">
+          <span className="flex items-center gap-1 text-[10px] text-muted-foreground/50">
+            <ExternalLink className="h-2.5 w-2.5" />
+            {data.chain === 'ethereum' ? 'via Tally' : 'via SubSquare'}
+          </span>
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+function MetricCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-sm font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function MiniSparkline({ data, color, height = 28 }: { data: number[]; color: string; height?: number }) {
+  if (data.length < 2) return null;
+
+  const width = 140;
+  const max = Math.max(...data, 100);
+  const min = Math.min(...data, 0);
+  const range = max - min || 1;
+  const padding = 2;
+
+  const points = data.map((v, i) => ({
+    x: padding + (i / (data.length - 1)) * (width - padding * 2),
+    y: padding + (1 - (v - min) / range) * (height - padding * 2),
+  }));
+
+  const pathD = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+  const areaD = `${pathD} L ${points[points.length - 1].x} ${height} L ${points[0].x} ${height} Z`;
+
+  return (
+    <svg width={width} height={height} className="w-full" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+      <defs>
+        <linearGradient id={`spark-${color.replace('#', '')}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path d={areaD} fill={`url(#spark-${color.replace('#', '')})`} />
+      <path d={pathD} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}

--- a/components/DelegatorGovernanceCard.tsx
+++ b/components/DelegatorGovernanceCard.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Award, Calendar, Shield, Share2 } from 'lucide-react';
+import { useWallet } from '@/utils/wallet';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Card, CardContent } from './ui/card';
+import { Button } from './ui/button';
+import { ShareActions } from './ShareActions';
+import { fadeInUp, spring } from '@/lib/animations';
+import { BASE_URL } from '@/lib/constants';
+
+interface GovernanceIdentity {
+  drepName: string | null;
+  drepScore: number | null;
+  drepId: string | null;
+  delegatedSinceEpoch: number | null;
+  currentEpoch: number | null;
+  quizAlignment: string | null;
+  delegationStreak: number;
+}
+
+export function DelegatorGovernanceCard() {
+  const { isAuthenticated, address, delegatedDrepId } = useWallet();
+  const [identity, setIdentity] = useState<GovernanceIdentity | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setLoading(false);
+      return;
+    }
+
+    const token = getStoredSession();
+    if (!token) { setLoading(false); return; }
+
+    const params = new URLSearchParams();
+    if (delegatedDrepId) params.set('drepId', delegatedDrepId);
+
+    fetch(`/api/governance/holder?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!data) return;
+        setIdentity({
+          drepName: data.delegation?.drepName ?? null,
+          drepScore: data.delegation?.drepScore ?? null,
+          drepId: data.delegation?.drepId ?? delegatedDrepId ?? null,
+          delegatedSinceEpoch: data.delegation?.delegatedSinceEpoch ?? null,
+          currentEpoch: data.currentEpoch ?? null,
+          quizAlignment: data.quizResult?.topAlignment ?? null,
+          delegationStreak: data.delegation?.streak ?? 0,
+        });
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [isAuthenticated, delegatedDrepId]);
+
+  if (!isAuthenticated || loading || !identity) return null;
+
+  const epochsActive = identity.currentEpoch && identity.delegatedSinceEpoch
+    ? identity.currentEpoch - identity.delegatedSinceEpoch
+    : null;
+
+  const shareUrl = `${BASE_URL}/governance`;
+  const shareText = identity.drepName
+    ? `I've been an active governance citizen for ${epochsActive ?? '?'} epochs, delegating to ${identity.drepName} (score: ${identity.drepScore ?? '?'}/100) on @drepscore.`
+    : `I'm participating in Cardano governance on @drepscore.`;
+
+  return (
+    <motion.div
+      variants={fadeInUp}
+      initial="hidden"
+      animate="visible"
+    >
+      <Card className="relative overflow-hidden border-primary/20">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+        <CardContent className="p-5">
+          <div className="mb-4 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                <Shield className="h-4 w-4 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold">Your Governance Identity</h3>
+                <p className="text-[11px] text-muted-foreground">Share your governance participation</p>
+              </div>
+            </div>
+            <ShareActions
+              url={shareUrl}
+              text={shareText}
+              imageUrl={`${BASE_URL}/api/og/governance-identity?wallet=${address ?? ''}`}
+              imageFilename="governance-identity.png"
+              surface="delegator_governance_card"
+              variant="compact"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {epochsActive != null && (
+              <StatBadge
+                icon={<Calendar className="h-3.5 w-3.5" />}
+                label="Epochs Active"
+                value={String(epochsActive)}
+              />
+            )}
+            {identity.drepName && (
+              <StatBadge
+                icon={<Shield className="h-3.5 w-3.5" />}
+                label="Delegated To"
+                value={identity.drepName.length > 14 ? `${identity.drepName.slice(0, 14)}...` : identity.drepName}
+              />
+            )}
+            {identity.drepScore != null && (
+              <StatBadge
+                icon={<Award className="h-3.5 w-3.5" />}
+                label="DRep Score"
+                value={`${identity.drepScore}/100`}
+              />
+            )}
+            {identity.quizAlignment && (
+              <StatBadge
+                icon={<Share2 className="h-3.5 w-3.5" />}
+                label="Alignment"
+                value={identity.quizAlignment}
+              />
+            )}
+          </div>
+
+          {identity.delegatedSinceEpoch && (
+            <div className="mt-3 rounded-lg bg-primary/5 px-3 py-1.5 text-center">
+              <span className="text-[11px] font-medium text-primary">
+                Governance Citizen since Epoch {identity.delegatedSinceEpoch}
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}
+
+function StatBadge({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="rounded-lg border bg-card/50 px-3 py-2 text-center">
+      <div className="mb-1 flex justify-center text-muted-foreground">{icon}</div>
+      <div className="text-xs font-semibold tabular-nums">{value}</div>
+      <div className="text-[10px] text-muted-foreground">{label}</div>
+    </div>
+  );
+}

--- a/components/DeveloperPage.tsx
+++ b/components/DeveloperPage.tsx
@@ -1,0 +1,353 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Code2, Blocks, Zap, Key, ArrowRight, Globe, BarChart3, Users } from 'lucide-react';
+import { fadeInUp, staggerContainer, spring } from '@/lib/animations';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Button } from './ui/button';
+import { ApiExplorer } from './ApiExplorer';
+import { CodeExample } from './CodeExample';
+import Link from 'next/link';
+
+const QUICK_START_CODE = {
+  javascript: `// Get the top 5 DReps by score
+const response = await fetch(
+  "https://drepscore.io/api/v1/dreps?limit=5&sort=score"
+);
+const { data, meta } = await response.json();
+
+data.forEach(drep => {
+  console.log(\`\${drep.name}: \${drep.score}/100\`);
+});`,
+  python: `import requests
+
+# Get the top 5 DReps by score
+response = requests.get(
+    "https://drepscore.io/api/v1/dreps",
+    params={"limit": 5, "sort": "score"}
+)
+data = response.json()
+
+for drep in data["data"]:
+    print(f'{drep["name"]}: {drep["score"]}/100')`,
+  curl: `# Get the top 5 DReps by score
+curl "https://drepscore.io/api/v1/dreps?limit=5&sort=score"`,
+};
+
+const EMBED_CODE = {
+  html: `<!-- Embed a DRep score card -->
+<iframe
+  src="https://drepscore.io/embed/drep/DREP_ID?theme=dark"
+  width="320"
+  height="200"
+  frameBorder="0"
+  style="border-radius: 12px; overflow: hidden;"
+></iframe>`,
+  javascript: `<!-- Or use the script loader -->
+<div id="drepscore-widget"></div>
+<script
+  src="https://drepscore.io/embed.js"
+  data-type="drep"
+  data-id="DREP_ID"
+  data-theme="dark"
+></script>`,
+};
+
+export function DeveloperPage() {
+  return (
+    <div className="min-h-screen">
+      {/* Hero */}
+      <section className="relative overflow-hidden border-b border-border/40">
+        <div className="absolute inset-0 bg-gradient-to-b from-primary/5 via-transparent to-transparent" />
+        <div className="container mx-auto max-w-6xl px-4 py-20 relative">
+          <motion.div
+            variants={staggerContainer}
+            initial="hidden"
+            animate="visible"
+            className="mx-auto max-w-3xl text-center space-y-6"
+          >
+            <motion.div variants={fadeInUp} className="flex justify-center">
+              <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-1.5 text-sm font-medium text-primary">
+                <Code2 className="h-4 w-4" />
+                Developer Platform
+              </span>
+            </motion.div>
+            <motion.h1 variants={fadeInUp} className="text-4xl font-bold tracking-tight sm:text-5xl">
+              Build on Governance Intelligence
+            </motion.h1>
+            <motion.p variants={fadeInUp} className="text-lg text-muted-foreground">
+              Access scored DRep data, governance health metrics, and proposal intelligence via a simple REST API. Embed governance widgets on any site.
+            </motion.p>
+            <motion.div variants={fadeInUp} className="flex justify-center gap-3">
+              <Button size="lg" asChild>
+                <a href="#explorer">
+                  Explore the API <ArrowRight className="ml-2 h-4 w-4" />
+                </a>
+              </Button>
+              <Button size="lg" variant="outline" asChild>
+                <a href="#widgets">Embed Widgets</a>
+              </Button>
+            </motion.div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Quick start */}
+      <section className="container mx-auto max-w-6xl px-4 py-16 space-y-8">
+        <motion.div
+          variants={fadeInUp}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          className="text-center space-y-2"
+        >
+          <h2 className="text-2xl font-bold">Get Started in 60 Seconds</h2>
+          <p className="text-muted-foreground">No API key needed for public endpoints.</p>
+        </motion.div>
+
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          className="grid grid-cols-1 gap-6 md:grid-cols-3"
+        >
+          <StepCard
+            step={1}
+            icon={<Zap className="h-5 w-5" />}
+            title="Copy your first call"
+            description="Public endpoints require no authentication. Just fetch and go."
+          />
+          <StepCard
+            step={2}
+            icon={<BarChart3 className="h-5 w-5" />}
+            title="See governance data"
+            description="DRep scores, alignment data, proposals, and ecosystem health — all structured JSON."
+          />
+          <StepCard
+            step={3}
+            icon={<Blocks className="h-5 w-5" />}
+            title="Embed a widget"
+            description="Drop a governance widget on your site with a single iframe or script tag."
+          />
+        </motion.div>
+
+        <CodeExample code={QUICK_START_CODE} />
+      </section>
+
+      {/* API Explorer */}
+      <section id="explorer" className="border-t border-border/40">
+        <div className="container mx-auto max-w-6xl px-4 py-16 space-y-8">
+          <motion.div
+            variants={fadeInUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            className="space-y-2"
+          >
+            <h2 className="text-2xl font-bold">API Explorer</h2>
+            <p className="text-muted-foreground">
+              Interactive documentation for all v1 endpoints. Click &quot;Try it&quot; to make a real request.
+            </p>
+          </motion.div>
+
+          <ApiExplorer />
+        </div>
+      </section>
+
+      {/* Embeddable Widgets */}
+      <section id="widgets" className="border-t border-border/40 bg-muted/5">
+        <div className="container mx-auto max-w-6xl px-4 py-16 space-y-8">
+          <motion.div
+            variants={fadeInUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            className="space-y-2"
+          >
+            <h2 className="text-2xl font-bold">Embeddable Widgets</h2>
+            <p className="text-muted-foreground">
+              Add governance intelligence to any website. DRep score cards, health gauges, and more.
+            </p>
+          </motion.div>
+
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Users className="h-4 w-4 text-primary" />
+                  DRep Score Card
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  Embeddable DRep card with score, alignment radar, and identity color. Available in SVG, HTML, and JSON.
+                </p>
+                <CodeExample code={EMBED_CODE} />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Globe className="h-4 w-4 text-primary" />
+                  Governance Health Gauge
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  Live governance health gauge with trend sparkline. Updates automatically.
+                </p>
+                <CodeExample code={{
+                  html: `<iframe
+  src="https://drepscore.io/embed/ghi?theme=dark"
+  width="280"
+  height="160"
+  frameBorder="0"
+  style="border-radius: 12px;"
+></iframe>`,
+                }} />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Rate limits and tiers */}
+      <section className="border-t border-border/40">
+        <div className="container mx-auto max-w-6xl px-4 py-16 space-y-8">
+          <motion.div
+            variants={fadeInUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            className="space-y-2"
+          >
+            <h2 className="text-2xl font-bold">Rate Limits &amp; Tiers</h2>
+            <p className="text-muted-foreground">
+              Public endpoints are free. Upgrade for higher limits and Pro-only data.
+            </p>
+          </motion.div>
+
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <Card className="relative overflow-hidden">
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-muted-foreground/20 to-transparent" />
+              <CardHeader>
+                <CardTitle className="text-lg">Free</CardTitle>
+                <p className="text-sm text-muted-foreground">No API key required</p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <TierFeature text="10 requests / hour" />
+                <TierFeature text="DRep list + details" />
+                <TierFeature text="Proposals + governance health" />
+                <TierFeature text="Embed widgets (SVG, HTML, JSON)" />
+              </CardContent>
+            </Card>
+
+            <Card className="relative overflow-hidden border-primary/30">
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <CardTitle className="text-lg">Pro</CardTitle>
+                  <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[10px] font-bold text-primary">Coming Soon</span>
+                </div>
+                <p className="text-sm text-muted-foreground">API key authenticated</p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <TierFeature text="10,000 requests / day" highlight />
+                <TierFeature text="All Free tier endpoints" />
+                <TierFeature text="Voting history + rationale" highlight />
+                <TierFeature text="Score history (trend data)" highlight />
+                <TierFeature text="Priority support" />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Auth */}
+      <section className="border-t border-border/40 bg-muted/5">
+        <div className="container mx-auto max-w-6xl px-4 py-16 space-y-8">
+          <motion.div
+            variants={fadeInUp}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            className="space-y-2"
+          >
+            <h2 className="text-2xl font-bold">Authentication</h2>
+            <p className="text-muted-foreground">
+              Pass your API key as a Bearer token in the Authorization header.
+            </p>
+          </motion.div>
+
+          <CodeExample code={{
+            curl: `curl "https://drepscore.io/api/v1/dreps?limit=5" \\
+  -H "Authorization: Bearer ds_live_YOUR_API_KEY"`,
+            javascript: `const response = await fetch("https://drepscore.io/api/v1/dreps?limit=5", {
+  headers: {
+    "Authorization": "Bearer ds_live_YOUR_API_KEY"
+  }
+});`,
+            python: `response = requests.get(
+    "https://drepscore.io/api/v1/dreps",
+    headers={"Authorization": "Bearer ds_live_YOUR_API_KEY"},
+    params={"limit": 5}
+)`,
+          }} />
+
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Key className="h-4 w-4" />
+            <span>API keys start with <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">ds_live_</code>. Pro tier keys coming soon.</span>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="border-t border-border/40">
+        <div className="container mx-auto max-w-6xl px-4 py-16 text-center space-y-4">
+          <h2 className="text-2xl font-bold">Ready to build?</h2>
+          <p className="text-muted-foreground">
+            Start with the API Explorer above, or check out the Pulse page to see governance intelligence in action.
+          </p>
+          <div className="flex justify-center gap-3">
+            <Button asChild>
+              <a href="#explorer">API Explorer</a>
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href="/pulse">View Governance Pulse</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function StepCard({ step, icon, title, description }: { step: number; icon: React.ReactNode; title: string; description: string }) {
+  return (
+    <motion.div variants={fadeInUp}>
+      <Card className="h-full">
+        <CardContent className="p-5 space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-sm font-bold">
+              {step}
+            </div>
+            <div className="text-primary">{icon}</div>
+          </div>
+          <h3 className="font-semibold">{title}</h3>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}
+
+function TierFeature({ text, highlight = false }: { text: string; highlight?: boolean }) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <ChevronRight className={`h-3.5 w-3.5 ${highlight ? 'text-primary' : 'text-muted-foreground'}`} />
+      <span className={highlight ? 'text-foreground font-medium' : 'text-muted-foreground'}>{text}</span>
+    </div>
+  );
+}

--- a/components/EmbedCrossChain.tsx
+++ b/components/EmbedCrossChain.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CHAIN_IDENTITIES, getGradeColor, type Chain } from '@/lib/crossChain';
+
+interface EmbedCrossChainProps {
+  theme: 'dark' | 'light';
+}
+
+interface BenchmarkData {
+  governance_score: number | null;
+  grade: string | null;
+  participation_rate: number | null;
+}
+
+export function EmbedCrossChain({ theme }: EmbedCrossChainProps) {
+  const isDark = theme === 'dark';
+  const [benchmarks, setBenchmarks] = useState<Record<string, BenchmarkData | null>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/governance/benchmarks')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.benchmarks) setBenchmarks(data.benchmarks);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const chains: Chain[] = ['cardano', 'ethereum', 'polkadot'];
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center justify-center p-6"
+        style={{ backgroundColor: isDark ? '#0a0b14' : '#fff', minHeight: 120 }}
+      >
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" style={{ borderColor: '#06b6d4', borderTopColor: 'transparent' }} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="p-4 rounded-xl"
+      style={{
+        backgroundColor: isDark ? '#0a0b14' : '#fff',
+        color: isDark ? '#fff' : '#0a0b14',
+        border: `1px solid rgba(6, 182, 212, 0.15)`,
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: 360,
+      }}
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-wider mb-3" style={{ color: isDark ? '#6b7280' : '#9ca3af' }}>
+        Governance Across Chains
+      </div>
+
+      <div className="space-y-2">
+        {chains.map(chain => {
+          const b = benchmarks[chain];
+          const identity = CHAIN_IDENTITIES[chain];
+          const grade = b?.grade ?? '—';
+          const gradeColor = b?.grade ? getGradeColor(b.grade) : '#6b7280';
+
+          return (
+            <div
+              key={chain}
+              className="flex items-center gap-3 rounded-lg p-2"
+              style={{ backgroundColor: `${identity.color}08` }}
+            >
+              <div
+                className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-bold"
+                style={{ backgroundColor: `${identity.color}15`, color: identity.color }}
+              >
+                {identity.name[0]}
+              </div>
+              <span className="flex-1 text-sm font-medium">{identity.name}</span>
+              <span
+                className="text-xl font-black"
+                style={{ color: gradeColor }}
+              >
+                {grade}
+              </span>
+              <span className="text-xs tabular-nums" style={{ color: isDark ? '#6b7280' : '#9ca3af' }}>
+                {b?.governance_score ?? '—'}/100
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex justify-between items-center">
+        <a
+          href="https://drepscore.io/pulse"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-medium hover:underline"
+          style={{ color: '#06b6d4' }}
+        >
+          View full comparison →
+        </a>
+        <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
+          drepscore.io
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/EmbedDRepCard.tsx
+++ b/components/EmbedDRepCard.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { extractAlignments, getIdentityColor, getDominantDimension } from '@/lib/drepIdentity';
+import { getDRepPrimaryName } from '@/utils/display';
+import type { EnrichedDRep } from '@/types/drep';
+
+interface EmbedDRepCardProps {
+  drep: EnrichedDRep;
+  theme: 'dark' | 'light';
+}
+
+export function EmbedDRepCard({ drep, theme }: EmbedDRepCardProps) {
+  const isDark = theme === 'dark';
+  const alignments = extractAlignments(drep);
+  const dominant = getDominantDimension(alignments);
+  const identityColor = dominant ? getIdentityColor(dominant) : null;
+  const name = getDRepPrimaryName(drep);
+  const accentColor = identityColor?.hex ?? '#06b6d4';
+
+  return (
+    <div
+      className="p-4 rounded-xl overflow-hidden"
+      style={{
+        backgroundColor: isDark ? '#0a0b14' : '#ffffff',
+        border: `1px solid ${accentColor}25`,
+        color: isDark ? '#fff' : '#0a0b14',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: 320,
+      }}
+    >
+      {/* Top accent line */}
+      <div
+        className="h-0.5 -mx-4 -mt-4 mb-3"
+        style={{ background: `linear-gradient(90deg, transparent, ${accentColor}, transparent)` }}
+      />
+
+      <div className="flex items-center gap-3 mb-3">
+        <div
+          className="flex h-10 w-10 items-center justify-center rounded-lg text-sm font-bold"
+          style={{ backgroundColor: `${accentColor}15`, color: accentColor }}
+        >
+          {(name?.[0] ?? 'D').toUpperCase()}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-semibold truncate">{name}</div>
+          <div className="text-xs" style={{ color: isDark ? '#9ca3af' : '#6b7280' }}>
+            {identityColor?.label ?? 'DRep'}
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-2xl font-black tabular-nums" style={{ color: accentColor }}>
+            {drep.drepScore}
+          </div>
+          <div className="text-[10px]" style={{ color: isDark ? '#6b7280' : '#9ca3af' }}>/100</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <MiniStat label="Participation" value={`${drep.effectiveParticipation ?? 0}%`} isDark={isDark} />
+        <MiniStat label="Rationale" value={`${drep.rationaleRate ?? 0}%`} isDark={isDark} />
+        <MiniStat label="Reliability" value={`${drep.reliabilityScore ?? 0}%`} isDark={isDark} />
+      </div>
+
+      <div className="mt-3 flex items-center justify-between">
+        <a
+          href={`https://drepscore.io/drep/${encodeURIComponent(drep.drepId)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-medium hover:underline"
+          style={{ color: accentColor }}
+        >
+          View full profile →
+        </a>
+        <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
+          drepscore.io
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function MiniStat({ label, value, isDark }: { label: string; value: string; isDark: boolean }) {
+  return (
+    <div>
+      <div className="text-[10px]" style={{ color: isDark ? '#6b7280' : '#9ca3af' }}>{label}</div>
+      <div className="text-xs font-semibold tabular-nums">{value}</div>
+    </div>
+  );
+}

--- a/components/EmbedGHI.tsx
+++ b/components/EmbedGHI.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { GHI_BAND_COLORS, GHI_BAND_LABELS, type GHIBand } from '@/lib/ghi';
+
+interface EmbedGHIProps {
+  theme: 'dark' | 'light';
+}
+
+interface GHIData {
+  current: { score: number; band: GHIBand; components: { name: string; value: number }[] };
+  history: { epoch_no: number; score: number }[];
+  trend: { direction: string };
+}
+
+export function EmbedGHI({ theme }: EmbedGHIProps) {
+  const isDark = theme === 'dark';
+  const [data, setData] = useState<GHIData | null>(null);
+
+  useEffect(() => {
+    fetch('/api/governance/health-index/history?epochs=10')
+      .then(r => r.ok ? r.json() : null)
+      .then(setData)
+      .catch(() => {});
+  }, []);
+
+  if (!data) {
+    return (
+      <div
+        className="flex items-center justify-center p-6"
+        style={{ backgroundColor: isDark ? '#0a0b14' : '#fff', minHeight: 120 }}
+      >
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" style={{ borderColor: '#06b6d4', borderTopColor: 'transparent' }} />
+      </div>
+    );
+  }
+
+  const { score, band } = data.current;
+  const bandColor = GHI_BAND_COLORS[band];
+  const bandLabel = GHI_BAND_LABELS[band];
+
+  return (
+    <div
+      className="p-4 rounded-xl"
+      style={{
+        backgroundColor: isDark ? '#0a0b14' : '#fff',
+        color: isDark ? '#fff' : '#0a0b14',
+        border: `1px solid ${bandColor}25`,
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        maxWidth: 280,
+      }}
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-wider mb-2" style={{ color: isDark ? '#6b7280' : '#9ca3af' }}>
+        Governance Health Index
+      </div>
+
+      <div className="flex items-end gap-2 mb-3">
+        <span className="text-4xl font-black tabular-nums" style={{ color: bandColor }}>
+          {score}
+        </span>
+        <span className="mb-1 text-xs font-medium" style={{ color: bandColor }}>
+          {bandLabel}
+        </span>
+      </div>
+
+      {data.history.length > 1 && (
+        <svg className="w-full" height="24" viewBox="0 0 140 24" preserveAspectRatio="none">
+          <defs>
+            <linearGradient id="ghi-embed-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={bandColor} stopOpacity={0.2} />
+              <stop offset="100%" stopColor={bandColor} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          {(() => {
+            const pts = data.history.map(h => h.score);
+            const max = Math.max(...pts, 100);
+            const min = Math.min(...pts, 0);
+            const range = max - min || 1;
+            const coords = pts.map((v, i) => ({
+              x: 2 + (i / (pts.length - 1)) * 136,
+              y: 2 + (1 - (v - min) / range) * 20,
+            }));
+            const lineD = coords.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ');
+            const areaD = `${lineD} L ${coords[coords.length - 1].x} 24 L ${coords[0].x} 24 Z`;
+            return (
+              <>
+                <path d={areaD} fill="url(#ghi-embed-grad)" />
+                <path d={lineD} fill="none" stroke={bandColor} strokeWidth={1.5} strokeLinecap="round" />
+              </>
+            );
+          })()}
+        </svg>
+      )}
+
+      <div className="mt-2 flex justify-between items-center">
+        <a
+          href="https://drepscore.io/pulse"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] font-medium hover:underline"
+          style={{ color: '#06b6d4' }}
+        >
+          View full report →
+        </a>
+        <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
+          drepscore.io
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/FeatureGate.tsx
+++ b/components/FeatureGate.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { fetchClientFlags } from '@/lib/featureFlags';
+
+interface FeatureGateProps {
+  flag: string;
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+let clientFlagCache: Record<string, boolean> | null = null;
+let clientCachePromise: Promise<Record<string, boolean>> | null = null;
+
+function getClientFlags(): Promise<Record<string, boolean>> {
+  if (clientFlagCache) return Promise.resolve(clientFlagCache);
+  if (!clientCachePromise) {
+    clientCachePromise = fetchClientFlags().then(flags => {
+      clientFlagCache = flags;
+      setTimeout(() => { clientFlagCache = null; clientCachePromise = null; }, 60_000);
+      return flags;
+    });
+  }
+  return clientCachePromise;
+}
+
+/**
+ * Client-side feature gate. Renders children only if the flag is enabled.
+ * Shows nothing (or fallback) while loading or if flag is disabled.
+ */
+export function FeatureGate({ flag, children, fallback = null }: FeatureGateProps) {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    getClientFlags().then(flags => {
+      setEnabled(flags[flag] ?? true);
+    });
+  }, [flag]);
+
+  if (enabled === null) return null;
+  if (!enabled) return <>{fallback}</>;
+  return <>{children}</>;
+}
+
+/**
+ * Hook for checking a feature flag in client components.
+ * Returns null while loading, then boolean.
+ */
+export function useFeatureFlag(flag: string): boolean | null {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    getClientFlags().then(flags => {
+      setEnabled(flags[flag] ?? true);
+    });
+  }, [flag]);
+
+  return enabled;
+}

--- a/components/GovernanceObservatory.tsx
+++ b/components/GovernanceObservatory.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Globe, Share2 } from 'lucide-react';
+import { staggerContainer, fadeInUp } from '@/lib/animations';
+import { CrossChainReportCard } from './CrossChainReportCard';
+import { ShareActions } from './ShareActions';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { BASE_URL } from '@/lib/constants';
+import type { Chain } from '@/lib/crossChain';
+
+interface BenchmarkData {
+  chain: string;
+  participation_rate: number | null;
+  delegate_count: number | null;
+  proposal_count: number | null;
+  governance_score: number | null;
+  grade: string | null;
+  fetched_at: string | null;
+}
+
+interface HistoryPoint {
+  periodLabel: string;
+  score: number | null;
+  grade: string | null;
+}
+
+interface GovernanceObservatoryProps {
+  variant?: 'full' | 'compact';
+  className?: string;
+}
+
+export function GovernanceObservatory({ variant = 'full', className = '' }: GovernanceObservatoryProps) {
+  const [benchmarks, setBenchmarks] = useState<Record<string, BenchmarkData | null>>({});
+  const [history, setHistory] = useState<Record<string, HistoryPoint[]>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/governance/benchmarks');
+        if (!res.ok) return;
+        const data = await res.json();
+        setBenchmarks(data.benchmarks ?? {});
+        setHistory(data.history ?? {});
+      } catch {
+        // Graceful degradation — don't show section
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const chains: Chain[] = ['cardano', 'ethereum', 'polkadot'];
+  const hasData = chains.some(c => benchmarks[c] != null);
+
+  if (loading) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Globe className="h-5 w-5 text-primary" />
+            Governance Across Chains
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="h-48 animate-pulse rounded-xl bg-muted/20" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!hasData) return null;
+
+  if (variant === 'compact') {
+    return (
+      <motion.div
+        variants={fadeInUp}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true }}
+        className={`flex flex-wrap items-center justify-center gap-4 text-sm ${className}`}
+      >
+        <span className="flex items-center gap-1.5 text-muted-foreground">
+          <Globe className="h-3.5 w-3.5" />
+          Governance across 3 chains:
+        </span>
+        {chains.map(chain => {
+          const b = benchmarks[chain];
+          if (!b) return null;
+          return (
+            <span key={chain} className="flex items-center gap-1.5">
+              <span className="font-medium capitalize">{chain}</span>
+              <span
+                className="rounded-md px-1.5 py-0.5 text-xs font-bold"
+                style={{
+                  backgroundColor: `${getChainColor(chain)}15`,
+                  color: getChainColor(chain),
+                }}
+              >
+                {b.grade ?? '—'}
+              </span>
+            </span>
+          );
+        })}
+      </motion.div>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Globe className="h-5 w-5 text-primary" />
+            Governance Across Chains
+          </CardTitle>
+          <ShareActions
+            url={`${BASE_URL}/pulse`}
+            text="How does governance health compare across Cardano, Ethereum, and Polkadot? Check the report cards on @drepscore:"
+            imageUrl={`${BASE_URL}/api/og/cross-chain`}
+            imageFilename="cross-chain-governance.png"
+            surface="cross_chain_observatory"
+            variant="compact"
+          />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          How does Cardano&apos;s governance stack up against other major chains?
+        </p>
+      </CardHeader>
+      <CardContent>
+        <motion.div
+          variants={staggerContainer}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true }}
+          className="grid grid-cols-1 gap-4 sm:grid-cols-3"
+        >
+          {chains.map(chain => {
+            const b = benchmarks[chain];
+            if (!b) return null;
+            return (
+              <CrossChainReportCard
+                key={chain}
+                data={{
+                  chain,
+                  participationRate: b.participation_rate,
+                  delegateCount: b.delegate_count,
+                  proposalCount: b.proposal_count,
+                  governanceScore: b.governance_score,
+                  grade: b.grade,
+                  fetchedAt: b.fetched_at,
+                }}
+                history={history[chain] ?? []}
+              />
+            );
+          })}
+        </motion.div>
+
+        {/* Methodology note */}
+        <p className="mt-4 text-center text-[11px] text-muted-foreground/60">
+          Scores computed from on-chain participation, delegate activity, and proposal throughput.
+          Data: Cardano (GHI), Ethereum (Tally), Polkadot (SubSquare). Updated weekly.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function getChainColor(chain: Chain): string {
+  const colors: Record<Chain, string> = {
+    cardano: '#06b6d4',
+    ethereum: '#a855f7',
+    polkadot: '#ec4899',
+  };
+  return colors[chain];
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -42,6 +42,7 @@ import {
   Clock,
   Activity,
   Inbox,
+  Code2,
 } from 'lucide-react';
 import { MobileNav } from './MobileNav';
 import { GovernanceHeartbeat } from './GovernanceHeartbeat';
@@ -184,6 +185,10 @@ export function Header() {
               <span>Dashboard</span>
             </Link>
           )}
+          <Link href="/developers" className={`${navLinkClass('/developers')} hidden lg:flex`}>
+            <Code2 className="h-4 w-4" />
+            <span>Developers</span>
+          </Link>
           
           {isAuthenticated && sessionAddress ? (
             <>

--- a/components/HomepageDualMode.tsx
+++ b/components/HomepageDualMode.tsx
@@ -7,6 +7,8 @@ import { HowItWorksV2 } from '@/components/HowItWorksV2';
 import { DRepDiscoveryPreview } from '@/components/DRepDiscoveryPreview';
 import { CardanoGovernanceExplainer } from '@/components/CardanoGovernanceExplainer';
 import { GovernanceHealthIndex } from '@/components/GovernanceHealthIndex';
+import { GovernanceObservatory } from '@/components/GovernanceObservatory';
+import { FeatureGate } from '@/components/FeatureGate';
 
 interface PreviewDRep {
   drepId: string;
@@ -70,6 +72,10 @@ export function HomepageDualMode({ pulseData, topDReps, ssrHolderData, ssrWallet
         <div className="flex justify-center">
           <GovernanceHealthIndex size="compact" className="opacity-80 hover:opacity-100 transition-opacity" />
         </div>
+
+        <FeatureGate flag="cross_chain_observatory">
+          <GovernanceObservatory variant="compact" className="opacity-80 hover:opacity-100 transition-opacity" />
+        </FeatureGate>
 
         <HowItWorksV2 />
 

--- a/components/admin/FeatureFlagAdmin.tsx
+++ b/components/admin/FeatureFlagAdmin.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, CheckCircle2, XCircle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface FlagDetail {
+  key: string;
+  enabled: boolean;
+  description: string | null;
+  updatedAt: string;
+}
+
+export function FeatureFlagAdmin() {
+  const [flags, setFlags] = useState<FlagDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/admin/feature-flags');
+      if (!res.ok) return;
+      const data = await res.json();
+      setFlags(data.details ?? []);
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const toggle = async (key: string, enabled: boolean) => {
+    setToggling(key);
+    try {
+      const res = await fetch('/api/admin/feature-flags', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key, enabled }),
+      });
+      if (res.ok) {
+        setFlags(prev => prev.map(f => f.key === key ? { ...f, enabled } : f));
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading flags...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Button variant="ghost" size="sm" onClick={load} className="gap-1.5 text-xs">
+          <RefreshCw className="h-3 w-3" />
+          Refresh
+        </Button>
+      </div>
+
+      {flags.map(flag => (
+        <Card key={flag.key}>
+          <CardContent className="flex items-center gap-4 p-4">
+            <Switch
+              checked={flag.enabled}
+              onCheckedChange={(checked) => toggle(flag.key, checked)}
+              disabled={toggling === flag.key}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <code className="text-sm font-mono font-medium">{flag.key}</code>
+                <Badge variant={flag.enabled ? 'default' : 'secondary'} className="text-[10px]">
+                  {flag.enabled ? 'ON' : 'OFF'}
+                </Badge>
+              </div>
+              {flag.description && (
+                <p className="text-xs text-muted-foreground mt-0.5">{flag.description}</p>
+              )}
+            </div>
+            <div className="flex items-center shrink-0">
+              {toggling === flag.key ? (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              ) : flag.enabled ? (
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+              ) : (
+                <XCircle className="h-4 w-4 text-red-500" />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+
+      {flags.length === 0 && (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          No feature flags found. Add them via the database.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/docs/strategy/product-wow-plan-v2.md
+++ b/docs/strategy/product-wow-plan-v2.md
@@ -1,6 +1,6 @@
 # Product "Wow" Plan v2 — DRepScore
 
-> From comprehensive governance tool to the app that makes the entire crypto space say "wow." Sessions 12-19 transform the product through emotional design, visual identity, architecture, narrative, intelligence, social mechanics, cross-chain positioning, and sensory polish.
+> From comprehensive governance tool to the app that makes the entire crypto space say "wow." Sessions 12-21 transform the product through emotional design, visual identity, architecture, narrative, intelligence, social mechanics, cross-chain positioning, developer distribution, community flywheel, on-chain actions, and sensory polish.
 
 **Created:** March 2, 2026
 **Predecessors:** `product-wow-plan.md` (Sessions 1-7), `product-wow-plan-v1.5.md` (Sessions 8-11)
@@ -20,11 +20,13 @@
 8. [Session 15 — The Narrative & Feel Layer](#session-15--the-narrative--feel-layer)
 9. [Session 16 — Governance Intelligence Engine](#session-16--governance-intelligence-engine)
 10. [Session 17 — The Live Social Layer](#session-17--the-live-social-layer)
-11. [Session 18 — Cross-Chain Intelligence & Developer Platform](#session-18--cross-chain-intelligence--developer-platform)
+11. [Session 18 — Cross-Chain Governance Intelligence Hub](#session-18--cross-chain-governance-intelligence-hub)
 12. [Session 19 — Sensory Polish & Performance](#session-19--sensory-polish--performance)
-13. [Execution Order](#execution-order-and-dependencies)
-14. [Anti-Patterns](#anti-patterns)
-15. [Deferred Items](#deferred-items)
+13. [Session 20 — Governance Wrapped & Community Flywheel](#session-20--governance-wrapped--community-flywheel)
+14. [Session 21 — On-Chain Actions & Real-Time](#session-21--on-chain-actions--real-time)
+15. [Execution Order](#execution-order-and-dependencies)
+16. [Anti-Patterns](#anti-patterns)
+17. [Deferred Items](#deferred-items)
 
 ---
 
@@ -87,8 +89,10 @@ Our north star is getting DRepScore as close to 100/100 on a "wow" factor scale 
 | S15 | ~69-72 | +7-10 | Narrative layer, GHI number, basic insights, empty states (note: page transitions, social proof not built) |
 | S16 | ~78-82 | +9-10 | Intelligence engine, GHI trend/sparkline, AI narratives, State of Governance report, expanded insights |
 | S17 | ~87 | +5 | Social layer, page transitions (S15 gap), activity feeds, sharing culture |
-| S18 | ~91 | +4 | Cross-chain intelligence, developer platform, API explorer |
-| S19 | ~95-96 | +4-5 | Sensory polish, sound design, scroll storytelling, performance audit, community showcase |
+| S18 | ~92-93 | +5-6 | Cross-chain intelligence hub, developer platform, embeddable widgets, delegator identity, feature flags |
+| S19 | ~96 | +3-4 | Sensory polish, sound design, scroll storytelling, Cmd+K, PWA, performance, community showcase |
+| S20 | ~97 | +1 | Governance Wrapped, community flywheel, editorial content |
+| S21 | ~98+ | +1 | On-chain actions, real-time WebSocket, offline-first |
 
 All agents working on sessions should internalize this scoring framework and proactively identify opportunities to push the score higher within their session's scope.
 
@@ -565,30 +569,59 @@ DRepScore is a read-only analytical tool where all communication is one-directio
 
 ---
 
-## Session 18 — Cross-Chain Intelligence & Developer Platform
+## Session 18 — Cross-Chain Governance Intelligence Hub
 
 ### Thesis
 
-With S16's intelligence engine and S17's social layer in place, Session 18 positions DRepScore beyond Cardano. Cross-chain governance benchmarking (automated via public APIs) and a developer platform make DRepScore THE governance intelligence hub, not just a Cardano tool.
+With S16's intelligence engine and S17's social layer in place, Session 18 positions DRepScore beyond Cardano. The original scope was three items (cross-chain benchmarking, developer page, API docs). The expanded session transforms DRepScore into a governance intelligence hub with five pillars: cross-chain observatory, developer platform, embeddable widget ecosystem, delegator governance identity, and feature flag infrastructure for safe rollout. This is the "not just Cardano" moment.
 
-### What Changes
+### What Was Built (S18 Delivery)
 
-**1. Cross-chain governance benchmarking.** Automated data collection from public APIs: Tally (Ethereum governance), SubSquare (Polkadot OpenGov). Comparison dashboard showing participation rates, delegate counts, proposal throughput across chains. New `governance_benchmarks` table with automated sync. Positions DRepScore as cross-chain governance authority.
+**1. Cross-Chain Governance Observatory.** Automated data collection from Tally (Ethereum) and SubSquare (Polkadot) via weekly Inngest cron. New `governance_benchmarks` table stores participation rates, delegate counts, proposal throughput, computed governance scores (0-100), and letter grades per chain. `lib/crossChain.ts` centralizes adapters, scoring, and grade computation. `CrossChainReportCard` components display each chain with sparkline trends, identity colors, and Framer Motion animations. `GovernanceObservatory` orchestrates the three-chain display on both the Pulse page (full) and Homepage (compact stat strip). OG image route at `/api/og/cross-chain` for social sharing.
 
-**2. Developer experience page (`/developers`).** Interactive API explorer, code examples (JS, Python, cURL), embed widget generator. API keys for Pro tier. Rate limits: 100/min public, 1000/min Pro.
+**2. Developer Experience Platform (`/developers`).** Stripe-quality developer page with: guided quick-start flow (get key → install → query), interactive `ApiExplorer` component with endpoint browser, parameter docs, and live "Try It" with real responses. Multi-language `CodeExample` component (cURL, JavaScript, Python) with copy-to-clipboard. Rate limit tiers documented: Anonymous (30/min), Free (100/min), Pro (1000/min), Enterprise (unlimited). Fixed critical rate limit bug where authenticated API keys were incorrectly using anonymous limits. Added `/developers` link to main navigation header.
 
-**3. API documentation and explorer.** Full documentation of the v1 API with interactive try-it-out interface.
+**3. Embeddable Widget Ecosystem.** Four embed types: DRep Card (`/embed/drep/[drepId]`), GHI Gauge (`/embed/ghi`), Cross-Chain Comparison (`/embed/cross-chain`), and Governance Radar (existing). Dedicated `app/embed/layout.tsx` strips global chrome for clean iframe rendering. Self-contained embed components (`EmbedDRepCard`, `EmbedGHI`, `EmbedCrossChain`) with theme support (dark/light). `public/embed.js` script loader for zero-code integration via data attributes. Widget builder section on the developer page with copy-paste iframe/script snippets.
+
+**4. Delegator Governance Identity Card.** `DelegatorGovernanceCard` component on the Governance page shows a user's governance age, delegated DRep (with score), quiz alignment match, and delegation streak. OG image route at `/api/og/governance-identity` generates personalized shareable cards. Share prompt encourages delegators to broadcast their governance participation.
+
+**5. Feature Flag Infrastructure.** Supabase-backed `feature_flags` table with admin UI at `/admin/flags` for instant toggles without redeployment. `lib/featureFlags.ts` provides server-side `getFeatureFlag()` and client-side `<FeatureGate>` wrapper with 60s in-memory cache, env var overrides (`FF_<KEY>=true|false`), and upgrade path to per-user targeting. Cross-chain features gated by three flags: `cross_chain_observatory`, `cross_chain_embed`, `cross_chain_sync`. Critical capability for pre-market feature management.
+
+### Current State (for agent context)
+
+- `lib/crossChain.ts` — Chain types, adapters (Tally GraphQL, SubSquare REST), scoring, grading, identities
+- `inngest/functions/sync-governance-benchmarks.ts` — Weekly cron with feature flag check
+- `app/api/governance/benchmarks/route.ts` — Benchmarks API (flag-gated)
+- `components/CrossChainReportCard.tsx` — Single chain report card with sparkline
+- `components/GovernanceObservatory.tsx` — Three-chain orchestrator (full + compact variants)
+- `app/developers/page.tsx` + `components/DeveloperPage.tsx` — Developer platform shell + content
+- `components/ApiExplorer.tsx` — Interactive endpoint browser with try-it
+- `components/CodeExample.tsx` — Multi-language code snippets
+- `app/embed/layout.tsx` — Minimal embed layout
+- `app/embed/drep/[drepId]/page.tsx`, `app/embed/ghi/page.tsx`, `app/embed/cross-chain/page.tsx` — Embed pages
+- `components/EmbedDRepCard.tsx`, `components/EmbedGHI.tsx`, `components/EmbedCrossChain.tsx` — Embed components
+- `public/embed.js` — Script loader for zero-code embedding
+- `components/DelegatorGovernanceCard.tsx` — Delegator identity card
+- `lib/featureFlags.ts` — Feature flag system
+- `components/FeatureGate.tsx` — Client-side feature gate wrapper
+- `app/admin/flags/page.tsx` + `components/admin/FeatureFlagAdmin.tsx` — Admin toggle UI
+- Database: `governance_benchmarks` table, `feature_flags` table
+- Feature flags: `cross_chain_observatory`, `cross_chain_embed`, `cross_chain_sync` (all default ON)
 
 ### Success Criteria
 
 - Cross-chain benchmarking brings non-Cardano users to DRepScore
 - At least 3 external integrations from developer platform within 3 months
-- API documentation reduces support burden
+- Embeddable widgets appear on at least 5 external sites within 6 months
+- Delegator identity cards generate social sharing within Cardano community
+- Feature flags enable safe rollout of controversial features without code changes
 
 ### Risks
 
-- Cross-chain API reliability: Tally and SubSquare APIs may change without notice. Build with fallback/caching.
-- Developer platform requires API key management infrastructure.
+- **Cross-chain API reliability**: Tally and SubSquare APIs may change without notice. Built with 7-day cache, graceful degradation, and feature flags for instant kill switch.
+- **Cross-chain governance score methodology**: Different chains have fundamentally different structures. The "grade" is inherently opinionated. Methodology should be published transparently and community feedback solicited before removing feature flag.
+- **Developer platform adoption**: Interactive explorer could balloon in scope. Shipped functional v1; iterate based on actual developer feedback.
+- **Embed security**: iframes are sandboxed but script loader requires trust. CSP headers and origin validation planned for v2.
 
 ---
 
@@ -596,7 +629,7 @@ With S16's intelligence engine and S17's social layer in place, Session 18 posit
 
 ### Thesis
 
-After Sessions 15-18 deliver narrative, intelligence, social, and cross-chain features, Session 19 is a dedicated polish pass to push from 91 to 95+ on the wow scale. Pure quality — no new features, just refinement of everything already built.
+After Sessions 15-18 deliver narrative, intelligence, social, cross-chain, and developer features, Session 19 is a dedicated polish pass to push from ~92-93 to ~96. Pure quality — no new features, just refinement of everything already built, plus pro-tool power-user touches.
 
 ### What Changes
 
@@ -612,18 +645,96 @@ After Sessions 15-18 deliver narrative, intelligence, social, and cross-chain fe
 
 **6. Advanced OG image system.** Dynamic OG images that update in real-time (e.g., DRep OG image shows current score, not cached score). Makes shared links always current. Upgrade existing OG routes to use ISR with shorter revalidation.
 
+**7. Cmd+K command palette.** Keyboard-first search and navigation using `cmdk` library (~5KB). Search DReps, jump to proposals, toggle dark mode, navigate to any page. Power user delight. Think Linear/Raycast — fast, beautiful, and addictive.
+
+**8. PWA installability.** `manifest.json`, service worker for offline shell, install prompt. For users who check governance daily — the app should live on their homescreen/dock.
+
+**9. Keyboard shortcuts.** `?` for help overlay, `d` for discover, `p` for proposals, `g` for governance. Pro-tool feel that rewards frequent users.
+
+**10. Micro-interaction Easter eggs.** Subtle surprises: hover a perfect 100 score for a confetti burst, delegation anniversary celebration, secret konami code for constellation fireworks. Delight moments that reward exploration.
+
 ### Success Criteria
 
 - Core Web Vitals green on all pages
 - "DRep of the Epoch" generates community engagement and repeat visits
 - Sound design, when enabled, creates memorable "moments" without being annoying
 - Scroll-driven storytelling makes DRep profiles feel like premium product pages
+- Cmd+K becomes the primary navigation method for power users
+- At least 100 PWA installs within first month
 
 ### Risks
 
 - Sound design requires careful taste — bad audio is worse than no audio. Start with 1-2 sounds, test extensively.
 - Performance optimization may require architectural changes (RSC boundaries, streaming).
 - Community showcase requires editorial process — plan for content moderation.
+- Cmd+K requires careful index of all navigable content to be useful.
+
+---
+
+## Session 20 — Governance Wrapped & Community Flywheel
+
+### Thesis
+
+Session 19 polishes the product to near-perfection. Session 20 adds the community and content flywheel that makes DRepScore self-sustaining — users create content that attracts more users. The centerpiece is a full "Governance Wrapped" annual experience that becomes the most shared Cardano governance artifact of the year.
+
+### What Changes
+
+**1. Governance Wrapped — annual shareable experience.** Full multi-slide interactive story (deferred from S17) showing a user's governance year: votes influenced, proposals they cared about, DRep loyalty, governance personality evolution, community impact. Each slide is a shareable OG image. Think Spotify Wrapped for governance. This is the single highest-virality feature in the roadmap.
+
+**2. Community showcase expansion.** "DRep of the Epoch" editorial system with community nomination and voting. Spotlight page with DRep's governance story, identity radar, and key votes. Drives repeat visits and DRep engagement.
+
+**3. Community-submitted governance stories.** Moderated submission flow for delegators and DReps to share governance experiences, case studies, and perspectives. Curated on the Pulse page. Creates owned content that compounds over time.
+
+**4. Governance leaderboards with seasonal resets.** Epoch-based leaderboard seasons with historical archives. Seasonal badges for top performers. Gamification that resets ensures ongoing engagement rather than permanent dominance by early adopters.
+
+**5. User-generated insights and commentary.** Moderated proposal commentary system — lightweight annotations on proposals from community members. Not full discussion threads (deferred), but curated perspectives that add context.
+
+### Success Criteria
+
+- Governance Wrapped generates >1000 shares in first week
+- Community showcase drives 20%+ increase in DRep profile claims
+- Seasonal leaderboards increase weekly active users by 15%+
+- Community stories become a cited resource in Cardano forums
+
+### Risks
+
+- Governance Wrapped requires careful data pipeline to aggregate a full year of user activity. Plan data collection early.
+- Editorial content requires moderation infrastructure and human review — not fully automatable.
+- Seasonal leaderboards must balance competitiveness with inclusivity — avoid rewarding only whale DReps.
+
+---
+
+## Session 21 — On-Chain Actions & Real-Time
+
+### Thesis
+
+DRepScore has been a read-only intelligence layer. Session 21 closes the loop by enabling direct on-chain governance actions from within the app and upgrading the entire experience to real-time. This is the final "wow" — DRepScore becomes the command center where governance actually happens, not just where it's observed.
+
+### What Changes
+
+**1. Direct vote casting from DRepScore.** If GovTool adoption patterns confirm demand (monitor through S18-S20), build native vote submission. DReps can cast votes, submit rationale, and delegate — all without leaving DRepScore. Uses MeshSDK (already integrated for delegation).
+
+**2. Real-time WebSocket governance feed.** Replace all polling (activity ticker, feeds, social proof, GHI) with Supabase Realtime subscriptions. Governance events appear instantly. The entire platform feels alive — not periodically refreshed.
+
+**3. Full offline-first PWA.** Service worker caching of governance data, proposals, and DRep profiles. Users can browse cached data offline and sync when reconnected. Critical for users in regions with unreliable connectivity.
+
+**4. Actionable push notifications.** Deep-link notifications that take users directly to the relevant action: "Proposal X expires in 2 hours — vote now" links directly to the proposal with vote UI ready. Reduces friction from awareness to action.
+
+**5. Floating compare tray.** While browsing DReps on Discover, pin candidates to a floating comparison tray at the bottom. Click to expand into full comparison view. Deferred since S14 — now the interaction design is mature enough to build it well.
+
+### Success Criteria
+
+- >50% of DRep votes cast through DRepScore within 3 months of launch
+- Real-time feed creates a "live dashboard" sensation — users keep the tab open
+- Offline-first enables governance participation in connectivity-constrained environments
+- Actionable notifications achieve >30% click-through rate
+
+### Risks
+
+- On-chain transaction signing requires extensive wallet compatibility testing (Eternl, Lace, Nami, Flint, etc.)
+- Real-time subscriptions at scale require Supabase Realtime capacity planning
+- Offline-first PWA with real-time creates complex sync conflict scenarios
+- Vote casting carries legal/liability considerations — ensure clear disclaimers
 
 ---
 
@@ -636,20 +747,23 @@ graph LR
     S14 --> S15[Session 15: Narrative & Feel]
     S15 --> S16[Session 16: Intelligence]
     S15 --> S17[Session 17: Social Layer]
-    S16 --> S18[Session 18: Cross-Chain & Platform]
+    S16 --> S18[Session 18: Cross-Chain Intelligence Hub]
     S17 --> S18
     S18 --> S19[Session 19: Sensory Polish]
+    S19 --> S20[Session 20: Governance Wrapped]
+    S19 --> S21[Session 21: On-Chain Actions]
 ```
 
-- **Sessions 12-15** are shipped and deployed.
-- **Session 16** builds the intelligence engine — GHI trends, AI narratives, State of Governance report, expanded insights. **Shipped.**
-- **Session 17** adds the social layer + page transitions (S15 gap) — this is where "feel" and "wow" compound.
-- **Session 18** extends intelligence cross-chain and builds the developer platform — the "not just Cardano" moment.
-- **Session 19** is pure polish: sound, scroll storytelling, performance, community showcase — pushing past 95.
+- **Sessions 12-17** are shipped and deployed.
+- **Session 18** expands DRepScore beyond Cardano — cross-chain observatory, developer platform, embeddable widgets, delegator identity, feature flags. **Shipped.**
+- **Session 19** is pure polish: sound, scroll storytelling, Cmd+K, PWA, performance, community showcase — pushing from ~93 to ~96.
+- **Session 20** adds the community flywheel: Governance Wrapped, editorial content, seasonal leaderboards — pushing to ~97.
+- **Session 21** closes the loop with on-chain actions, real-time WebSocket, and offline-first PWA — pushing to ~98+.
+- **S20 and S21** are independent of each other and could be parallelized or reordered based on demand signals (on-chain actions require monitoring GovTool adoption; community flywheel requires editorial capacity).
 
 ### Target Score Projections (Revised March 2026)
 
-> Corrected to reflect honest post-S15 baseline and S16 delivery.
+> Updated post-S18 to reflect expanded session scope, feature flag infrastructure, and new future sessions.
 
 | Session | Estimated Score | Delta | Key Contributions |
 |---------|----------------|-------|-------------------|
@@ -657,8 +771,10 @@ graph LR
 | Post S15 | ~69-72/100 | +7-10 | Narrative layer, GHI number, basic insights |
 | Post S16 | ~78-82/100 | +9-10 | Intelligence engine, AI narratives, State of Governance, GHI trend |
 | Post S17 | ~87/100 | +5-9 | Page transitions, social layer, sharing culture |
-| Post S18 | ~91/100 | +4 | Cross-chain benchmarking, developer platform |
-| Post S19 | ~95-96/100 | +4-5 | Sound design, scroll storytelling, performance, community showcase |
+| Post S18 | ~92-93/100 | +5-6 | Cross-chain intelligence, developer platform, widget distribution, delegator identity, feature flags |
+| Post S19 | ~96/100 | +3-4 | Sound design, scroll storytelling, Cmd+K, PWA, performance, community showcase |
+| Post S20 | ~97/100 | +1 | Governance Wrapped, community flywheel, editorial content |
+| Post S21 | ~98+/100 | +1 | On-chain actions, real-time WebSocket, offline-first |
 
 Each session gets its own worktree (`drepscore-<session-name>`) and detailed implementation plan (`.cursor/plans/<session>.plan.md`) before building begins.
 
@@ -681,14 +797,16 @@ In addition to all anti-patterns from v1 and v1.5:
 
 | Item | Rationale |
 |------|-----------|
-| On-chain rationale/voting submission | Monitor GovTool usage patterns first. If DReps consistently draft in DRepScore then context-switch to GovTool, demand signal is clear. |
+| On-chain rationale/voting submission | Planned for Session 21 — contingent on GovTool adoption patterns confirming demand. |
 | AI score coach chatbot | Score Simulator + AI brief cover the "how do I improve" use case. Revisit when demand signal emerges. |
 | Proposal discussion threads | Q&A channel in Session 17 is the lightweight version. Full threading has high moderation overhead. |
 | Multi-DRep team dashboard | Very few organizations run team DReps. Revisit when demand signals emerge. |
 | View Transitions API | Browser support still experimental in 2026. Framer Motion (Session 13) covers animation needs. |
 | Custom iconography | Lucide is high quality and consistent. Custom icons require a designer. |
 | Route-level URL restructuring for governance pages | Sub-nav achieves the same UX benefit without SEO/redirect risk. |
-| Floating compare tray while browsing DReps | Complex interaction design. Revisit post-S17. |
-| Sound design | Moved to Session 19 — Sensory Polish & Performance. |
-| Cross-chain governance benchmarking | Originally Session 16, moved to Session 18 — Cross-Chain Intelligence & Developer Platform. |
+| Floating compare tray while browsing DReps | Planned for Session 21 — interaction design matured enough to build well. |
+| Sound design | Planned for Session 19 — Sensory Polish & Performance. |
+| Cross-chain governance benchmarking | Built in Session 18 (feature-flagged). **Shipped.** |
+| Full Governance Wrapped experience | Planned for Session 20 — annual timing makes more sense. |
+| Real-time WebSocket governance feed | Planned for Session 21 — replaces polling architecture. |
 | Internationalization | Important but separate workstream — doesn't affect the "wow" factor for English-speaking crypto audience. |

--- a/inngest/functions/sync-governance-benchmarks.ts
+++ b/inngest/functions/sync-governance-benchmarks.ts
@@ -1,0 +1,100 @@
+/**
+ * Inngest Function: sync-governance-benchmarks
+ *
+ * Runs weekly (Sunday 06:00 UTC) to fetch governance metrics from
+ * Tally (Ethereum) and SubSquare (Polkadot), plus Cardano GHI data.
+ * Stores snapshots in governance_benchmarks table.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import {
+  fetchEthereumBenchmark,
+  fetchPolkadotBenchmark,
+  fetchCardanoBenchmark,
+  computeGovernanceScore,
+  computeGrade,
+  type ChainBenchmark,
+} from '@/lib/crossChain';
+
+export const syncGovernanceBenchmarks = inngest.createFunction(
+  {
+    id: 'sync-governance-benchmarks',
+    name: 'Sync Governance Benchmarks',
+    retries: 2,
+  },
+  { cron: '0 6 * * 0' },
+  async ({ step }) => {
+    const enabled = await step.run('check-feature-flag', async () => {
+      return getFeatureFlag('cross_chain_sync');
+    });
+    if (!enabled) {
+      return { skipped: true, reason: 'cross_chain_sync flag is disabled' };
+    }
+
+    const cardano = await step.run('fetch-cardano', async () => {
+      return fetchCardanoBenchmark();
+    });
+
+    const ethereum = await step.run('fetch-ethereum', async () => {
+      return fetchEthereumBenchmark();
+    });
+
+    const polkadot = await step.run('fetch-polkadot', async () => {
+      return fetchPolkadotBenchmark();
+    });
+
+    const results = await step.run('store-benchmarks', async () => {
+      const supabase = getSupabaseAdmin();
+      const stored: string[] = [];
+
+      const benchmarks = [cardano, ethereum, polkadot].filter(Boolean) as Omit<ChainBenchmark, 'grade' | 'governanceScore'>[];
+
+      for (const b of benchmarks) {
+        const governanceScore = b.chain === 'cardano'
+          ? (b.rawData as { ghiScore?: number })?.ghiScore ?? computeGovernanceScore({
+              participationRate: b.participationRate,
+              delegateCount: b.delegateCount,
+              proposalThroughput: b.proposalThroughput,
+              rationaleRate: b.avgRationaleRate,
+            })
+          : computeGovernanceScore({
+              participationRate: b.participationRate,
+              delegateCount: b.delegateCount,
+              proposalThroughput: b.proposalThroughput,
+              rationaleRate: b.avgRationaleRate,
+            });
+
+        const grade = computeGrade(governanceScore);
+
+        const { error } = await supabase
+          .from('governance_benchmarks')
+          .upsert({
+            chain: b.chain,
+            period_label: b.periodLabel,
+            participation_rate: b.participationRate,
+            delegate_count: b.delegateCount,
+            proposal_count: b.proposalCount,
+            proposal_throughput: b.proposalThroughput,
+            avg_rationale_rate: b.avgRationaleRate,
+            governance_score: governanceScore,
+            grade,
+            raw_data: b.rawData,
+            fetched_at: b.fetchedAt,
+          }, { onConflict: 'chain,period_label' });
+
+        if (error) {
+          console.error(`[sync-benchmarks] Failed to store ${b.chain}:`, error.message);
+        } else {
+          stored.push(`${b.chain}: ${governanceScore} (${grade})`);
+        }
+      }
+
+      return { stored, total: benchmarks.length };
+    });
+
+    console.log(`[sync-benchmarks] Stored ${results.stored.length}/${results.total} benchmarks:`, results.stored);
+    return results;
+  },
+);

--- a/lib/api/handler.ts
+++ b/lib/api/handler.ts
@@ -65,7 +65,13 @@ export function withApiHandler(handler: ApiHandler, options: HandlerOptions = {}
 
       let rlHeaders: Record<string, string> = {};
       if (!options.skipRateLimit) {
-        const rl = await checkRateLimit({ keyId, ipHash });
+        const keyResult = keyId ? await import('./keys').then(m => m.getTierDefaults(tier)) : undefined;
+        const rl = await checkRateLimit({
+          keyId,
+          ipHash,
+          limit: keyResult?.rateLimit,
+          window: keyResult?.rateWindow,
+        });
         rlHeaders = rateLimitHeaders(rl);
 
         if (!rl.allowed) {

--- a/lib/crossChain.ts
+++ b/lib/crossChain.ts
@@ -1,0 +1,377 @@
+/**
+ * Cross-Chain Governance Intelligence
+ *
+ * Adapters for Tally (Ethereum) and SubSquare (Polkadot) APIs,
+ * plus score/grade computation for cross-chain governance benchmarking.
+ */
+
+export type Chain = 'cardano' | 'ethereum' | 'polkadot';
+
+export interface ChainBenchmark {
+  chain: Chain;
+  periodLabel: string;
+  participationRate: number | null;
+  delegateCount: number | null;
+  proposalCount: number | null;
+  proposalThroughput: number | null;
+  avgRationaleRate: number | null;
+  governanceScore: number | null;
+  grade: string | null;
+  rawData: Record<string, unknown>;
+  fetchedAt: string;
+}
+
+export interface ChainIdentity {
+  chain: Chain;
+  name: string;
+  color: string;
+  logo: string;
+}
+
+export const CHAIN_IDENTITIES: Record<Chain, ChainIdentity> = {
+  cardano: { chain: 'cardano', name: 'Cardano', color: '#06b6d4', logo: '/chains/cardano.svg' },
+  ethereum: { chain: 'ethereum', name: 'Ethereum', color: '#a855f7', logo: '/chains/ethereum.svg' },
+  polkadot: { chain: 'polkadot', name: 'Polkadot', color: '#ec4899', logo: '/chains/polkadot.svg' },
+};
+
+// ---------------------------------------------------------------------------
+// Grade computation
+// ---------------------------------------------------------------------------
+
+const GRADE_THRESHOLDS = [
+  { min: 93, grade: 'A+' },
+  { min: 85, grade: 'A' },
+  { min: 80, grade: 'A-' },
+  { min: 77, grade: 'B+' },
+  { min: 73, grade: 'B' },
+  { min: 70, grade: 'B-' },
+  { min: 67, grade: 'C+' },
+  { min: 63, grade: 'C' },
+  { min: 60, grade: 'C-' },
+  { min: 57, grade: 'D+' },
+  { min: 53, grade: 'D' },
+  { min: 50, grade: 'D-' },
+  { min: 0, grade: 'F' },
+] as const;
+
+export function computeGrade(score: number): string {
+  for (const t of GRADE_THRESHOLDS) {
+    if (score >= t.min) return t.grade;
+  }
+  return 'F';
+}
+
+export function computeGovernanceScore(metrics: {
+  participationRate: number | null;
+  delegateCount: number | null;
+  proposalThroughput: number | null;
+  rationaleRate: number | null;
+}): number {
+  const participation = metrics.participationRate ?? 0;
+  const throughput = metrics.proposalThroughput ?? 0;
+
+  const delegateScore = Math.min(100, ((metrics.delegateCount ?? 0) / 500) * 100);
+
+  const rationaleScore = metrics.rationaleRate ?? 0;
+
+  const score =
+    participation * 0.35 +
+    throughput * 0.25 +
+    delegateScore * 0.20 +
+    rationaleScore * 0.20;
+
+  return Math.min(100, Math.max(0, Math.round(score)));
+}
+
+// ---------------------------------------------------------------------------
+// Tally adapter (Ethereum)
+// ---------------------------------------------------------------------------
+
+const TALLY_API_URL = 'https://api.tally.xyz/query';
+
+const TALLY_ORGS_QUERY = `
+  query TopOrgs {
+    organizations(input: { sort: { field: POPULAR, order: DESC }, page: { limit: 20 } }) {
+      nodes {
+        ... on Organization {
+          id
+          slug
+          name
+          delegatesCount
+          delegatesVotesCount
+          tokenOwnersCount
+          proposalsCount
+          hasActiveProposals
+        }
+      }
+    }
+  }
+`;
+
+const TALLY_ORG_PROPOSALS_QUERY = `
+  query OrgProposals($slug: String!) {
+    proposals(input: { organizationSlug: $slug, page: { limit: 20 }, sort: { field: START_BLOCK, order: DESC } }) {
+      nodes {
+        ... on Proposal {
+          id
+          status
+          voteStats {
+            type
+            votesCount
+            votersCount
+            percent
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface TallyOrgNode {
+  slug: string;
+  name: string;
+  delegatesCount: number;
+  delegatesVotesCount: number;
+  tokenOwnersCount: number;
+  proposalsCount: number;
+}
+
+async function tallyFetch(query: string, variables?: Record<string, unknown>): Promise<unknown> {
+  const apiKey = process.env.TALLY_API_KEY;
+  if (!apiKey) {
+    console.warn('[crossChain] TALLY_API_KEY not set, skipping Ethereum fetch');
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+
+  try {
+    const res = await fetch(TALLY_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Api-Key': apiKey,
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    if (!res.ok) {
+      console.error(`[crossChain] Tally API error: ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    const json = await res.json();
+    if (json.errors) {
+      console.error('[crossChain] Tally GraphQL errors:', json.errors);
+      return null;
+    }
+
+    return json.data;
+  } catch (err) {
+    console.error('[crossChain] Tally fetch failed:', err);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchEthereumBenchmark(): Promise<Omit<ChainBenchmark, 'grade' | 'governanceScore'> | null> {
+  const orgsData = await tallyFetch(TALLY_ORGS_QUERY) as { organizations?: { nodes: TallyOrgNode[] } } | null;
+  if (!orgsData?.organizations?.nodes?.length) return null;
+
+  const orgs = orgsData.organizations.nodes;
+
+  const totalDelegates = orgs.reduce((s, o) => s + (o.delegatesCount || 0), 0);
+  const totalProposals = orgs.reduce((s, o) => s + (o.proposalsCount || 0), 0);
+  const totalTokenOwners = orgs.reduce((s, o) => s + (o.tokenOwnersCount || 0), 0);
+
+  const topSlug = orgs[0]?.slug;
+  let participationRate: number | null = null;
+  let proposalThroughput: number | null = null;
+
+  if (topSlug) {
+    const proposalsData = await tallyFetch(TALLY_ORG_PROPOSALS_QUERY, { slug: topSlug }) as {
+      proposals?: { nodes: { status: string; voteStats: { votersCount: number }[] }[] }
+    } | null;
+
+    if (proposalsData?.proposals?.nodes?.length) {
+      const props = proposalsData.proposals.nodes;
+      const withVotes = props.filter(p => p.voteStats?.some(v => v.votersCount > 0));
+      proposalThroughput = Math.round((withVotes.length / props.length) * 100);
+
+      const avgVoters = withVotes.reduce((s, p) => {
+        const total = p.voteStats.reduce((vs, v) => vs + v.votersCount, 0);
+        return s + total;
+      }, 0) / Math.max(withVotes.length, 1);
+
+      participationRate = totalDelegates > 0
+        ? Math.min(100, Math.round((avgVoters / totalDelegates) * 100))
+        : null;
+    }
+  }
+
+  const now = new Date();
+  const periodLabel = `${now.getFullYear()}-W${String(getISOWeek(now)).padStart(2, '0')}`;
+
+  return {
+    chain: 'ethereum',
+    periodLabel,
+    participationRate,
+    delegateCount: totalDelegates,
+    proposalCount: totalProposals,
+    proposalThroughput,
+    avgRationaleRate: null,
+    rawData: { orgs: orgs.map(o => ({ slug: o.slug, name: o.name, delegates: o.delegatesCount, proposals: o.proposalsCount })), totalTokenOwners },
+    fetchedAt: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SubSquare adapter (Polkadot)
+// ---------------------------------------------------------------------------
+
+const SUBSQUARE_BASE = 'https://polkadot.subsquare.io/api';
+
+async function subsquareFetch(path: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+
+  try {
+    const res = await fetch(`${SUBSQUARE_BASE}${path}`, {
+      headers: { 'Accept': 'application/json' },
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    if (!res.ok) {
+      console.error(`[crossChain] SubSquare API error: ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    return await res.json();
+  } catch (err) {
+    console.error('[crossChain] SubSquare fetch failed:', err);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchPolkadotBenchmark(): Promise<Omit<ChainBenchmark, 'grade' | 'governanceScore'> | null> {
+  const [summaryData, referendaData] = await Promise.all([
+    subsquareFetch('/summary'),
+    subsquareFetch('/gov2/referendums?page=1&page_size=20'),
+  ]);
+
+  const summary = summaryData as {
+    gov2Referenda?: { all?: number; active?: number };
+    fellowshipReferenda?: { all?: number };
+  } | null;
+
+  const referenda = referendaData as {
+    items?: { state?: { name: string }; tally?: { ayes: string; nays: string } }[];
+    total?: number;
+  } | null;
+
+  if (!summary && !referenda) return null;
+
+  const totalReferenda = summary?.gov2Referenda?.all ?? referenda?.total ?? 0;
+  const activeReferenda = summary?.gov2Referenda?.active ?? 0;
+
+  let proposalThroughput: number | null = null;
+  let participationRate: number | null = null;
+
+  if (referenda?.items?.length) {
+    const withVotes = referenda.items.filter(r => {
+      const ayes = parseInt(r.tally?.ayes || '0', 10);
+      const nays = parseInt(r.tally?.nays || '0', 10);
+      return (ayes + nays) > 0;
+    });
+    proposalThroughput = Math.round((withVotes.length / referenda.items.length) * 100);
+
+    participationRate = activeReferenda > 0 ? Math.min(100, Math.round((activeReferenda / Math.max(totalReferenda, 1)) * 100 * 5)) : null;
+  }
+
+  const now = new Date();
+  const periodLabel = `${now.getFullYear()}-W${String(getISOWeek(now)).padStart(2, '0')}`;
+
+  return {
+    chain: 'polkadot',
+    periodLabel,
+    participationRate,
+    delegateCount: null,
+    proposalCount: totalReferenda,
+    proposalThroughput,
+    avgRationaleRate: null,
+    rawData: { summary, recentReferendaCount: referenda?.items?.length ?? 0 },
+    fetchedAt: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cardano adapter (reads from existing GHI)
+// ---------------------------------------------------------------------------
+
+export async function fetchCardanoBenchmark(): Promise<Omit<ChainBenchmark, 'grade' | 'governanceScore'> | null> {
+  const { computeGHI } = await import('./ghi');
+  const { createClient } = await import('./supabase');
+
+  try {
+    const ghi = await computeGHI();
+    const supabase = createClient();
+
+    const [drepsRes, proposalsRes, epochRes] = await Promise.all([
+      supabase.from('dreps').select('id, info', { count: 'exact', head: true }),
+      supabase.from('proposals').select('tx_hash', { count: 'exact', head: true }),
+      supabase.from('governance_stats').select('current_epoch').eq('id', 1).single(),
+    ]);
+
+    const activeDrepCount = drepsRes.count ?? 0;
+    const proposalCount = proposalsRes.count ?? 0;
+    const epoch = epochRes.data?.current_epoch ?? 0;
+
+    const participationComp = ghi.components.find(c => c.name === 'Participation');
+    const rationaleComp = ghi.components.find(c => c.name === 'Rationale');
+    const throughputComp = ghi.components.find(c => c.name === 'Proposal Throughput');
+
+    const now = new Date();
+    const periodLabel = epoch > 0 ? `epoch-${epoch}` : `${now.getFullYear()}-W${String(getISOWeek(now)).padStart(2, '0')}`;
+
+    return {
+      chain: 'cardano',
+      periodLabel,
+      participationRate: participationComp?.value ?? null,
+      delegateCount: activeDrepCount,
+      proposalCount,
+      proposalThroughput: throughputComp?.value ?? null,
+      avgRationaleRate: rationaleComp?.value ?? null,
+      rawData: { ghiScore: ghi.score, ghiBand: ghi.band, components: ghi.components },
+      fetchedAt: now.toISOString(),
+    };
+  } catch (err) {
+    console.error('[crossChain] Cardano benchmark fetch failed:', err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getISOWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+export function getGradeColor(grade: string): string {
+  if (grade.startsWith('A')) return '#10b981';
+  if (grade.startsWith('B')) return '#06b6d4';
+  if (grade.startsWith('C')) return '#f59e0b';
+  if (grade.startsWith('D')) return '#f97316';
+  return '#ef4444';
+}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -1,0 +1,141 @@
+/**
+ * Feature Flags — Supabase-backed with in-memory caching.
+ *
+ * Server components: use getFeatureFlag() or getAllFlags()
+ * Client components: use <FeatureGate flag="key"> or useFeatureFlag("key")
+ *
+ * Flags are cached for 60s in memory to avoid per-request DB hits.
+ * Toggle instantly via the admin UI at /admin/flags — no redeploy needed.
+ *
+ * Targeting (future): the `targeting` JSONB column supports per-wallet overrides:
+ *   { "wallets": { "stake1...": true } }  — enable for specific wallet even if globally off
+ */
+
+import { createClient } from './supabase';
+
+export interface FeatureFlag {
+  key: string;
+  enabled: boolean;
+  description: string | null;
+  targeting: Record<string, unknown>;
+  updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache (server-side, shared across requests in the same process)
+// ---------------------------------------------------------------------------
+
+let flagCache: Map<string, boolean> = new Map();
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 60_000;
+
+async function loadFlags(): Promise<Map<string, boolean>> {
+  const now = Date.now();
+  if (flagCache.size > 0 && now - cacheTimestamp < CACHE_TTL_MS) {
+    return flagCache;
+  }
+
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('feature_flags')
+      .select('key, enabled');
+
+    if (error || !data) {
+      console.warn('[featureFlags] Failed to load flags, using cache/defaults:', error?.message);
+      return flagCache;
+    }
+
+    const fresh = new Map<string, boolean>();
+    for (const row of data) {
+      fresh.set(row.key, row.enabled);
+    }
+    flagCache = fresh;
+    cacheTimestamp = now;
+    return flagCache;
+  } catch (err) {
+    console.warn('[featureFlags] Unexpected error loading flags:', err);
+    return flagCache;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server-side API
+// ---------------------------------------------------------------------------
+
+export async function getFeatureFlag(key: string, defaultValue = true): Promise<boolean> {
+  const envOverride = process.env[`FF_${key.toUpperCase()}`];
+  if (envOverride !== undefined) {
+    return envOverride === 'true' || envOverride === '1';
+  }
+
+  const flags = await loadFlags();
+  return flags.get(key) ?? defaultValue;
+}
+
+export async function getAllFlags(): Promise<FeatureFlag[]> {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('feature_flags')
+      .select('key, enabled, description, targeting, updated_at')
+      .order('key');
+
+    if (error || !data) return [];
+
+    return data.map(row => ({
+      key: row.key,
+      enabled: row.enabled,
+      description: row.description,
+      targeting: row.targeting ?? {},
+      updatedAt: row.updated_at,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function setFeatureFlag(key: string, enabled: boolean): Promise<boolean> {
+  try {
+    const { getSupabaseAdmin } = await import('./supabase');
+    const supabase = getSupabaseAdmin();
+    const { error } = await supabase
+      .from('feature_flags')
+      .update({ enabled, updated_at: new Date().toISOString() })
+      .eq('key', key);
+
+    if (error) {
+      console.error('[featureFlags] Failed to update flag:', error.message);
+      return false;
+    }
+
+    flagCache.set(key, enabled);
+    return true;
+  } catch (err) {
+    console.error('[featureFlags] Unexpected error updating flag:', err);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client-side API route
+// ---------------------------------------------------------------------------
+
+export async function fetchClientFlags(): Promise<Record<string, boolean>> {
+  try {
+    const res = await fetch('/api/admin/feature-flags');
+    if (!res.ok) return {};
+    const data = await res.json();
+    return data.flags ?? {};
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Invalidation (call after toggling a flag to bust the cache)
+// ---------------------------------------------------------------------------
+
+export function invalidateFlagCache() {
+  cacheTimestamp = 0;
+}

--- a/public/embed.js
+++ b/public/embed.js
@@ -1,0 +1,52 @@
+/**
+ * DRepScore Embed Script Loader
+ *
+ * Usage:
+ *   <script src="https://drepscore.io/embed.js" data-type="drep" data-id="drep1..." data-theme="dark"></script>
+ *   <script src="https://drepscore.io/embed.js" data-type="ghi" data-theme="dark"></script>
+ *   <script src="https://drepscore.io/embed.js" data-type="cross-chain" data-theme="dark"></script>
+ */
+(function () {
+  var BASE = 'https://drepscore.io';
+  var scripts = document.querySelectorAll('script[src*="embed.js"]');
+
+  scripts.forEach(function (script) {
+    var type = script.getAttribute('data-type') || 'drep';
+    var id = script.getAttribute('data-id') || '';
+    var theme = script.getAttribute('data-theme') || 'dark';
+    var width = script.getAttribute('data-width') || '320';
+    var height = script.getAttribute('data-height') || '200';
+
+    var src;
+    switch (type) {
+      case 'drep':
+        src = BASE + '/embed/drep/' + encodeURIComponent(id) + '?theme=' + theme;
+        break;
+      case 'ghi':
+        src = BASE + '/embed/ghi?theme=' + theme;
+        height = '160';
+        width = '280';
+        break;
+      case 'cross-chain':
+        src = BASE + '/embed/cross-chain?theme=' + theme;
+        height = '220';
+        width = '360';
+        break;
+      default:
+        return;
+    }
+
+    var iframe = document.createElement('iframe');
+    iframe.src = src;
+    iframe.width = width;
+    iframe.height = height;
+    iframe.frameBorder = '0';
+    iframe.style.border = 'none';
+    iframe.style.borderRadius = '12px';
+    iframe.style.overflow = 'hidden';
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('title', 'DRepScore ' + type + ' widget');
+
+    script.parentNode.insertBefore(iframe, script.nextSibling);
+  });
+})();

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -247,8 +247,9 @@ Patterns, mistakes, and architectural decisions captured during development. Rev
 **Takeaway**: In this workspace (Windows + PowerShell), always use `;` to chain commands or run them as separate tool calls. Never use `&&`.
 
 ### 2026-03-01: Pre-push hook runs full build — budget ~4 minutes
-**Issue**: The repo's pre-push hook runs `tsc --noEmit` + `vitest run` + `next build --webpack` sequentially. This takes ~4 minutes locally. Not just type-check — the full build catches import resolution, static generation, and module boundary errors that `tsc` alone misses.
-**Takeaway**: Budget 4-5 minutes per push. Don't background the push and assume it succeeded. Wait for the hook to complete and verify exit code 0.
+**Issue**: The repo's pre-push hook ran `tsc --noEmit` + `vitest run` + `next build --webpack` sequentially (~4 minutes per push).
+**Resolution**: Build was dropped from pre-push in `81c2c12`. Hooks were removed entirely in S17 — CI is the sole gate. This lesson is retained for historical context only.
+**Takeaway**: Don't duplicate CI checks in local hooks. Budget time for CI instead (~3-5 min).
 
 ### 2026-03-01: Viral surfaces need view + share + outcome events — not just share
 **Issue**: Session 4 built 7 viral share surfaces (wrapped cards, delegation ceremony, score change moments, milestone celebrations, DNA reveal, badge embed, pulse page) with `ShareActions` wired for share clicks, but zero view/impression events. Without `*_viewed` events, we can't calculate share rates (views → shares) or identify which surfaces drive engagement.
@@ -359,9 +360,27 @@ Server-side API routes also need `captureServerEvent` for success + error tracki
 **Root cause**: The Ship It Checklist is documented as a post-implementation step. Agents treat "implementation complete" as their finish line because todo lists end at the last code task. The deployment pipeline is never represented in the task list.
 **Takeaway**: Every session's todo list MUST include Ship It Checklist steps as explicit tasks: (1) create branch, (2) commit, (3) push + PR, (4) CI green, (5) merge, (6) confirm deploy. These are not post-session cleanup — they ARE the session. A feature is not done until it is in production. Never report completion until the deploy is confirmed.
 
+### 2026-03-02: Local hooks removed — CI is the sole quality gate
+**Issue**: Pre-commit and pre-push hooks ran `tsc --noEmit` + `vitest run`, adding 45-75s per commit+push cycle. CI runs the same checks plus lint and build — the hooks had zero unique coverage. They also didn't run ESLint, so `react-hooks/refs` errors (like in `NavDirectionProvider.tsx`) slipped through locally but failed CI anyway.
+**Fix**: Removed husky, pre-commit, and pre-push hooks entirely. CI (branch protection) is the sole quality gate. For early local feedback, run `npm run type-check ; npm run lint` before pushing.
+**Takeaway**: Don't duplicate CI checks in local hooks unless they catch something CI doesn't. Hooks that are a strict subset of CI are pure friction.
+
+### 2026-03-02: React 19 compiler lint — no ref access during render
+**Issue**: `NavDirectionProvider` used `useRef` + `useCallback` to compute direction during render by reading `prevPathRef.current`. The `react-hooks/refs` rule flags this as an error: "Cannot access refs during render."
+**Fix**: Convert to `useState` + `useEffect`. The ref is only read inside the effect (not during render), and direction is stored in state so the provider re-renders when it changes.
+**Takeaway**: Any component that reads `.current` from a ref during the render body (not inside an effect or event handler) will fail lint. The pattern of "compute from ref in render" is dead under React 19 compiler rules. Use `useState` for values that affect rendering; use refs only in effects and handlers.
+
+### 2026-03-02: Branch protection "not up to date" adds ~5 min to Ship It
+**Issue**: `gh pr merge --squash` failed with "head branch is not up to date with the base branch" because a prior hotfix had advanced `main`. Required stash → `git rebase origin/main` → stash pop → force-push → full CI re-run (~5 min).
+**Takeaway**: When branch protection requires up-to-date branches, budget time for a rebase cycle if main has moved. Fetch and rebase before pushing the initial PR to avoid the round-trip.
+
 ### 2026-03-02: Shell tool calls don't preserve working directory or branch across invocations
 **Pattern**: `git checkout -b feat/...` ran in one Shell call, but subsequent Shell calls reverted to `main` because each Shell invocation starts fresh. This caused the first commit attempt to only partially stage files and the branch context was lost.
 **Takeaway**: Always chain branch-dependent git commands in a single Shell call or verify `git branch --show-current` at the start of each new Shell call. Never assume a prior checkout persists.
+
+### 2026-03-02: Feature flags — Supabase-backed for instant toggles
+**Pattern**: Introduced `lib/featureFlags.ts` with Supabase `feature_flags` table, 60s in-memory cache, env var overrides (`FF_<KEY>=true|false`), and admin UI at `/admin/flags`. Server components use `getFeatureFlag(key)`, client components use `<FeatureGate flag="key">` or `useFeatureFlag(key)`.
+**Takeaway**: Always gate risky or controversial features behind flags before shipping. Wrap at the call site (server component) or with `<FeatureGate>` (client component). The Inngest cron check ensures background jobs also respect flags. Upgrading to per-user targeting later only requires changes in `lib/featureFlags.ts`.
 
 *Last updated: 2026-03-02*
 *Review this file at the start of every session.*


### PR DESCRIPTION
## Summary

Five pillars transforming DRepScore from Cardano tool to cross-chain governance hub:

- **Cross-Chain Observatory**: `governance_benchmarks` table, Tally/SubSquare API adapters, weekly Inngest sync, `CrossChainReportCard` + `GovernanceObservatory` on Pulse and Homepage, OG image at `/api/og/cross-chain`
- **Developer Platform**: `/developers` page with interactive `ApiExplorer`, multi-lang `CodeExample` (cURL/JS/Python), rate limit bug fix (authenticated keys now use correct tier limits), nav link added
- **Embeddable Widget Ecosystem**: DRep card, GHI gauge, cross-chain comparison embeds with dedicated `app/embed/layout.tsx`, `public/embed.js` script loader for zero-code integration
- **Delegator Governance Identity**: `DelegatorGovernanceCard` on `/governance`, personalized OG image at `/api/og/governance-identity`
- **Feature Flags**: Supabase-backed `feature_flags` table, admin UI at `/admin/flags`, `lib/featureFlags.ts` with 60s cache + env var overrides, `FeatureGate` client component. Cross-chain features gated by 3 flags (`cross_chain_observatory`, `cross_chain_embed`, `cross_chain_sync`) for safe rollout.

Strategy doc updated: S18 rewritten to reflect expanded scope, S19 augmented (Cmd+K, PWA, keyboard shortcuts, micro-interactions), new S20 (Governance Wrapped and Community Flywheel), new S21 (On-Chain Actions and Real-Time), score projections revised (~92-93 post-S18, path to ~98+).

## DB Migrations

- `create_governance_benchmarks`: new table for cross-chain metrics with RLS
- `create_feature_flags`: new table for feature flag management with RLS + 3 initial flags

## Test Plan

- [ ] Cross-chain report cards render on Pulse page (or hidden when flag is off)
- [ ] Homepage compact observatory renders (or hidden when flag is off)
- [ ] `/developers` page loads with API explorer, code examples, and endpoint docs
- [ ] Embed pages render: `/embed/drep/[id]`, `/embed/ghi`, `/embed/cross-chain`
- [ ] `/admin/flags` page loads and toggles work
- [ ] Toggling `cross_chain_observatory` OFF hides report cards on Pulse and Homepage
- [ ] `/api/governance/benchmarks` returns empty when flag is off
- [ ] OG images generate: `/api/og/cross-chain`, `/api/og/governance-identity`
- [ ] Rate limit bug fix: authenticated API keys use their tier limits, not anonymous
- [ ] Delegator governance card renders on `/governance` for connected wallets


Made with [Cursor](https://cursor.com)