### PR TITLE
chore: strengthen deploy verification in critical rules

### DIFF
--- a/.cursor/rules/critical.md
+++ b/.cursor/rules/critical.md
@@ -12,7 +12,7 @@ These override all other guidance when in conflict. Violations of these rules ha
 Always create a feature branch (`feat/<name>`). The only exception is hotfixes when the user explicitly says "hotfix." Check `git branch --show-current` before any `git add`.
 
 ## 2. Ship It is part of the task, not a follow-up
-Implementation is NOT complete until: branch created → committed → pushed → PR opened → merged → deploy verified healthy. Never report "all todos done" without shipping. Include Ship It steps in the FIRST `TodoWrite` call alongside implementation tasks.
+Implementation is NOT complete until: branch created → committed → pushed → PR opened → merged → deploy verified healthy. Never report "all todos done" without shipping. Include Ship It steps in the FIRST `TodoWrite` call alongside implementation tasks. **If CI or deploy fails, diagnose and fix in the same session** — create a follow-up PR and keep iterating until the pipeline is fully green and the deploy shows `state: "success"`. A red pipeline is never "done."
 
 ## 3. Railway, NOT Vercel
 This project deploys on Railway via Docker. Never reference `VERCEL_URL`, `VERCEL_ENV`, any `VERCEL_*` env var, `vercel.json`, or `@vercel/*` packages. Use `BASE_URL` from `lib/constants.ts` for all server-side URL construction.
@@ -42,4 +42,4 @@ All admin pages: `app/admin/*` route, client-side auth via `POST /api/admin/chec
 Before doing anything, read lessons for patterns that prevent repeat mistakes.
 
 ## 12. Verify deploy, don't assume it
-After merge, poll deployment status until `success` is confirmed. Hit the affected page on `drepscore.io` to smoke-test. Deploy failures from your changes are your responsibility — fix and re-push immediately.
+After merge, poll CI jobs until ALL pass (lint → test → type-check → build → sentry-release). Then poll Railway deployment status until `state: "success"`. If ANY step fails: read the logs, diagnose, fix, and push a follow-up PR in the same session. Hit the affected page on `drepscore.io` to smoke-test. **Never report completion while CI is red or deploy is pending.** A failure previously masked by an earlier failure (e.g., lint hid a build error) is still your responsibility.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -447,5 +447,15 @@ Server-side API routes also need `captureServerEvent` for success + error tracki
 **Fix**: Standardized: all admin pages under `app/admin/`, all use `POST /api/admin/check` client-side auth, all write endpoints validate `address` against `ADMIN_WALLETS`, all linked in Header dropdown + MobileNav Admin section.
 **Takeaway**: Admin pages are a security surface. The convention must be followed for every new admin page — auth guard, API validation, nav integration. The architecture.md rule now documents this.
 
-*Last updated: 2026-03-02*
+### 2026-03-03: Cascading CI failures — fix ALL stages, not just the first
+**Issue**: Lint errors had been failing CI for multiple commits, which masked a build error (offline page missing `'use client'` directive). When I fixed the lint errors (PR #43), the build failure was revealed (prerender crash on `/offline`). Required a second follow-up PR (#44) to fully green the pipeline.
+**Pattern**: When lint fails, build is skipped. When you fix lint, build may now expose errors that were previously invisible. After fixing any CI stage, you MUST wait for the full pipeline to complete — don't assume downstream stages will pass just because they were skipped before.
+**Takeaway**: Always monitor CI through to full green (all stages pass + deploy succeeds). Promoted to critical.md rules #2 and #12.
+
+### 2026-03-03: Hooks before early returns (react-hooks/rules-of-hooks)
+**Issue**: `CompareButton.tsx` had `useFeatureFlag()` followed by an early return before `useState`/`useEffect`/`useCallback` calls, violating React's rules of hooks. `ScrollStoryReveal.tsx` had `useTransform` calls inside ternary conditionals.
+**Fix**: CompareButton — moved early return after all hooks. ScrollStoryReveal — always call `useTransform` with no-op values when variant doesn't use that transform axis.
+**Takeaway**: When adding feature flag gates to existing client components, always place the `useFeatureFlag()` call alongside other hooks and move any early-return guard AFTER all hook calls. Never put hooks inside conditionals or ternaries.
+
+*Last updated: 2026-03-03*
 *Review this file at the start of every session.*


### PR DESCRIPTION
Strengthen critical.md rules #2 and #12 to require fixing failures in-session and monitoring all CI stages. Add lessons for cascading CI failures and hooks-before-returns pattern.

Made with [Cursor](https://cursor.com)