### PR TITLE
fix: add 'use client' to offline page for prerender

### DIFF
--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 export default function OfflinePage() {
   return (
     <div className="min-h-screen flex items-center justify-center px-4">


### PR DESCRIPTION
Offline page uses onClick but was missing 'use client' directive, causing prerender failure. This was previously masked by lint errors that skipped the build step.