### PR TITLE
docs: critical.md — 12 non-negotiable rules for every session

### DIFF
--- a/.cursor/rules/critical.md
+++ b/.cursor/rules/critical.md
@@ -1,0 +1,45 @@
+---
+description: Non-negotiable rules. Every rule here has been violated at least once and caused real damage. Read these FIRST, honor them ALWAYS.
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Critical Rules (Non-Negotiable)
+
+These override all other guidance when in conflict. Violations of these rules have caused production failures, wasted sessions, or security issues.
+
+## 1. NEVER commit to `main` directly
+Always create a feature branch (`feat/<name>`). The only exception is hotfixes when the user explicitly says "hotfix." Check `git branch --show-current` before any `git add`.
+
+## 2. Ship It is part of the task, not a follow-up
+Implementation is NOT complete until: branch created → committed → pushed → PR opened → merged → deploy verified healthy. Never report "all todos done" without shipping. Include Ship It steps in the FIRST `TodoWrite` call alongside implementation tasks.
+
+## 3. Railway, NOT Vercel
+This project deploys on Railway via Docker. Never reference `VERCEL_URL`, `VERCEL_ENV`, any `VERCEL_*` env var, `vercel.json`, or `@vercel/*` packages. Use `BASE_URL` from `lib/constants.ts` for all server-side URL construction.
+
+## 4. `force-dynamic` on all server routes
+Any `app/**/page.tsx` or `app/**/route.ts` that touches Supabase, env vars, or any runtime service MUST export `const dynamic = 'force-dynamic'`. Railway's Docker build has no env vars — static prerendering crashes the build. NEVER use `export const revalidate` on these routes.
+
+## 5. PowerShell syntax only
+This is Windows/PowerShell. Use `;` not `&&` to chain commands. Write multi-line strings to files (e.g., `commit-msg.txt`) instead of heredocs. Use `git commit -F <file>` and `gh pr create --body-file <file>`. No `grep`/`cat`/`head`/`tail` — use the Read/Grep tools.
+
+## 6. Feature-flag risky features
+Controversial, untested, or costly features ship behind a flag. Use `getFeatureFlag()` (server) or `<FeatureGate>` (client). Every flag needs a category and a row in the `feature_flags` table via migration.
+
+## 7. Register every Inngest function in `serve()`
+Creating an Inngest function file without adding it to `app/api/inngest/route.ts` `serve()` array means it will never run. Do both in the same commit.
+
+## 8. Database-first, Supabase-only reads
+All frontend reads go through Supabase via `lib/data.ts`. No direct external API calls from pages or components. Koios/Tally/SubSquare calls only happen inside sync functions.
+
+## 9. No `git add -A` without review
+Use targeted `git add <files>`. `git add -A` picks up `.cursor/`, `commit-msg.txt`, and workspace artifacts. Always run `git diff --cached --name-only` after staging.
+
+## 10. Admin pages follow the standard pattern
+All admin pages: `app/admin/*` route, client-side auth via `POST /api/admin/check`, write endpoints validate `address` against `ADMIN_WALLETS`, linked in Header + MobileNav Admin section.
+
+## 11. Read `tasks/lessons.md` at session start
+Before doing anything, read lessons for patterns that prevent repeat mistakes.
+
+## 12. Verify deploy, don't assume it
+After merge, poll deployment status until `success` is confirmed. Hit the affected page on `drepscore.io` to smoke-test. Deploy failures from your changes are your responsibility — fix and re-push immediately.

--- a/.cursor/rules/workflow.md
+++ b/.cursor/rules/workflow.md
@@ -6,6 +6,8 @@ alwaysApply: true
 
 # DRepScore Workflow Protocol
 
+> **Read `.cursor/rules/critical.md` FIRST.** It contains 12 non-negotiable rules that override everything in this file when in conflict. Every rule there has caused a production failure or wasted session.
+
 ## Session Start
 1. Read `tasks/lessons.md` for relevant patterns before doing anything
 2. Read `tasks/todo.md` for any in-progress work from prior sessions

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -425,6 +425,12 @@ Server-side API routes also need `captureServerEvent` for success + error tracki
 **Fix**: All 17 Inngest functions now registered in serve(). Added treasury to freshness guard thresholds. Added event trigger to treasury snapshot. Created `/api/sync/treasury` manual route. Added proposals self-heal (trigger sync on empty data, same pattern as DReps). Improved empty states (GHI shows "syncing" instead of infinite skeleton; proposals distinguishes "not synced" from "filters hiding results").
 **Takeaway**: Every new Inngest function must be registered in `app/api/inngest/route.ts` in the same commit that creates it. The orphan audit at session start should explicitly compare `ls inngest/functions/` against the `serve()` functions array. If counts don't match, something is missing.
 
+### 2026-03-02: Critical rules need a separate, short file
+**Promoted to rule**: Yes — created `.cursor/rules/critical.md` with `alwaysApply: true`.
+**Issue**: `workflow.md` is 230+ lines. Agents reliably miss the most important rules (commit to main, ship after execution, PowerShell syntax, Vercel references) because they're buried in a wall of guidelines. The rules that have been violated 3+ times are not visually differentiated from nice-to-haves.
+**Fix**: Created `critical.md` with 12 non-negotiable rules — every one has been violated at least once. Added a callout at the top of `workflow.md` pointing to it.
+**Takeaway**: Rule files over ~50 lines lose enforcement power. Critical rules need to be short, numbered, and in their own `alwaysApply` file. Keep `critical.md` under 15 items or it becomes another wall.
+
 ### 2026-03-02: Always ship after completing all todos
 **Promoted to rule**: Reinforces existing workflow.md "Ship It" step.
 **Issue**: After completing all 14 implementation todos, I reported completion but did not automatically create a branch, commit, open a PR, merge, or verify the deploy. The user had to explicitly ask.


### PR DESCRIPTION
## Summary
- New `.cursor/rules/critical.md` with `alwaysApply: true` — 12 non-negotiable rules
- Every rule has been violated at least once (commit to main, forgot to ship, Vercel refs, PowerShell syntax, revalidate crashes, unregistered Inngest functions)
- `workflow.md` now references critical.md at the top with a callout
- Lesson added to `tasks/lessons.md`

## Rationale
workflow.md is 230+ lines. Agents reliably miss critical rules because they're buried. This extracts the ones that cause real damage into a short, numbered, dedicated file.
