### PR TITLE
feat: Session 19 — Sensory Polish & Performance

### DIFF
--- a/app/api/og/compare/route.tsx
+++ b/app/api/og/compare/route.tsx
@@ -92,7 +92,7 @@ export async function GET(request: NextRequest) {
       {
         width: 1200,
         height: 630,
-        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
       }
     );
   } catch (error) {

--- a/app/api/og/drep/[drepId]/route.tsx
+++ b/app/api/og/drep/[drepId]/route.tsx
@@ -106,7 +106,7 @@ export async function GET(
       {
         width: 1200,
         height: 630,
-        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
       }
     );
   } catch (error) {

--- a/app/api/og/epoch-summary/route.tsx
+++ b/app/api/og/epoch-summary/route.tsx
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
         </div>
       </OGBackground>
     ),
-    { width: 1200, height: 630 }
+    { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
   );
 }
 

--- a/app/api/og/governance-identity/[drepId]/route.tsx
+++ b/app/api/og/governance-identity/[drepId]/route.tsx
@@ -107,7 +107,7 @@ export async function GET(
     const drep = await getDRepById(decodeURIComponent(drepId));
 
     if (!drep) {
-      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1200, height: 630 });
+      return new ImageResponse(<OGFallback message="DRep not found" />, { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } });
     }
 
     const name = getDRepPrimaryName(drep);
@@ -239,9 +239,9 @@ export async function GET(
           />
         </OGBackground>
       ),
-      { width: 1200, height: 630 },
+      { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } },
     );
   } catch {
-    return new ImageResponse(<OGFallback message="Error generating image" />, { width: 1200, height: 630 });
+    return new ImageResponse(<OGFallback message="Error generating image" />, { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } });
   }
 }

--- a/app/api/og/treasury-accountability/route.tsx
+++ b/app/api/og/treasury-accountability/route.tsx
@@ -54,12 +54,12 @@ export async function GET() {
           <OGFooter />
         </div>
       </OGBackground>,
-      { width: 1200, height: 630 }
+      { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
     );
   } catch {
     return new ImageResponse(
       <OGBackground><div style={{ display: 'flex', padding: '60px', fontSize: '24px', color: OG.textMuted }}>Accountability OG Error</div></OGBackground>,
-      { width: 1200, height: 630 }
+      { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
     );
   }
 }

--- a/app/api/og/treasury-scenario/route.tsx
+++ b/app/api/og/treasury-scenario/route.tsx
@@ -37,6 +37,6 @@ export async function GET(request: NextRequest) {
         <OGFooter />
       </div>
     </OGBackground>,
-    { width: 1200, height: 630 }
+    { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
   );
 }

--- a/app/api/og/treasury/route.tsx
+++ b/app/api/og/treasury/route.tsx
@@ -15,7 +15,7 @@ export async function GET() {
     if (!balance) {
       return new ImageResponse(
         <OGBackground><div style={{ display: 'flex', padding: '60px', alignItems: 'center', justifyContent: 'center', fontSize: '24px', color: OG.textMuted }}>Treasury data unavailable</div></OGBackground>,
-        { width: 1200, height: 630 }
+        { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
       );
     }
 
@@ -70,12 +70,12 @@ export async function GET() {
           <OGFooter />
         </div>
       </OGBackground>,
-      { width: 1200, height: 630 }
+      { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
     );
   } catch {
     return new ImageResponse(
       <OGBackground><div style={{ display: 'flex', padding: '60px', fontSize: '24px', color: OG.textMuted }}>Treasury OG Error</div></OGBackground>,
-      { width: 1200, height: 630 }
+      { width: 1200, height: 630, headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' } }
     );
   }
 }

--- a/app/api/og/wrapped/drep/[drepId]/route.tsx
+++ b/app/api/og/wrapped/drep/[drepId]/route.tsx
@@ -112,7 +112,7 @@ export async function GET(
       {
         width: 1080,
         height: 1080,
-        headers: { 'Cache-Control': 'public, max-age=900, s-maxage=900' },
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
       }
     );
   } catch (error) {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -29,7 +29,12 @@ import {
 import { ScoreHistoryChart } from '@/components/ScoreHistoryChart';
 import { DRepDashboard } from '@/components/DRepDashboard';
 import { GovernanceInboxWidget } from '@/components/GovernanceInboxWidget';
-import { DelegatorTrendChart } from '@/components/DelegatorTrendChart';
+import dynamic from 'next/dynamic';
+
+const DelegatorTrendChart = dynamic(
+  () => import('@/components/DelegatorTrendChart').then((m) => m.DelegatorTrendChart),
+  { ssr: false },
+);
 import { CompetitiveContext } from '@/components/CompetitiveContext';
 import { OnboardingChecklist } from '@/components/OnboardingChecklist';
 import { RepresentationScorecard } from '@/components/RepresentationScorecard';
@@ -41,7 +46,10 @@ import { BadgeEmbed } from '@/components/BadgeEmbed';
 import { WrappedShareCard } from '@/components/WrappedShareCard';
 import { ScoreChangeMoment } from '@/components/ScoreChangeMoment';
 import { DashboardUrgentBar } from '@/components/DashboardUrgentBar';
-import { MilestoneCelebrationManager } from '@/components/MilestoneCelebration';
+const MilestoneCelebrationManager = dynamic(
+  () => import('@/components/MilestoneCelebration').then((m) => m.MilestoneCelebrationManager),
+  { ssr: false },
+);
 import { DRepQuestionsInbox } from '@/components/DRepQuestionsInbox';
 import { AnimatedTabs, type TabDefinition } from '@/components/AnimatedTabs';
 import { applyRationaleCurve, getMissingProfileFields } from '@/utils/scoring';
@@ -277,7 +285,7 @@ export default function MyDRepPage() {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-3">
           <Shield className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold">
+          <h1 className="text-2xl font-bold tracking-tight">
             {isViewingOther ? 'DRep Dashboard' : 'My Dashboard'}
           </h1>
           {isViewingOther && (

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -16,7 +16,7 @@ export default async function DiscoverPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="space-y-2 mb-6">
-        <h1 className="text-2xl font-bold">Discover DReps</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Discover DReps</h1>
         <p className="text-sm text-muted-foreground">
           Find Cardano governance representatives aligned with your governance values.
         </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -234,12 +234,14 @@
    ============================================================ */
 
 [data-slot="card"] {
-  transition: box-shadow 0.3s ease, transform 0.2s ease, border-color 0.3s ease;
+  transition: box-shadow 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+              transform 0.25s cubic-bezier(0.22, 1, 0.36, 1),
+              border-color 0.25s ease;
 }
 
 [data-slot="card"]:hover {
   box-shadow: 0 4px 16px rgb(0 0 0 / 0.06);
-  transform: translateY(-1px);
+  transform: translateY(-1px) scale(1.003);
 }
 
 .dark [data-slot="card"] {
@@ -252,7 +254,7 @@
   box-shadow:
     0 0 0 1px rgb(var(--identity-rgb) / 0.08),
     0 4px 24px rgb(var(--identity-rgb) / 0.04);
-  transform: translateY(-1px);
+  transform: translateY(-1px) scale(1.003);
 }
 
 /* ============================================================
@@ -391,8 +393,13 @@ button:not(:disabled):active,
    ============================================================ */
 
 @keyframes breathing-glow {
-  0%, 100% { opacity: 0.6; }
+  0%, 100% { opacity: 0.5; }
   50% { opacity: 1; }
+}
+
+@keyframes hex-shimmer {
+  0% { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -1000; }
 }
 
 .animate-breathing-glow {
@@ -413,6 +420,56 @@ button:not(:disabled):active,
 
 .scroll-snap-align-start {
   scroll-snap-align: start;
+}
+
+/* ============================================================
+   Button ripple — identity-tinted, CSS-only
+   ============================================================ */
+
+[data-slot="button"][data-variant="default"] {
+  position: relative;
+  overflow: hidden;
+}
+
+[data-slot="button"][data-variant="default"]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--ripple-x, 50%) var(--ripple-y, 50%), rgb(255 255 255 / 0.2) 0%, transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+[data-slot="button"][data-variant="default"]:active::after {
+  opacity: 1;
+}
+
+/* ============================================================
+   Focus states — identity-colored, keyboard only
+   ============================================================ */
+
+:focus-visible {
+  outline: 2px solid rgb(var(--identity-rgb) / 0.5);
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* ============================================================
+   Skeleton → content crossfade
+   ============================================================ */
+
+.skeleton-transition-enter {
+  animation: skeleton-crossfade 0.2s ease-out both;
+}
+
+@keyframes skeleton-crossfade {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* ============================================================

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,12 @@ import { BrandedLoader } from "@/components/BrandedLoader";
 import { MobileBottomNav } from "@/components/MobileBottomNav";
 import { NavDirectionProvider } from "@/components/NavDirectionProvider";
 import { SyncFreshnessBanner } from "@/components/SyncFreshnessBanner";
+import { CommandPalette } from "@/components/CommandPalette";
+import { KeyboardShortcuts } from "@/components/KeyboardShortcuts";
+import { ShortcutsHelpOverlay } from "@/components/ShortcutsHelpOverlay";
+import { InstallPrompt } from "@/components/InstallPrompt";
+import { OfflineBanner } from "@/components/OfflineBanner";
+import { EasterEggs } from "@/components/EasterEggs";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -71,6 +77,12 @@ export default function RootLayout({
               </main>
               <Footer />
               <MobileBottomNav />
+              <CommandPalette />
+              <KeyboardShortcuts />
+              <ShortcutsHelpOverlay />
+              <InstallPrompt />
+              <OfflineBanner />
+              <EasterEggs />
             </NavDirectionProvider>
           </Providers>
         </ThemeProvider>

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -1,0 +1,22 @@
+export default function OfflinePage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center max-w-md space-y-6">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-primary/10">
+          <span className="text-3xl font-bold text-primary font-mono">$</span>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight">You&apos;re offline</h1>
+        <p className="text-muted-foreground leading-relaxed">
+          DRepScore needs an internet connection for live governance data.
+          Please check your connection and refresh.
+        </p>
+        <button
+          onClick={() => window.location.reload()}
+          className="inline-flex items-center justify-center rounded-lg bg-primary text-primary-foreground px-6 py-2.5 text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/proposals/page.tsx
+++ b/app/proposals/page.tsx
@@ -48,7 +48,7 @@ export default async function ProposalsPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="space-y-2 mb-6">
-        <h1 className="text-3xl font-bold">Governance Proposals</h1>
+        <h1 className="text-3xl font-bold tracking-tight">Governance Proposals</h1>
         <p className="text-muted-foreground">
           Track Cardano governance proposals, DRep votes, and treasury decisions in real time.
         </p>

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,8 +1,25 @@
-fix: add missing PostHog events and Discord alerts from plan review
+feat: Session 19 — Sensory Polish & Performance
 
-- Emit sync_validation_error PostHog event + Discord alert on Zod failures
-  in proposals (Inngest + route), votes, and dreps sync routes
-- Emit sync_self_healed PostHog event from freshness guard
-- Add proposals integration tests (happy path, Koios error, empty, malformed)
+Phase 1 — Performance Foundation & Power User Layer:
+- Lazy-load 5 heavy chart/celebration components
+- Cmd+K command palette with DRep/proposal/page/action search (cmdk)
+- Global keyboard shortcuts (H/D/P/G navigation, ? help, / search)
+- PWA: manifest, service worker, install prompt, offline fallback
 
-Closes gaps G1-G4 from pre-PR plan review.
+Phase 2 — Signature Visuals & Interaction Craft:
+- GovernanceRadar overhaul: triple-layer glow, per-axis spring animation, vertex breathing, gradient axis lines, identity-colored labels
+- HexScore overhaul: noise texture removed, triple-layer glow, edge shimmer, breathing, /100 treatment
+- ScoreCard redesign: side-by-side desktop hero, responsive HexScore (hero-lg 172px), 2-column pillar grid, gradient progress bars
+- ScrollStoryReveal component, profile hero parallax
+- Card hover scale, button ripple, skeleton crossfade
+- Haptics utility, Konami code constellation burst
+
+Phase 3 — Quality Sweep:
+- ConnectionError component, OfflineBanner with network detection
+- Typography audit: tracking-tight on display headings, toLocaleString on numbers
+- Custom focus-visible rings using identity colors
+- useOptimistic + useOptimisticToggle hooks
+- Cache-Control headers on 8 OG routes with stale-while-revalidate
+- Web Audio API delegation chime + milestone chime (off by default)
+
+Strategy doc: moved community showcase to S20, added S22 (Personalization), revised score projections

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Command } from 'cmdk';
+import { useRouter } from 'next/navigation';
+import { useTheme } from 'next-themes';
+import { useWallet } from '@/utils/wallet';
+import { Search, ArrowRight } from 'lucide-react';
+import {
+  PAGE_COMMANDS,
+  buildActionCommands,
+  searchDReps,
+  searchProposals,
+  type CommandItem,
+  type SearchableDRep,
+  type SearchableProposal,
+} from '@/lib/commandIndex';
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+  const { resolvedTheme, setTheme } = useTheme();
+  const { isAuthenticated, logout } = useWallet();
+
+  const [dreps, setDreps] = useState<SearchableDRep[]>([]);
+  const [proposals, setProposals] = useState<SearchableProposal[]>([]);
+  const dataLoaded = useRef(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
+  useEffect(() => {
+    if (open && !dataLoaded.current) {
+      dataLoaded.current = true;
+      fetch('/api/dreps?limit=500&fields=drepId,name,ticker,drepScore')
+        .then((r) => (r.ok ? r.json() : { dreps: [] }))
+        .then((d) => setDreps(d.dreps || d || []))
+        .catch(() => {});
+      fetch('/api/proposals?limit=100&fields=txHash,index,title,status,type')
+        .then((r) => (r.ok ? r.json() : { proposals: [] }))
+        .then((d) => setProposals(d.proposals || d || []))
+        .catch(() => {});
+    }
+  }, [open]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  }, [resolvedTheme, setTheme]);
+
+  const openWallet = useCallback(() => {
+    window.dispatchEvent(new CustomEvent('openWalletConnect', { detail: {} }));
+  }, []);
+
+  const actionCommands = buildActionCommands({
+    toggleTheme,
+    isDark: resolvedTheme === 'dark',
+    openWallet,
+    isAuthenticated,
+    logout,
+  });
+
+  const drepResults = searchDReps(dreps, query);
+  const proposalResults = searchProposals(proposals, query);
+
+  const onSelect = useCallback(
+    (item: CommandItem) => {
+      setOpen(false);
+      setQuery('');
+      if (item.action) {
+        item.action();
+      } else if (item.href) {
+        router.push(item.href);
+      }
+      if (item.id === 'action-shortcuts') {
+        window.dispatchEvent(new CustomEvent('openShortcutsHelp'));
+      }
+    },
+    [router],
+  );
+
+  return (
+    <Command.Dialog
+      open={open}
+      onOpenChange={setOpen}
+      label="Command palette"
+      className="fixed inset-0 z-[100]"
+      shouldFilter={false}
+    >
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={() => setOpen(false)}
+      />
+
+      {/* Dialog */}
+      <div className="fixed top-[20%] left-1/2 -translate-x-1/2 w-full max-w-xl px-4">
+        <div className="rounded-xl border border-border/50 bg-popover/95 backdrop-blur-xl shadow-2xl shadow-black/20 overflow-hidden ring-1 ring-white/5">
+          {/* Input */}
+          <div className="flex items-center gap-3 border-b border-border/50 px-4">
+            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Command.Input
+              value={query}
+              onValueChange={setQuery}
+              placeholder="Search DReps, proposals, pages..."
+              className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+            <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
+              ESC
+            </kbd>
+          </div>
+
+          {/* Results */}
+          <Command.List className="max-h-[320px] overflow-y-auto p-2">
+            <Command.Empty className="py-8 text-center text-sm text-muted-foreground">
+              No results found.
+            </Command.Empty>
+
+            {/* DRep results */}
+            {drepResults.length > 0 && (
+              <Command.Group
+                heading="DReps"
+                className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+              >
+                {drepResults.map((item) => (
+                  <Command.Item
+                    key={item.id}
+                    value={item.id}
+                    onSelect={() => onSelect(item)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm cursor-pointer aria-selected:bg-accent aria-selected:text-accent-foreground transition-colors"
+                  >
+                    {item.score !== undefined && (
+                      <span className="inline-flex items-center justify-center h-6 w-6 rounded text-[10px] font-bold font-mono bg-primary/10 text-primary shrink-0">
+                        {item.score}
+                      </span>
+                    )}
+                    <span className="flex-1 truncate">{item.label}</span>
+                    {item.sublabel && (
+                      <span className="text-xs text-muted-foreground font-mono">
+                        ${item.sublabel}
+                      </span>
+                    )}
+                    <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            )}
+
+            {/* Proposal results */}
+            {proposalResults.length > 0 && (
+              <Command.Group
+                heading="Proposals"
+                className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+              >
+                {proposalResults.map((item) => (
+                  <Command.Item
+                    key={item.id}
+                    value={item.id}
+                    onSelect={() => onSelect(item)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm cursor-pointer aria-selected:bg-accent aria-selected:text-accent-foreground transition-colors"
+                  >
+                    <span className="flex-1 truncate">{item.label}</span>
+                    {item.sublabel && (
+                      <span className="text-xs text-muted-foreground capitalize">
+                        {item.sublabel}
+                      </span>
+                    )}
+                    <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            )}
+
+            {/* Pages */}
+            <Command.Group
+              heading="Pages"
+              className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+            >
+              {PAGE_COMMANDS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <Command.Item
+                    key={item.id}
+                    value={`${item.id} ${item.label}`}
+                    onSelect={() => onSelect(item)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm cursor-pointer aria-selected:bg-accent aria-selected:text-accent-foreground transition-colors"
+                  >
+                    {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                    <span className="flex-1">{item.label}</span>
+                    {item.shortcut && (
+                      <kbd className="hidden sm:inline-flex h-5 items-center rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
+                        {item.shortcut}
+                      </kbd>
+                    )}
+                  </Command.Item>
+                );
+              })}
+            </Command.Group>
+
+            {/* Actions */}
+            <Command.Group
+              heading="Actions"
+              className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+            >
+              {actionCommands.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <Command.Item
+                    key={item.id}
+                    value={`${item.id} ${item.label}`}
+                    onSelect={() => onSelect(item)}
+                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm cursor-pointer aria-selected:bg-accent aria-selected:text-accent-foreground transition-colors"
+                  >
+                    {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                    <span className="flex-1">{item.label}</span>
+                    {item.shortcut && (
+                      <kbd className="hidden sm:inline-flex h-5 items-center rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
+                        {item.shortcut}
+                      </kbd>
+                    )}
+                  </Command.Item>
+                );
+              })}
+            </Command.Group>
+          </Command.List>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[10px] text-muted-foreground">
+            <span>
+              <kbd className="font-mono">↑↓</kbd> navigate{' '}
+              <kbd className="font-mono">↵</kbd> select{' '}
+              <kbd className="font-mono">esc</kbd> close
+            </span>
+            <span className="font-mono text-primary/60">$drepscore</span>
+          </div>
+        </div>
+      </div>
+    </Command.Dialog>
+  );
+}

--- a/components/CompareView.tsx
+++ b/components/CompareView.tsx
@@ -288,7 +288,7 @@ export function CompareView({ initialDrepIds }: CompareViewProps) {
               <ArrowLeft className="h-4 w-4" />
             </Link>
             <div>
-              <h1 className="text-2xl font-bold">Compare DReps</h1>
+              <h1 className="text-2xl font-bold tracking-tight">Compare DReps</h1>
               <p className="text-xs text-muted-foreground">
                 Side-by-side comparison of scores, voting records, and alignment
               </p>
@@ -344,7 +344,7 @@ export function CompareView({ initialDrepIds }: CompareViewProps) {
                     </div>
                     <div className="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground">
                       <span>{formatAda(drep.votingPower)} ADA</span>
-                      <span>{drep.delegatorCount} delegator{drep.delegatorCount !== 1 ? 's' : ''}</span>
+                      <span>{drep.delegatorCount.toLocaleString()} delegator{drep.delegatorCount !== 1 ? 's' : ''}</span>
                     </div>
                   </div>
                 </div>

--- a/components/ConnectionError.tsx
+++ b/components/ConnectionError.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+
+interface ConnectionErrorProps {
+  message?: string;
+  onRetry?: () => void;
+  compact?: boolean;
+}
+
+export function ConnectionError({
+  message = 'Having trouble connecting',
+  onRetry,
+  compact = false,
+}: ConnectionErrorProps) {
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    if (!onRetry) return;
+    setRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-sm">
+        <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" />
+        <span className="text-muted-foreground flex-1">{message}</span>
+        {onRetry && (
+          <button
+            onClick={handleRetry}
+            disabled={retrying}
+            className="text-primary hover:text-primary/80 text-xs font-medium"
+          >
+            {retrying ? 'Retrying...' : 'Retry'}
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center rounded-xl">
+      <div className="rounded-full p-4 mb-4 bg-amber-500/10">
+        <AlertTriangle className="h-8 w-8 text-amber-500" />
+      </div>
+      <h3 className="text-lg font-semibold mb-2">{message}</h3>
+      <p className="text-sm text-muted-foreground max-w-sm mb-6">
+        Please check your connection and try again. If the problem persists, our servers may be experiencing high demand.
+      </p>
+      {onRetry && (
+        <Button
+          variant="outline"
+          onClick={handleRetry}
+          disabled={retrying}
+          className="gap-2"
+        >
+          <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} />
+          {retrying ? 'Retrying...' : 'Try Again'}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -226,7 +226,7 @@ export function ConstellationHero({ stats, ssrHolderData, ssrWalletAddress, onPe
       {!showPersonalCard && (
         <div className={`absolute inset-0 flex flex-col items-center justify-start pt-[14vh] md:justify-center md:pt-0 z-10 pointer-events-none px-4 transition-opacity duration-700 ${constellationReady ? 'opacity-100' : 'opacity-0'}`}>
           <h1
-            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold text-center max-w-4xl leading-tight animate-fade-in-up hero-text-shadow"
+            className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-center max-w-4xl leading-tight animate-fade-in-up hero-text-shadow"
           >
             <span className="text-white">
               This is what decentralized governance looks like.

--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
 import { HexScore } from '@/components/HexScore';
 import { AccentProvider } from '@/components/AccentProvider';
@@ -46,13 +47,17 @@ export function DRepProfileHero({
   const identityColor = getIdentityColor(dominant);
   const gradient = getIdentityGradient(dominant);
   const personality = getPersonalityLabel(alignments);
+  const heroRef = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: heroRef, offset: ['start start', 'end start'] });
+  const bgY = useTransform(scrollYProgress, [0, 1], [0, 40]);
 
   return (
     <AccentProvider dimension={dominant} className="relative">
-      {/* Identity gradient background */}
-      <div
+      <div ref={heroRef}>
+      {/* Identity gradient background with parallax */}
+      <motion.div
         className="absolute inset-0 -mx-4 sm:-mx-6 lg:-mx-8 pointer-events-none"
-        style={{ background: gradient }}
+        style={{ background: gradient, y: bgY, willChange: 'transform' }}
         aria-hidden
       />
 
@@ -148,6 +153,7 @@ export function DRepProfileHero({
           </div>
         </motion.div>
       </motion.div>
+      </div>
     </AccentProvider>
   );
 }

--- a/components/DRepProfileTabs.tsx
+++ b/components/DRepProfileTabs.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { AnimatedTabs, type TabDefinition } from '@/components/AnimatedTabs';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BarChart3, Vote, Landmark, User } from 'lucide-react';

--- a/components/DRepQuickView.tsx
+++ b/components/DRepQuickView.tsx
@@ -126,7 +126,7 @@ export function DRepQuickView({
               {formatAda(drep.votingPower)} ADA
             </span>
             <span className="text-xs text-muted-foreground">
-              {drep.delegatorCount} delegator{drep.delegatorCount !== 1 ? 's' : ''}
+              {drep.delegatorCount.toLocaleString()} delegator{drep.delegatorCount !== 1 ? 's' : ''}
             </span>
           </div>
 

--- a/components/EasterEggs.tsx
+++ b/components/EasterEggs.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+
+const KONAMI = [
+  'ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+  'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight',
+  'b', 'a',
+];
+
+function fireConstellationBurst() {
+  import('canvas-confetti').then(({ default: confetti }) => {
+    const colors = ['#06b6d4', '#a855f7', '#3b82f6', '#10b981', '#f59e0b', '#dc2626'];
+    const end = Date.now() + 3000;
+
+    const frame = () => {
+      confetti({
+        particleCount: 3,
+        angle: 60 + Math.random() * 60,
+        spread: 60,
+        origin: { x: Math.random(), y: Math.random() * 0.6 },
+        colors: [colors[Math.floor(Math.random() * colors.length)]],
+        ticks: 100,
+        gravity: 0.6,
+        scalar: 0.8,
+      });
+      if (Date.now() < end) requestAnimationFrame(frame);
+    };
+    frame();
+  });
+}
+
+export function EasterEggs() {
+  const pathname = usePathname();
+  const bufferRef = useRef<string[]>([]);
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (pathname !== '/') return;
+      bufferRef.current.push(e.key);
+      if (bufferRef.current.length > KONAMI.length) {
+        bufferRef.current = bufferRef.current.slice(-KONAMI.length);
+      }
+      if (bufferRef.current.length === KONAMI.length &&
+          bufferRef.current.every((k, i) => k === KONAMI[i])) {
+        fireConstellationBurst();
+        bufferRef.current = [];
+      }
+    },
+    [pathname],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [handleKey]);
+
+  return null;
+}

--- a/components/GovernanceDashboard.tsx
+++ b/components/GovernanceDashboard.tsx
@@ -90,7 +90,7 @@ export function GovernanceDashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">My Governance</h1>
+        <h1 className="text-2xl font-bold tracking-tight">My Governance</h1>
         <p className="text-sm text-muted-foreground">
           Track your delegation, voice your opinion, and see how well you&apos;re represented.
         </p>

--- a/components/GovernanceHealthIndex.tsx
+++ b/components/GovernanceHealthIndex.tsx
@@ -146,7 +146,7 @@ function GHIHero({ data, history, trend, className }: { data: GHIData; history: 
         </svg>
 
         <div className="absolute inset-0 flex flex-col items-center justify-end pb-3">
-          <motion.span className="text-5xl font-bold tabular-nums" style={{ color }}>
+          <motion.span className="text-5xl font-bold tracking-tight tabular-nums" style={{ color }}>
             {displayScore}
           </motion.span>
           <span className="text-xs font-medium uppercase tracking-wider mt-0.5" style={{ color }}>

--- a/components/GovernanceRadar.tsx
+++ b/components/GovernanceRadar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRef, useMemo } from 'react';
-import { motion, useInView } from 'framer-motion';
+import { useRef, useMemo, useEffect, useState, useCallback } from 'react';
+import { motion, useInView, useSpring, useMotionValue } from 'framer-motion';
 import {
   type AlignmentScores,
   type AlignmentDimension,
@@ -11,15 +11,7 @@ import {
   getDimensionOrder,
   alignmentsToArray,
 } from '@/lib/drepIdentity';
-import { spring } from '@/lib/animations';
 import { cn } from '@/lib/utils';
-
-/* ──────────────────────────────────────────────
-   GovernanceRadar — THE signature visual.
-   Custom SVG radar showing 6 alignment dimensions.
-   Three sizes: full (200px), medium (80px), mini (32px).
-   Compare mode overlays two DRep polygons.
-   ────────────────────────────────────────────── */
 
 type RadarSize = 'full' | 'medium' | 'mini';
 
@@ -31,145 +23,114 @@ interface GovernanceRadarProps {
   animate?: boolean;
 }
 
-const SIZE_MAP: Record<RadarSize, number> = {
-  full: 200,
-  medium: 80,
-  mini: 32,
-};
-
-const PADDING_MAP: Record<RadarSize, number> = {
-  full: 40,
-  medium: 8,
-  mini: 2,
-};
+const SIZE_MAP: Record<RadarSize, number> = { full: 220, medium: 80, mini: 32 };
+const PADDING_MAP: Record<RadarSize, number> = { full: 44, medium: 8, mini: 2 };
 
 function getPolygonPoints(
   scores: number[],
-  centerX: number,
-  centerY: number,
-  maxRadius: number,
-): [number, number][] {
-  return scores.map((score, i) => {
-    const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
-    const r = maxRadius * (score / 100);
-    return [centerX + r * Math.cos(angle), centerY + r * Math.sin(angle)];
-  });
+  cx: number,
+  cy: number,
+  maxR: number,
+): string {
+  return scores
+    .map((score, i) => {
+      const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+      const r = maxR * (score / 100);
+      return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+    })
+    .join(' ');
 }
 
-function pointsToSvgPath(pts: [number, number][]): string {
-  return pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+function useAnimatedScores(targets: number[], shouldAnimate: boolean): number[] {
+  const springs = [
+    useSpring(shouldAnimate ? 0 : targets[0], { stiffness: 180, damping: 22 }),
+    useSpring(shouldAnimate ? 0 : targets[1], { stiffness: 180, damping: 22 }),
+    useSpring(shouldAnimate ? 0 : targets[2], { stiffness: 180, damping: 22 }),
+    useSpring(shouldAnimate ? 0 : targets[3], { stiffness: 180, damping: 22 }),
+    useSpring(shouldAnimate ? 0 : targets[4], { stiffness: 180, damping: 22 }),
+    useSpring(shouldAnimate ? 0 : targets[5], { stiffness: 180, damping: 22 }),
+  ];
+
+  const [values, setValues] = useState(shouldAnimate ? [0, 0, 0, 0, 0, 0] : targets);
+
+  useEffect(() => {
+    if (!shouldAnimate) {
+      setValues(targets);
+      return;
+    }
+    springs.forEach((s, i) => {
+      setTimeout(() => s.set(targets[i]), i * 60);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldAnimate, ...targets]);
+
+  useEffect(() => {
+    const unsubs = springs.map((s, i) =>
+      s.on('change', (v) =>
+        setValues((prev) => {
+          const next = [...prev];
+          next[i] = v;
+          return next;
+        }),
+      ),
+    );
+    return () => unsubs.forEach((u) => u());
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return values;
 }
 
-function getAxisEndpoints(
-  centerX: number,
-  centerY: number,
-  radius: number,
-): [number, number][] {
-  return Array.from({ length: 6 }, (_, i) => {
-    const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
-    return [
-      centerX + radius * Math.cos(angle),
-      centerY + radius * Math.sin(angle),
-    ] as [number, number];
-  });
-}
-
-/** Rings for the grid background (25%, 50%, 75%, 100%) */
-function GridRings({
+function BreathingVertices({
+  scores,
   cx,
   cy,
   maxR,
+  color,
 }: {
+  scores: number[];
   cx: number;
   cy: number;
   maxR: number;
+  color: string;
 }) {
+  const [offsets, setOffsets] = useState(() => scores.map(() => 0));
+  const rafRef = useRef(0);
+
+  const animate = useCallback(() => {
+    const now = Date.now();
+    setOffsets(
+      scores.map((_, i) => Math.sin(now / 1200 + i * 1.05) * 1.8),
+    );
+    rafRef.current = requestAnimationFrame(animate);
+  }, [scores]);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (mq.matches) return;
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [animate]);
+
   return (
     <>
-      {[0.25, 0.5, 0.75, 1].map((pct) => (
-        <polygon
-          key={pct}
-          points={pointsToSvgPath(
-            Array.from({ length: 6 }, (_, i) => {
-              const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
-              const r = maxR * pct;
-              return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)] as [number, number];
-            })
-          )}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={pct === 1 ? 0.8 : 0.4}
-          className="text-border"
-          strokeDasharray={pct === 1 ? 'none' : '2 3'}
-        />
-      ))}
-    </>
-  );
-}
-
-/** The main data polygon with identity-colored glow */
-function DataPolygon({
-  points,
-  color,
-  filterId,
-  opacity = 0.2,
-  shouldAnimate,
-}: {
-  points: string;
-  color: { hex: string; rgb: [number, number, number] };
-  filterId: string;
-  opacity?: number;
-  shouldAnimate: boolean;
-}) {
-  const polygonVariants = {
-    hidden: {
-      scale: 0,
-      opacity: 0,
-    },
-    visible: {
-      scale: 1,
-      opacity: 1,
-      transition: spring.smooth,
-    },
-  };
-
-  return (
-    <motion.g
-      variants={shouldAnimate ? polygonVariants : undefined}
-      initial={shouldAnimate ? 'hidden' : undefined}
-      animate={shouldAnimate ? 'visible' : undefined}
-      style={{ transformOrigin: 'center' }}
-    >
-      {/* Glow layer */}
-      <polygon
-        points={points}
-        fill={`rgba(${color.rgb.join(',')}, ${opacity * 0.6})`}
-        stroke={color.hex}
-        strokeWidth={1.5}
-        filter={`url(#${filterId})`}
-      />
-      {/* Crisp layer on top */}
-      <polygon
-        points={points}
-        fill={`rgba(${color.rgb.join(',')}, ${opacity})`}
-        stroke={color.hex}
-        strokeWidth={1.5}
-        strokeLinejoin="round"
-      />
-      {/* Vertex dots */}
-      {points.split(' ').map((pt, i) => {
-        const [x, y] = pt.split(',').map(Number);
+      {scores.map((score, i) => {
+        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+        const r = maxR * (score / 100) + offsets[i];
+        const x = cx + r * Math.cos(angle);
+        const y = cy + r * Math.sin(angle);
         return (
           <circle
             key={i}
             cx={x}
             cy={y}
-            r={2.5}
-            fill={color.hex}
+            r={3}
+            fill={color}
+            opacity={0.9}
           />
         );
       })}
-    </motion.g>
+    </>
   );
 }
 
@@ -181,7 +142,7 @@ export function GovernanceRadar({
   animate = true,
 }: GovernanceRadarProps) {
   const ref = useRef<SVGSVGElement>(null);
-  const isInView = useInView(ref, { once: true, margin: '-50px' });
+  const isInView = useInView(ref, { once: true, margin: '-40px' });
   const shouldAnimate = animate && isInView;
 
   const svgSize = SIZE_MAP[size];
@@ -191,31 +152,60 @@ export function GovernanceRadar({
   const maxR = (svgSize - padding * 2) / 2;
 
   const dimensions = getDimensionOrder();
-  const scores = alignmentsToArray(alignments);
+  const rawScores = alignmentsToArray(alignments);
   const dominant = getDominantDimension(alignments);
   const identityColor = getIdentityColor(dominant);
 
+  const animatedScores = useAnimatedScores(rawScores, shouldAnimate && size === 'full');
+  const displayScores = size === 'full' ? animatedScores : rawScores;
+
   const mainPoints = useMemo(
-    () => pointsToSvgPath(getPolygonPoints(scores, cx, cy, maxR)),
-    [scores, cx, cy, maxR],
+    () => getPolygonPoints(displayScores, cx, cy, maxR),
+    [displayScores, cx, cy, maxR],
   );
 
   const axisEndpoints = useMemo(
-    () => getAxisEndpoints(cx, cy, maxR),
+    () =>
+      Array.from({ length: 6 }, (_, i) => {
+        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+        return [cx + maxR * Math.cos(angle), cy + maxR * Math.sin(angle)] as [number, number];
+      }),
     [cx, cy, maxR],
   );
 
-  const compareData = useMemo(() => {
+  const comparePoints = useMemo(() => {
     if (!compareAlignments) return null;
     const cScores = alignmentsToArray(compareAlignments);
-    const cDominant = getDominantDimension(compareAlignments);
-    const cColor = getIdentityColor(cDominant);
-    const cPoints = pointsToSvgPath(getPolygonPoints(cScores, cx, cy, maxR));
-    return { points: cPoints, color: cColor };
+    return getPolygonPoints(cScores, cx, cy, maxR);
   }, [compareAlignments, cx, cy, maxR]);
 
-  const filterId = `radar-glow-${size}`;
-  const compareFilterId = `radar-glow-compare-${size}`;
+  const compareColor = useMemo(() => {
+    if (!compareAlignments) return null;
+    return getIdentityColor(getDominantDimension(compareAlignments));
+  }, [compareAlignments]);
+
+  const uid = useMemo(() => `radar-${size}-${Math.random().toString(36).slice(2, 6)}`, [size]);
+
+  if (size === 'mini') {
+    return (
+      <svg
+        viewBox={`0 0 ${svgSize} ${svgSize}`}
+        width={svgSize}
+        height={svgSize}
+        className={cn('shrink-0', className)}
+        role="img"
+        aria-label="Governance radar"
+      >
+        <polygon
+          points={getPolygonPoints(rawScores, cx, cy, maxR)}
+          fill={`rgba(${identityColor.rgb.join(',')}, 0.25)`}
+          stroke={identityColor.hex}
+          strokeWidth={1}
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
 
   return (
     <svg
@@ -226,72 +216,156 @@ export function GovernanceRadar({
       className={cn('shrink-0', className)}
       role="img"
       aria-label={`Governance radar: ${dimensions
-        .map((d, i) => `${getDimensionLabel(d)} ${scores[i]}`)
+        .map((d, i) => `${getDimensionLabel(d)} ${rawScores[i]}`)
         .join(', ')}`}
     >
       <defs>
-        {/* Identity-colored glow filter */}
-        <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'full' ? 6 : size === 'medium' ? 3 : 1} />
-          <feComposite in2="SourceGraphic" operator="over" />
+        <filter id={`${uid}-bloom`} x="-60%" y="-60%" width="220%" height="220%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'full' ? 12 : 4} />
         </filter>
-        {compareData && (
-          <filter id={compareFilterId} x="-50%" y="-50%" width="200%" height="200%">
-            <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'full' ? 6 : 3} />
-            <feComposite in2="SourceGraphic" operator="over" />
-          </filter>
-        )}
-        {/* Radial gradient for the fill */}
-        <radialGradient id={`radar-fill-${size}`} cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor={identityColor.hex} stopOpacity={0.3} />
-          <stop offset="100%" stopColor={identityColor.hex} stopOpacity={0.05} />
+        <filter id={`${uid}-glow`} x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'full' ? 4 : 2} />
+        </filter>
+        <radialGradient id={`${uid}-fill`} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor={identityColor.hex} stopOpacity={0.4} />
+          <stop offset="100%" stopColor={identityColor.hex} stopOpacity={0.08} />
         </radialGradient>
+        {compareColor && (
+          <radialGradient id={`${uid}-cfill`} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={compareColor.hex} stopOpacity={0.25} />
+            <stop offset="100%" stopColor={compareColor.hex} stopOpacity={0.04} />
+          </radialGradient>
+        )}
+        {/* Axis gradient */}
+        {axisEndpoints.map((_, i) => {
+          const dimColor = getIdentityColor(dimensions[i]);
+          return (
+            <linearGradient key={i} id={`${uid}-axis-${i}`} x1="50%" y1="50%" x2={`${(axisEndpoints[i][0] / svgSize) * 100}%`} y2={`${(axisEndpoints[i][1] / svgSize) * 100}%`}>
+              <stop offset="0%" stopColor={dimColor.hex} stopOpacity={0} />
+              <stop offset="50%" stopColor={dimColor.hex} stopOpacity={0.3} />
+              <stop offset="100%" stopColor={dimColor.hex} stopOpacity={0.1} />
+            </linearGradient>
+          );
+        })}
       </defs>
 
-      {/* Grid rings + axis lines */}
-      <GridRings cx={cx} cy={cy} maxR={maxR} />
-
-      {axisEndpoints.map(([ex, ey], i) => (
-        <line
-          key={i}
-          x1={cx}
-          y1={cy}
-          x2={ex}
-          y2={ey}
-          stroke="currentColor"
-          strokeWidth={0.5}
-          className="text-border"
+      {/* Grid rings — solid, subtle */}
+      {[0.25, 0.5, 0.75, 1].map((pct) => (
+        <polygon
+          key={pct}
+          points={Array.from({ length: 6 }, (_, i) => {
+            const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+            const r = maxR * pct;
+            return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+          }).join(' ')}
+          fill="none"
+          stroke={pct === 1 ? `rgba(${identityColor.rgb.join(',')}, 0.12)` : 'currentColor'}
+          strokeWidth={pct === 1 ? 0.8 : 0.4}
+          className={pct === 1 ? undefined : 'text-border'}
+          opacity={pct === 1 ? 1 : 0.5}
         />
       ))}
 
+      {/* Axis lines with gradient */}
+      {axisEndpoints.map(([ex, ey], i) => (
+        <g key={`axis-${i}`}>
+          <line
+            x1={cx}
+            y1={cy}
+            x2={ex}
+            y2={ey}
+            stroke={`url(#${uid}-axis-${i})`}
+            strokeWidth={0.8}
+          />
+          {/* Glowing dot at axis tip */}
+          <circle
+            cx={ex}
+            cy={ey}
+            r={size === 'full' ? 2.5 : 1.5}
+            fill={getIdentityColor(dimensions[i]).hex}
+            opacity={0.6}
+          />
+        </g>
+      ))}
+
       {/* Compare polygon (behind main) */}
-      {compareData && (
-        <DataPolygon
-          points={compareData.points}
-          color={compareData.color}
-          filterId={compareFilterId}
-          opacity={0.12}
-          shouldAnimate={shouldAnimate}
+      {comparePoints && compareColor && (
+        <>
+          <polygon
+            points={comparePoints}
+            fill={`url(#${uid}-cfill)`}
+            stroke={compareColor.hex}
+            strokeWidth={1}
+            strokeLinejoin="round"
+            opacity={0.5}
+          />
+        </>
+      )}
+
+      {/* Layer 1: Wide bloom */}
+      <polygon
+        points={mainPoints}
+        fill={`rgba(${identityColor.rgb.join(',')}, 0.08)`}
+        stroke={identityColor.hex}
+        strokeWidth={1.5}
+        filter={`url(#${uid}-bloom)`}
+      />
+
+      {/* Layer 2: Tight glow */}
+      <polygon
+        points={mainPoints}
+        fill={`rgba(${identityColor.rgb.join(',')}, 0.15)`}
+        stroke={identityColor.hex}
+        strokeWidth={1.5}
+        filter={`url(#${uid}-glow)`}
+      />
+
+      {/* Layer 3: Crisp shape */}
+      <polygon
+        points={mainPoints}
+        fill={`url(#${uid}-fill)`}
+        stroke={identityColor.hex}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+
+      {/* Breathing vertex dots — full size only */}
+      {size === 'full' && shouldAnimate && (
+        <BreathingVertices
+          scores={rawScores}
+          cx={cx}
+          cy={cy}
+          maxR={maxR}
+          color={identityColor.hex}
         />
       )}
 
-      {/* Main data polygon */}
-      <DataPolygon
-        points={mainPoints}
-        color={identityColor}
-        filterId={filterId}
-        shouldAnimate={shouldAnimate}
-      />
+      {/* Static vertex dots for medium or pre-animation */}
+      {(size === 'medium' || !shouldAnimate) &&
+        displayScores.map((score, i) => {
+          const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+          const r = maxR * (score / 100);
+          return (
+            <circle
+              key={i}
+              cx={cx + r * Math.cos(angle)}
+              cy={cy + r * Math.sin(angle)}
+              r={size === 'full' ? 3 : 2}
+              fill={identityColor.hex}
+              opacity={0.9}
+            />
+          );
+        })}
 
       {/* Dimension labels — full size only */}
       {size === 'full' &&
         axisEndpoints.map(([ex, ey], i) => {
           const dim = dimensions[i];
           const label = getDimensionLabel(dim);
-          const score = scores[i];
+          const score = rawScores[i];
           const dimColor = getIdentityColor(dim);
 
-          const labelOffset = 16;
+          const labelOffset = 20;
           const dx = ex - cx;
           const dy = ey - cy;
           const len = Math.sqrt(dx * dx + dy * dy);
@@ -308,24 +382,27 @@ export function GovernanceRadar({
             <g key={dim}>
               <text
                 x={lx}
-                y={ly - 6}
+                y={ly - 7}
                 textAnchor={textAnchor}
                 dominantBaseline="auto"
-                className="fill-muted-foreground"
-                fontSize={9}
+                fill={dimColor.hex}
+                fontSize={10}
+                fontWeight={600}
                 fontFamily="var(--font-geist-sans)"
+                opacity={0.85}
               >
                 {label}
               </text>
               <text
                 x={lx}
-                y={ly + 6}
+                y={ly + 7}
                 textAnchor={textAnchor}
                 dominantBaseline="hanging"
-                fill={dimColor.hex}
-                fontSize={10}
-                fontWeight={600}
+                fill="white"
+                fontSize={12}
+                fontWeight={700}
                 fontFamily="var(--font-geist-mono)"
+                style={{ textShadow: `0 0 8px ${dimColor.hex}60` }}
               >
                 {score}
               </text>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -43,6 +43,7 @@ import {
   Activity,
   Inbox,
   Code2,
+  Search,
 } from 'lucide-react';
 import { MobileNav } from './MobileNav';
 import { GovernanceHeartbeat } from './GovernanceHeartbeat';
@@ -193,6 +194,19 @@ export function Header() {
             </Link>
           </FeatureGate>
           
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }))}
+            className="hidden sm:inline-flex items-center gap-2 text-muted-foreground hover:text-foreground h-8 px-2"
+          >
+            <Search className="h-3.5 w-3.5" />
+            <span className="text-xs">Search</span>
+            <kbd className="hidden md:inline-flex h-5 items-center rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
+              ⌘K
+            </kbd>
+          </Button>
+
           {isAuthenticated && sessionAddress ? (
             <>
               <DropdownMenu>

--- a/components/HexScore.tsx
+++ b/components/HexScore.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useEffect, useMemo, useCallback, useState } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import { motion, useInView, useSpring } from 'framer-motion';
 import {
   type AlignmentScores,
@@ -11,13 +11,7 @@ import {
 } from '@/lib/drepIdentity';
 import { cn } from '@/lib/utils';
 
-/* ──────────────────────────────────────────────
-   HexScore — Procedural hexagonal score display.
-   6 vertices mapped to alignment dimensions.
-   Three sizes: hero (120px), card (48px), badge (24px).
-   ────────────────────────────────────────────── */
-
-type HexSize = 'hero' | 'card' | 'badge';
+type HexSize = 'hero' | 'hero-lg' | 'card' | 'badge';
 
 interface HexScoreProps {
   score: number;
@@ -28,118 +22,34 @@ interface HexScoreProps {
 }
 
 const SIZE_MAP: Record<HexSize, number> = {
+  'hero-lg': 172,
   hero: 120,
   card: 48,
   badge: 24,
 };
 
+const FONT_MAP: Record<HexSize, number> = {
+  'hero-lg': 38,
+  hero: 28,
+  card: 14,
+  badge: 0,
+};
+
 function useCountUp(target: number, shouldAnimate: boolean): number {
   const [display, setDisplay] = useState(shouldAnimate ? 0 : target);
-  const springValue = useSpring(0, {
-    stiffness: 80,
-    damping: 20,
-    restDelta: 0.5,
-  });
+  const springValue = useSpring(0, { stiffness: 80, damping: 20, restDelta: 0.5 });
 
   useEffect(() => {
-    if (shouldAnimate) {
-      springValue.set(target);
-    } else {
-      setDisplay(target);
-    }
+    if (shouldAnimate) springValue.set(target);
+    else setDisplay(target);
   }, [target, shouldAnimate, springValue]);
 
   useEffect(() => {
-    const unsubscribe = springValue.on('change', (v) => {
-      setDisplay(Math.round(v));
-    });
-    return unsubscribe;
+    const unsub = springValue.on('change', (v) => setDisplay(Math.round(v)));
+    return unsub;
   }, [springValue]);
 
   return display;
-}
-
-/** Edge particles — hero size only, disabled on reduced-motion and mobile */
-function EdgeParticles({
-  vertices,
-  color,
-  size,
-}: {
-  vertices: [number, number][];
-  color: string;
-  size: number;
-}) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const particlesRef = useRef<
-    { x: number; y: number; vx: number; vy: number; life: number; maxLife: number }[]
-  >([]);
-  const rafRef = useRef<number>(0);
-
-  const animate = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    ctx.clearRect(0, 0, size, size);
-
-    const particles = particlesRef.current;
-
-    if (particles.length < 20 && Math.random() > 0.6) {
-      const edgeIdx = Math.floor(Math.random() * 6);
-      const [x1, y1] = vertices[edgeIdx];
-      const [x2, y2] = vertices[(edgeIdx + 1) % 6];
-      const t = Math.random();
-      particles.push({
-        x: x1 + (x2 - x1) * t,
-        y: y1 + (y2 - y1) * t,
-        vx: (Math.random() - 0.5) * 0.3,
-        vy: (Math.random() - 0.5) * 0.3,
-        life: 0,
-        maxLife: 40 + Math.random() * 40,
-      });
-    }
-
-    for (let i = particles.length - 1; i >= 0; i--) {
-      const p = particles[i];
-      p.x += p.vx;
-      p.y += p.vy;
-      p.life++;
-
-      if (p.life > p.maxLife) {
-        particles.splice(i, 1);
-        continue;
-      }
-
-      const alpha = 1 - p.life / p.maxLife;
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, 1, 0, Math.PI * 2);
-      ctx.fillStyle = `${color}${Math.round(alpha * 180).toString(16).padStart(2, '0')}`;
-      ctx.fill();
-    }
-
-    rafRef.current = requestAnimationFrame(animate);
-  }, [vertices, color, size]);
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    if (mq.matches) return;
-
-    const isMobile = window.innerWidth < 768;
-    if (isMobile) return;
-
-    rafRef.current = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [animate]);
-
-  return (
-    <canvas
-      ref={canvasRef}
-      width={size}
-      height={size}
-      className="absolute inset-0 pointer-events-none"
-    />
-  );
 }
 
 export function HexScore({
@@ -154,27 +64,29 @@ export function HexScore({
   const shouldAnimate = enableAnim && isInView;
 
   const svgSize = SIZE_MAP[size];
+  const fontSize = FONT_MAP[size];
   const dominant = getDominantDimension(alignments);
   const identityColor = getIdentityColor(dominant);
 
-  const vertices = useMemo(
-    () => getHexVertices(alignments, svgSize),
-    [alignments, svgSize],
-  );
-
-  const polygonPoints = useMemo(
-    () => hexVerticesToPath(vertices),
-    [vertices],
-  );
+  const vertices = useMemo(() => getHexVertices(alignments, svgSize), [alignments, svgSize]);
+  const polygonPoints = useMemo(() => hexVerticesToPath(vertices), [vertices]);
 
   const animatedScore = useCountUp(score, shouldAnimate);
+  const uid = useMemo(() => `hex-${size}-${Math.random().toString(36).slice(2, 6)}`, [size]);
 
-  const filterId = `hex-glow-${size}`;
-  const noiseId = `hex-noise-${size}`;
-
-  const showParticles = size === 'hero';
   const showNumber = size !== 'badge';
   const showGlow = size !== 'badge';
+  const showShimmer = size === 'hero' || size === 'hero-lg';
+
+  const perimeterLength = useMemo(() => {
+    let len = 0;
+    for (let i = 0; i < vertices.length; i++) {
+      const [x1, y1] = vertices[i];
+      const [x2, y2] = vertices[(i + 1) % vertices.length];
+      len += Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+    }
+    return Math.round(len);
+  }, [vertices]);
 
   return (
     <div
@@ -186,85 +98,115 @@ export function HexScore({
         viewBox={`0 0 ${svgSize} ${svgSize}`}
         width={svgSize}
         height={svgSize}
-        initial={shouldAnimate ? { scale: 0.8, opacity: 0 } : undefined}
+        initial={shouldAnimate ? { scale: 0.85, opacity: 0 } : undefined}
         animate={shouldAnimate ? { scale: 1, opacity: 1 } : undefined}
-        transition={{ type: 'spring', stiffness: 300, damping: 15 }}
+        transition={{ type: 'spring', stiffness: 280, damping: 18 }}
         role="img"
         aria-label={`Score: ${score}`}
       >
         <defs>
           {showGlow && (
-            <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
-              <feGaussianBlur
-                in="SourceGraphic"
-                stdDeviation={size === 'hero' ? 8 : 3}
-              />
-              <feComposite in2="SourceGraphic" operator="over" />
-            </filter>
+            <>
+              <filter id={`${uid}-bloom`} x="-60%" y="-60%" width="220%" height="220%">
+                <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'hero-lg' ? 14 : size === 'hero' ? 10 : 3} />
+              </filter>
+              <filter id={`${uid}-glow`} x="-40%" y="-40%" width="180%" height="180%">
+                <feGaussianBlur in="SourceGraphic" stdDeviation={size === 'hero-lg' ? 5 : size === 'hero' ? 4 : 2} />
+              </filter>
+            </>
           )}
-          {size === 'hero' && (
-            <filter id={noiseId}>
-              <feTurbulence
-                type="fractalNoise"
-                baseFrequency="0.8"
-                numOctaves="4"
-                stitchTiles="stitch"
-              />
-              <feColorMatrix type="saturate" values="0" />
-              <feBlend in="SourceGraphic" mode="overlay" />
-            </filter>
-          )}
+          <radialGradient id={`${uid}-fill`} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={identityColor.hex} stopOpacity={0.2} />
+            <stop offset="100%" stopColor={identityColor.hex} stopOpacity={0.04} />
+          </radialGradient>
         </defs>
 
-        {/* Glow layer */}
+        {/* Layer 1: Wide bloom */}
         {showGlow && (
           <polygon
             points={polygonPoints}
-            fill={`rgba(${identityColor.rgb.join(',')}, 0.15)`}
+            fill={`rgba(${identityColor.rgb.join(',')}, 0.08)`}
             stroke={identityColor.hex}
-            strokeWidth={size === 'hero' ? 1.5 : 1}
-            filter={`url(#${filterId})`}
-            className={size === 'hero' ? 'animate-breathing-glow' : undefined}
+            strokeWidth={size === 'hero-lg' || size === 'hero' ? 1.5 : 1}
+            filter={`url(#${uid}-bloom)`}
+            className="animate-breathing-glow"
           />
         )}
 
-        {/* Main hex with noise texture (hero) or solid fill */}
+        {/* Layer 2: Tight glow */}
+        {showGlow && (
+          <polygon
+            points={polygonPoints}
+            fill={`rgba(${identityColor.rgb.join(',')}, 0.18)`}
+            stroke={identityColor.hex}
+            strokeWidth={size === 'hero-lg' || size === 'hero' ? 1.5 : 1}
+            filter={`url(#${uid}-glow)`}
+          />
+        )}
+
+        {/* Layer 3: Crisp shape */}
         <polygon
           points={polygonPoints}
-          fill={`rgba(${identityColor.rgb.join(',')}, ${size === 'hero' ? 0.08 : 0.12})`}
+          fill={size === 'badge' ? `rgba(${identityColor.rgb.join(',')}, 0.3)` : `url(#${uid}-fill)`}
           stroke={identityColor.hex}
-          strokeWidth={size === 'hero' ? 1.5 : size === 'card' ? 1 : 0.5}
+          strokeWidth={size === 'hero-lg' || size === 'hero' ? 1.5 : size === 'card' ? 1 : 0.5}
           strokeLinejoin="round"
-          filter={size === 'hero' ? `url(#${noiseId})` : undefined}
         />
+
+        {/* Edge shimmer — animated dash traveling along the hex edge */}
+        {showShimmer && (
+          <polygon
+            points={polygonPoints}
+            fill="none"
+            stroke="white"
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            strokeDasharray={`${Math.round(perimeterLength * 0.06)} ${Math.round(perimeterLength * 0.94)}`}
+            strokeLinecap="round"
+            opacity={0.5}
+            style={{
+              animation: `hex-shimmer ${Math.max(3, perimeterLength / 80)}s linear infinite`,
+              strokeDashoffset: 0,
+            }}
+          />
+        )}
 
         {/* Score number */}
         {showNumber && (
-          <text
-            x={svgSize / 2}
-            y={svgSize / 2}
-            textAnchor="middle"
-            dominantBaseline="central"
-            fill="white"
-            fontSize={size === 'hero' ? 28 : 14}
-            fontWeight={700}
-            fontFamily="var(--font-geist-mono)"
-            style={{
-              textShadow: `0 0 12px ${identityColor.hex}`,
-            }}
-          >
-            {animatedScore}
-          </text>
+          <>
+            <text
+              x={svgSize / 2}
+              y={size === 'card' ? svgSize / 2 : svgSize / 2 - 2}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill="white"
+              fontSize={fontSize}
+              fontWeight={700}
+              letterSpacing="0.04em"
+              fontFamily="var(--font-geist-mono)"
+              style={{
+                textShadow: `0 0 20px ${identityColor.hex}, 0 0 40px ${identityColor.hex}40`,
+              }}
+            >
+              {animatedScore}
+            </text>
+            {(size === 'hero' || size === 'hero-lg') && (
+              <text
+                x={svgSize / 2}
+                y={svgSize / 2 + fontSize * 0.55}
+                textAnchor="middle"
+                dominantBaseline="hanging"
+                fill="white"
+                fontSize={11}
+                fontFamily="var(--font-geist-mono)"
+                opacity={0.35}
+              >
+                / 100
+              </text>
+            )}
+          </>
         )}
       </motion.svg>
-
-      {showParticles && (
-        <EdgeParticles
-          vertices={vertices}
-          color={identityColor.hex}
-          size={svgSize}
-        />
-      )}
     </div>
   );
 }

--- a/components/InlineDelegationCTA.tsx
+++ b/components/InlineDelegationCTA.tsx
@@ -11,9 +11,14 @@ import {
   ExternalLink,
   AlertTriangle,
 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { DelegationRisksModal } from './InfoModal';
-import { DelegationCeremony } from './DelegationCeremony';
 import { useState } from 'react';
+
+const DelegationCeremony = dynamic(
+  () => import('./DelegationCeremony').then((m) => m.DelegationCeremony),
+  { ssr: false },
+);
 import { useFeatureFlag } from '@/components/FeatureGate';
 import { type AlignmentScores } from '@/lib/drepIdentity';
 

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { X, Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export function InstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem('pwa-install-dismissed');
+    if (dismissed) return;
+
+    const visits = parseInt(localStorage.getItem('pwa-visit-count') || '0', 10) + 1;
+    localStorage.setItem('pwa-visit-count', String(visits));
+
+    if (visits < 3) return;
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setShow(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', handler as EventListener);
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener);
+  }, []);
+
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch(() => {});
+    }
+  }, []);
+
+  if (!show || !deferredPrompt) return null;
+
+  const handleInstall = async () => {
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') {
+      setShow(false);
+    }
+    setDeferredPrompt(null);
+  };
+
+  const handleDismiss = () => {
+    setShow(false);
+    localStorage.setItem('pwa-install-dismissed', '1');
+  };
+
+  return (
+    <div className="fixed top-[68px] left-0 right-0 z-40 flex justify-center px-4 animate-fade-in-up">
+      <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-popover/95 backdrop-blur-xl shadow-lg px-4 py-2.5 max-w-lg">
+        <Download className="h-4 w-4 text-primary shrink-0" />
+        <p className="text-sm flex-1">
+          Add DRepScore to your homescreen for instant access.
+        </p>
+        <Button size="sm" variant="default" onClick={handleInstall} className="shrink-0 h-7 text-xs">
+          Install
+        </Button>
+        <button onClick={handleDismiss} className="p-1 rounded hover:bg-muted transition-colors shrink-0">
+          <X className="h-3.5 w-3.5 text-muted-foreground" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/KeyboardShortcuts.tsx
+++ b/components/KeyboardShortcuts.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { isInputFocused } from '@/lib/shortcuts';
+
+export function KeyboardShortcuts() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isInputFocused()) return;
+
+      const cmdkOpen = document.querySelector('[cmdk-dialog]');
+      if (cmdkOpen) return;
+
+      switch (e.key) {
+        case '?':
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent('openShortcutsHelp'));
+          break;
+        case '/':
+          e.preventDefault();
+          document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true }),
+          );
+          break;
+        case 'h':
+          router.push('/');
+          break;
+        case 'd':
+          router.push('/discover');
+          break;
+        case 'p':
+          router.push('/proposals');
+          break;
+        case 'g':
+          router.push('/governance');
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [router]);
+
+  return null;
+}

--- a/components/OfflineBanner.tsx
+++ b/components/OfflineBanner.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { WifiOff } from 'lucide-react';
+
+export function OfflineBanner() {
+  const [offline, setOffline] = useState(false);
+
+  useEffect(() => {
+    const goOffline = () => setOffline(true);
+    const goOnline = () => setOffline(false);
+    
+    setOffline(!navigator.onLine);
+    
+    window.addEventListener('offline', goOffline);
+    window.addEventListener('online', goOnline);
+    return () => {
+      window.removeEventListener('offline', goOffline);
+      window.removeEventListener('online', goOnline);
+    };
+  }, []);
+
+  if (!offline) return null;
+
+  return (
+    <div className="fixed top-16 left-0 right-0 z-40 flex justify-center px-4 animate-fade-in-up">
+      <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-950/90 backdrop-blur-sm shadow-lg px-4 py-2 text-sm">
+        <WifiOff className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+        <span className="text-amber-200">You&apos;re offline — showing cached data</span>
+      </div>
+    </div>
+  );
+}

--- a/components/PillarCard.tsx
+++ b/components/PillarCard.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef } from 'react';
+import { useInView } from 'framer-motion';
 import { CheckCircle2, AlertTriangle, AlertCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { type PillarStatus } from '@/utils/scoring';
@@ -18,28 +20,32 @@ const STATUS_CONFIG: Record<PillarStatus, {
   badgeLabel: string;
   badgeClass: string;
   iconClass: string;
-  barColor: string;
+  barGradient: string;
+  accentBorder: string;
 }> = {
   strong: {
     icon: CheckCircle2,
     badgeLabel: 'Strong',
     badgeClass: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800',
     iconClass: 'text-green-600 dark:text-green-400',
-    barColor: 'bg-green-500 dark:bg-green-400',
+    barGradient: 'from-green-500 to-green-400',
+    accentBorder: 'border-l-green-500',
   },
   'needs-work': {
     icon: AlertTriangle,
     badgeLabel: 'Needs Work',
     badgeClass: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 border-amber-200 dark:border-amber-800',
     iconClass: 'text-amber-600 dark:text-amber-400',
-    barColor: 'bg-amber-500 dark:bg-amber-400',
+    barGradient: 'from-amber-500 to-amber-400',
+    accentBorder: 'border-l-amber-500',
   },
   low: {
     icon: AlertCircle,
     badgeLabel: 'Low',
     badgeClass: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800',
     iconClass: 'text-red-600 dark:text-red-400',
-    barColor: 'bg-red-500 dark:bg-red-400',
+    barGradient: 'from-red-500 to-red-400',
+    accentBorder: 'border-l-red-500',
   },
 };
 
@@ -55,8 +61,14 @@ export function PillarCard({ label, value, weight, maxPoints, status, hint }: Pi
   const tierDistance = getTierDistance(value, status);
   const contribution = Math.round(value * maxPoints / 100);
 
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: '-20px' });
+
   return (
-    <div className="space-y-2">
+    <div
+      ref={ref}
+      className={`space-y-2 p-3 rounded-lg bg-card/50 border-l-2 ${config.accentBorder}`}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Icon className={`h-4 w-4 ${config.iconClass}`} />
@@ -74,14 +86,14 @@ export function PillarCard({ label, value, weight, maxPoints, status, hint }: Pi
           </span>
         </div>
       </div>
-      {/* Color-coded progress bar with tier markers */}
-      <div className="relative h-2 w-full rounded-full bg-muted overflow-hidden">
+      {/* Progress bar with gradient fill and animated width */}
+      <div className="relative h-2.5 w-full rounded-full bg-muted overflow-hidden">
         <div
-          className={`h-full rounded-full transition-all ${config.barColor}`}
-          style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+          className={`h-full rounded-full bg-gradient-to-r ${config.barGradient} transition-all duration-700 ease-out`}
+          style={{ width: isInView ? `${Math.min(100, Math.max(0, value))}%` : '0%' }}
         />
-        <div className="absolute top-0 left-[50%] w-px h-full bg-foreground/15" />
-        <div className="absolute top-0 left-[80%] w-px h-full bg-foreground/15" />
+        <div className="absolute top-0 left-[50%] w-px h-full bg-foreground/20" />
+        <div className="absolute top-0 left-[80%] w-px h-full bg-foreground/20" />
       </div>
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted-foreground">{hint}</p>

--- a/components/ScoreCard.tsx
+++ b/components/ScoreCard.tsx
@@ -43,11 +43,11 @@ export function ScoreCard({
   percentile, participationHint, rationaleHint, reliabilityHint, profileHint,
 }: ScoreCardProps) {
   const { isAuthenticated, ownDRepId } = useWallet();
-  
+
   const isOwnProfile = isAuthenticated && ownDRepId === drep.drepId;
   const shareUrl = buildDRepUrl(drep.drepId);
   const ogImageUrl = `/api/og/drep/${encodeURIComponent(drep.drepId)}`;
-  
+
   const shareText = isOwnProfile
     ? `My DRepScore is ${drep.drepScore}/100!\n\nParticipation: ${drep.effectiveParticipation}% | Rationale: ${adjustedRationale}% | Reliability: ${drep.reliabilityScore}%\n\nSee my full report on @drepscore:`
     : `${drep.name || 'This DRep'} scored ${drep.drepScore}/100 on @drepscore!\n\nCheck out their governance track record:`;
@@ -82,57 +82,53 @@ export function ScoreCard({
         </div>
       </CardHeader>
       <CardContent className="space-y-5">
-        {/* Score hex + percentile */}
-        <div className="flex flex-col items-center gap-3">
-          <HexScore score={drep.drepScore} alignments={extractAlignments(drep as Record<string, unknown>)} size="hero" />
-          {percentile > 0 && (
-            <span className="text-xs text-muted-foreground">
-              Higher than {percentile}% of DReps
-            </span>
-          )}
-        </div>
-
-        {/* Score range bar */}
-        <div className="space-y-1">
-          <div className="relative flex h-2 rounded-full overflow-hidden">
-            <div className="flex-[60] bg-red-200 dark:bg-red-900/40" />
-            <div className="flex-[20] bg-amber-200 dark:bg-amber-900/40" />
-            <div className="flex-[20] bg-green-200 dark:bg-green-900/40" />
-            {/* Position marker */}
-            <div
-              className="absolute top-[-3px] h-[14px] w-[3px] rounded-full bg-foreground"
-              style={{ left: `${Math.min(99, Math.max(1, drep.drepScore))}%` }}
+        {/* Score hero — side-by-side on desktop */}
+        <div className="grid grid-cols-1 lg:grid-cols-[auto_1fr] gap-6 items-center">
+          <div className="flex justify-center lg:justify-start">
+            <HexScore
+              score={drep.drepScore}
+              alignments={extractAlignments(drep as Record<string, unknown>)}
+              size="hero-lg"
+              className="hidden lg:inline-flex"
+            />
+            <HexScore
+              score={drep.drepScore}
+              alignments={extractAlignments(drep as Record<string, unknown>)}
+              size="hero"
+              className="lg:hidden"
             />
           </div>
-          <div className="flex text-[10px] text-muted-foreground">
-            <span className="flex-[60]">Low</span>
-            <span className="flex-[20] text-center">Good</span>
-            <span className="flex-[20] text-right">Strong</span>
+          <div className="flex flex-col items-center lg:items-start gap-3">
+            {percentile > 0 && (
+              <span className="text-sm font-medium text-foreground/80">
+                Higher than {percentile}% of DReps
+              </span>
+            )}
+            {quickWin && (
+              <div className="bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 flex items-center gap-2 w-full">
+                <Lightbulb className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
+                <p className="text-xs font-medium text-blue-800 dark:text-blue-300">
+                  Biggest opportunity: {quickWin}
+                </p>
+              </div>
+            )}
           </div>
         </div>
 
-        {/* Biggest opportunity callout */}
-        {quickWin && (
-          <div className="bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 flex items-center gap-2">
-            <Lightbulb className="h-4 w-4 text-blue-600 dark:text-blue-400 shrink-0" />
-            <p className="text-xs font-medium text-blue-800 dark:text-blue-300">
-              Biggest opportunity: {quickWin}
-            </p>
-          </div>
-        )}
-
-        {/* Pillar cards */}
-        {pillars.map((p, i) => (
-          <PillarCard
-            key={p.label}
-            label={p.label}
-            value={p.value}
-            weight={p.weight}
-            maxPoints={p.maxPoints}
-            status={pillarStatuses[i]}
-            hint={hints[i]}
-          />
-        ))}
+        {/* Pillar cards — 2-column on desktop */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          {pillars.map((p, i) => (
+            <PillarCard
+              key={p.label}
+              label={p.label}
+              value={p.value}
+              weight={p.weight}
+              maxPoints={p.maxPoints}
+              status={pillarStatuses[i]}
+              hint={hints[i]}
+            />
+          ))}
+        </div>
 
         <div className="border-t pt-4">
           <MethodologyAccordion />

--- a/components/ScrollStoryReveal.tsx
+++ b/components/ScrollStoryReveal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { type ReactNode, useRef } from 'react';
+import { motion, useScroll, useTransform, type MotionValue } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+interface ScrollStoryRevealProps {
+  children: ReactNode;
+  className?: string;
+  variant?: 'fadeUp' | 'slideLeft' | 'slideRight' | 'scaleIn' | 'parallax';
+  offset?: number;
+}
+
+function useScrollProgress(ref: React.RefObject<HTMLDivElement | null>): MotionValue<number> {
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start end', 'end start'],
+  });
+  return scrollYProgress;
+}
+
+const VARIANT_CONFIG = {
+  fadeUp: { y: [30, 0], opacity: [0, 1], range: [0, 0.35] },
+  slideLeft: { x: [-40, 0], opacity: [0, 1], range: [0, 0.35] },
+  slideRight: { x: [40, 0], opacity: [0, 1], range: [0, 0.35] },
+  scaleIn: { scale: [0.92, 1], opacity: [0, 1], range: [0, 0.35] },
+  parallax: { y: [20, -20], opacity: [1, 1], range: [0, 1] },
+};
+
+export function ScrollStoryReveal({
+  children,
+  className,
+  variant = 'fadeUp',
+  offset = 0,
+}: ScrollStoryRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const progress = useScrollProgress(ref);
+  const config = VARIANT_CONFIG[variant];
+
+  const rangeStart = config.range[0] + offset * 0.05;
+  const rangeEnd = config.range[1] + offset * 0.05;
+
+  const opacity = useTransform(progress, [rangeStart, rangeEnd], config.opacity);
+  const y = 'y' in config ? useTransform(progress, [rangeStart, rangeEnd], config.y) : undefined;
+  const x = 'x' in config ? useTransform(progress, [rangeStart, rangeEnd], config.x) : undefined;
+  const scale = 'scale' in config ? useTransform(progress, [rangeStart, rangeEnd], config.scale) : undefined;
+
+  return (
+    <motion.div
+      ref={ref}
+      className={cn(className)}
+      style={{
+        opacity,
+        y: y as MotionValue<number> | undefined,
+        x: x as MotionValue<number> | undefined,
+        scale: scale as MotionValue<number> | undefined,
+        willChange: 'transform, opacity',
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+interface ParallaxHeroProps {
+  children: ReactNode;
+  className?: string;
+  speed?: number;
+}
+
+export function ParallaxHero({ children, className, speed = 0.3 }: ParallaxHeroProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start start', 'end start'],
+  });
+  const y = useTransform(scrollYProgress, [0, 1], [0, 100 * speed]);
+
+  return (
+    <div ref={ref} className={cn('relative overflow-hidden', className)}>
+      <motion.div style={{ y, willChange: 'transform' }}>
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/components/ShortcutsHelpOverlay.tsx
+++ b/components/ShortcutsHelpOverlay.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SHORTCUTS } from '@/lib/shortcuts';
+import { X } from 'lucide-react';
+
+export function ShortcutsHelpOverlay() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener('openShortcutsHelp', handler);
+    return () => window.removeEventListener('openShortcutsHelp', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  if (!open) return null;
+
+  const navigation = SHORTCUTS.filter((s) => s.category === 'navigation');
+  const actions = SHORTCUTS.filter((s) => s.category === 'actions');
+
+  return (
+    <div className="fixed inset-0 z-[100]">
+      <div
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={() => setOpen(false)}
+      />
+      <div className="fixed top-[15%] left-1/2 -translate-x-1/2 w-full max-w-md px-4">
+        <div className="rounded-xl border border-border/50 bg-popover/95 backdrop-blur-xl shadow-2xl overflow-hidden ring-1 ring-white/5">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-border/50">
+            <h2 className="text-sm font-semibold">Keyboard Shortcuts</h2>
+            <button
+              onClick={() => setOpen(false)}
+              className="rounded-md p-1 hover:bg-muted transition-colors"
+            >
+              <X className="h-4 w-4 text-muted-foreground" />
+            </button>
+          </div>
+          <div className="p-5 space-y-5">
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground mb-2.5 uppercase tracking-wider">
+                Navigation
+              </h3>
+              <div className="space-y-2">
+                {navigation.map((s) => (
+                  <div key={s.key} className="flex items-center justify-between">
+                    <span className="text-sm">{s.description}</span>
+                    <kbd className="inline-flex h-6 items-center rounded border border-border/50 bg-muted/50 px-2 font-mono text-[11px] text-muted-foreground">
+                      {s.label}
+                    </kbd>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div>
+              <h3 className="text-xs font-medium text-muted-foreground mb-2.5 uppercase tracking-wider">
+                Actions
+              </h3>
+              <div className="space-y-2">
+                {actions.map((s) => (
+                  <div key={s.key} className="flex items-center justify-between">
+                    <span className="text-sm">{s.description}</span>
+                    <kbd className="inline-flex h-6 items-center rounded border border-border/50 bg-muted/50 px-2 font-mono text-[11px] text-muted-foreground">
+                      {s.label}
+                    </kbd>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TreasuryDashboard.tsx
+++ b/components/TreasuryDashboard.tsx
@@ -20,9 +20,17 @@ import {
 import Link from 'next/link';
 import { posthog } from '@/lib/posthog';
 import { formatAda } from '@/lib/treasury';
-import { TreasuryCharts } from '@/components/TreasuryCharts';
+import dynamic from 'next/dynamic';
 import { TreasuryPendingProposals } from '@/components/TreasuryPendingProposals';
-import { TreasurySimulator } from '@/components/TreasurySimulator';
+
+const TreasuryCharts = dynamic(
+  () => import('@/components/TreasuryCharts').then((m) => m.TreasuryCharts),
+  { ssr: false },
+);
+const TreasurySimulator = dynamic(
+  () => import('@/components/TreasurySimulator').then((m) => m.TreasurySimulator),
+  { ssr: false },
+);
 import { TreasuryAccountabilitySection } from '@/components/TreasuryAccountabilitySection';
 import { TreasuryHistoryTimeline } from '@/components/TreasuryHistoryTimeline';
 import { useFeatureFlag } from '@/components/FeatureGate';
@@ -83,7 +91,7 @@ export function TreasuryDashboard() {
       <div className="space-y-2">
         <div className="flex items-center gap-3">
           <Landmark className="h-6 w-6 text-primary" />
-          <h1 className="text-2xl font-bold">Treasury Intelligence</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Treasury Intelligence</h1>
         </div>
         <p className="text-muted-foreground text-sm">
           Real-time Cardano treasury health, spending analysis, and accountability tracking.

--- a/components/VotingHistoryWithPrefs.tsx
+++ b/components/VotingHistoryWithPrefs.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from 'react';
 import { VoteRecord, UserPrefKey } from '@/types/drep';
 import { getUserPrefs } from '@/utils/userPrefs';
-import { VotingHistoryChart } from '@/components/VotingHistoryChart';
+import dynamic from 'next/dynamic';
+
+const VotingHistoryChart = dynamic(
+  () => import('@/components/VotingHistoryChart').then((m) => m.VotingHistoryChart),
+  { ssr: false },
+);
 
 interface VotingHistoryWithPrefsProps {
   votes: VoteRecord[];

--- a/docs/strategy/product-wow-plan-v2.md
+++ b/docs/strategy/product-wow-plan-v2.md
@@ -1,6 +1,6 @@
 # Product "Wow" Plan v2 — DRepScore
 
-> From comprehensive governance tool to the app that makes the entire crypto space say "wow." Sessions 12-21 transform the product through emotional design, visual identity, architecture, narrative, intelligence, social mechanics, cross-chain positioning, developer distribution, community flywheel, on-chain actions, and sensory polish.
+> From comprehensive governance tool to the app that makes the entire crypto space say "wow." Sessions 12-22 transform the product through emotional design, visual identity, architecture, narrative, intelligence, social mechanics, cross-chain positioning, developer distribution, community flywheel, on-chain actions, sensory polish, and personalization.
 
 **Created:** March 2, 2026
 **Predecessors:** `product-wow-plan.md` (Sessions 1-7), `product-wow-plan-v1.5.md` (Sessions 8-11)
@@ -24,9 +24,10 @@
 12. [Session 19 — Sensory Polish & Performance](#session-19--sensory-polish--performance)
 13. [Session 20 — Governance Wrapped & Community Flywheel](#session-20--governance-wrapped--community-flywheel)
 14. [Session 21 — On-Chain Actions & Real-Time](#session-21--on-chain-actions--real-time)
-15. [Execution Order](#execution-order-and-dependencies)
-16. [Anti-Patterns](#anti-patterns)
-17. [Deferred Items](#deferred-items)
+15. [Session 22 — Personalization & Governance Feed Intelligence](#session-22--personalization--governance-feed-intelligence)
+16. [Execution Order](#execution-order-and-dependencies)
+17. [Anti-Patterns](#anti-patterns)
+18. [Deferred Items](#deferred-items)
 
 ---
 
@@ -641,7 +642,7 @@ After Sessions 15-18 deliver narrative, intelligence, social, cross-chain, and d
 
 **4. Haptic feedback on mobile.** `navigator.vibrate()` for key actions (delegation, vote submission, milestone achievement) on supported devices. Subtle 10-20ms pulses, never distracting.
 
-**5. Community showcase.** Curated "DRep of the Epoch" spotlight, community-submitted governance stories. This is the content flywheel that makes the platform self-sustaining. New section on Pulse page with editorial curation.
+**5. ~~Community showcase.~~** *Moved to Session 20 — community/editorial items belong in the Community Flywheel session, not a sensory polish pass.*
 
 **6. Advanced OG image system.** Dynamic OG images that update in real-time (e.g., DRep OG image shows current score, not cached score). Makes shared links always current. Upgrade existing OG routes to use ISR with shorter revalidation.
 
@@ -688,6 +689,10 @@ Session 19 polishes the product to near-perfection. Session 20 adds the communit
 **4. Governance leaderboards with seasonal resets.** Epoch-based leaderboard seasons with historical archives. Seasonal badges for top performers. Gamification that resets ensures ongoing engagement rather than permanent dominance by early adopters.
 
 **5. User-generated insights and commentary.** Moderated proposal commentary system — lightweight annotations on proposals from community members. Not full discussion threads (deferred), but curated perspectives that add context.
+
+**6. Community showcase / "DRep of the Epoch" (moved from S19).** Curated spotlight with community nomination and voting. Drives repeat visits and DRep engagement. This is a content/editorial item better suited to the Community Flywheel session.
+
+**7. Sound design expansion.** If the 2 proof-of-concept sounds from S19 (delegation chime, milestone chime) resonate with users, expand to 3-4 additional sounds: score reveal, poll vote confirmation, etc. Still off by default.
 
 ### Success Criteria
 
@@ -738,6 +743,39 @@ DRepScore has been a read-only intelligence layer. Session 21 closes the loop by
 
 ---
 
+## Session 22 — Personalization & Governance Feed Intelligence
+
+### Thesis
+
+DRepScore treats every user the same. A delegator who cares about treasury should see different content than one passionate about decentralization. This session adds a personalized intelligence layer that makes every visit uniquely relevant — the final step from "great tool" to "indispensable governance companion."
+
+### What Changes
+
+**1. "For You" governance feed on homepage.** Proposals and DRep actions ranked by the user's alignment dimensions (from DNA quiz). Users who care about treasury see treasury proposals first. Users passionate about decentralization see related DRep activity. Falls back to popularity-based ranking for users without quiz data.
+
+**2. Personalized proposal recommendations.** "Based on your governance personality, you might care about..." prompts on the proposals page. Uses alignment similarity scoring against proposal type/domain tags.
+
+**3. DRep recommendation refinement.** Collaborative filtering: users with similar quiz results also delegated to X. Surfaces complementary DReps beyond simple alignment matching — "Delegators like you also explored..."
+
+**4. Governance learning path for new users.** Progressive complexity based on engagement signals. New users see simplified governance concepts; returning users see advanced analytics. Not a tutorial — intelligent content depth adjustment.
+
+**5. Personalized GHI perspective.** "How does governance health look from YOUR perspective?" — GHI components weighted by user's priority dimensions. A treasury-focused user sees treasury health weighted more heavily. Creates personal ownership of the governance health narrative.
+
+### Success Criteria
+
+- Homepage "For You" feed increases average session duration by 25%+
+- Personalized DRep recommendations drive 15%+ more delegation explorations
+- New user retention improves measurably with progressive learning path
+- Users share their personalized GHI as a governance identity artifact
+
+### Risks
+
+- Cold start problem: new users without quiz data get generic experience. Mitigate with early DNA quiz prompt.
+- Collaborative filtering requires sufficient delegation data volume. May need minimum threshold before activating.
+- Personalization bubbles: ensure users can always access the full unfiltered view alongside personalized recommendations.
+
+---
+
 ## Execution Order and Dependencies
 
 ```mermaid
@@ -752,14 +790,16 @@ graph LR
     S18 --> S19[Session 19: Sensory Polish]
     S19 --> S20[Session 20: Governance Wrapped]
     S19 --> S21[Session 21: On-Chain Actions]
+    S20 --> S22[Session 22: Personalization]
+    S21 --> S22
 ```
 
-- **Sessions 12-17** are shipped and deployed.
-- **Session 18** expands DRepScore beyond Cardano — cross-chain observatory, developer platform, embeddable widgets, delegator identity, feature flags. **Shipped.**
-- **Session 19** is pure polish: sound, scroll storytelling, Cmd+K, PWA, performance, community showcase — pushing from ~93 to ~96.
-- **Session 20** adds the community flywheel: Governance Wrapped, editorial content, seasonal leaderboards — pushing to ~97.
-- **Session 21** closes the loop with on-chain actions, real-time WebSocket, and offline-first PWA — pushing to ~98+.
-- **S20 and S21** are independent of each other and could be parallelized or reordered based on demand signals (on-chain actions require monitoring GovTool adoption; community flywheel requires editorial capacity).
+- **Sessions 12-18** are shipped and deployed.
+- **Session 19** is pure polish: radar/hex visual overhaul, Cmd+K, scroll storytelling, PWA, performance, quality sweep — pushing from ~92-93 to ~95-96.
+- **Session 20** adds the community flywheel: Governance Wrapped, community showcase (moved from S19), sound expansion, editorial content, seasonal leaderboards — pushing to ~96-97.
+- **Session 21** closes the loop with on-chain actions, real-time WebSocket, and offline-first PWA — pushing to ~97-98.
+- **Session 22** adds personalized governance feeds, recommendations, and learning paths — pushing to ~98-99.
+- **S20 and S21** are independent of each other and could be parallelized or reordered. S22 depends on both S20 (community content to personalize) and S21 (real-time infrastructure for personalized feeds).
 
 ### Target Score Projections (Revised March 2026)
 
@@ -772,9 +812,10 @@ graph LR
 | Post S16 | ~78-82/100 | +9-10 | Intelligence engine, AI narratives, State of Governance, GHI trend |
 | Post S17 | ~87/100 | +5-9 | Page transitions, social layer, sharing culture |
 | Post S18 | ~92-93/100 | +5-6 | Cross-chain intelligence, developer platform, widget distribution, delegator identity, feature flags |
-| Post S19 | ~96/100 | +3-4 | Sound design, scroll storytelling, Cmd+K, PWA, performance, community showcase |
-| Post S20 | ~97/100 | +1 | Governance Wrapped, community flywheel, editorial content |
-| Post S21 | ~98+/100 | +1 | On-chain actions, real-time WebSocket, offline-first |
+| Post S19 | ~95-96/100 | +3-4 | Radar/Hex overhaul, Cmd+K, scroll storytelling, performance, PWA, quality sweep |
+| Post S20 | ~96-97/100 | +2 | Governance Wrapped, community showcase, sound expansion |
+| Post S21 | ~97-98/100 | +1 | On-chain actions, real-time WebSocket, offline-first |
+| Post S22 | ~98-99/100 | +1 | Personalization, governance feed intelligence |
 
 Each session gets its own worktree (`drepscore-<session-name>`) and detailed implementation plan (`.cursor/plans/<session>.plan.md`) before building begins.
 

--- a/hooks/useOptimistic.ts
+++ b/hooks/useOptimistic.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback, useRef } from 'react';
+
+interface UseOptimisticOptions<T> {
+  onMutate: () => Promise<T>;
+  onSuccess?: (result: T) => void;
+  onError?: (error: Error) => void;
+}
+
+interface UseOptimisticReturn<T> {
+  execute: () => Promise<void>;
+  isPending: boolean;
+  error: Error | null;
+  reset: () => void;
+}
+
+export function useOptimistic<T = void>(
+  options: UseOptimisticOptions<T>,
+): UseOptimisticReturn<T> {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const execute = useCallback(async () => {
+    setIsPending(true);
+    setError(null);
+    try {
+      const result = await optionsRef.current.onMutate();
+      optionsRef.current.onSuccess?.(result);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error('Mutation failed');
+      setError(err);
+      optionsRef.current.onError?.(err);
+    } finally {
+      setIsPending(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => setError(null), []);
+
+  return { execute, isPending, error, reset };
+}
+
+export function useOptimisticToggle(opts: {
+  currentValue: boolean;
+  onToggle: (newValue: boolean) => Promise<void>;
+  onError?: (error: Error) => void;
+}) {
+  const [optimisticValue, setOptimisticValue] = useState<boolean | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const displayValue = optimisticValue ?? opts.currentValue;
+
+  const toggle = useCallback(async () => {
+    const newValue = !displayValue;
+    setOptimisticValue(newValue);
+    setIsPending(true);
+    try {
+      await opts.onToggle(newValue);
+    } catch (e) {
+      setOptimisticValue(null);
+      opts.onError?.(e instanceof Error ? e : new Error('Toggle failed'));
+    } finally {
+      setIsPending(false);
+      setOptimisticValue(null);
+    }
+  }, [displayValue, opts]);
+
+  return { value: displayValue, toggle, isPending };
+}

--- a/lib/commandIndex.ts
+++ b/lib/commandIndex.ts
@@ -1,0 +1,135 @@
+import {
+  Compass,
+  ScrollText,
+  Vote,
+  Sparkles,
+  BarChart3,
+  Landmark,
+  Code2,
+  Home,
+  Sun,
+  Moon,
+  Wallet,
+  LogOut,
+  HelpCircle,
+  type LucideIcon,
+} from 'lucide-react';
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  sublabel?: string;
+  group: 'pages' | 'dreps' | 'proposals' | 'actions';
+  icon?: LucideIcon;
+  href?: string;
+  action?: () => void;
+  shortcut?: string;
+  score?: number;
+}
+
+export const PAGE_COMMANDS: CommandItem[] = [
+  { id: 'page-home', label: 'Home', group: 'pages', icon: Home, href: '/', shortcut: 'H' },
+  { id: 'page-discover', label: 'Discover DReps', group: 'pages', icon: Compass, href: '/discover', shortcut: 'D' },
+  { id: 'page-proposals', label: 'Proposals', group: 'pages', icon: ScrollText, href: '/proposals', shortcut: 'P' },
+  { id: 'page-governance', label: 'My Delegation', group: 'pages', icon: Vote, href: '/governance', shortcut: 'G' },
+  { id: 'page-dashboard', label: 'DRep Dashboard', group: 'pages', icon: Sparkles, href: '/dashboard' },
+  { id: 'page-pulse', label: 'Governance Pulse', group: 'pages', icon: BarChart3, href: '/pulse' },
+  { id: 'page-treasury', label: 'Treasury', group: 'pages', icon: Landmark, href: '/treasury' },
+  { id: 'page-developers', label: 'Developers', group: 'pages', icon: Code2, href: '/developers' },
+];
+
+export function buildActionCommands(opts: {
+  toggleTheme: () => void;
+  isDark: boolean;
+  openWallet: () => void;
+  isAuthenticated: boolean;
+  logout: () => void;
+}): CommandItem[] {
+  const actions: CommandItem[] = [
+    {
+      id: 'action-theme',
+      label: opts.isDark ? 'Switch to Light Mode' : 'Switch to Dark Mode',
+      group: 'actions',
+      icon: opts.isDark ? Sun : Moon,
+      action: opts.toggleTheme,
+    },
+    {
+      id: 'action-shortcuts',
+      label: 'Keyboard Shortcuts',
+      group: 'actions',
+      icon: HelpCircle,
+      shortcut: '?',
+    },
+  ];
+
+  if (opts.isAuthenticated) {
+    actions.push({
+      id: 'action-logout',
+      label: 'Sign Out',
+      group: 'actions',
+      icon: LogOut,
+      action: opts.logout,
+    });
+  } else {
+    actions.push({
+      id: 'action-connect',
+      label: 'Connect Wallet',
+      group: 'actions',
+      icon: Wallet,
+      action: opts.openWallet,
+    });
+  }
+
+  return actions;
+}
+
+export interface SearchableDRep {
+  drepId: string;
+  name: string | null;
+  ticker: string | null;
+  drepScore: number;
+}
+
+export interface SearchableProposal {
+  txHash: string;
+  index: number;
+  title: string;
+  status: string;
+  type: string;
+}
+
+export function searchDReps(dreps: SearchableDRep[], query: string): CommandItem[] {
+  if (!query || query.length < 2) return [];
+  const q = query.toLowerCase();
+  return dreps
+    .filter((d) => {
+      const name = (d.name || '').toLowerCase();
+      const ticker = (d.ticker || '').toLowerCase();
+      const id = d.drepId.toLowerCase();
+      return name.includes(q) || ticker.includes(q) || id.includes(q);
+    })
+    .slice(0, 8)
+    .map((d) => ({
+      id: `drep-${d.drepId}`,
+      label: d.name || d.drepId.slice(0, 16) + '...',
+      sublabel: d.ticker || undefined,
+      group: 'dreps' as const,
+      href: `/drep/${encodeURIComponent(d.drepId)}`,
+      score: d.drepScore,
+    }));
+}
+
+export function searchProposals(proposals: SearchableProposal[], query: string): CommandItem[] {
+  if (!query || query.length < 2) return [];
+  const q = query.toLowerCase();
+  return proposals
+    .filter((p) => p.title.toLowerCase().includes(q) || p.txHash.toLowerCase().includes(q))
+    .slice(0, 6)
+    .map((p) => ({
+      id: `proposal-${p.txHash}-${p.index}`,
+      label: p.title || `${p.txHash.slice(0, 12)}...`,
+      sublabel: p.status,
+      group: 'proposals' as const,
+      href: `/proposals/${encodeURIComponent(p.txHash)}/${p.index}`,
+    }));
+}

--- a/lib/haptics.ts
+++ b/lib/haptics.ts
@@ -1,0 +1,17 @@
+export function hapticLight(): void {
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate(10);
+  }
+}
+
+export function hapticMedium(): void {
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate(20);
+  }
+}
+
+export function hapticSuccess(): void {
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate([10, 50, 10]);
+  }
+}

--- a/lib/shortcuts.ts
+++ b/lib/shortcuts.ts
@@ -1,0 +1,26 @@
+export interface Shortcut {
+  key: string;
+  label: string;
+  description: string;
+  category: 'navigation' | 'actions';
+}
+
+export const SHORTCUTS: Shortcut[] = [
+  { key: '⌘K', label: 'Cmd+K', description: 'Open command palette', category: 'actions' },
+  { key: '?', label: '?', description: 'Show keyboard shortcuts', category: 'actions' },
+  { key: '/', label: '/', description: 'Open search', category: 'actions' },
+  { key: 'Esc', label: 'Escape', description: 'Close dialog / palette', category: 'actions' },
+  { key: 'H', label: 'H', description: 'Go to Home', category: 'navigation' },
+  { key: 'D', label: 'D', description: 'Go to Discover', category: 'navigation' },
+  { key: 'P', label: 'P', description: 'Go to Proposals', category: 'navigation' },
+  { key: 'G', label: 'G', description: 'Go to My Delegation', category: 'navigation' },
+];
+
+export function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+  return false;
+}

--- a/lib/sounds.ts
+++ b/lib/sounds.ts
@@ -1,0 +1,72 @@
+let audioCtx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  if (!audioCtx) {
+    try {
+      audioCtx = new AudioContext();
+    } catch {
+      return null;
+    }
+  }
+  return audioCtx;
+}
+
+function isSoundEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem('drepscore-sound-enabled') === '1';
+}
+
+export function setSoundEnabled(enabled: boolean): void {
+  localStorage.setItem('drepscore-sound-enabled', enabled ? '1' : '0');
+}
+
+export function getSoundEnabled(): boolean {
+  return isSoundEnabled();
+}
+
+export function playDelegationChime(): void {
+  if (!isSoundEnabled()) return;
+  const ctx = getCtx();
+  if (!ctx) return;
+  
+  const now = ctx.currentTime;
+  
+  // C major chord arpeggio — C5 E5 G5
+  [523.25, 659.25, 783.99].forEach((freq, i) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0, now + i * 0.05);
+    gain.gain.linearRampToValueAtTime(0.12, now + i * 0.05 + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + i * 0.05 + 0.3);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(now + i * 0.05);
+    osc.stop(now + i * 0.05 + 0.35);
+  });
+}
+
+export function playMilestoneChime(): void {
+  if (!isSoundEnabled()) return;
+  const ctx = getCtx();
+  if (!ctx) return;
+  
+  const now = ctx.currentTime;
+  
+  // Celebratory ascending: G5 → C6
+  [783.99, 880, 987.77, 1046.5].forEach((freq, i) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    gain.gain.setValueAtTime(0, now + i * 0.06);
+    gain.gain.linearRampToValueAtTime(0.1, now + i * 0.06 + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + i * 0.06 + 0.4);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(now + i * 0.06);
+    osc.stop(now + i * 0.06 + 0.45);
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "d3-array": "^3.2.4",
         "d3-scale": "^4.0.2",
         "d3-shape": "^3.2.0",
@@ -168,6 +169,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -625,7 +627,8 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cardano-ogmios/client": {
       "version": "6.9.0",
@@ -1088,6 +1091,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.4.0.tgz",
       "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.4.2"
       }
@@ -1305,6 +1309,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2199,6 +2204,7 @@
       "resolved": "https://registry.npmjs.org/@harmoniclabs/bytestring/-/bytestring-1.0.0.tgz",
       "integrity": "sha512-d5m10O0okKc6QNX0pSRriFTkk/kNMnMBGbo5X3kEZwKaXTI4tDVoTZBL7bwbYHwOEdSxWJjVtlO9xtB7ZrYZNg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/uint8array-utils": "^1.0.0"
       }
@@ -2209,6 +2215,7 @@
       "integrity": "sha512-gzRqqcJL8sulc2/6iqRXZdWUCEeK3A+jwJ88sbVNzgk4IeMFQLSFg4Ck8ZBETu/W/q1zdknjNfJYyH1OxVriQA==",
       "deprecated": "update to 1.6.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/bytestring": "^1.0.0",
         "@harmoniclabs/obj-utils": "^1.0.0",
@@ -2223,6 +2230,7 @@
       "resolved": "https://registry.npmjs.org/@harmoniclabs/crypto/-/crypto-0.2.5.tgz",
       "integrity": "sha512-t2saWMFWBx8tOHotiYTTfQKhPGpWT4AMLXxq3u0apShVXNV0vgL0gEgSMudBjES/wrKByCqa2xmU70gadz26hA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/bitstream": "^1.0.0",
         "@harmoniclabs/uint8array-utils": "^1.0.3"
@@ -2238,13 +2246,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/pair/-/pair-1.0.0.tgz",
       "integrity": "sha512-D9OBowsUsy1LctHxWzd9AngTzoo5x3rBiJ0gu579t41Q23pb+VNx1euEfluUEiaYbgljcl1lb/4D1fFTZd1tRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@harmoniclabs/plutus-data": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@harmoniclabs/plutus-data/-/plutus-data-1.2.4.tgz",
       "integrity": "sha512-cpr6AnJRultH6PJRDriewHEgNLQs2IGLampZrLjmK5shzTsHICD0yD0Zig9eKdcS7dmY6mlzvSpAJWPGeTxbCA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/biguint": "^1.0.0",
         "@harmoniclabs/crypto": "^0.2.4",
@@ -3080,7 +3090,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3349,6 +3358,7 @@
       "resolved": "https://registry.npmjs.org/@harmoniclabs/cbor/-/cbor-1.6.0.tgz",
       "integrity": "sha512-KI25p8pHI1rmFZC9NYSxATwlCZ+KJdjydpptKebHcw03Iy7M+E8mF+hSnN5dTbS45xw5ZyKUgPLRgLo1sTuIoQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/bytestring": "^1.0.0",
         "@harmoniclabs/obj-utils": "^1.0.0",
@@ -3363,6 +3373,7 @@
       "resolved": "https://registry.npmjs.org/@harmoniclabs/plutus-data/-/plutus-data-1.2.6.tgz",
       "integrity": "sha512-rF046GZ07XDpjZBNybALKYSycjxCLzXKbhLylu9pRuZiii5fVXReEfgtLB29TsPBvGY6ZBeiyHgJnLgm+huZBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@harmoniclabs/biguint": "^1.0.0",
         "@harmoniclabs/crypto": "^0.2.4",
@@ -3910,6 +3921,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4020,6 +4032,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4136,6 +4149,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
       "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -4148,6 +4162,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5546,6 +5561,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
       "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.212.0",
         "import-in-the-middle": "^2.0.6",
@@ -6967,6 +6983,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
       "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -7049,6 +7066,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -8782,6 +8800,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.2.1.tgz",
       "integrity": "sha512-ljDiQiJDu/Fq//vSIIP0z5Nuvt4+DX1RqGasstChDGJB/14ogd4VdNS9aacoede/ZjGy3o3Qb+cxyS+XgM6SwQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8794,6 +8813,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/button/-/button-0.2.1.tgz",
       "integrity": "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8806,6 +8826,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-block/-/code-block-0.2.1.tgz",
       "integrity": "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prismjs": "^1.30.0"
       },
@@ -8821,6 +8842,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/code-inline/-/code-inline-0.0.6.tgz",
       "integrity": "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8896,6 +8918,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/container/-/container-0.0.16.tgz",
       "integrity": "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8932,6 +8955,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/heading/-/heading-0.0.16.tgz",
       "integrity": "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8944,6 +8968,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/hr/-/hr-0.0.12.tgz",
       "integrity": "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8968,6 +8993,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/img/-/img-0.0.12.tgz",
       "integrity": "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -8980,6 +9006,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/link/-/link-0.0.13.tgz",
       "integrity": "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -9007,6 +9034,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/preview/-/preview-0.0.14.tgz",
       "integrity": "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -9101,6 +9129,7 @@
       "resolved": "https://registry.npmjs.org/@react-email/text/-/text-0.1.6.tgz",
       "integrity": "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -9153,6 +9182,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -9276,6 +9306,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11595,7 +11626,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -11606,7 +11636,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -11693,6 +11722,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -11743,6 +11773,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11753,6 +11784,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -11792,6 +11824,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
       "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -11887,6 +11920,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -12596,7 +12630,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -12606,29 +12639,25 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -12639,15 +12668,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -12660,7 +12687,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -12670,7 +12696,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -12679,15 +12704,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -12704,7 +12727,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -12718,7 +12740,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -12731,7 +12752,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -12746,7 +12766,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -12781,15 +12800,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -12859,6 +12876,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12880,7 +12898,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -13409,6 +13426,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -14089,6 +14107,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -14156,8 +14175,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -14521,7 +14539,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -14628,6 +14645,22 @@
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/code-block-writer": {
@@ -16040,6 +16073,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16225,6 +16259,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -16518,7 +16553,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -16603,6 +16637,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -17486,8 +17521,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -17844,6 +17878,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
       "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
       "devOptional": true,
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -19085,7 +19120,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -19100,7 +19134,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -19744,7 +19777,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -21043,8 +21075,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -21060,6 +21091,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -25109,6 +25141,7 @@
       "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.3.tgz",
       "integrity": "sha512-5qCFp8j62nWL6sSVv/RKuHscQUIV+VMMgWeHLYZQEBpAk7G+r3jA3bSKON7gZjiuxdZ/F4PXj2Jc1oPh/7Eg+g==",
       "license": "Zlib",
+      "peer": true,
       "peerDependencies": {
         "three": ">= 0.157.0 < 0.184.0"
       }
@@ -25651,6 +25684,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25660,6 +25694,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -26074,6 +26109,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26222,6 +26258,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -26331,7 +26368,6 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -26368,7 +26404,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -26386,7 +26421,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -26398,8 +26432,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/seed-random": {
       "version": "2.2.0",
@@ -26521,7 +26554,6 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -27012,7 +27044,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -27594,7 +27625,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -27698,7 +27730,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -27717,7 +27748,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -27751,8 +27781,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -27821,7 +27850,8 @@
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
       "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -27944,6 +27974,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -28293,6 +28324,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -28523,6 +28555,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29139,6 +29172,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -29255,6 +29289,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -29268,6 +29303,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -29366,7 +29402,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -29461,7 +29496,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
       "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -29510,7 +29544,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -29519,15 +29552,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -29541,7 +29572,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -29855,6 +29885,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -30025,6 +30056,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "d3-array": "^3.2.4",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "name": "DRepScore",
+  "name": "DRepScore — Cardano Governance Intelligence",
   "short_name": "DRepScore",
-  "description": "Discover and delegate to Cardano DReps aligned with your values",
+  "description": "Discover and delegate to Cardano DReps aligned with your values. Governance scores, voting records, and real-time intelligence.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#1a56db",
+  "background_color": "#0a0b14",
+  "theme_color": "#0a0b14",
   "orientation": "any",
   "categories": ["governance", "finance"],
   "icons": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,26 @@
+const CACHE_NAME = 'drepscore-shell-v1';
+const SHELL_ASSETS = ['/offline'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/offline'))
+    );
+  }
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -425,6 +425,11 @@ Server-side API routes also need `captureServerEvent` for success + error tracki
 **Fix**: All 17 Inngest functions now registered in serve(). Added treasury to freshness guard thresholds. Added event trigger to treasury snapshot. Created `/api/sync/treasury` manual route. Added proposals self-heal (trigger sync on empty data, same pattern as DReps). Improved empty states (GHI shows "syncing" instead of infinite skeleton; proposals distinguishes "not synced" from "filters hiding results").
 **Takeaway**: Every new Inngest function must be registered in `app/api/inngest/route.ts` in the same commit that creates it. The orphan audit at session start should explicitly compare `ls inngest/functions/` against the `serve()` functions array. If counts don't match, something is missing.
 
+### 2026-03-02: Always ship after completing all todos
+**Promoted to rule**: Reinforces existing workflow.md "Ship It" step.
+**Issue**: After completing all 14 implementation todos, I reported completion but did not automatically create a branch, commit, open a PR, merge, or verify the deploy. The user had to explicitly ask.
+**Takeaway**: Completing implementation is NOT done until the code is committed, PR'd, merged, and the deploy is verified healthy. This is the "Ship It" step in workflow.md and must be automatic — never stop after the last code edit.
+
 ### 2026-03-02: Feature flags need categories at scale (41 flags)
 **Issue**: With 41 feature flags, the flat list admin UI became unnavigable. The original 3-flag implementation had no grouping mechanism.
 **Fix**: Added `category TEXT` column to `feature_flags` table. Upgraded `FeatureFlagAdmin` to group flags by category with collapsible sections, showing enabled/total counts per category. Added admin auth guard (page + PATCH endpoint) matching the integrity dashboard pattern.


### PR DESCRIPTION
## Summary

Session 19 is a **craft session** — no new features, pure polish. Every interaction, transition, error state, and loading moment gets the same attention the constellation hero got. The goal: a designer at Linear or Stripe opens this app and thinks "these people care about the details."

### Phase 1 — Performance Foundation & Power User Layer
- **Performance:** Lazy-loaded 5 heavy d3 chart/celebration components via `next/dynamic`, cleaned dead imports
- **Cmd+K Command Palette:** `cmdk` integration with DRep/proposal/page/action search, glassmorphism UI, keyboard hints
- **Keyboard Shortcuts:** Global shortcuts (H/D/P/G navigation, ? help overlay, / search), input-guarded
- **PWA:** Updated manifest (dark theme), service worker (app shell caching), install prompt (3rd visit), offline fallback page

### Phase 2 — Signature Visuals & Interaction Craft
- **GovernanceRadar Overhaul (CRITICAL):** Triple-layer glow system (bloom + tight + crisp), per-axis staggered spring animation with 60ms stagger, continuous vertex breathing via RAF, gradient axis lines with glowing tips, identity-colored dimension labels in Geist font
- **HexScore Overhaul:** Killed noise texture (feTurbulence), triple-layer glow, Tron-style edge shimmer via animated stroke-dashoffset, visible breathing animation, "/100" muted treatment below score
- **ScoreCard Redesign:** Side-by-side hero layout on desktop, responsive HexScore (`hero-lg` 172px desktop / `hero` 120px mobile), removed redundant range bar, 2-column pillar grid, gradient progress bars with scroll-animated fills
- **PillarCard Upgrade:** Left accent border in status color, contained card-like feel, gradient progress bars, tier distance hints
- **Scroll Storytelling:** `ScrollStoryReveal` component with 5 variants (fadeUp, slideLeft, slideRight, scaleIn, parallax), `ParallaxHero` component, profile hero parallax background
- **Micro-interactions:** Card hover scale(1.003), CSS-only button ripple, skeleton-to-content crossfade
- **Haptics & Easter Eggs:** `lib/haptics.ts` (light/medium/success patterns), Konami code constellation burst on homepage

### Phase 3 — Quality Sweep
- **Error States:** `ConnectionError` (full + compact variants with retry), `OfflineBanner` (network detection, auto-dismiss)
- **Typography Audit:** `tracking-tight` on 8 major display headings, `toLocaleString()` on raw number displays
- **Focus States:** Custom `:focus-visible` rings using identity colors, skip-to-content already in layout
- **Optimistic UI:** `useOptimistic` + `useOptimisticToggle` generic hooks for any mutation
- **OG Image ISR:** Cache-Control headers added/upgraded on 8 OG routes with `stale-while-revalidate`
- **Sound Design:** Web Audio API delegation chime (C major arpeggio) + milestone chime (ascending), off by default via localStorage

### Strategy Doc Updates
- Moved community showcase from S19 to S20
- Added Session 22 (Personalization & Governance Feed Intelligence)
- Revised score projections: S19 ~95-96, S20 ~96-97, S21 ~97-98, S22 ~98-99
- Updated execution order with S22 dependency graph

## Test plan
- [ ] Verify Cmd+K opens with Ctrl+K / Cmd+K and searches DReps, proposals, pages
- [ ] Verify keyboard shortcuts (H, D, P, G, ?, /) work correctly
- [ ] Verify GovernanceRadar renders with triple-layer glow and per-axis animation on DRep profiles
- [ ] Verify HexScore renders with edge shimmer and "/100" treatment
- [ ] Verify ScoreCard shows side-by-side layout on desktop with hero-lg HexScore
- [ ] Verify PillarCard progress bars animate on scroll into view
- [ ] Verify PWA install prompt appears after 3rd visit
- [ ] Verify offline page shows when navigating without network
- [ ] Verify OfflineBanner appears when going offline mid-session
- [ ] Verify OG images render with updated Cache-Control headers
- [ ] Verify Konami code triggers confetti on homepage
- [ ] Run Lighthouse on key pages to validate CWV targets
