### PR TITLE
fix: resolve react-hooks/rules-of-hooks lint errors

### DIFF
--- a/components/CompareButton.tsx
+++ b/components/CompareButton.tsx
@@ -28,8 +28,6 @@ export function CompareButton({ currentDrepId, currentDrepName }: CompareButtonP
   const router = useRouter();
   const { delegatedDrepId, connected } = useWallet();
   const compareEnabled = useFeatureFlag('compare_page');
-
-  if (compareEnabled === false || compareEnabled === null) return null;
   const [open, setOpen] = useState(false);
   const [allDreps, setAllDreps] = useState<EnrichedDRep[]>([]);
   const [loading, setLoading] = useState(false);
@@ -131,6 +129,8 @@ export function CompareButton({ currentDrepId, currentDrepName }: CompareButtonP
   }, [delegatedDrepId, currentDrepId, router]);
 
   const showCompareWithYours = connected && delegatedDrepId && delegatedDrepId !== currentDrepId;
+
+  if (compareEnabled === false || compareEnabled === null) return null;
 
   return (
     <div className="flex items-center gap-2">

--- a/components/ScrollStoryReveal.tsx
+++ b/components/ScrollStoryReveal.tsx
@@ -40,10 +40,18 @@ export function ScrollStoryReveal({
   const rangeStart = config.range[0] + offset * 0.05;
   const rangeEnd = config.range[1] + offset * 0.05;
 
+  const hasY = 'y' in config;
+  const hasX = 'x' in config;
+  const hasScale = 'scale' in config;
+
   const opacity = useTransform(progress, [rangeStart, rangeEnd], config.opacity);
-  const y = 'y' in config ? useTransform(progress, [rangeStart, rangeEnd], config.y) : undefined;
-  const x = 'x' in config ? useTransform(progress, [rangeStart, rangeEnd], config.x) : undefined;
-  const scale = 'scale' in config ? useTransform(progress, [rangeStart, rangeEnd], config.scale) : undefined;
+  const yVal = useTransform(progress, [rangeStart, rangeEnd], hasY ? (config as any).y : [0, 0]);
+  const xVal = useTransform(progress, [rangeStart, rangeEnd], hasX ? (config as any).x : [0, 0]);
+  const scaleVal = useTransform(progress, [rangeStart, rangeEnd], hasScale ? (config as any).scale : [1, 1]);
+
+  const y = hasY ? yVal : undefined;
+  const x = hasX ? xVal : undefined;
+  const scale = hasScale ? scaleVal : undefined;
 
   return (
     <motion.div


### PR DESCRIPTION
## Summary
- Fix `react-hooks/rules-of-hooks` lint errors that broke CI on main
- `CompareButton.tsx`: move feature flag early return after all hook calls
- `ScrollStoryReveal.tsx`: call `useTransform` unconditionally (use no-op values when variant doesn't need the transform)

## Test plan
- [x] Local lint passes with `--quiet`
- [ ] CI lint job passes (was previously failing)
- [ ] Deploy succeeds on Railway
