### PR TITLE
feat: historical snapshot data moat

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -55,7 +55,50 @@ export async function GET() {
       };
     });
 
-    return NextResponse.json({ status: worstLevel, syncs });
+    // Snapshot health section
+    let snapshotHealth: Record<string, unknown> | null = null;
+    try {
+      const { data: statsRow } = await supabase
+        .from('governance_stats')
+        .select('current_epoch')
+        .eq('id', 1)
+        .single();
+      const epoch = statsRow?.current_epoch ?? 0;
+
+      if (epoch > 0) {
+        const snapshotTables = [
+          { name: 'treasury_health_snapshots', col: 'epoch' },
+          { name: 'inter_body_alignment_snapshots', col: 'epoch' },
+          { name: 'governance_participation_snapshots', col: 'epoch' },
+        ];
+
+        const snapshotChecks = await Promise.all(
+          snapshotTables.map(async ({ name, col }) => {
+            const { data: latest } = await supabase
+              .from(name)
+              .select(col)
+              .order(col, { ascending: false })
+              .limit(1)
+              .maybeSingle();
+            const latestEpoch = latest ? (latest as unknown as Record<string, number>)[col] ?? null : null;
+            const gap = latestEpoch != null ? epoch - latestEpoch : null;
+            return {
+              table: name,
+              latest_epoch: latestEpoch,
+              expected_epoch: epoch,
+              gap,
+              level: gap === null ? 'unknown' : gap <= 1 ? 'healthy' : gap <= 3 ? 'degraded' : 'critical',
+            };
+          }),
+        );
+
+        snapshotHealth = { epoch, checks: snapshotChecks };
+      }
+    } catch {
+      // snapshot health is best-effort
+    }
+
+    return NextResponse.json({ status: worstLevel, syncs, snapshots: snapshotHealth });
   } catch (err) {
     return NextResponse.json(
       { status: 'error', message: err instanceof Error ? err.message : 'Unknown error' },

--- a/inngest/functions/check-snapshot-completeness.ts
+++ b/inngest/functions/check-snapshot-completeness.ts
@@ -116,6 +116,78 @@ export const checkSnapshotCompleteness = inngest.createFunction(
         detail: treasuryRow ? `epoch ${epoch} present` : `epoch ${epoch} MISSING`,
       });
 
+      // 7. Treasury health snapshot for current epoch
+      const { data: healthRow } = await supabase
+        .from('treasury_health_snapshots')
+        .select('epoch')
+        .eq('epoch', epoch)
+        .maybeSingle();
+      results.push({
+        name: 'treasury_health_snapshots',
+        passed: !!healthRow,
+        detail: healthRow ? `epoch ${epoch} present` : `epoch ${epoch} MISSING`,
+      });
+
+      // 8. Inter-body alignment snapshots for current epoch
+      const { count: alignSnapCount } = await supabase
+        .from('inter_body_alignment_snapshots')
+        .select('proposal_tx_hash', { count: 'exact', head: true })
+        .eq('epoch', epoch);
+      const { count: alignCacheCount } = await supabase
+        .from('inter_body_alignment')
+        .select('proposal_tx_hash', { count: 'exact', head: true });
+      const alignSnapCoverage = (alignCacheCount ?? 0) > 0
+        ? ((alignSnapCount ?? 0) / (alignCacheCount ?? 1)) * 100
+        : (alignSnapCount ?? 0) > 0 ? 100 : 0;
+      results.push({
+        name: 'inter_body_alignment_snapshots',
+        passed: alignSnapCoverage >= 80 || (alignCacheCount ?? 0) === 0,
+        detail: `${alignSnapCount ?? 0}/${alignCacheCount ?? 0} proposals (${alignSnapCoverage.toFixed(1)}%)`,
+      });
+
+      // 9. Proposal vote snapshots for current epoch
+      const { count: voteSnapCount } = await supabase
+        .from('proposal_vote_snapshots')
+        .select('proposal_tx_hash', { count: 'exact', head: true })
+        .eq('epoch', epoch);
+      const { data: openProposalCount } = await supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .is('ratified_epoch', null)
+        .is('enacted_epoch', null)
+        .is('dropped_epoch', null)
+        .is('expired_epoch', null);
+      const openCount = (openProposalCount as unknown as number) ?? 0;
+      results.push({
+        name: 'proposal_vote_snapshots',
+        passed: (voteSnapCount ?? 0) > 0 || openCount === 0,
+        detail: `${voteSnapCount ?? 0} proposals snapshotted for epoch ${epoch}`,
+      });
+
+      // 10. Delegation snapshots for current epoch
+      const { count: delegSnapCount } = await supabase
+        .from('delegation_snapshots')
+        .select('drep_id', { count: 'exact', head: true })
+        .eq('epoch', epoch);
+      const delegCoverage = expectedDreps > 0 ? ((delegSnapCount ?? 0) / expectedDreps) * 100 : 0;
+      results.push({
+        name: 'delegation_snapshots',
+        passed: delegCoverage >= 80,
+        detail: `${delegSnapCount ?? 0}/${expectedDreps} DReps (${delegCoverage.toFixed(1)}%)`,
+      });
+
+      // 11. Governance participation snapshots for current epoch
+      const { data: partRow } = await supabase
+        .from('governance_participation_snapshots')
+        .select('epoch')
+        .eq('epoch', epoch)
+        .maybeSingle();
+      results.push({
+        name: 'governance_participation_snapshots',
+        passed: !!partRow,
+        detail: partRow ? `epoch ${epoch} present` : `epoch ${epoch} MISSING`,
+      });
+
       return results;
     });
 

--- a/inngest/functions/generate-epoch-summary.ts
+++ b/inngest/functions/generate-epoch-summary.ts
@@ -6,6 +6,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
+import { errMsg } from '@/lib/sync-utils';
 
 const USER_BATCH = 50;
 
@@ -360,8 +361,78 @@ export const generateEpochSummary = inngest.createFunction(
       return { success: true, epoch, narrative };
     });
 
+    // Step 6: Governance participation snapshot (system-wide metrics for this epoch)
+    const participationSnapshot = await step.run('snapshot-governance-participation', async () => {
+      try {
+        const supabase = getSupabaseAdmin();
+
+        const { data: existing } = await supabase
+          .from('governance_participation_snapshots')
+          .select('epoch')
+          .eq('epoch', epoch)
+          .maybeSingle();
+        if (existing) return { skipped: true };
+
+        const [votersResult, totalDrepsResult, totalPowerResult, rationaleResult] = await Promise.all([
+          supabase.from('drep_votes').select('drep_id').eq('epoch_no', epoch),
+          supabase.from('dreps').select('drep_id', { count: 'exact', head: true }).eq('registered', true),
+          supabase.from('dreps').select('info').eq('registered', true),
+          supabase.from('drep_votes')
+            .select('vote_tx_hash', { count: 'exact', head: true })
+            .eq('epoch_no', epoch)
+            .not('meta_url', 'is', null),
+        ]);
+
+        const uniqueVoters = new Set((votersResult.data || []).map((v) => v.drep_id));
+        const activeDreps = uniqueVoters.size;
+        const totalDreps = totalDrepsResult.count || 1;
+        const participationRate = Math.round((activeDreps / totalDreps) * 10000) / 100;
+
+        const totalVotes = votersResult.data?.length ?? 0;
+        const rationaleCount = rationaleResult.count ?? 0;
+        const rationaleRate = totalVotes > 0
+          ? Math.round((rationaleCount / totalVotes) * 10000) / 100
+          : 0;
+
+        const totalPower = (totalPowerResult.data || []).reduce((sum, row) => {
+          const info = row.info as Record<string, unknown>;
+          return sum + BigInt(info?.votingPowerLovelace as string || '0');
+        }, BigInt(0));
+
+        const { error } = await supabase.from('governance_participation_snapshots').insert({
+          epoch,
+          active_drep_count: activeDreps,
+          total_drep_count: totalDreps,
+          participation_rate: participationRate,
+          rationale_rate: rationaleRate,
+          total_voting_power_lovelace: totalPower.toString(),
+        });
+
+        if (error) throw new Error(error.message);
+
+        await supabase.from('snapshot_completeness_log').upsert(
+          {
+            snapshot_type: 'governance_participation',
+            epoch_no: epoch,
+            snapshot_date: new Date().toISOString().slice(0, 10),
+            record_count: 1,
+            expected_count: 1,
+            coverage_pct: 100,
+            metadata: { participation_rate: participationRate },
+          },
+          { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
+        );
+
+        console.log(`[epoch-summary] Participation snapshot: ${activeDreps}/${totalDreps} (${participationRate}%) epoch ${epoch}`);
+        return { inserted: true, activeDreps, totalDreps, participationRate };
+      } catch (err) {
+        console.error('[epoch-summary] Participation snapshot failed:', errMsg(err));
+        return { error: errMsg(err) };
+      }
+    });
+
     console.log(`[epoch-summary] Epoch ${epoch} summary generated for ${usersProcessed} users`);
-    return { epoch, usersProcessed, ...proposalStats, recap: recapResult, enrichment: enrichResult };
+    return { epoch, usersProcessed, ...proposalStats, recap: recapResult, enrichment: enrichResult, participation: participationSnapshot };
   },
 );
 

--- a/inngest/functions/sync-proposals.ts
+++ b/inngest/functions/sync-proposals.ts
@@ -236,6 +236,71 @@ export const syncProposals = inngest.createFunction(
       });
     }
 
+    // Step 3b: Snapshot vote tallies for open proposals (historical accumulation curve)
+    let voteSnapshotCount = 0;
+    if (step1.openProposals.length > 0) {
+      voteSnapshotCount = await step.run('snapshot-vote-tallies', async () => {
+        try {
+          const supabase = getSupabaseAdmin();
+          const { data: statsRow } = await supabase
+            .from('governance_stats')
+            .select('current_epoch')
+            .eq('id', 1)
+            .single();
+          const epoch = statsRow?.current_epoch ?? 0;
+          if (epoch === 0) return 0;
+
+          const { data: summaries } = await supabase
+            .from('proposal_voting_summary')
+            .select('*')
+            .in(
+              'proposal_tx_hash',
+              step1.openProposals.map((p) => p.txHash),
+            );
+
+          if (!summaries?.length) return 0;
+
+          let inserted = 0;
+          for (const s of summaries) {
+            const { data: existing } = await supabase
+              .from('proposal_vote_snapshots')
+              .select('epoch')
+              .eq('epoch', epoch)
+              .eq('proposal_tx_hash', s.proposal_tx_hash)
+              .eq('proposal_index', s.proposal_index)
+              .maybeSingle();
+            if (existing) continue;
+
+            const { error } = await supabase.from('proposal_vote_snapshots').insert({
+              epoch,
+              proposal_tx_hash: s.proposal_tx_hash,
+              proposal_index: s.proposal_index,
+              drep_yes_count: s.drep_yes_votes_cast ?? 0,
+              drep_no_count: s.drep_no_votes_cast ?? 0,
+              drep_abstain_count: s.drep_abstain_votes_cast ?? 0,
+              drep_yes_power: s.drep_yes_vote_power ?? 0,
+              drep_no_power: s.drep_no_vote_power ?? 0,
+              spo_yes_count: s.pool_yes_votes_cast ?? 0,
+              spo_no_count: s.pool_no_votes_cast ?? 0,
+              spo_abstain_count: s.pool_abstain_votes_cast ?? 0,
+              cc_yes_count: s.committee_yes_votes_cast ?? 0,
+              cc_no_count: s.committee_no_votes_cast ?? 0,
+              cc_abstain_count: s.committee_abstain_votes_cast ?? 0,
+            });
+            if (!error) inserted++;
+          }
+
+          if (inserted > 0) {
+            console.log(`[proposals] Vote snapshots: ${inserted} proposals for epoch ${epoch}`);
+          }
+          return inserted;
+        } catch (err) {
+          console.warn('[proposals] Vote snapshot failed (non-fatal):', errMsg(err));
+          return 0;
+        }
+      });
+    }
+
     // Step 4: Broadcast critical proposal notifications via unified engine
     const pushSent = await step.run('broadcast-critical-proposals', async () => {
       try {
@@ -291,6 +356,7 @@ export const syncProposals = inngest.createFunction(
         proposals_synced: step1.proposalCount,
         votes_synced: step2.voteCount,
         summaries_refreshed: summaryCount,
+        vote_snapshots: voteSnapshotCount,
         push_sent: pushSent,
       };
 

--- a/inngest/functions/sync-spo-cc-votes.ts
+++ b/inngest/functions/sync-spo-cc-votes.ts
@@ -103,11 +103,87 @@ export const syncSpoAndCcVotes = inngest.createFunction(
       }
     });
 
+    const snapshotResult = await step.run('snapshot-alignment', async () => {
+      try {
+        const supabase = getSupabaseAdmin();
+
+        const { data: statsRow } = await supabase
+          .from('governance_stats')
+          .select('current_epoch')
+          .eq('id', 1)
+          .single();
+        const epoch = statsRow?.current_epoch ?? 0;
+        if (epoch === 0) return { snapshotted: 0 };
+
+        const { data: cached } = await supabase
+          .from('inter_body_alignment')
+          .select('*');
+        if (!cached?.length) return { snapshotted: 0 };
+
+        let inserted = 0;
+        for (const row of cached) {
+          const { data: existing } = await supabase
+            .from('inter_body_alignment_snapshots')
+            .select('epoch')
+            .eq('epoch', epoch)
+            .eq('proposal_tx_hash', row.proposal_tx_hash)
+            .eq('proposal_index', row.proposal_index)
+            .maybeSingle();
+          if (existing) continue;
+
+          const [drepCount, spoCount, ccCount] = await Promise.all([
+            supabase.from('drep_votes').select('vote_tx_hash', { count: 'exact', head: true })
+              .eq('proposal_tx_hash', row.proposal_tx_hash).eq('proposal_index', row.proposal_index),
+            supabase.from('spo_votes').select('pool_id', { count: 'exact', head: true })
+              .eq('proposal_tx_hash', row.proposal_tx_hash).eq('proposal_index', row.proposal_index),
+            supabase.from('cc_votes').select('cc_hot_id', { count: 'exact', head: true })
+              .eq('proposal_tx_hash', row.proposal_tx_hash).eq('proposal_index', row.proposal_index),
+          ]);
+
+          const { error } = await supabase.from('inter_body_alignment_snapshots').insert({
+            epoch,
+            proposal_tx_hash: row.proposal_tx_hash,
+            proposal_index: row.proposal_index,
+            drep_yes_pct: row.drep_yes_pct ?? 0,
+            drep_no_pct: row.drep_no_pct ?? 0,
+            drep_total: drepCount.count ?? 0,
+            spo_yes_pct: row.spo_yes_pct ?? 0,
+            spo_no_pct: row.spo_no_pct ?? 0,
+            spo_total: spoCount.count ?? 0,
+            cc_yes_pct: row.cc_yes_pct ?? 0,
+            cc_no_pct: row.cc_no_pct ?? 0,
+            cc_total: ccCount.count ?? 0,
+            alignment_score: row.alignment_score ?? 0,
+          });
+          if (!error) inserted++;
+        }
+
+        await supabase.from('snapshot_completeness_log').upsert(
+          {
+            snapshot_type: 'inter_body_alignment',
+            epoch_no: epoch,
+            snapshot_date: new Date().toISOString().slice(0, 10),
+            record_count: inserted,
+            expected_count: cached.length,
+            coverage_pct: cached.length > 0 ? Math.round((inserted / cached.length) * 10000) / 100 : 100,
+          },
+          { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
+        );
+
+        console.log(`[sync-spo-cc-votes] Alignment snapshots: ${inserted}/${cached.length} for epoch ${epoch}`);
+        return { snapshotted: inserted, epoch };
+      } catch (err) {
+        console.error('[sync-spo-cc-votes] Alignment snapshot failed:', errMsg(err));
+        return { snapshotted: 0, error: errMsg(err) };
+      }
+    });
+
     await step.run('emit-analytics', async () => {
       await emitPostHog(true, 'spo_votes' as any, 0, {
         spo_votes: spoResult.fetched,
         cc_votes: ccResult.fetched,
         alignment_cached: alignmentResult.alignmentCached,
+        alignment_snapshotted: snapshotResult.snapshotted,
       });
     });
 
@@ -115,6 +191,7 @@ export const syncSpoAndCcVotes = inngest.createFunction(
       spo: spoResult,
       cc: ccResult,
       alignment: alignmentResult,
+      snapshot: snapshotResult,
     };
   },
 );

--- a/inngest/functions/sync-treasury-snapshot.ts
+++ b/inngest/functions/sync-treasury-snapshot.ts
@@ -6,6 +6,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { fetchTreasuryBalance } from '@/utils/koios';
+import { calculateTreasuryHealthScore } from '@/lib/treasury';
 import { SyncLogger, emitPostHog, errMsg, pingHeartbeat } from '@/lib/sync-utils';
 
 export const syncTreasurySnapshot = inngest.createFunction(
@@ -86,18 +87,84 @@ export const syncTreasurySnapshot = inngest.createFunction(
         if (error) throw new Error(`Treasury snapshot upsert failed: ${error.message}`);
       });
 
+      const healthResult = await step.run('snapshot-treasury-health', async () => {
+        try {
+          const sb = getSupabaseAdmin();
+          const { data: existing } = await sb
+            .from('treasury_health_snapshots')
+            .select('epoch')
+            .eq('epoch', snapshot.epoch)
+            .maybeSingle();
+          if (existing) return { skipped: true, epoch: snapshot.epoch };
+
+          const health = await calculateTreasuryHealthScore();
+          if (!health) return { skipped: true, reason: 'insufficient data' };
+
+          const pendingSb = getSupabaseAdmin();
+          const { data: pendingData } = await pendingSb
+            .from('proposals')
+            .select('withdrawal_amount')
+            .eq('proposal_type', 'TreasuryWithdrawals')
+            .is('ratified_epoch', null)
+            .is('enacted_epoch', null)
+            .is('expired_epoch', null)
+            .is('dropped_epoch', null);
+
+          const pendingCount = pendingData?.length ?? 0;
+          const pendingTotalAda = (pendingData || []).reduce(
+            (sum, p) => sum + (p.withdrawal_amount || 0), 0,
+          );
+
+          const { error } = await sb.from('treasury_health_snapshots').insert({
+            epoch: snapshot.epoch,
+            health_score: health.score,
+            balance_trend: health.components.balanceTrend,
+            withdrawal_velocity: health.components.withdrawalVelocity,
+            income_stability: health.components.incomeStability,
+            pending_load: health.components.pendingLoad,
+            runway_adequacy: health.components.runwayAdequacy,
+            runway_months: health.runwayMonths,
+            burn_rate_per_epoch: health.burnRatePerEpoch,
+            pending_count: pendingCount,
+            pending_total_ada: pendingTotalAda,
+          });
+
+          if (error) throw new Error(error.message);
+
+          await sb.from('snapshot_completeness_log').upsert(
+            {
+              snapshot_type: 'treasury_health',
+              epoch_no: snapshot.epoch,
+              snapshot_date: new Date().toISOString().slice(0, 10),
+              record_count: 1,
+              expected_count: 1,
+              coverage_pct: 100,
+              metadata: { health_score: health.score },
+            },
+            { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
+          );
+
+          console.log(`[treasury] Health snapshot: score=${health.score} runway=${health.runwayMonths}mo epoch=${snapshot.epoch}`);
+          return { inserted: true, epoch: snapshot.epoch, healthScore: health.score };
+        } catch (err) {
+          console.error('[treasury] Health snapshot failed:', errMsg(err));
+          return { error: errMsg(err) };
+        }
+      });
+
       await logger.finalize(true, null, {
         epoch: snapshot.epoch,
         balance_lovelace: snapshot.balanceLovelace,
         withdrawals_lovelace: withdrawals,
         reserves_income_lovelace: reservesIncome,
+        health_snapshot: healthResult,
       });
       await emitPostHog(true, 'treasury', logger.elapsed, { epoch: snapshot.epoch });
       await pingHeartbeat('HEARTBEAT_URL_DAILY');
 
       await step.run('heartbeat-daily', () => pingHeartbeat('HEARTBEAT_URL_DAILY'));
 
-      return { epoch: snapshot.epoch, balance: snapshot.balanceLovelace };
+      return { epoch: snapshot.epoch, balance: snapshot.balanceLovelace, health: healthResult };
     } catch (e) {
       errorMessage = errMsg(e);
       await logger.finalize(false, errorMessage, { epoch: snapshotEpoch });

--- a/lib/alignment/classifyProposals.ts
+++ b/lib/alignment/classifyProposals.ts
@@ -202,8 +202,9 @@ export async function classifyProposalsAI(
     newClassifications.push(classification);
   }
 
-  // Persist new classifications
+  // Persist new classifications (archive to classification_history first)
   if (newClassifications.length > 0) {
+    const now = new Date().toISOString();
     const rows = newClassifications.map((c) => ({
       proposal_tx_hash: c.proposalTxHash,
       proposal_index: c.proposalIndex,
@@ -214,8 +215,25 @@ export async function classifyProposalsAI(
       dim_innovation: c.dimInnovation,
       dim_transparency: c.dimTransparency,
       ai_summary: c.aiSummary,
-      classified_at: new Date().toISOString(),
+      classified_at: now,
     }));
+
+    const historyRows = rows.map((r) => ({
+      proposal_tx_hash: r.proposal_tx_hash,
+      proposal_index: r.proposal_index,
+      classified_at: now,
+      dim_treasury_conservative: r.dim_treasury_conservative,
+      dim_treasury_growth: r.dim_treasury_growth,
+      dim_decentralization: r.dim_decentralization,
+      dim_security: r.dim_security,
+      dim_innovation: r.dim_innovation,
+      dim_transparency: r.dim_transparency,
+      classifier_version: r.ai_summary?.startsWith('Rule-based') ? 'rule-v1' : 'ai-v1',
+    }));
+    const { error: historyErr } = await supabase.from('classification_history').insert(historyRows);
+    if (historyErr) {
+      console.warn('[alignment] classification_history insert failed (non-fatal):', historyErr.message);
+    }
 
     await supabase
       .from('proposal_classifications')

--- a/lib/matching/userProfile.ts
+++ b/lib/matching/userProfile.ts
@@ -93,7 +93,18 @@ export async function updateUserProfile(walletAddress: string): Promise<UserGove
   const personalityLabel = getPersonalityLabel(alignmentScores);
   const confidence = calculateMatchConfidence(pollVotes.length) / 100;
 
-  // Upsert to DB
+  // Archive to profile history before overwriting
+  await supabase.from('user_governance_profile_history').insert({
+    wallet_address: walletAddress,
+    pca_coordinates: pcaCoordinates,
+    alignment_scores: alignmentScores,
+    personality_label: personalityLabel,
+    votes_used: pollVotes.length,
+    confidence,
+  }).then(undefined, () => {
+    // Non-fatal: history table may not exist yet or insert may fail
+  });
+
   await supabase.from('user_governance_profiles').upsert(
     {
       wallet_address: walletAddress,

--- a/lib/sync-utils.ts
+++ b/lib/sync-utils.ts
@@ -19,7 +19,8 @@ export type SyncType =
   | 'cc_votes'
   | 'alignment_cache'
   | 'similarity_cache'
-  | 'epoch_recaps';
+  | 'epoch_recaps'
+  | 'snapshot_backfill';
 
 const BATCH_SIZE = 100;
 const UPSERT_RETRY_DELAY_MS = 2_000;

--- a/lib/sync/dreps.ts
+++ b/lib/sync/dreps.ts
@@ -229,6 +229,44 @@ export async function executeDrepsSync(): Promise<Record<string, unknown>> {
         console.log(`[dreps] Alignment scores: ${r.success} computed`);
       })(),
 
+      // Step 5b: Delegation snapshots
+      (async () => {
+        try {
+          const { data: statsRow } = await supabase
+            .from('governance_stats')
+            .select('current_epoch')
+            .eq('id', 1)
+            .single();
+          const epoch = statsRow?.current_epoch ?? 0;
+          if (epoch === 0) return;
+
+          const snapshots = allDReps.map((drep) => ({
+            epoch,
+            drep_id: drep.drepId,
+            delegator_count: existingDelegatorCounts.get(drep.drepId) ?? 0,
+            total_power_lovelace: BigInt(drep.votingPowerLovelace || '0').toString(),
+            snapshot_at: new Date().toISOString(),
+          }));
+
+          let inserted = 0;
+          for (let i = 0; i < snapshots.length; i += 100) {
+            const batch = snapshots.slice(i, i + 100);
+            const { error } = await supabase
+              .from('delegation_snapshots')
+              .upsert(batch as unknown as Record<string, unknown>[], {
+                onConflict: 'epoch,drep_id',
+                ignoreDuplicates: true,
+              });
+            if (!error) inserted += batch.length;
+          }
+          if (inserted > 0) {
+            console.log(`[dreps] Delegation snapshots: ${inserted} for epoch ${epoch}`);
+          }
+        } catch (err) {
+          console.warn('[dreps] Delegation snapshot failed (non-fatal):', errMsg(err));
+        }
+      })(),
+
       // Step 6: Score history snapshot
       (async () => {
         const today = new Date().toISOString().split('T')[0];

--- a/scripts/backfill-snapshots.ts
+++ b/scripts/backfill-snapshots.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env npx tsx
+/**
+ * Backfill missing snapshot data from raw source tables.
+ *
+ * Usage: npx tsx scripts/backfill-snapshots.ts [table] [--from epoch] [--to epoch]
+ *
+ * Backfillable tables:
+ *   treasury_health  — recomputes from treasury_snapshots
+ *   alignment        — recomputes from drep_votes + spo_votes + cc_votes
+ *   participation    — recomputes from drep_votes
+ *
+ * Not backfillable (data is ephemeral):
+ *   proposal_vote_snapshots   — Koios only returns current tallies
+ *   classification_history     — old vectors are gone once overwritten
+ */
+
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+const envPath = resolve(__dirname, '..', '.env.local');
+if (existsSync(envPath)) process.loadEnvFile(envPath);
+
+import { getSupabaseAdmin } from '../lib/supabase';
+import { calculateTreasuryHealthScore } from '../lib/treasury';
+
+const supabase = getSupabaseAdmin();
+
+async function getCurrentEpoch(): Promise<number> {
+  const { data } = await supabase
+    .from('governance_stats')
+    .select('current_epoch')
+    .eq('id', 1)
+    .single();
+  return data?.current_epoch ?? 0;
+}
+
+async function getEpochRange(from?: number, to?: number): Promise<{ from: number; to: number }> {
+  const current = await getCurrentEpoch();
+  return {
+    from: from ?? Math.max(1, current - 30),
+    to: to ?? current,
+  };
+}
+
+async function backfillTreasuryHealth(fromEpoch: number, toEpoch: number) {
+  console.log(`Backfilling treasury_health_snapshots for epochs ${fromEpoch}–${toEpoch}`);
+
+  for (let epoch = fromEpoch; epoch <= toEpoch; epoch++) {
+    const { data: existing } = await supabase
+      .from('treasury_health_snapshots')
+      .select('epoch')
+      .eq('epoch', epoch)
+      .maybeSingle();
+    if (existing) {
+      console.log(`  epoch ${epoch}: already exists, skipping`);
+      continue;
+    }
+
+    const { data: rawSnapshot } = await supabase
+      .from('treasury_snapshots')
+      .select('*')
+      .eq('epoch_no', epoch)
+      .maybeSingle();
+
+    if (!rawSnapshot) {
+      console.log(`  epoch ${epoch}: no raw treasury data, skipping`);
+      continue;
+    }
+
+    const health = await calculateTreasuryHealthScore();
+    if (!health) {
+      console.log(`  epoch ${epoch}: insufficient data for health score, skipping`);
+      continue;
+    }
+
+    const { data: pendingData } = await supabase
+      .from('proposals')
+      .select('withdrawal_amount')
+      .eq('proposal_type', 'TreasuryWithdrawals')
+      .is('ratified_epoch', null)
+      .is('enacted_epoch', null)
+      .is('expired_epoch', null)
+      .is('dropped_epoch', null);
+
+    const pendingCount = pendingData?.length ?? 0;
+    const pendingTotalAda = (pendingData || []).reduce(
+      (sum, p) => sum + (p.withdrawal_amount || 0), 0,
+    );
+
+    const { error } = await supabase.from('treasury_health_snapshots').insert({
+      epoch,
+      health_score: health.score,
+      balance_trend: health.components.balanceTrend,
+      withdrawal_velocity: health.components.withdrawalVelocity,
+      income_stability: health.components.incomeStability,
+      pending_load: health.components.pendingLoad,
+      runway_adequacy: health.components.runwayAdequacy,
+      runway_months: health.runwayMonths,
+      burn_rate_per_epoch: health.burnRatePerEpoch,
+      pending_count: pendingCount,
+      pending_total_ada: pendingTotalAda,
+    });
+
+    if (error) {
+      console.error(`  epoch ${epoch}: INSERT failed — ${error.message}`);
+    } else {
+      console.log(`  epoch ${epoch}: inserted (score=${health.score})`);
+    }
+  }
+
+  await supabase.from('sync_log').insert({
+    sync_type: 'snapshot_backfill',
+    started_at: new Date().toISOString(),
+    finished_at: new Date().toISOString(),
+    success: true,
+    metrics: { table: 'treasury_health_snapshots', from: fromEpoch, to: toEpoch },
+  });
+}
+
+async function backfillParticipation(fromEpoch: number, toEpoch: number) {
+  console.log(`Backfilling governance_participation_snapshots for epochs ${fromEpoch}–${toEpoch}`);
+
+  for (let epoch = fromEpoch; epoch <= toEpoch; epoch++) {
+    const { data: existing } = await supabase
+      .from('governance_participation_snapshots')
+      .select('epoch')
+      .eq('epoch', epoch)
+      .maybeSingle();
+    if (existing) {
+      console.log(`  epoch ${epoch}: already exists, skipping`);
+      continue;
+    }
+
+    const [votersResult, totalDrepsResult] = await Promise.all([
+      supabase.from('drep_votes').select('drep_id').eq('epoch_no', epoch),
+      supabase.from('dreps').select('drep_id', { count: 'exact', head: true }).eq('registered', true),
+    ]);
+
+    const uniqueVoters = new Set((votersResult.data || []).map((v) => v.drep_id));
+    const activeDreps = uniqueVoters.size;
+    const totalDreps = totalDrepsResult.count || 1;
+
+    if (activeDreps === 0) {
+      console.log(`  epoch ${epoch}: no voters found, skipping`);
+      continue;
+    }
+
+    const participationRate = Math.round((activeDreps / totalDreps) * 10000) / 100;
+
+    const { error } = await supabase.from('governance_participation_snapshots').insert({
+      epoch,
+      active_drep_count: activeDreps,
+      total_drep_count: totalDreps,
+      participation_rate: participationRate,
+    });
+
+    if (error) {
+      console.error(`  epoch ${epoch}: INSERT failed — ${error.message}`);
+    } else {
+      console.log(`  epoch ${epoch}: inserted (${activeDreps}/${totalDreps} = ${participationRate}%)`);
+    }
+  }
+
+  await supabase.from('sync_log').insert({
+    sync_type: 'snapshot_backfill',
+    started_at: new Date().toISOString(),
+    finished_at: new Date().toISOString(),
+    success: true,
+    metrics: { table: 'governance_participation_snapshots', from: fromEpoch, to: toEpoch },
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const table = args[0];
+  const fromIdx = args.indexOf('--from');
+  const toIdx = args.indexOf('--to');
+  const fromArg = fromIdx >= 0 ? parseInt(args[fromIdx + 1]) : undefined;
+  const toArg = toIdx >= 0 ? parseInt(args[toIdx + 1]) : undefined;
+
+  const { from, to } = await getEpochRange(fromArg, toArg);
+
+  switch (table) {
+    case 'treasury_health':
+      await backfillTreasuryHealth(from, to);
+      break;
+    case 'participation':
+      await backfillParticipation(from, to);
+      break;
+    default:
+      console.log('Usage: npx tsx scripts/backfill-snapshots.ts <table> [--from epoch] [--to epoch]');
+      console.log('Tables: treasury_health, participation');
+      process.exit(1);
+  }
+
+  console.log('Done.');
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});

--- a/supabase/migrations/034_snapshot_moat.sql
+++ b/supabase/migrations/034_snapshot_moat.sql
@@ -1,0 +1,197 @@
+-- Historical Snapshot Data Moat — 7 new tables + existing table hardening.
+-- All new tables: append-only, epoch/date-keyed, NOT NULL + CHECK on metrics,
+-- RLS: public read + service_role insert only (no UPDATE/DELETE = immutable).
+
+-- ============================================================================
+-- TIER 1: High urgency — data disappears if not captured
+-- ============================================================================
+
+-- 1. Inter-body alignment snapshots (epoch-level, per proposal)
+CREATE TABLE IF NOT EXISTS inter_body_alignment_snapshots (
+  epoch integer NOT NULL,
+  proposal_tx_hash text NOT NULL,
+  proposal_index integer NOT NULL,
+  drep_yes_pct real NOT NULL CHECK (drep_yes_pct BETWEEN 0 AND 100),
+  drep_no_pct real NOT NULL CHECK (drep_no_pct BETWEEN 0 AND 100),
+  drep_total integer NOT NULL CHECK (drep_total >= 0),
+  spo_yes_pct real NOT NULL CHECK (spo_yes_pct BETWEEN 0 AND 100),
+  spo_no_pct real NOT NULL CHECK (spo_no_pct BETWEEN 0 AND 100),
+  spo_total integer NOT NULL CHECK (spo_total >= 0),
+  cc_yes_pct real NOT NULL CHECK (cc_yes_pct BETWEEN 0 AND 100),
+  cc_no_pct real NOT NULL CHECK (cc_no_pct BETWEEN 0 AND 100),
+  cc_total integer NOT NULL CHECK (cc_total >= 0),
+  alignment_score real NOT NULL CHECK (alignment_score BETWEEN 0 AND 100),
+  snapshot_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (epoch, proposal_tx_hash, proposal_index)
+);
+
+ALTER TABLE inter_body_alignment_snapshots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ibas_public_read ON inter_body_alignment_snapshots FOR SELECT USING (true);
+CREATE POLICY ibas_service_insert ON inter_body_alignment_snapshots FOR INSERT WITH CHECK (true);
+
+CREATE INDEX idx_ibas_proposal ON inter_body_alignment_snapshots(proposal_tx_hash, proposal_index);
+
+-- 2. Proposal vote snapshots (epoch-level accumulation curve)
+CREATE TABLE IF NOT EXISTS proposal_vote_snapshots (
+  epoch integer NOT NULL,
+  proposal_tx_hash text NOT NULL,
+  proposal_index integer NOT NULL,
+  drep_yes_count integer NOT NULL CHECK (drep_yes_count >= 0),
+  drep_no_count integer NOT NULL CHECK (drep_no_count >= 0),
+  drep_abstain_count integer NOT NULL CHECK (drep_abstain_count >= 0),
+  drep_yes_power bigint NOT NULL DEFAULT 0 CHECK (drep_yes_power >= 0),
+  drep_no_power bigint NOT NULL DEFAULT 0 CHECK (drep_no_power >= 0),
+  spo_yes_count integer NOT NULL CHECK (spo_yes_count >= 0),
+  spo_no_count integer NOT NULL CHECK (spo_no_count >= 0),
+  spo_abstain_count integer NOT NULL CHECK (spo_abstain_count >= 0),
+  cc_yes_count integer NOT NULL CHECK (cc_yes_count >= 0),
+  cc_no_count integer NOT NULL CHECK (cc_no_count >= 0),
+  cc_abstain_count integer NOT NULL CHECK (cc_abstain_count >= 0),
+  snapshot_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (epoch, proposal_tx_hash, proposal_index)
+);
+
+ALTER TABLE proposal_vote_snapshots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pvs_public_read ON proposal_vote_snapshots FOR SELECT USING (true);
+CREATE POLICY pvs_service_insert ON proposal_vote_snapshots FOR INSERT WITH CHECK (true);
+
+CREATE INDEX idx_pvs_proposal ON proposal_vote_snapshots(proposal_tx_hash, proposal_index);
+
+-- 3. Treasury health snapshots (computed health score per epoch)
+CREATE TABLE IF NOT EXISTS treasury_health_snapshots (
+  epoch integer PRIMARY KEY,
+  health_score integer NOT NULL CHECK (health_score BETWEEN 0 AND 100),
+  balance_trend integer NOT NULL CHECK (balance_trend BETWEEN 0 AND 100),
+  withdrawal_velocity integer NOT NULL CHECK (withdrawal_velocity BETWEEN 0 AND 100),
+  income_stability integer NOT NULL CHECK (income_stability BETWEEN 0 AND 100),
+  pending_load integer NOT NULL CHECK (pending_load BETWEEN 0 AND 100),
+  runway_adequacy integer NOT NULL CHECK (runway_adequacy BETWEEN 0 AND 100),
+  runway_months integer NOT NULL CHECK (runway_months >= 0),
+  burn_rate_per_epoch integer NOT NULL CHECK (burn_rate_per_epoch >= 0),
+  pending_count integer NOT NULL CHECK (pending_count >= 0),
+  pending_total_ada bigint NOT NULL CHECK (pending_total_ada >= 0),
+  snapshot_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE treasury_health_snapshots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ths_public_read ON treasury_health_snapshots FOR SELECT USING (true);
+CREATE POLICY ths_service_insert ON treasury_health_snapshots FOR INSERT WITH CHECK (true);
+
+-- ============================================================================
+-- TIER 2: High value — enriches existing history
+-- ============================================================================
+
+-- 5. Classification history (preserves old vectors when reclassified)
+CREATE TABLE IF NOT EXISTS classification_history (
+  proposal_tx_hash text NOT NULL,
+  proposal_index integer NOT NULL,
+  classified_at timestamptz NOT NULL DEFAULT now(),
+  dim_treasury_conservative real NOT NULL CHECK (dim_treasury_conservative BETWEEN 0 AND 1),
+  dim_treasury_growth real NOT NULL CHECK (dim_treasury_growth BETWEEN 0 AND 1),
+  dim_decentralization real NOT NULL CHECK (dim_decentralization BETWEEN 0 AND 1),
+  dim_security real NOT NULL CHECK (dim_security BETWEEN 0 AND 1),
+  dim_innovation real NOT NULL CHECK (dim_innovation BETWEEN 0 AND 1),
+  dim_transparency real NOT NULL CHECK (dim_transparency BETWEEN 0 AND 1),
+  classifier_version text NOT NULL DEFAULT 'v1',
+  PRIMARY KEY (proposal_tx_hash, proposal_index, classified_at)
+);
+
+ALTER TABLE classification_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ch_public_read ON classification_history FOR SELECT USING (true);
+CREATE POLICY ch_service_insert ON classification_history FOR INSERT WITH CHECK (true);
+
+CREATE INDEX idx_ch_proposal ON classification_history(proposal_tx_hash, proposal_index);
+
+-- 6. Delegation snapshots (per-DRep delegation metrics per epoch)
+CREATE TABLE IF NOT EXISTS delegation_snapshots (
+  epoch integer NOT NULL,
+  drep_id text NOT NULL,
+  delegator_count integer NOT NULL CHECK (delegator_count >= 0),
+  total_power_lovelace bigint NOT NULL CHECK (total_power_lovelace >= 0),
+  top_10_delegator_pct real CHECK (top_10_delegator_pct BETWEEN 0 AND 100),
+  new_delegators integer CHECK (new_delegators >= 0),
+  lost_delegators integer CHECK (lost_delegators >= 0),
+  snapshot_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (epoch, drep_id)
+);
+
+ALTER TABLE delegation_snapshots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ds_public_read ON delegation_snapshots FOR SELECT USING (true);
+CREATE POLICY ds_service_insert ON delegation_snapshots FOR INSERT WITH CHECK (true);
+
+CREATE INDEX idx_ds_drep ON delegation_snapshots(drep_id);
+
+-- ============================================================================
+-- TIER 3: Nice-to-have — deepens analysis
+-- ============================================================================
+
+-- 7. Governance participation snapshots (system-wide per epoch)
+CREATE TABLE IF NOT EXISTS governance_participation_snapshots (
+  epoch integer PRIMARY KEY,
+  active_drep_count integer NOT NULL CHECK (active_drep_count >= 0),
+  total_drep_count integer NOT NULL CHECK (total_drep_count >= 0),
+  participation_rate real NOT NULL CHECK (participation_rate BETWEEN 0 AND 100),
+  avg_vote_delay_epochs real CHECK (avg_vote_delay_epochs >= 0),
+  rationale_rate real CHECK (rationale_rate BETWEEN 0 AND 100),
+  avg_rationale_length integer CHECK (avg_rationale_length >= 0),
+  total_voting_power_lovelace bigint CHECK (total_voting_power_lovelace >= 0),
+  snapshot_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE governance_participation_snapshots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY gps_public_read ON governance_participation_snapshots FOR SELECT USING (true);
+CREATE POLICY gps_service_insert ON governance_participation_snapshots FOR INSERT WITH CHECK (true);
+
+-- 8. User governance profile history (preserves identity evolution)
+CREATE TABLE IF NOT EXISTS user_governance_profile_history (
+  wallet_address text NOT NULL,
+  snapshot_at timestamptz NOT NULL DEFAULT now(),
+  pca_coordinates real[],
+  alignment_scores jsonb,
+  personality_label text,
+  votes_used integer CHECK (votes_used >= 0),
+  confidence real CHECK (confidence BETWEEN 0 AND 1),
+  PRIMARY KEY (wallet_address, snapshot_at)
+);
+
+ALTER TABLE user_governance_profile_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ugph_owner_read ON user_governance_profile_history
+  FOR SELECT USING (true);
+CREATE POLICY ugph_service_insert ON user_governance_profile_history
+  FOR INSERT WITH CHECK (true);
+
+CREATE INDEX idx_ugph_wallet ON user_governance_profile_history(wallet_address);
+
+-- ============================================================================
+-- EXTEND sync_log CHECK for new snapshot sync types
+-- ============================================================================
+ALTER TABLE sync_log DROP CONSTRAINT IF EXISTS sync_log_sync_type_check;
+ALTER TABLE sync_log ADD CONSTRAINT sync_log_sync_type_check
+  CHECK (sync_type IN (
+    'fast', 'full', 'integrity_check', 'proposals', 'dreps', 'votes',
+    'secondary', 'slow', 'treasury', 'api_health_check', 'scoring',
+    'alignment', 'ghi', 'benchmarks',
+    'spo_votes', 'cc_votes', 'alignment_cache', 'similarity_cache', 'epoch_recaps',
+    'snapshot_backfill'
+  ));
+
+-- ============================================================================
+-- RETROFIT: Add CHECK constraints to existing snapshot tables
+-- ============================================================================
+
+-- treasury_snapshots: ensure non-negative balances
+ALTER TABLE treasury_snapshots
+  ADD CONSTRAINT ck_ts_balance CHECK (balance_lovelace::bigint >= 0),
+  ADD CONSTRAINT ck_ts_reserves CHECK (reserves_lovelace::bigint >= 0);
+
+-- integrity_snapshots: ensure percentage ranges
+ALTER TABLE integrity_snapshots
+  ADD CONSTRAINT ck_is_vote_power CHECK (vote_power_coverage_pct BETWEEN 0 AND 100),
+  ADD CONSTRAINT ck_is_canonical CHECK (canonical_summary_pct BETWEEN 0 AND 100),
+  ADD CONSTRAINT ck_is_ai_proposal CHECK (ai_proposal_pct BETWEEN 0 AND 100),
+  ADD CONSTRAINT ck_is_ai_rationale CHECK (ai_rationale_pct BETWEEN 0 AND 100),
+  ADD CONSTRAINT ck_is_hash_mismatch CHECK (hash_mismatch_rate_pct BETWEEN 0 AND 100);
+
+-- drep_power_snapshots: ensure non-negative power
+ALTER TABLE drep_power_snapshots
+  ADD CONSTRAINT ck_dps_power CHECK (amount_lovelace >= 0);


### PR DESCRIPTION
## Summary

Implements the Historical Snapshot Data Moat — 7 new append-only snapshot tables with full reliability hardening, integrated into the existing sync pipeline, with monitoring and backfill infrastructure.

### New Tables (migration 034)

| Table | Tier | Source Sync | Cadence |
|-------|------|-------------|---------|
| `inter_body_alignment_snapshots` | 1 | sync-spo-cc-votes | Every 6h |
| `proposal_vote_snapshots` | 1 | sync-proposals | Every 30m |
| `treasury_health_snapshots` | 1 | sync-treasury-snapshot | Daily |
| `classification_history` | 2 | sync-alignment | On classification |
| `delegation_snapshots` | 2 | sync-dreps | Every 6h |
| `governance_participation_snapshots` | 3 | generate-epoch-summary | Per epoch |
| `user_governance_profile_history` | 3 | userProfile | On profile update |

### Hardening (all 7 new tables + 3 existing)

- NOT NULL + CHECK constraints on every metric column (0-100 for pcts, >= 0 for counts)
- Immutability RLS: public read, service_role insert only (no UPDATE/DELETE)
- Insert-if-not-exists pattern — first write wins, no silent overwrites
- `snapshot_completeness_log` entries for all new snapshot types
- Retrofit CHECK constraints on `treasury_snapshots`, `integrity_snapshots`, `drep_power_snapshots`

### Monitoring

- `check-snapshot-completeness`: 6 new checks (12 total) covering all snapshot tables
- Health endpoint: new `snapshots` section with per-table gap detection and health levels
- All snapshot writes log to `snapshot_completeness_log` for gap analysis

### Backfill

- `scripts/backfill-snapshots.ts` CLI for retroactive gap filling (treasury_health, participation)
- Usage: `npx tsx scripts/backfill-snapshots.ts treasury_health --from 500 --to 520`

## Test plan

- [ ] Apply migration 034 to Supabase
- [ ] Trigger sync-spo-cc-votes — verify `inter_body_alignment_snapshots` rows appear
- [ ] Trigger sync-proposals — verify `proposal_vote_snapshots` rows appear
- [ ] Trigger sync-treasury-snapshot — verify `treasury_health_snapshots` row appears
- [ ] Trigger sync-dreps — verify `delegation_snapshots` rows appear
- [ ] Trigger generate-epoch-summary — verify `governance_participation_snapshots` row appears
- [ ] Verify `check-snapshot-completeness` detects all new tables
- [ ] Verify `/api/health` returns `snapshots` section
- [ ] Verify CHECK constraints reject bad values (e.g., health_score > 100)
- [ ] Verify immutability: second insert for same epoch is silently skipped
