### PR TITLE
feat: DNA Quiz + Matching UX — PCA matching, confidence, Quick Match, rich reveal

### DIFF
--- a/app/api/governance/matches/route.ts
+++ b/app/api/governance/matches/route.ts
@@ -1,15 +1,26 @@
 /**
  * Governance DNA Matches API
  * Returns match scores for all DReps based on a user's poll vote history.
- * Used by the discovery page to show behavioral match % on cards/table.
+ * Primary: PCA cosine similarity ranking. Fallback: vote-overlap matching.
+ * Always computes overlap stats for display + confidence scoring.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { validateSessionToken } from '@/lib/supabaseAuth';
-import { findBestMatchDReps } from '@/lib/representationMatch';
+import { projectUserVector, cosineSimilarity } from '@/lib/representationMatch';
+import { loadActivePCA } from '@/lib/alignment/pca';
+import { calculateMatchConfidence } from '@/lib/matching/confidence';
+import { computeDimensionAgreement, deriveUserAlignments } from '@/lib/matching/dimensionAgreement';
+import { extractAlignments } from '@/lib/drepIdentity';
+import type { AlignmentDimension, AlignmentScores } from '@/lib/drepIdentity';
+import { createClient } from '@/lib/supabase';
 import { captureServerEvent } from '@/lib/posthog-server';
 
 export const dynamic = 'force-dynamic';
+
+function normalizeVote(vote: string): string {
+  return vote.charAt(0).toUpperCase() + vote.slice(1).toLowerCase();
+}
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('Authorization');
@@ -26,11 +37,200 @@ export async function GET(request: NextRequest) {
   const excludeDrepId = request.nextUrl.searchParams.get('currentDrepId') || undefined;
 
   try {
-    const { matches, currentDRepMatch } = await findBestMatchDReps(session.walletAddress, {
-      excludeDrepId,
-      minOverlap: 1,
-      minMatchRate: 0,
-      limit: 200,
+    const supabase = createClient();
+
+    const { data: pollVotes } = await supabase
+      .from('poll_responses')
+      .select('proposal_tx_hash, proposal_index, vote')
+      .eq('wallet_address', session.walletAddress);
+
+    if (!pollVotes?.length) {
+      return NextResponse.json({
+        matches: [],
+        currentDRepMatch: null,
+        overallConfidence: 0,
+        matchMethod: 'none',
+      });
+    }
+
+    // Build lookup maps
+    const userProposalTxHashes = [...new Set(pollVotes.map((v) => v.proposal_tx_hash))];
+    const pollVoteMap = new Map<string, string>();
+    for (const pv of pollVotes) {
+      pollVoteMap.set(`${pv.proposal_tx_hash}-${pv.proposal_index}`, normalizeVote(pv.vote));
+    }
+
+    // Fetch all DRep votes on proposals the user voted on
+    const { data: candidateVotes } = await supabase
+      .from('drep_votes')
+      .select('drep_id, proposal_tx_hash, proposal_index, vote')
+      .in('proposal_tx_hash', userProposalTxHashes);
+
+    // Per-DRep overlap stats (always needed for display + confidence)
+    const overlapMap = new Map<string, { agreed: number; total: number }>();
+    if (candidateVotes) {
+      for (const cv of candidateVotes) {
+        const key = `${cv.proposal_tx_hash}-${cv.proposal_index}`;
+        const userVote = pollVoteMap.get(key);
+        if (!userVote) continue;
+
+        const entry = overlapMap.get(cv.drep_id) || { agreed: 0, total: 0 };
+        entry.total++;
+        if (userVote === cv.vote) entry.agreed++;
+        overlapMap.set(cv.drep_id, entry);
+      }
+    }
+
+    // Try PCA matching for ranking
+    let matchMethod: 'pca' | 'vote_overlap' = 'vote_overlap';
+    let rankedDrepIds: string[];
+    const pcaScoreMap = new Map<string, number>();
+
+    const pca = await loadActivePCA();
+    if (pca) {
+      const userVoteMap = new Map<string, number>();
+      for (const pv of pollVotes) {
+        const key = `${pv.proposal_tx_hash}-${pv.proposal_index}`;
+        const v = pv.vote.toLowerCase();
+        userVoteMap.set(key, v === 'yes' ? 1 : v === 'no' ? -1 : 0);
+      }
+
+      const userCoords = projectUserVector(userVoteMap, pca.loadings, pca.proposalIds);
+      if (userCoords) {
+        const { data: coordRows } = await supabase
+          .from('drep_pca_coordinates')
+          .select('drep_id, coordinates')
+          .eq('run_id', pca.runId);
+
+        if (coordRows?.length) {
+          matchMethod = 'pca';
+          const similarities = coordRows.map((row) => ({
+            drepId: row.drep_id as string,
+            similarity: Math.round(
+              cosineSimilarity(userCoords, row.coordinates as number[]) * 100,
+            ),
+          }));
+          similarities.sort((a, b) => b.similarity - a.similarity);
+
+          rankedDrepIds = similarities.slice(0, 200).map((s) => s.drepId);
+          for (const s of similarities) {
+            pcaScoreMap.set(s.drepId, s.similarity);
+          }
+        } else {
+          rankedDrepIds = rankByOverlap(overlapMap);
+        }
+      } else {
+        rankedDrepIds = rankByOverlap(overlapMap);
+      }
+    } else {
+      rankedDrepIds = rankByOverlap(overlapMap);
+    }
+
+    // Current DRep match
+    let currentDRepMatch = null;
+    if (excludeDrepId) {
+      const stats = overlapMap.get(excludeDrepId);
+      if (stats && stats.total > 0) {
+        currentDRepMatch = {
+          matchScore:
+            matchMethod === 'pca' && pcaScoreMap.has(excludeDrepId)
+              ? pcaScoreMap.get(excludeDrepId)!
+              : Math.round((stats.agreed / stats.total) * 100),
+          agreed: stats.agreed,
+          total: stats.total,
+        };
+      }
+    }
+
+    const filteredIds = rankedDrepIds.filter((id) => id !== excludeDrepId).slice(0, 200);
+
+    // Fetch DRep metadata + alignment scores, and proposal classifications in parallel
+    const [drepResult, classResult] = await Promise.all([
+      supabase
+        .from('dreps')
+        .select(
+          'id, info, score, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+        )
+        .in('id', filteredIds.length > 0 ? filteredIds : ['__none__']),
+      supabase
+        .from('proposal_classifications')
+        .select(
+          'proposal_tx_hash, proposal_index, dim_treasury_conservative, dim_treasury_growth, dim_decentralization, dim_security, dim_innovation, dim_transparency',
+        )
+        .in('proposal_tx_hash', userProposalTxHashes),
+    ]);
+
+    const drepInfoMap = new Map<
+      string,
+      { name: string | null; score: number; alignments: AlignmentScores }
+    >();
+    if (drepResult.data) {
+      for (const d of drepResult.data) {
+        drepInfoMap.set(d.id, {
+          name: ((d.info as Record<string, unknown>)?.name as string) || null,
+          score: Number(d.score) || 0,
+          alignments: extractAlignments(d),
+        });
+      }
+    }
+
+    // Build classification map for user alignment derivation
+    const classificationMap = new Map<string, Record<AlignmentDimension, number>>();
+    if (classResult.data) {
+      for (const c of classResult.data) {
+        const key = `${c.proposal_tx_hash}-${c.proposal_index}`;
+        classificationMap.set(key, {
+          treasuryConservative: Number(c.dim_treasury_conservative) || 0,
+          treasuryGrowth: Number(c.dim_treasury_growth) || 0,
+          decentralization: Number(c.dim_decentralization) || 0,
+          security: Number(c.dim_security) || 0,
+          innovation: Number(c.dim_innovation) || 0,
+          transparency: Number(c.dim_transparency) || 0,
+        });
+      }
+    }
+
+    // Derive user alignment scores from their votes + classifications
+    const userAlignments =
+      classificationMap.size > 0 ? deriveUserAlignments(pollVotes, classificationMap) : null;
+
+    const overallConfidence = calculateMatchConfidence(pollVotes.length);
+
+    const matches = filteredIds.map((drepId) => {
+      const info = drepInfoMap.get(drepId);
+      const overlap = overlapMap.get(drepId) || { agreed: 0, total: 0 };
+      const matchScore =
+        matchMethod === 'pca'
+          ? (pcaScoreMap.get(drepId) ??
+            (overlap.total > 0 ? Math.round((overlap.agreed / overlap.total) * 100) : 0))
+          : overlap.total > 0
+            ? Math.round((overlap.agreed / overlap.total) * 100)
+            : 0;
+      const confidence = calculateMatchConfidence(overlap.total);
+
+      let dimensionAgreement = undefined;
+      let agreeDimensions = undefined;
+      let differDimensions = undefined;
+      if (userAlignments && info?.alignments) {
+        const dimResult = computeDimensionAgreement(userAlignments, info.alignments);
+        dimensionAgreement = dimResult.dimensionAgreement;
+        agreeDimensions = dimResult.agreeDimensions;
+        differDimensions = dimResult.differDimensions;
+      }
+
+      return {
+        drepId,
+        drepName: info?.name || null,
+        drepScore: info?.score || 0,
+        matchScore,
+        agreed: overlap.agreed,
+        overlapping: overlap.total,
+        confidence,
+        dimensionAgreement,
+        agreeDimensions,
+        differDimensions,
+        alignments: info?.alignments || null,
+      };
     });
 
     captureServerEvent(
@@ -39,22 +239,29 @@ export async function GET(request: NextRequest) {
         matches_count: matches.length,
         top_match_score: matches[0]?.matchScore ?? null,
         has_current_drep_match: !!currentDRepMatch,
+        match_method: matchMethod,
+        user_vote_count: pollVotes.length,
+        overall_confidence: overallConfidence,
       },
       session.walletAddress,
     );
 
     return NextResponse.json({
       matches,
-      currentDRepMatch: currentDRepMatch
-        ? {
-            matchScore: currentDRepMatch.score,
-            agreed: currentDRepMatch.aligned,
-            total: currentDRepMatch.total,
-          }
-        : null,
+      currentDRepMatch,
+      overallConfidence,
+      matchMethod,
+      userAlignments,
     });
   } catch (error) {
     console.error('[Governance Matches API] Error:', error);
     return NextResponse.json({ error: 'Internal error' }, { status: 500 });
   }
+}
+
+function rankByOverlap(overlapMap: Map<string, { agreed: number; total: number }>): string[] {
+  return [...overlapMap.entries()]
+    .filter(([, m]) => m.total >= 1)
+    .sort((a, b) => b[1].agreed / b[1].total - a[1].agreed / a[1].total)
+    .map(([id]) => id);
 }

--- a/app/api/governance/my-profile/route.ts
+++ b/app/api/governance/my-profile/route.ts
@@ -1,0 +1,64 @@
+/**
+ * User governance profile API.
+ * Returns the user's alignment scores, personality label, confidence, and votes used.
+ * Creates/updates the profile on first access if it doesn't exist.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { validateSessionToken } from '@/lib/supabaseAuth';
+import { createClient } from '@/lib/supabase';
+import { updateUserProfile } from '@/lib/matching/userProfile';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const token = authHeader.slice(7);
+  const session = await validateSessionToken(token);
+  if (!session?.walletAddress) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = createClient();
+
+  // Try to load existing profile
+  const { data: existing } = await supabase
+    .from('user_governance_profiles')
+    .select('alignment_scores, personality_label, votes_used, confidence, updated_at')
+    .eq('wallet_address', session.walletAddress)
+    .single();
+
+  if (existing) {
+    return NextResponse.json({
+      alignmentScores: existing.alignment_scores,
+      personalityLabel: existing.personality_label,
+      votesUsed: existing.votes_used,
+      confidence: Math.round((existing.confidence ?? 0) * 100),
+      updatedAt: existing.updated_at,
+    });
+  }
+
+  // No profile yet — compute and store
+  const profile = await updateUserProfile(session.walletAddress);
+  if (!profile) {
+    return NextResponse.json({
+      alignmentScores: null,
+      personalityLabel: null,
+      votesUsed: 0,
+      confidence: 0,
+      updatedAt: null,
+    });
+  }
+
+  return NextResponse.json({
+    alignmentScores: profile.alignmentScores,
+    personalityLabel: profile.personalityLabel,
+    votesUsed: profile.votesUsed,
+    confidence: profile.confidence,
+    updatedAt: new Date().toISOString(),
+  });
+}

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -1,0 +1,159 @@
+/**
+ * Quick Match API — converts 3 value-based answers into an alignment vector
+ * and matches against DRep alignment scores using Euclidean distance.
+ * No wallet/auth required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import {
+  extractAlignments,
+  getPersonalityLabel,
+  getDominantDimension,
+  getIdentityColor,
+} from '@/lib/drepIdentity';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+export const dynamic = 'force-dynamic';
+
+const ANSWER_VECTORS: Record<string, Record<string, Partial<AlignmentScores>>> = {
+  treasury: {
+    conservative: { treasuryConservative: 85, treasuryGrowth: 20 },
+    growth: { treasuryConservative: 20, treasuryGrowth: 85 },
+    balanced: { treasuryConservative: 55, treasuryGrowth: 55 },
+  },
+  protocol: {
+    caution: { security: 85, innovation: 25 },
+    innovation: { security: 25, innovation: 85 },
+    case_by_case: { security: 55, innovation: 55 },
+  },
+  transparency: {
+    essential: { transparency: 90, decentralization: 70 },
+    nice_to_have: { transparency: 55, decentralization: 50 },
+    doesnt_matter: { transparency: 20, decentralization: 35 },
+  },
+};
+
+const DIMENSIONS: AlignmentDimension[] = [
+  'treasuryConservative',
+  'treasuryGrowth',
+  'decentralization',
+  'security',
+  'innovation',
+  'transparency',
+];
+
+function euclideanDistance(a: AlignmentScores, b: AlignmentScores): number {
+  let sum = 0;
+  for (const dim of DIMENSIONS) {
+    const diff = (a[dim] ?? 50) - (b[dim] ?? 50);
+    sum += diff * diff;
+  }
+  return Math.sqrt(sum);
+}
+
+function distanceToScore(distance: number): number {
+  // Max possible distance = sqrt(6 * 100^2) ≈ 245
+  const maxDist = 245;
+  return Math.max(0, Math.round((1 - distance / maxDist) * 100));
+}
+
+export async function POST(request: NextRequest) {
+  let body: { treasury?: string; protocol?: string; transparency?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { treasury, protocol, transparency } = body;
+
+  if (!treasury || !ANSWER_VECTORS.treasury[treasury]) {
+    return NextResponse.json({ error: 'Invalid treasury answer' }, { status: 400 });
+  }
+  if (!protocol || !ANSWER_VECTORS.protocol[protocol]) {
+    return NextResponse.json({ error: 'Invalid protocol answer' }, { status: 400 });
+  }
+  if (!transparency || !ANSWER_VECTORS.transparency[transparency]) {
+    return NextResponse.json({ error: 'Invalid transparency answer' }, { status: 400 });
+  }
+
+  // Build user alignment vector from answers
+  const userAlignments: AlignmentScores = {
+    treasuryConservative: 50,
+    treasuryGrowth: 50,
+    decentralization: 50,
+    security: 50,
+    innovation: 50,
+    transparency: 50,
+  };
+
+  for (const [, dimScores] of [
+    ['treasury', ANSWER_VECTORS.treasury[treasury]],
+    ['protocol', ANSWER_VECTORS.protocol[protocol]],
+    ['transparency', ANSWER_VECTORS.transparency[transparency]],
+  ] as [string, Partial<AlignmentScores>][]) {
+    for (const dim of DIMENSIONS) {
+      if (dimScores[dim] !== undefined) {
+        userAlignments[dim] = dimScores[dim]!;
+      }
+    }
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: dreps } = await supabase
+    .from('dreps')
+    .select(
+      'id, info, score, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+    )
+    .not('alignment_treasury_conservative', 'is', null);
+
+  if (!dreps?.length) {
+    return NextResponse.json({ matches: [], userAlignments, personalityLabel: null });
+  }
+
+  const ranked = dreps
+    .map((d) => {
+      const drepAlignments = extractAlignments(d);
+      const distance = euclideanDistance(userAlignments, drepAlignments);
+      return {
+        drepId: d.id,
+        drepName: ((d.info as Record<string, unknown>)?.name as string) || null,
+        drepScore: Number(d.score) || 0,
+        matchScore: distanceToScore(distance),
+        alignments: drepAlignments,
+        dominantDimension: getDominantDimension(drepAlignments),
+      };
+    })
+    .sort((a, b) => b.matchScore - a.matchScore)
+    .slice(0, 5);
+
+  const personalityLabel = getPersonalityLabel(userAlignments);
+  const dominant = getDominantDimension(userAlignments);
+  const identityColor = getIdentityColor(dominant);
+
+  captureServerEvent('quick_match_completed', {
+    treasury,
+    protocol,
+    transparency,
+    personality_label: personalityLabel,
+    top_match_score: ranked[0]?.matchScore ?? null,
+    matches_count: ranked.length,
+  });
+
+  return NextResponse.json({
+    matches: ranked.map((r) => ({
+      drepId: r.drepId,
+      drepName: r.drepName,
+      drepScore: r.drepScore,
+      matchScore: r.matchScore,
+      identityColor: getIdentityColor(r.dominantDimension).hex,
+      personalityLabel: getPersonalityLabel(r.alignments),
+    })),
+    userAlignments,
+    personalityLabel,
+    identityColor: identityColor.hex,
+  });
+}

--- a/app/api/governance/quiz-proposals/route.ts
+++ b/app/api/governance/quiz-proposals/route.ts
@@ -1,11 +1,46 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase';
+import type { AlignmentDimension } from '@/lib/drepIdentity';
 
 export const dynamic = 'force-dynamic';
 
+const QUIZ_SIZE = 7;
+const MIN_DECISIVE_VOTES = 3;
+const MIN_DISCRIMINATION = 0.4;
+const MIN_DIMENSION_COVERAGE = 0.3;
+const MIN_DISTINCT_TYPES = 3;
+
+const DIMENSION_KEYS: AlignmentDimension[] = [
+  'treasuryConservative',
+  'treasuryGrowth',
+  'decentralization',
+  'security',
+  'innovation',
+  'transparency',
+];
+
+const DIM_DB_COLUMNS: Record<AlignmentDimension, string> = {
+  treasuryConservative: 'dim_treasury_conservative',
+  treasuryGrowth: 'dim_treasury_growth',
+  decentralization: 'dim_decentralization',
+  security: 'dim_security',
+  innovation: 'dim_innovation',
+  transparency: 'dim_transparency',
+};
+
+interface ScoredProposal {
+  key: string;
+  txHash: string;
+  index: number;
+  discriminationScore: number;
+  total: number;
+  proposalType: string;
+  dimScores: Record<AlignmentDimension, number>;
+}
+
 /**
- * Select proposals where DReps are most split (30-70% Yes/No ratio).
- * These are maximally discriminating for the Governance DNA quiz.
+ * Select proposals where DReps are most split (30-70% Yes/No ratio)
+ * with type diversity and alignment dimension coverage.
  */
 export async function GET() {
   const supabase = createClient();
@@ -34,61 +69,244 @@ export async function GET() {
     proposalVotes.set(key, entry);
   }
 
-  // Score by how close to 50/50 the Yes/No split is (ignoring abstains for discrimination)
+  // Score by discrimination
   const scored: { key: string; txHash: string; index: number; score: number; total: number }[] = [];
   for (const [key, counts] of proposalVotes) {
     const decisive = counts.yes + counts.no;
-    if (decisive < 3) continue; // need minimum participation
+    if (decisive < MIN_DECISIVE_VOTES) continue;
     const yesPct = counts.yes / decisive;
-    const discriminationScore = 1 - Math.abs(yesPct - 0.5) * 2; // 1.0 = perfect 50/50, 0.0 = unanimous
-    if (discriminationScore < 0.4) continue; // at least 30-70 split
+    const discriminationScore = 1 - Math.abs(yesPct - 0.5) * 2;
+    if (discriminationScore < MIN_DISCRIMINATION) continue;
     const [txHash, indexStr] = key.split(':');
-    scored.push({
-      key,
-      txHash,
-      index: parseInt(indexStr, 10),
-      score: discriminationScore,
-      total: counts.total,
-    });
+    scored.push({ key, txHash, index: parseInt(indexStr, 10), score: discriminationScore, total: counts.total });
   }
 
   scored.sort((a, b) => b.score - a.score || b.total - a.total);
-  const topKeys = scored.slice(0, 10);
-
-  if (topKeys.length === 0) {
+  if (scored.length === 0) {
     return NextResponse.json({ proposals: [] });
   }
 
-  // Fetch proposal metadata
-  const { data: proposals, error: proposalError } = await supabase
-    .from('proposals')
-    .select(
-      'tx_hash, proposal_index, proposal_type, title, abstract, withdrawal_amount, treasury_tier, ai_summary',
-    );
+  // Fetch proposal metadata + classifications in parallel
+  const [proposalResult, classResult] = await Promise.all([
+    supabase
+      .from('proposals')
+      .select('tx_hash, proposal_index, proposal_type, title, abstract, withdrawal_amount, treasury_tier, ai_summary'),
+    supabase
+      .from('proposal_classifications')
+      .select('proposal_tx_hash, proposal_index, dim_treasury_conservative, dim_treasury_growth, dim_decentralization, dim_security, dim_innovation, dim_transparency'),
+  ]);
 
-  if (proposalError) {
-    console.error('[quiz-proposals] Failed to fetch proposals:', proposalError.message);
+  if (proposalResult.error) {
+    console.error('[quiz-proposals] Failed to fetch proposals:', proposalResult.error.message);
     return NextResponse.json({ error: 'Failed to fetch proposals' }, { status: 500 });
   }
 
-  const proposalMap = new Map<string, (typeof proposals)[number]>();
-  for (const p of proposals || []) {
+  const proposalMap = new Map<string, (typeof proposalResult.data)[number]>();
+  for (const p of proposalResult.data || []) {
     proposalMap.set(`${p.tx_hash}:${p.proposal_index}`, p);
   }
 
-  const result = topKeys.slice(0, 7).map(({ txHash, index, score }) => {
-    const p = proposalMap.get(`${txHash}:${index}`);
+  const classMap = new Map<string, Record<AlignmentDimension, number>>();
+  if (classResult.data) {
+    for (const c of classResult.data) {
+      const key = `${c.proposal_tx_hash}:${c.proposal_index}`;
+      classMap.set(key, {
+        treasuryConservative: Number(c.dim_treasury_conservative) || 0,
+        treasuryGrowth: Number(c.dim_treasury_growth) || 0,
+        decentralization: Number(c.dim_decentralization) || 0,
+        security: Number(c.dim_security) || 0,
+        innovation: Number(c.dim_innovation) || 0,
+        transparency: Number(c.dim_transparency) || 0,
+      });
+    }
+  }
+
+  // Build enriched scored proposals
+  const enriched: ScoredProposal[] = scored.map((s) => ({
+    ...s,
+    discriminationScore: s.score,
+    proposalType: proposalMap.get(s.key)?.proposal_type || 'Unknown',
+    dimScores: classMap.get(s.key) || Object.fromEntries(DIMENSION_KEYS.map((d) => [d, 0])) as Record<AlignmentDimension, number>,
+  }));
+
+  // Greedy diversified selection: guarantee type diversity
+  const selected = greedyDiverseSelect(enriched, QUIZ_SIZE, MIN_DISTINCT_TYPES);
+
+  // Dimension coverage swap: fill gaps if any dimension is under-covered
+  if (classMap.size > 0) {
+    applyDimensionCoverage(selected, enriched);
+  }
+
+  const result = selected.map((s) => {
+    const p = proposalMap.get(s.key);
+    const topDims = getTopDimensions(s.dimScores, 2);
+
     return {
-      txHash,
-      index,
-      proposalType: p?.proposal_type || 'Unknown',
-      title: p?.title || `Proposal ${txHash.slice(0, 8)}...`,
+      txHash: s.txHash,
+      index: s.index,
+      proposalType: s.proposalType,
+      title: p?.title || `Proposal ${s.txHash.slice(0, 8)}...`,
       summary: p?.ai_summary || p?.abstract || null,
       withdrawalAmount: p?.withdrawal_amount ? Number(p.withdrawal_amount) / 1_000_000 : null,
       treasuryTier: p?.treasury_tier || null,
-      discriminationScore: Math.round(score * 100),
+      discriminationScore: Math.round(s.discriminationScore * 100),
+      discriminationLabel: getDiscriminationLabel(s.discriminationScore),
+      stakesLabel: getStakesLabel(s.proposalType, p?.withdrawal_amount ? Number(p.withdrawal_amount) / 1_000_000 : null),
+      dimensionTags: topDims,
     };
   });
 
   return NextResponse.json({ proposals: result });
+}
+
+function greedyDiverseSelect(
+  candidates: ScoredProposal[],
+  size: number,
+  minTypes: number,
+): ScoredProposal[] {
+  if (candidates.length <= size) return [...candidates];
+
+  const selected: ScoredProposal[] = [];
+  const used = new Set<string>();
+
+  // Pick the highest-scoring proposal overall
+  selected.push(candidates[0]);
+  used.add(candidates[0].key);
+
+  while (selected.length < size) {
+    const typeCounts = new Map<string, number>();
+    for (const s of selected) {
+      typeCounts.set(s.proposalType, (typeCounts.get(s.proposalType) || 0) + 1);
+    }
+
+    const distinctTypes = typeCounts.size;
+    let best: ScoredProposal | null = null;
+
+    if (distinctTypes < minTypes) {
+      // Prioritize unseen types
+      for (const c of candidates) {
+        if (used.has(c.key)) continue;
+        if (!typeCounts.has(c.proposalType)) {
+          best = c;
+          break;
+        }
+      }
+    }
+
+    if (!best) {
+      // Pick from least-represented type
+      const minCount = Math.min(...typeCounts.values(), 0);
+      const leastTypes = new Set(
+        [...typeCounts.entries()].filter(([, count]) => count === minCount).map(([t]) => t),
+      );
+
+      // Also consider types not yet in selection
+      for (const c of candidates) {
+        if (used.has(c.key)) continue;
+        if (!typeCounts.has(c.proposalType) || leastTypes.has(c.proposalType)) {
+          best = c;
+          break;
+        }
+      }
+
+      // Fallback: just pick the next best
+      if (!best) {
+        for (const c of candidates) {
+          if (!used.has(c.key)) {
+            best = c;
+            break;
+          }
+        }
+      }
+    }
+
+    if (!best) break;
+    selected.push(best);
+    used.add(best.key);
+  }
+
+  return selected;
+}
+
+function applyDimensionCoverage(
+  selected: ScoredProposal[],
+  allCandidates: ScoredProposal[],
+): void {
+  const selectedKeys = new Set(selected.map((s) => s.key));
+
+  // Compute dimension coverage
+  const coverage: Record<AlignmentDimension, number> = {} as any;
+  for (const dim of DIMENSION_KEYS) {
+    coverage[dim] = selected.reduce((sum, s) => sum + s.dimScores[dim], 0);
+  }
+
+  for (const dim of DIMENSION_KEYS) {
+    if (coverage[dim] >= MIN_DIMENSION_COVERAGE) continue;
+
+    // Find the weakest-discriminating proposal in selection
+    let weakestIdx = 0;
+    for (let i = 1; i < selected.length; i++) {
+      if (selected[i].discriminationScore < selected[weakestIdx].discriminationScore) {
+        weakestIdx = i;
+      }
+    }
+
+    // Find the best candidate that covers this gap and isn't already selected
+    const replacement = allCandidates.find(
+      (c) => !selectedKeys.has(c.key) && c.dimScores[dim] > 0.3,
+    );
+
+    if (replacement) {
+      const removed = selected[weakestIdx];
+      selectedKeys.delete(removed.key);
+      selected[weakestIdx] = replacement;
+      selectedKeys.add(replacement.key);
+
+      // Recompute coverage after swap
+      for (const d of DIMENSION_KEYS) {
+        coverage[d] = selected.reduce((sum, s) => sum + s.dimScores[d], 0);
+      }
+    }
+  }
+}
+
+function getTopDimensions(scores: Record<AlignmentDimension, number>, count: number): string[] {
+  const LABELS: Record<AlignmentDimension, string> = {
+    treasuryConservative: 'Treasury Conservative',
+    treasuryGrowth: 'Treasury Growth',
+    decentralization: 'Decentralization',
+    security: 'Security',
+    innovation: 'Innovation',
+    transparency: 'Transparency',
+  };
+
+  return DIMENSION_KEYS
+    .filter((d) => scores[d] > 0)
+    .sort((a, b) => scores[b] - scores[a])
+    .slice(0, count)
+    .map((d) => LABELS[d]);
+}
+
+function getDiscriminationLabel(score: number): string {
+  if (score > 0.8) return 'DReps are divided';
+  if (score > 0.6) return 'DReps lean one way';
+  return 'Close call';
+}
+
+function getStakesLabel(proposalType: string, withdrawalAmountAda: number | null): string | null {
+  if (withdrawalAmountAda !== null && withdrawalAmountAda > 0) {
+    const formatted =
+      withdrawalAmountAda >= 1_000_000
+        ? `${(withdrawalAmountAda / 1_000_000).toFixed(1)}M ADA`
+        : `${Math.round(withdrawalAmountAda).toLocaleString()} ADA`;
+    return `${formatted} at stake`;
+  }
+  const normalizedType = proposalType.toLowerCase();
+  if (normalizedType.includes('parameter') || normalizedType.includes('protocol')) {
+    return 'Protocol parameter change';
+  }
+  if (normalizedType.includes('constitution') || normalizedType.includes('governance')) {
+    return 'Governance structure change';
+  }
+  return null;
 }

--- a/app/api/polls/vote/route.ts
+++ b/app/api/polls/vote/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
+import { updateUserProfile } from '@/lib/matching/userProfile';
 
 const VALID_VOTES = ['yes', 'no', 'abstain'] as const;
 type Vote = (typeof VALID_VOTES)[number];
@@ -186,6 +187,11 @@ export async function POST(request: NextRequest) {
     .then(({ error: evtErr }) => {
       if (evtErr) console.error('[Poll Vote] governance_event write failed:', evtErr);
     });
+
+  // Update user governance profile (fire-and-forget, don't block response)
+  updateUserProfile(walletAddress).catch((err) => {
+    console.error('[Poll Vote] Failed to update user profile:', err);
+  });
 
   const { data: allVotes } = await supabase
     .from('poll_responses')

--- a/app/match/page.tsx
+++ b/app/match/page.tsx
@@ -1,0 +1,33 @@
+import { Metadata } from 'next';
+import { QuickMatch } from '@/components/QuickMatch';
+import { PageViewTracker } from '@/components/PageViewTracker';
+
+export const metadata: Metadata = {
+  title: 'Quick Match — Find Your DRep in 30 Seconds | DRepScore',
+  description:
+    'Answer 3 questions about your governance values and find DReps who align with you. No wallet required.',
+  openGraph: {
+    title: 'Find Your DRep in 30 Seconds',
+    description:
+      'Answer 3 questions about your governance values and find DReps who align with you.',
+  },
+};
+
+export default function MatchPage() {
+  return (
+    <main className="container max-w-4xl mx-auto px-4 py-12">
+      <PageViewTracker event="quick_match_page_viewed" />
+
+      <div className="text-center mb-10">
+        <h1 className="text-3xl font-bold tracking-tight">
+          Find Your DRep in 30 Seconds
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          3 questions about your governance values. No wallet needed.
+        </p>
+      </div>
+
+      <QuickMatch />
+    </main>
+  );
+}

--- a/components/DRepCard.tsx
+++ b/components/DRepCard.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils';
 interface DRepCardProps {
   drep: EnrichedDRep;
   matchScore?: number | null;
+  matchConfidence?: number | null;
   isWatchlisted?: boolean;
   onWatchlistToggle?: (drepId: string) => void;
   isDelegated?: boolean;
@@ -23,6 +24,7 @@ interface DRepCardProps {
 export function DRepCard({
   drep,
   matchScore,
+  matchConfidence,
   isWatchlisted = false,
   onWatchlistToggle,
   isDelegated = false,
@@ -105,6 +107,16 @@ export function DRepCard({
       {matchScore != null && (
         <div className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-primary/5 border border-primary/10">
           <span className="text-xs font-medium text-primary">{matchScore}% match</span>
+          {matchConfidence != null && (
+            <span
+              className={cn(
+                'text-[10px]',
+                matchConfidence >= 50 ? 'text-green-500' : 'text-amber-500',
+              )}
+            >
+              · {matchConfidence >= 80 ? 'high' : matchConfidence >= 40 ? 'med' : 'low'}
+            </span>
+          )}
         </div>
       )}
 

--- a/components/DRepCardGrid.tsx
+++ b/components/DRepCardGrid.tsx
@@ -7,6 +7,7 @@ import { DRepCard } from '@/components/DRepCard';
 interface DRepCardGridProps {
   dreps: EnrichedDRep[];
   matchData?: Record<string, number>;
+  matchConfidence?: Record<string, number>;
   watchlist?: string[];
   onWatchlistToggle?: (drepId: string) => void;
   delegatedDrepId?: string | null;
@@ -16,6 +17,7 @@ interface DRepCardGridProps {
 export function DRepCardGrid({
   dreps,
   matchData = {},
+  matchConfidence = {},
   watchlist = [],
   onWatchlistToggle,
   delegatedDrepId,
@@ -46,6 +48,7 @@ export function DRepCardGrid({
           key={drep.drepId}
           drep={drep}
           matchScore={matchData[drep.drepId] ?? null}
+          matchConfidence={matchConfidence[drep.drepId] ?? null}
           isWatchlisted={watchlist.includes(drep.drepId)}
           onWatchlistToggle={onWatchlistToggle}
           isDelegated={delegatedDrepId === drep.drepId}

--- a/components/DRepTableClient.tsx
+++ b/components/DRepTableClient.tsx
@@ -52,6 +52,7 @@ interface DRepTableClientProps {
   onWatchlistToggle?: (drepId: string) => void;
   isConnected?: boolean;
   matchData?: Record<string, number>;
+  matchConfidence?: Record<string, number>;
 }
 
 export function DRepTableClient({
@@ -62,6 +63,7 @@ export function DRepTableClient({
   onWatchlistToggle,
   isConnected = false,
   matchData = {},
+  matchConfidence = {},
 }: DRepTableClientProps) {
   const router = useRouter();
   const { delegatedDrepId } = useWallet();
@@ -483,6 +485,7 @@ export function DRepTableClient({
           <DRepCardGrid
             dreps={sortedDReps.slice(0, visibleCardCount)}
             matchData={matchData}
+            matchConfidence={matchConfidence}
             watchlist={watchlist}
             onWatchlistToggle={onWatchlistToggle}
             delegatedDrepId={delegatedDrepId}

--- a/components/GovernanceDNAQuiz.tsx
+++ b/components/GovernanceDNAQuiz.tsx
@@ -18,6 +18,9 @@ interface QuizProposal {
   summary: string | null;
   withdrawalAmount: number | null;
   treasuryTier: string | null;
+  discriminationLabel?: string;
+  stakesLabel?: string | null;
+  dimensionTags?: string[];
 }
 
 type VoteChoice = 'yes' | 'no' | 'abstain';
@@ -93,7 +96,13 @@ export function GovernanceDNAQuiz({ onQuizComplete }: GovernanceDNAQuizProps) {
       const newVotes = [...votes, { txHash: proposal.txHash, index: proposal.index, vote }];
       setVotes(newVotes);
 
-      submitVote(proposal, vote);
+      const isLastVote = !(currentIdx + 1 < proposals.length && newVotes.length < 7);
+
+      if (isLastVote) {
+        await submitVote(proposal, vote);
+      } else {
+        submitVote(proposal, vote);
+      }
 
       import('@/lib/posthog')
         .then(({ posthog }) => {
@@ -105,7 +114,7 @@ export function GovernanceDNAQuiz({ onQuizComplete }: GovernanceDNAQuizProps) {
         })
         .catch(() => {});
 
-      if (currentIdx + 1 < proposals.length && newVotes.length < 7) {
+      if (!isLastVote) {
         setCurrentIdx(currentIdx + 1);
       } else {
         setPhase('submitting');
@@ -129,8 +138,15 @@ export function GovernanceDNAQuiz({ onQuizComplete }: GovernanceDNAQuizProps) {
                   matchScore: m.matchScore,
                   agreed: m.agreed,
                   total: m.overlapping,
+                  confidence: m.confidence,
+                  agreeDimensions: m.agreeDimensions,
+                  differDimensions: m.differDimensions,
+                  alignments: m.alignments ?? null,
                 })),
                 currentDRepMatch: data.currentDRepMatch ?? null,
+                overallConfidence: data.overallConfidence,
+                matchMethod: data.matchMethod,
+                userAlignments: data.userAlignments ?? null,
               });
               onQuizComplete?.(matchMap);
               import('@/lib/posthog')
@@ -238,21 +254,40 @@ export function GovernanceDNAQuiz({ onQuizComplete }: GovernanceDNAQuizProps) {
         </div>
 
         <div className="space-y-2">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <Badge variant="outline" className="text-[10px]">
               {proposal.proposalType.replace(/([A-Z])/g, ' $1').trim()}
             </Badge>
-            {proposal.withdrawalAmount && (
+            {proposal.stakesLabel && (
+              <Badge variant="secondary" className="text-[10px]">
+                {proposal.stakesLabel}
+              </Badge>
+            )}
+            {!proposal.stakesLabel && proposal.withdrawalAmount && (
               <Badge variant="secondary" className="text-[10px]">
                 {proposal.withdrawalAmount >= 1_000_000
                   ? `${(proposal.withdrawalAmount / 1_000_000).toFixed(1)}M ADA`
                   : `${Math.round(proposal.withdrawalAmount).toLocaleString()} ADA`}
               </Badge>
             )}
+            {proposal.discriminationLabel && (
+              <Badge variant="outline" className="text-[10px] text-muted-foreground">
+                {proposal.discriminationLabel}
+              </Badge>
+            )}
           </div>
           <h4 className="font-semibold text-base leading-snug">{proposal.title}</h4>
           {proposal.summary && (
             <p className="text-sm text-muted-foreground line-clamp-3">{proposal.summary}</p>
+          )}
+          {proposal.dimensionTags && proposal.dimensionTags.length > 0 && (
+            <div className="flex gap-1">
+              {proposal.dimensionTags.map((tag) => (
+                <span key={tag} className="text-[10px] text-primary/70 bg-primary/5 px-1.5 py-0.5 rounded">
+                  {tag}
+                </span>
+              ))}
+            </div>
           )}
         </div>
 

--- a/components/GovernanceDNAReveal.tsx
+++ b/components/GovernanceDNAReveal.tsx
@@ -1,13 +1,18 @@
 'use client';
 
 import { useEffect } from 'react';
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Dna, RefreshCw, ArrowRight, Share2 } from 'lucide-react';
+import { Dna, RefreshCw, ArrowRight, Share2, Vote } from 'lucide-react';
 import Link from 'next/link';
 import { ShareActions } from '@/components/ShareActions';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import { MatchCard } from '@/components/matching/MatchCard';
+import { ConfidenceBar } from '@/components/matching/ConfidenceBar';
 import { posthog } from '@/lib/posthog';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
 
 export interface QuizMatchDRep {
   drepId: string;
@@ -15,12 +20,20 @@ export interface QuizMatchDRep {
   matchScore: number;
   agreed: number;
   total: number;
+  confidence?: number;
+  agreeDimensions?: string[];
+  differDimensions?: string[];
+  alignments?: AlignmentScores | null;
 }
 
 export interface QuizResult {
   votesCount: number;
   topMatches: QuizMatchDRep[];
   currentDRepMatch: { matchScore: number; agreed: number; total: number } | null;
+  overallConfidence?: number;
+  matchMethod?: string;
+  userAlignments?: AlignmentScores | null;
+  personalityLabel?: string | null;
 }
 
 interface GovernanceDNARevealProps {
@@ -41,114 +54,196 @@ export function GovernanceDNAReveal({ result, onRetake }: GovernanceDNARevealPro
       top_match_score: result.topMatches[0]?.matchScore ?? null,
       matches_count: result.topMatches.length,
       has_current_drep_match: !!result.currentDRepMatch,
+      match_method: result.matchMethod ?? 'unknown',
+      overall_confidence: result.overallConfidence ?? null,
     });
   }, [result]);
 
-  return (
-    <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
-      <CardContent className="p-6 space-y-4">
-        <div className="flex items-center gap-2">
-          <Dna className="h-5 w-5 text-primary" />
-          <h3 className="text-lg font-semibold">Your Governance DNA</h3>
-        </div>
+  const hasAlignments = result.userAlignments && Object.values(result.userAlignments).some((v) => v !== null);
 
-        <p className="text-sm text-muted-foreground">
-          Based on {result.votesCount} vote{result.votesCount !== 1 ? 's' : ''}, your top matches:
-        </p>
+  return (
+    <div className="space-y-6">
+      {/* Section 1: Your Governance Identity */}
+      {hasAlignments && result.userAlignments && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
+            <CardContent className="p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <Dna className="h-5 w-5 text-primary" />
+                <h3 className="text-lg font-semibold">Your Governance Identity</h3>
+              </div>
+
+              <div className="flex flex-col sm:flex-row items-center gap-6">
+                <GovernanceRadar
+                  alignments={result.userAlignments}
+                  size="full"
+                  animate
+                />
+                <div className="text-center sm:text-left space-y-2">
+                  {result.personalityLabel && (
+                    <Badge variant="outline" className="text-sm px-3 py-1">
+                      {result.personalityLabel}
+                    </Badge>
+                  )}
+                  <p className="text-sm text-muted-foreground">
+                    Based on {result.votesCount} vote{result.votesCount !== 1 ? 's' : ''} on real governance proposals
+                  </p>
+                  {result.matchMethod === 'pca' && (
+                    <p className="text-[10px] text-muted-foreground/60">
+                      Matched using PCA cosine similarity
+                    </p>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      )}
+
+      {/* Section 2: Your Top Matches */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.15 }}
+        className="space-y-3"
+      >
+        <h3 className="text-lg font-semibold">Your Top Matches</h3>
 
         {result.topMatches.length > 0 ? (
-          <div className="space-y-2">
+          <div className="space-y-3">
             {result.topMatches.map((m, i) => (
-              <Link
+              <motion.div
                 key={m.drepId}
-                href={`/drep/${encodeURIComponent(m.drepId)}`}
-                className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors group"
+                initial={{ opacity: 0, x: -10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.2 + i * 0.1 }}
               >
-                <div className="flex items-center gap-3">
-                  <span className="text-sm font-bold text-muted-foreground w-5">{i + 1}.</span>
-                  <div>
-                    <span className="text-sm font-medium group-hover:text-primary transition-colors">
-                      {m.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground ml-2">
-                      agreed on {m.agreed}/{m.total}
-                    </span>
-                  </div>
-                </div>
-                <Badge variant="outline" className={getMatchColor(m.matchScore)}>
-                  {m.matchScore}% match
-                </Badge>
-              </Link>
+                <MatchCard
+                  rank={i + 1}
+                  drepId={m.drepId}
+                  drepName={m.name}
+                  matchScore={m.matchScore}
+                  confidence={m.confidence ?? 0}
+                  agreed={m.agreed}
+                  overlapping={m.total}
+                  agreeDimensions={m.agreeDimensions}
+                  differDimensions={m.differDimensions}
+                  userAlignments={result.userAlignments}
+                  drepAlignments={m.alignments}
+                  showRadar={!!result.userAlignments && !!m.alignments}
+                />
+              </motion.div>
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">
-            Not enough overlapping votes to calculate matches yet. Vote on more proposals to improve
-            accuracy.
-          </p>
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-sm text-muted-foreground">
+                Not enough overlapping votes to calculate matches yet.
+                Vote on more proposals to improve accuracy.
+              </p>
+            </CardContent>
+          </Card>
         )}
 
+        {/* Current DRep comparison */}
         {result.currentDRepMatch && (
-          <div className="p-3 rounded-lg bg-muted/50 border">
-            <p className="text-sm">
-              <span className="text-muted-foreground">vs your current DRep: </span>
-              <span
-                className={`font-semibold ${getMatchColor(result.currentDRepMatch.matchScore)}`}
-              >
-                {result.currentDRepMatch.matchScore}% match
-              </span>
-              <span className="text-xs text-muted-foreground ml-1">
-                ({result.currentDRepMatch.agreed}/{result.currentDRepMatch.total})
-              </span>
-            </p>
-          </div>
+          <Card className="border-amber-500/20 bg-amber-500/5">
+            <CardContent className="p-4">
+              <p className="text-sm">
+                <span className="text-muted-foreground">vs your current DRep: </span>
+                <span className={`font-semibold ${getMatchColor(result.currentDRepMatch.matchScore)}`}>
+                  {result.currentDRepMatch.matchScore}% match
+                </span>
+                <span className="text-xs text-muted-foreground ml-1">
+                  ({result.currentDRepMatch.agreed}/{result.currentDRepMatch.total})
+                </span>
+              </p>
+            </CardContent>
+          </Card>
         )}
+      </motion.div>
 
-        <p className="text-xs text-muted-foreground">
-          The DRep grid below is now sorted by your match.
-        </p>
+      {/* Section 3: Improve Your Matches */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.4 }}
+      >
+        <Card className="border-muted">
+          <CardContent className="p-6 space-y-4">
+            <h4 className="font-semibold text-sm">Improve Your Matches</h4>
 
-        {/* Share your Governance DNA — prominent callout */}
-        {result.topMatches.length > 0 && (
-          <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3">
-            <div className="flex items-center gap-2">
-              <Share2 className="h-4 w-4 text-primary" />
-              <p className="text-sm font-medium">Share your Governance DNA</p>
-            </div>
+            <ConfidenceBar votesUsed={result.votesCount} />
+
             <p className="text-xs text-muted-foreground">
-              Show the Cardano community your governance personality. Your top match:{' '}
-              <span className="font-semibold text-foreground">{result.topMatches[0].name}</span> (
-              {result.topMatches[0].matchScore}%)
+              Vote on more proposals to sharpen your results.
+              Each vote improves your governance profile and match accuracy.
             </p>
-            <ShareActions
-              url="https://drepscore.io/discover"
-              text={`I took the Governance DNA Quiz on @drepscore! My top match: ${result.topMatches[0].name} (${result.topMatches[0].matchScore}%). Find your ideal DRep:`}
-              imageUrl={`/api/og/governance-dna?votes=${result.votesCount}${result.topMatches
-                .slice(0, 3)
-                .map(
-                  (m, i) =>
-                    `&m${i + 1}name=${encodeURIComponent(m.name)}&m${i + 1}score=${m.matchScore}`,
-                )
-                .join('')}`}
-              imageFilename="my-governance-dna.png"
-              surface="governance_dna"
-              metadata={{ votes_count: result.votesCount, top_match: result.topMatches[0]?.drepId }}
-            />
-          </div>
-        )}
 
-        <div className="flex gap-2 pt-1">
-          <Button variant="outline" size="sm" onClick={onRetake} className="gap-1.5">
-            <RefreshCw className="h-3.5 w-3.5" />
-            Retake Quiz
-          </Button>
-          <Link href="/proposals">
-            <Button variant="ghost" size="sm" className="gap-1.5">
-              Vote on More Proposals <ArrowRight className="h-3.5 w-3.5" />
-            </Button>
-          </Link>
-        </div>
-      </CardContent>
-    </Card>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" onClick={onRetake} className="gap-1.5">
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retake Quiz
+              </Button>
+              <Link href="/proposals">
+                <Button variant="ghost" size="sm" className="gap-1.5">
+                  <Vote className="h-3.5 w-3.5" />
+                  Vote on Proposals
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+
+      {/* Share */}
+      {result.topMatches.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.55 }}
+        >
+          <Card className="border-primary/20 bg-primary/5">
+            <CardContent className="p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <Share2 className="h-4 w-4 text-primary" />
+                <p className="text-sm font-medium">Share your Governance DNA</p>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Show the Cardano community your governance personality. Your top match:{' '}
+                <span className="font-semibold text-foreground">{result.topMatches[0].name}</span> (
+                {result.topMatches[0].matchScore}%)
+              </p>
+              <ShareActions
+                url="https://drepscore.io/discover"
+                text={`I took the Governance DNA Quiz on @drepscore! My top match: ${result.topMatches[0].name} (${result.topMatches[0].matchScore}%). Find your ideal DRep:`}
+                imageUrl={`/api/og/governance-dna?votes=${result.votesCount}${result.topMatches
+                  .slice(0, 3)
+                  .map(
+                    (m, i) =>
+                      `&m${i + 1}name=${encodeURIComponent(m.name)}&m${i + 1}score=${m.matchScore}`,
+                  )
+                  .join('')}`}
+                imageFilename="my-governance-dna.png"
+                surface="governance_dna"
+                metadata={{
+                  votes_count: result.votesCount,
+                  top_match: result.topMatches[0]?.drepId,
+                }}
+              />
+            </CardContent>
+          </Card>
+        </motion.div>
+      )}
+
+      <p className="text-xs text-muted-foreground text-center">
+        The DRep grid below is now sorted by your match.
+      </p>
+    </div>
   );
 }

--- a/components/HomepageShell.tsx
+++ b/components/HomepageShell.tsx
@@ -7,6 +7,7 @@ import { FeatureGate } from '@/components/FeatureGate';
 import { useWallet } from '@/utils/wallet';
 import { getStoredSession } from '@/lib/supabaseAuth';
 import { EnrichedDRep } from '@/lib/koios';
+import { GovernanceIdentityCard } from '@/components/matching/GovernanceIdentityCard';
 
 const GovernanceWidget = dynamic(
   () => import('@/components/GovernanceWidget').then((m) => m.GovernanceWidget),
@@ -47,6 +48,13 @@ export function HomepageShell({
   const { isAuthenticated, sessionAddress } = useWallet();
   const [watchlist, setWatchlist] = useState<string[]>([]);
   const [matchData, setMatchData] = useState<Record<string, number>>({});
+  const [matchConfidence, setMatchConfidence] = useState<Record<string, number>>({});
+  const [userProfile, setUserProfile] = useState<{
+    personalityLabel: string | null;
+    votesUsed: number;
+    confidence: number;
+    alignmentScores: Record<string, number | null> | null;
+  } | null>(null);
 
   useEffect(() => {
     setWatchlist(getLocalWatchlist());
@@ -78,11 +86,31 @@ export function HomepageShell({
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data?.matches?.length > 0) {
-          const map: Record<string, number> = {};
+          const scoreMap: Record<string, number> = {};
+          const confMap: Record<string, number> = {};
           for (const m of data.matches) {
-            map[m.drepId] = m.matchScore;
+            scoreMap[m.drepId] = m.matchScore;
+            if (m.confidence != null) confMap[m.drepId] = m.confidence;
           }
-          setMatchData(map);
+          setMatchData(scoreMap);
+          setMatchConfidence(confMap);
+        }
+      })
+      .catch(console.error);
+
+    // Fetch user governance profile for identity card
+    fetch('/api/governance/my-profile', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.votesUsed > 0) {
+          setUserProfile({
+            personalityLabel: data.personalityLabel,
+            votesUsed: data.votesUsed,
+            confidence: data.confidence,
+            alignmentScores: data.alignmentScores,
+          });
         }
       })
       .catch(console.error);
@@ -118,6 +146,15 @@ export function HomepageShell({
     <div className="space-y-6">
       <GovernanceWidget />
 
+      {userProfile && (
+        <GovernanceIdentityCard
+          personalityLabel={userProfile.personalityLabel}
+          votesUsed={userProfile.votesUsed}
+          confidence={userProfile.confidence}
+          alignmentScores={userProfile.alignmentScores}
+        />
+      )}
+
       <FeatureGate flag="governance_dna_quiz">
         <GovernanceDNAQuiz onQuizComplete={setMatchData} />
       </FeatureGate>
@@ -131,6 +168,7 @@ export function HomepageShell({
         onWatchlistToggle={handleWatchlistToggle}
         isConnected={isAuthenticated}
         matchData={matchData}
+        matchConfidence={matchConfidence}
       />
     </div>
   );

--- a/components/QuickMatch.tsx
+++ b/components/QuickMatch.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ArrowRight, Loader2, Sparkles, ChevronRight } from 'lucide-react';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+interface QuickMatchResult {
+  matches: {
+    drepId: string;
+    drepName: string | null;
+    drepScore: number;
+    matchScore: number;
+    identityColor: string;
+    personalityLabel: string;
+  }[];
+  userAlignments: AlignmentScores;
+  personalityLabel: string;
+  identityColor: string;
+}
+
+interface Question {
+  id: 'treasury' | 'protocol' | 'transparency';
+  title: string;
+  subtitle: string;
+  options: { value: string; label: string; description: string }[];
+}
+
+const QUESTIONS: Question[] = [
+  {
+    id: 'treasury',
+    title: 'Treasury spending',
+    subtitle: 'When it comes to Cardano treasury funds, I prefer...',
+    options: [
+      {
+        value: 'conservative',
+        label: 'Conservative',
+        description: 'Protect the treasury. Only fund proven, essential projects.',
+      },
+      {
+        value: 'growth',
+        label: 'Growth',
+        description: 'Invest aggressively. Fund innovation to grow the ecosystem.',
+      },
+      {
+        value: 'balanced',
+        label: 'Balanced',
+        description: 'Case-by-case. Fund high-quality proposals regardless of size.',
+      },
+    ],
+  },
+  {
+    id: 'protocol',
+    title: 'Protocol changes',
+    subtitle: 'On protocol upgrades and parameter changes, I lean toward...',
+    options: [
+      {
+        value: 'caution',
+        label: 'Security first',
+        description: 'Move slowly. Stability and security are paramount.',
+      },
+      {
+        value: 'innovation',
+        label: 'Innovation first',
+        description: 'Move fast. Progress requires calculated risk-taking.',
+      },
+      {
+        value: 'case_by_case',
+        label: 'It depends',
+        description: 'Evaluate each change on its own merits.',
+      },
+    ],
+  },
+  {
+    id: 'transparency',
+    title: 'DRep transparency',
+    subtitle: 'How important is transparency from your DRep?',
+    options: [
+      {
+        value: 'essential',
+        label: 'Essential',
+        description: 'DReps must explain every vote publicly. Transparency is governance.',
+      },
+      {
+        value: 'nice_to_have',
+        label: 'Nice to have',
+        description: "I appreciate transparency but don't require it for every decision.",
+      },
+      {
+        value: 'doesnt_matter',
+        label: "Doesn't matter",
+        description: 'Results matter more than process. Just vote well.',
+      },
+    ],
+  },
+];
+
+const DEFAULT_ALIGNMENTS: AlignmentScores = {
+  treasuryConservative: 50,
+  treasuryGrowth: 50,
+  decentralization: 50,
+  security: 50,
+  innovation: 50,
+  transparency: 50,
+};
+
+const PARTIAL_VECTORS: Record<string, Record<string, Partial<AlignmentScores>>> = {
+  treasury: {
+    conservative: { treasuryConservative: 85, treasuryGrowth: 20 },
+    growth: { treasuryConservative: 20, treasuryGrowth: 85 },
+    balanced: { treasuryConservative: 55, treasuryGrowth: 55 },
+  },
+  protocol: {
+    caution: { security: 85, innovation: 25 },
+    innovation: { security: 25, innovation: 85 },
+    case_by_case: { security: 55, innovation: 55 },
+  },
+  transparency: {
+    essential: { transparency: 90, decentralization: 70 },
+    nice_to_have: { transparency: 55, decentralization: 50 },
+    doesnt_matter: { transparency: 20, decentralization: 35 },
+  },
+};
+
+export function QuickMatch() {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<QuickMatchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [liveAlignments, setLiveAlignments] = useState<AlignmentScores>(DEFAULT_ALIGNMENTS);
+
+  const handleAnswer = useCallback(
+    async (questionId: string, value: string) => {
+      const newAnswers = { ...answers, [questionId]: value };
+      setAnswers(newAnswers);
+
+      // Update live radar preview
+      const updated = { ...DEFAULT_ALIGNMENTS };
+      for (const [qId, ans] of Object.entries(newAnswers)) {
+        const vec = PARTIAL_VECTORS[qId]?.[ans];
+        if (vec) {
+          for (const [dim, val] of Object.entries(vec)) {
+            (updated as Record<string, number>)[dim] = val as number;
+          }
+        }
+      }
+      setLiveAlignments(updated);
+
+      if (step < QUESTIONS.length - 1) {
+        setTimeout(() => setStep(step + 1), 300);
+      } else {
+        setLoading(true);
+        try {
+          const res = await fetch('/api/governance/quick-match', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(newAnswers),
+          });
+          if (res.ok) {
+            setResult(await res.json());
+          }
+        } catch (err) {
+          console.error('Quick match failed:', err);
+        }
+        setLoading(false);
+      }
+    },
+    [answers, step],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-4">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-muted-foreground">Finding your DRep matches...</p>
+      </div>
+    );
+  }
+
+  if (result) {
+    return <QuickMatchResults result={result} />;
+  }
+
+  const question = QUESTIONS[step];
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* Progress */}
+      <div className="flex items-center gap-2">
+        {QUESTIONS.map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              'h-1.5 flex-1 rounded-full transition-colors',
+              i <= step ? 'bg-primary' : 'bg-muted',
+            )}
+          />
+        ))}
+      </div>
+
+      <div className="grid md:grid-cols-[1fr,200px] gap-8 items-start">
+        {/* Question */}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.25 }}
+            className="space-y-4"
+          >
+            <div>
+              <p className="text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                Question {step + 1} of {QUESTIONS.length}
+              </p>
+              <h2 className="text-xl font-semibold">{question.subtitle}</h2>
+            </div>
+
+            <div className="space-y-3">
+              {question.options.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => handleAnswer(question.id, opt.value)}
+                  className={cn(
+                    'w-full text-left p-4 rounded-lg border transition-all hover:border-primary/50 hover:bg-primary/5',
+                    answers[question.id] === opt.value &&
+                      'border-primary bg-primary/10',
+                  )}
+                >
+                  <p className="font-medium text-sm">{opt.label}</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">{opt.description}</p>
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        </AnimatePresence>
+
+        {/* Live radar preview */}
+        <div className="hidden md:flex flex-col items-center gap-2">
+          <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Your profile</p>
+          <GovernanceRadar alignments={liveAlignments} size="medium" animate />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function QuickMatchResults({ result }: { result: QuickMatchResult }) {
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* User profile */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col items-center text-center gap-4"
+      >
+        <GovernanceRadar alignments={result.userAlignments} size="full" animate />
+        <div>
+          <Badge
+            variant="outline"
+            className="text-sm px-3 py-1"
+            style={{ borderColor: result.identityColor, color: result.identityColor }}
+          >
+            {result.personalityLabel}
+          </Badge>
+          <p className="text-sm text-muted-foreground mt-2">
+            Your governance values profile
+          </p>
+        </div>
+      </motion.div>
+
+      {/* Matches */}
+      <div className="space-y-3">
+        <h3 className="text-lg font-semibold">Your Top Matches</h3>
+        {result.matches.slice(0, 3).map((match, i) => (
+          <motion.div
+            key={match.drepId}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 * (i + 1) }}
+          >
+            <Link href={`/drep/${encodeURIComponent(match.drepId)}`}>
+              <Card className="hover:border-primary/30 transition-colors cursor-pointer">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <span
+                      className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                      style={{ backgroundColor: match.identityColor }}
+                    >
+                      {i + 1}
+                    </span>
+                    <div>
+                      <p className="font-medium text-sm">
+                        {match.drepName || match.drepId.slice(0, 12) + '...'}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{match.personalityLabel}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        'tabular-nums',
+                        match.matchScore >= 70
+                          ? 'text-green-600 border-green-600/30'
+                          : match.matchScore >= 50
+                            ? 'text-amber-600 border-amber-600/30'
+                            : 'text-muted-foreground',
+                      )}
+                    >
+                      {match.matchScore}% match
+                    </Badge>
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Upsell */}
+      <Card className="border-primary/20 bg-gradient-to-br from-primary/5 to-transparent">
+        <CardContent className="p-6 text-center space-y-3">
+          <Sparkles className="h-6 w-6 text-primary mx-auto" />
+          <h4 className="font-semibold">Want better accuracy?</h4>
+          <p className="text-sm text-muted-foreground">
+            These matches are based on your values. The DNA Quiz votes on real proposals
+            for higher accuracy.
+          </p>
+          <Link href="/discover">
+            <Button className="gap-2">
+              Take the DNA Quiz <ArrowRight className="h-4 w-4" />
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/matching/ConfidenceBar.tsx
+++ b/components/matching/ConfidenceBar.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface ConfidenceBarProps {
+  votesUsed: number;
+  targetVotes?: number;
+  className?: string;
+}
+
+export function ConfidenceBar({ votesUsed, targetVotes = 15, className }: ConfidenceBarProps) {
+  const pct = Math.min(100, Math.round((votesUsed / targetVotes) * 100));
+  const isLow = pct < 50;
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">Match confidence</span>
+        <span className={cn('font-medium tabular-nums', isLow ? 'text-amber-500' : 'text-green-500')}>
+          {votesUsed}/{targetVotes} votes — {pct}%
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500',
+            isLow ? 'bg-amber-500' : 'bg-green-500',
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/matching/GovernanceIdentityCard.tsx
+++ b/components/matching/GovernanceIdentityCard.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import { ConfidenceBar } from './ConfidenceBar';
+import { Dna } from 'lucide-react';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+interface GovernanceIdentityCardProps {
+  personalityLabel: string | null;
+  votesUsed: number;
+  confidence: number;
+  alignmentScores: Record<string, number | null> | null;
+}
+
+export function GovernanceIdentityCard({
+  personalityLabel,
+  votesUsed,
+  confidence,
+  alignmentScores,
+}: GovernanceIdentityCardProps) {
+  if (!alignmentScores || !personalityLabel) return null;
+
+  const scores = alignmentScores as unknown as AlignmentScores;
+  const hasValues = Object.values(scores).some((v) => v !== null);
+  if (!hasValues) return null;
+
+  return (
+    <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-transparent">
+      <CardContent className="p-4">
+        <div className="flex items-center gap-4">
+          <GovernanceRadar alignments={scores} size="mini" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <Dna className="h-3.5 w-3.5 text-primary shrink-0" />
+              <span className="text-xs text-muted-foreground">Your governance identity</span>
+            </div>
+            <div className="flex items-center gap-2 mt-0.5">
+              <Badge variant="outline" className="text-xs">
+                {personalityLabel}
+              </Badge>
+              <span className="text-[10px] text-muted-foreground">
+                {votesUsed} vote{votesUsed !== 1 ? 's' : ''} · {confidence}% confidence
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/matching/MatchCard.tsx
+++ b/components/matching/MatchCard.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+import { RadarOverlay } from './RadarOverlay';
+import { cn } from '@/lib/utils';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+interface MatchCardProps {
+  rank: number;
+  drepId: string;
+  drepName: string | null;
+  matchScore: number;
+  confidence: number;
+  agreed: number;
+  overlapping: number;
+  agreeDimensions?: string[];
+  differDimensions?: string[];
+  userAlignments?: AlignmentScores | null;
+  drepAlignments?: AlignmentScores | null;
+  identityColor?: string;
+  showRadar?: boolean;
+  className?: string;
+}
+
+function getConfidenceLabel(confidence: number): string {
+  if (confidence >= 80) return 'high confidence';
+  if (confidence >= 40) return 'medium confidence';
+  return 'low confidence';
+}
+
+export function MatchCard({
+  rank,
+  drepId,
+  drepName,
+  matchScore,
+  confidence,
+  agreed,
+  overlapping,
+  agreeDimensions,
+  differDimensions,
+  userAlignments,
+  drepAlignments,
+  identityColor,
+  showRadar = true,
+  className,
+}: MatchCardProps) {
+  const displayName = drepName || drepId.slice(0, 12) + '...';
+
+  return (
+    <Card className={cn('overflow-hidden', className)}>
+      <CardContent className="p-4">
+        <div className="flex gap-4">
+          {/* Radar overlay */}
+          {showRadar && userAlignments && drepAlignments && (
+            <div className="hidden sm:block shrink-0">
+              <RadarOverlay
+                userAlignments={userAlignments}
+                drepAlignments={drepAlignments}
+                size={120}
+              />
+            </div>
+          )}
+
+          {/* Info */}
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <span
+                  className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
+                  style={{ backgroundColor: identityColor || 'hsl(var(--primary))' }}
+                >
+                  {rank}
+                </span>
+                <Link
+                  href={`/drep/${encodeURIComponent(drepId)}`}
+                  className="font-medium text-sm hover:text-primary transition-colors truncate"
+                >
+                  {displayName}
+                </Link>
+              </div>
+              <Badge
+                variant="outline"
+                className={cn(
+                  'shrink-0 tabular-nums',
+                  matchScore >= 70
+                    ? 'text-green-600 border-green-600/30'
+                    : matchScore >= 50
+                      ? 'text-amber-600 border-amber-600/30'
+                      : 'text-muted-foreground',
+                )}
+              >
+                {matchScore}% match
+              </Badge>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              {getConfidenceLabel(confidence)} · agreed on {agreed}/{overlapping}
+            </p>
+
+            {/* Dimension agreement */}
+            {(agreeDimensions?.length || differDimensions?.length) && (
+              <p className="text-xs text-muted-foreground">
+                {agreeDimensions?.length ? (
+                  <>
+                    <span className="text-green-600 dark:text-green-400">Agree on: </span>
+                    {agreeDimensions.join(', ')}
+                  </>
+                ) : null}
+                {agreeDimensions?.length && differDimensions?.length ? '. ' : ''}
+                {differDimensions?.length ? (
+                  <>
+                    <span className="text-amber-600 dark:text-amber-400">Differ on: </span>
+                    {differDimensions.join(', ')}
+                  </>
+                ) : null}
+              </p>
+            )}
+
+            <div className="flex gap-2 pt-1">
+              <Link href={`/drep/${encodeURIComponent(drepId)}`}>
+                <Button variant="outline" size="sm" className="text-xs gap-1 h-7">
+                  View Profile <ChevronRight className="h-3 w-3" />
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/matching/RadarOverlay.tsx
+++ b/components/matching/RadarOverlay.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useMemo } from 'react';
+import { alignmentsToArray, getDimensionOrder, getDimensionLabel } from '@/lib/drepIdentity';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import { cn } from '@/lib/utils';
+
+interface RadarOverlayProps {
+  userAlignments: AlignmentScores;
+  drepAlignments: AlignmentScores;
+  size?: number;
+  className?: string;
+}
+
+const PADDING = 20;
+
+function getPolygonPoints(scores: number[], cx: number, cy: number, maxR: number): string {
+  return scores
+    .map((score, i) => {
+      const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+      const r = maxR * (score / 100);
+      return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+    })
+    .join(' ');
+}
+
+export function RadarOverlay({
+  userAlignments,
+  drepAlignments,
+  size = 160,
+  className,
+}: RadarOverlayProps) {
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxR = (size - PADDING * 2) / 2;
+
+  const userScores = useMemo(() => alignmentsToArray(userAlignments), [userAlignments]);
+  const drepScores = useMemo(() => alignmentsToArray(drepAlignments), [drepAlignments]);
+  const dimensions = getDimensionOrder();
+
+  const userPoints = getPolygonPoints(userScores, cx, cy, maxR);
+  const drepPoints = getPolygonPoints(drepScores, cx, cy, maxR);
+
+  // Grid rings
+  const rings = [0.25, 0.5, 0.75, 1];
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className={cn('shrink-0', className)}
+    >
+      {/* Grid */}
+      {rings.map((r) => (
+        <polygon
+          key={r}
+          points={Array.from({ length: 6 }, (_, i) => {
+            const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+            const radius = maxR * r;
+            return `${(cx + radius * Math.cos(angle)).toFixed(1)},${(cy + radius * Math.sin(angle)).toFixed(1)}`;
+          }).join(' ')}
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity={0.08}
+          strokeWidth={0.5}
+        />
+      ))}
+
+      {/* Axis lines */}
+      {dimensions.map((_, i) => {
+        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+        return (
+          <line
+            key={i}
+            x1={cx}
+            y1={cy}
+            x2={cx + maxR * Math.cos(angle)}
+            y2={cy + maxR * Math.sin(angle)}
+            stroke="currentColor"
+            strokeOpacity={0.08}
+            strokeWidth={0.5}
+          />
+        );
+      })}
+
+      {/* DRep shape (background) */}
+      <polygon
+        points={drepPoints}
+        fill="hsl(var(--primary))"
+        fillOpacity={0.1}
+        stroke="hsl(var(--primary))"
+        strokeOpacity={0.4}
+        strokeWidth={1.5}
+      />
+
+      {/* User shape (foreground) */}
+      <polygon
+        points={userPoints}
+        fill="hsl(var(--chart-2))"
+        fillOpacity={0.15}
+        stroke="hsl(var(--chart-2))"
+        strokeOpacity={0.7}
+        strokeWidth={1.5}
+      />
+
+      {/* Dimension labels */}
+      {dimensions.map((dim, i) => {
+        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+        const labelR = maxR + 12;
+        const x = cx + labelR * Math.cos(angle);
+        const y = cy + labelR * Math.sin(angle);
+        return (
+          <text
+            key={dim}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="central"
+            className="fill-muted-foreground"
+            fontSize={7}
+          >
+            {getDimensionLabel(dim).replace('Treasury ', '')}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/lib/matching/confidence.ts
+++ b/lib/matching/confidence.ts
@@ -1,0 +1,11 @@
+/**
+ * Match confidence scoring.
+ * Confidence increases with the number of overlapping votes between user and DRep.
+ * 15 overlapping votes = full confidence.
+ */
+
+const FULL_CONFIDENCE_THRESHOLD = 15;
+
+export function calculateMatchConfidence(overlapCount: number): number {
+  return Math.min(100, Math.round((overlapCount / FULL_CONFIDENCE_THRESHOLD) * 100));
+}

--- a/lib/matching/dimensionAgreement.ts
+++ b/lib/matching/dimensionAgreement.ts
@@ -1,0 +1,100 @@
+/**
+ * Dimension-level agreement between a user's alignment profile and a DRep's alignment scores.
+ * Uses the simplified approach: per-dimension delta = 100 - |userScore - drepScore|.
+ */
+
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+
+const AGREE_THRESHOLD = 70;
+const DIFFER_THRESHOLD = 40;
+
+const DIMENSION_LABELS: Record<AlignmentDimension, string> = {
+  treasuryConservative: 'Treasury Conservative',
+  treasuryGrowth: 'Treasury Growth',
+  decentralization: 'Decentralization',
+  security: 'Security',
+  innovation: 'Innovation',
+  transparency: 'Transparency',
+};
+
+const DIMENSIONS: AlignmentDimension[] = [
+  'treasuryConservative',
+  'treasuryGrowth',
+  'decentralization',
+  'security',
+  'innovation',
+  'transparency',
+];
+
+export interface DimensionAgreementResult {
+  dimensionAgreement: Record<AlignmentDimension, number>;
+  agreeDimensions: string[];
+  differDimensions: string[];
+}
+
+export function computeDimensionAgreement(
+  userScores: AlignmentScores,
+  drepScores: AlignmentScores,
+): DimensionAgreementResult {
+  const dimensionAgreement = {} as Record<AlignmentDimension, number>;
+  const agreeDimensions: string[] = [];
+  const differDimensions: string[] = [];
+
+  for (const dim of DIMENSIONS) {
+    const userVal = userScores[dim] ?? 50;
+    const drepVal = drepScores[dim] ?? 50;
+    const agreement = Math.round(100 - Math.abs(userVal - drepVal));
+    dimensionAgreement[dim] = agreement;
+
+    if (agreement >= AGREE_THRESHOLD) {
+      agreeDimensions.push(DIMENSION_LABELS[dim]);
+    } else if (agreement < DIFFER_THRESHOLD) {
+      differDimensions.push(DIMENSION_LABELS[dim]);
+    }
+  }
+
+  return { dimensionAgreement, agreeDimensions, differDimensions };
+}
+
+/**
+ * Derive a user's approximate alignment scores from their poll votes
+ * and proposal classifications. Used when no stored user profile exists.
+ */
+export function deriveUserAlignments(
+  pollVotes: { proposal_tx_hash: string; proposal_index: number; vote: string }[],
+  classifications: Map<string, Record<AlignmentDimension, number>>,
+): AlignmentScores {
+  const totals = {} as Record<AlignmentDimension, number>;
+  const weights = {} as Record<AlignmentDimension, number>;
+
+  for (const dim of DIMENSIONS) {
+    totals[dim] = 0;
+    weights[dim] = 0;
+  }
+
+  for (const pv of pollVotes) {
+    const key = `${pv.proposal_tx_hash}-${pv.proposal_index}`;
+    const cls = classifications.get(key);
+    if (!cls) continue;
+
+    const voteVal = pv.vote.toLowerCase() === 'yes' ? 1 : pv.vote.toLowerCase() === 'no' ? 0 : 0.5;
+
+    for (const dim of DIMENSIONS) {
+      const relevance = cls[dim];
+      if (relevance <= 0) continue;
+      totals[dim] += voteVal * relevance;
+      weights[dim] += relevance;
+    }
+  }
+
+  const scores = {} as AlignmentScores;
+  for (const dim of DIMENSIONS) {
+    if (weights[dim] > 0) {
+      scores[dim] = Math.round((totals[dim] / weights[dim]) * 100);
+    } else {
+      scores[dim] = null;
+    }
+  }
+
+  return scores;
+}

--- a/lib/matching/userProfile.ts
+++ b/lib/matching/userProfile.ts
@@ -1,0 +1,118 @@
+/**
+ * Progressive user governance profile.
+ * Recomputes the user's PCA position, alignment scores, and personality
+ * after every vote. Lightweight: poll_responses fetch + matrix multiply.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { loadActivePCA } from '@/lib/alignment/pca';
+import { projectUserVector } from '@/lib/representationMatch';
+import { getPersonalityLabel } from '@/lib/drepIdentity';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import { deriveUserAlignments } from './dimensionAgreement';
+import { calculateMatchConfidence } from './confidence';
+
+const DIMENSIONS: AlignmentDimension[] = [
+  'treasuryConservative',
+  'treasuryGrowth',
+  'decentralization',
+  'security',
+  'innovation',
+  'transparency',
+];
+
+export interface UserGovernanceProfile {
+  walletAddress: string;
+  pcaCoordinates: number[] | null;
+  alignmentScores: AlignmentScores;
+  personalityLabel: string;
+  votesUsed: number;
+  confidence: number;
+}
+
+export async function updateUserProfile(walletAddress: string): Promise<UserGovernanceProfile | null> {
+  const supabase = getSupabaseAdmin();
+
+  const { data: pollVotes } = await supabase
+    .from('poll_responses')
+    .select('proposal_tx_hash, proposal_index, vote')
+    .eq('wallet_address', walletAddress);
+
+  if (!pollVotes?.length) return null;
+
+  // Load PCA for projection
+  const pca = await loadActivePCA();
+  let pcaCoordinates: number[] | null = null;
+
+  if (pca) {
+    const userVoteMap = new Map<string, number>();
+    for (const pv of pollVotes) {
+      const key = `${pv.proposal_tx_hash}-${pv.proposal_index}`;
+      const v = pv.vote.toLowerCase();
+      userVoteMap.set(key, v === 'yes' ? 1 : v === 'no' ? -1 : 0);
+    }
+    pcaCoordinates = projectUserVector(userVoteMap, pca.loadings, pca.proposalIds);
+  }
+
+  // Load proposal classifications for alignment derivation
+  const proposalTxHashes = [...new Set(pollVotes.map((v) => v.proposal_tx_hash))];
+  const { data: classifications } = await supabase
+    .from('proposal_classifications')
+    .select(
+      'proposal_tx_hash, proposal_index, dim_treasury_conservative, dim_treasury_growth, dim_decentralization, dim_security, dim_innovation, dim_transparency',
+    )
+    .in('proposal_tx_hash', proposalTxHashes);
+
+  const classMap = new Map<string, Record<AlignmentDimension, number>>();
+  if (classifications) {
+    for (const c of classifications) {
+      const key = `${c.proposal_tx_hash}-${c.proposal_index}`;
+      classMap.set(key, {
+        treasuryConservative: Number(c.dim_treasury_conservative) || 0,
+        treasuryGrowth: Number(c.dim_treasury_growth) || 0,
+        decentralization: Number(c.dim_decentralization) || 0,
+        security: Number(c.dim_security) || 0,
+        innovation: Number(c.dim_innovation) || 0,
+        transparency: Number(c.dim_transparency) || 0,
+      });
+    }
+  }
+
+  const alignmentScores =
+    classMap.size > 0
+      ? deriveUserAlignments(pollVotes, classMap)
+      : ({
+          treasuryConservative: null,
+          treasuryGrowth: null,
+          decentralization: null,
+          security: null,
+          innovation: null,
+          transparency: null,
+        } satisfies AlignmentScores);
+
+  const personalityLabel = getPersonalityLabel(alignmentScores);
+  const confidence = calculateMatchConfidence(pollVotes.length) / 100;
+
+  // Upsert to DB
+  await supabase.from('user_governance_profiles').upsert(
+    {
+      wallet_address: walletAddress,
+      pca_coordinates: pcaCoordinates,
+      alignment_scores: alignmentScores,
+      personality_label: personalityLabel,
+      votes_used: pollVotes.length,
+      confidence,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'wallet_address' },
+  );
+
+  return {
+    walletAddress,
+    pcaCoordinates,
+    alignmentScores,
+    personalityLabel,
+    votesUsed: pollVotes.length,
+    confidence: Math.round(confidence * 100),
+  };
+}

--- a/lib/representationMatch.ts
+++ b/lib/representationMatch.ts
@@ -202,7 +202,7 @@ export async function findBestMatchDReps(
 // PCA-BASED MATCHING (cosine similarity in PCA space)
 // ============================================================================
 
-function cosineSimilarity(a: number[], b: number[]): number {
+export function cosineSimilarity(a: number[], b: number[]): number {
   let dot = 0,
     magA = 0,
     magB = 0;
@@ -219,7 +219,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
  * Project a user's partial vote vector into PCA space using active loadings.
  * userVotes: map of proposalId ("txHash-index") → vote value (+1, -1, 0)
  */
-function projectUserVector(
+export function projectUserVector(
   userVotes: Map<string, number>,
   loadings: number[][],
   proposalIds: string[],

--- a/supabase/migrations/031_user_governance_profiles.sql
+++ b/supabase/migrations/031_user_governance_profiles.sql
@@ -1,0 +1,15 @@
+-- User governance profiles for progressive matching.
+-- Updated after every poll vote and quiz completion.
+
+CREATE TABLE IF NOT EXISTS user_governance_profiles (
+  wallet_address   TEXT PRIMARY KEY,
+  pca_coordinates  REAL[],
+  alignment_scores JSONB,
+  personality_label TEXT,
+  votes_used       INTEGER NOT NULL DEFAULT 0,
+  confidence       REAL NOT NULL DEFAULT 0,
+  updated_at       TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_gov_profiles_updated
+  ON user_governance_profiles (updated_at DESC);


### PR DESCRIPTION
## Summary

Full implementation of the DNA Quiz + Matching UX plan — upgrades matching from flat vote-overlap to PCA cosine similarity with confidence scoring, enriched quiz selection, dimension-level agreement, user governance profiles, Quick Match flow, and rich reveal UX.

### What changed

**Backend (matching engine)**
- `/api/governance/matches` now uses PCA cosine similarity as primary ranking with vote-overlap fallback
- Each match includes confidence score (based on overlap count / 15 target) and dimension-level agreement
- User alignment scores derived from votes + proposal classifications
- New `lib/matching/` module: `confidence.ts`, `dimensionAgreement.ts`, `userProfile.ts`

**Quiz improvements**
- Fixed race condition: last quiz vote is now awaited before fetching matches
- Smart proposal selection: type diversity enforcement (≥3 types) + alignment dimension coverage
- Enriched metadata: discrimination labels, stakes labels, dimension tags in quiz UI

**User governance profiles (Phase 4)**
- Migration 031: `user_governance_profiles` table with PCA coordinates, alignment scores, personality label
- Progressive update: profile recomputes after every poll vote (fire-and-forget from `/api/polls/vote`)
- New `/api/governance/my-profile` route

**Quick Match (Phase 5)**
- New `/match` page: 3-question values quiz, no wallet required
- New `/api/governance/quick-match` API: Euclidean distance matching against DRep alignment scores
- Live radar animation as user answers, results with top 3 matches + DNA Quiz upsell

**Rich reveal UX (Phase 6)**
- Rewritten `GovernanceDNAReveal` with 3 sections: governance identity (radar + personality), top matches (MatchCard with RadarOverlay), improve matches (ConfidenceBar)
- New shared components: `MatchCard`, `RadarOverlay`, `ConfidenceBar`

**Discover integration (Phase 7)**
- Confidence badges on DRep cards (high/med/low)
- Governance identity mini-card at top of Discover page when user has a profile

### New files (11)
- `lib/matching/confidence.ts`, `dimensionAgreement.ts`, `userProfile.ts`
- `app/api/governance/my-profile/route.ts`, `quick-match/route.ts`
- `app/match/page.tsx`, `components/QuickMatch.tsx`
- `components/matching/MatchCard.tsx`, `RadarOverlay.tsx`, `ConfidenceBar.tsx`, `GovernanceIdentityCard.tsx`
- `supabase/migrations/031_user_governance_profiles.sql`

### Modified files (10)
- `app/api/governance/matches/route.ts` — PCA primary path + confidence + dimensions
- `app/api/governance/quiz-proposals/route.ts` — type diversity + dimension coverage
- `components/GovernanceDNAQuiz.tsx` — race condition fix + enriched data passthrough
- `components/GovernanceDNAReveal.tsx` — full rich reveal rewrite
- `app/api/polls/vote/route.ts` — triggers profile update
- `components/HomepageShell.tsx` — identity card + confidence data
- `components/DRepTableClient.tsx`, `DRepCardGrid.tsx`, `DRepCard.tsx` — confidence threading
- `lib/representationMatch.ts` — exported `projectUserVector`, `cosineSimilarity`

## Test plan

- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] All 241 existing tests pass (`vitest run`)
- [ ] Production build succeeds (`next build --webpack`)
- [ ] Apply migration 031 to production via Supabase MCP
- [ ] Verify `/api/governance/matches` returns `matchMethod: 'pca'` when PCA data exists
- [ ] Verify `/api/governance/matches` falls back to `vote_overlap` when no PCA data
- [ ] Test Quick Match flow at `/match` — 3 questions, results with top DReps
- [ ] Test DNA Quiz flow: enriched metadata shows, reveal shows radar + match cards
- [ ] Verify confidence badges appear on DRep cards on Discover page
- [ ] Verify governance identity mini-card appears after quiz completion
