### PR TITLE
fix: alignment sync — 3 compounding bugs causing 8 consecutive failures

### DIFF
--- a/inngest/functions/sync-alignment.ts
+++ b/inngest/functions/sync-alignment.ts
@@ -2,9 +2,11 @@
  * Dedicated alignment sync function — runs after sync-dreps completes.
  *
  * Split into multiple Inngest steps to avoid step-level timeouts:
+ *   0. init-sync-log — memoized SyncLogger entry (prevents ghost rows)
  *   1. classify-proposals — AI classification (cached, writes to DB)
  *   2. score-rationales — AI rationale scoring (cached, writes to DB)
  *   3. compute-and-persist — dimension scores, normalization, PCA, snapshots
+ *   4. finalize-sync-log — update sync_log with result
  */
 
 import { inngest } from '@/lib/inngest';
@@ -23,8 +25,44 @@ import { scoreRationalesBatch } from '@/lib/alignment/rationaleQuality';
 import { normalizeToPercentiles, type RawScoreRow } from '@/lib/alignment/normalize';
 import { computePCA, storePCAResults } from '@/lib/alignment/pca';
 import { validateDimensionIndependence } from '@/lib/alignment/validate';
-import { batchUpsert, SyncLogger, errMsg, emitPostHog } from '@/lib/sync-utils';
+import { batchUpsert, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import type { ProposalInfo } from '@/types/koios';
+
+/**
+ * Map a DB proposals row to the ProposalInfo shape the alignment pipeline expects.
+ * The DB uses different column names than the Koios API response.
+ */
+function mapDBProposal(row: Record<string, unknown>): ProposalInfo {
+  const withdrawalAmount = row.withdrawal_amount as string | null;
+  return {
+    proposal_tx_hash: row.tx_hash as string,
+    proposal_index: row.proposal_index as number,
+    proposal_id: (row.proposal_id as string) || '',
+    proposal_type: row.proposal_type as ProposalInfo['proposal_type'],
+    proposal_description: null,
+    deposit: '0',
+    return_address: '',
+    proposed_epoch: (row.proposed_epoch as number) || 0,
+    ratified_epoch: (row.ratified_epoch as number) || null,
+    enacted_epoch: (row.enacted_epoch as number) || null,
+    dropped_epoch: (row.dropped_epoch as number) || null,
+    expired_epoch: (row.expired_epoch as number) || null,
+    expiration: (row.expiration_epoch as number) || null,
+    meta_url: null,
+    meta_hash: null,
+    meta_json: (row.meta_json as ProposalInfo['meta_json']) || null,
+    meta_comment: null,
+    meta_is_valid: null,
+    withdrawal: withdrawalAmount
+      ? [{ stake_address: '', amount: String(withdrawalAmount) }]
+      : null,
+    param_proposal: (row.param_changes as Record<string, unknown>) || null,
+    block_time: (row.block_time as number) || 0,
+  };
+}
+
+const DB_PROPOSAL_COLUMNS =
+  'tx_hash, proposal_index, proposal_id, proposal_type, meta_json, withdrawal_amount, param_changes, proposed_epoch, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch, expiration_epoch, block_time';
 
 export const syncAlignment = inngest.createFunction(
   {
@@ -34,26 +72,52 @@ export const syncAlignment = inngest.createFunction(
   },
   [{ event: 'drepscore/sync.alignment' }, { cron: '0 3 * * *' }],
   async ({ step }) => {
-    const supabase = getSupabaseAdmin();
-    const logger = new SyncLogger(supabase, 'alignment');
-    await logger.start();
+    const startTime = Date.now();
+
+    // Step 0: Memoized sync_log entry (runs once, prevents ghost rows on replay)
+    const logId = await step.run('init-sync-log', async () => {
+      const sb = getSupabaseAdmin();
+      const { data } = await sb
+        .from('sync_log')
+        .insert({
+          sync_type: 'alignment',
+          started_at: new Date().toISOString(),
+          success: false,
+        })
+        .select('id')
+        .single();
+      return data?.id ?? null;
+    });
 
     // Step 1: AI-classify proposals (slow — isolated to avoid timeout)
     const classifyResult = await step.run('classify-proposals', async () => {
       const sb = getSupabaseAdmin();
-      const { data: rawProposals } = await sb.from('proposals').select('*');
+      const { data: dbRows } = await sb.from('proposals').select(DB_PROPOSAL_COLUMNS);
 
-      if (!rawProposals?.length) {
+      if (!dbRows?.length) {
         return { classified: 0, skipped: true };
       }
 
-      const proposals = rawProposals as unknown as ProposalInfo[];
+      const proposals = dbRows.map(mapDBProposal);
       const classifications = await classifyProposalsAI(proposals);
       return { classified: classifications.length, skipped: false };
     });
 
     if (classifyResult.skipped) {
-      await logger.finalize(true, null, { skipped: true, reason: 'no proposals' });
+      await step.run('finalize-skipped', async () => {
+        if (!logId) return;
+        const sb = getSupabaseAdmin();
+        await sb
+          .from('sync_log')
+          .update({
+            finished_at: new Date().toISOString(),
+            duration_ms: Date.now() - startTime,
+            success: true,
+            error_message: 'skipped: no proposals',
+            metrics: { skipped: true, reason: 'no proposals' },
+          })
+          .eq('id', logId);
+      });
       return { success: true, skipped: true };
     }
 
@@ -62,8 +126,8 @@ export const syncAlignment = inngest.createFunction(
       const sb = getSupabaseAdmin();
       const { data: voteRows } = await sb
         .from('drep_votes')
-        .select('drep_id, proposal_tx_hash, proposal_index, rationale_text, rationale_quality')
-        .not('rationale_text', 'is', null)
+        .select('drep_id, proposal_tx_hash, proposal_index, meta_url, rationale_quality')
+        .not('meta_url', 'is', null)
         .is('rationale_quality', null);
 
       if (!voteRows?.length) return { scored: 0 };
@@ -72,7 +136,7 @@ export const syncAlignment = inngest.createFunction(
         drepId: v.drep_id,
         proposalTxHash: v.proposal_tx_hash,
         proposalIndex: v.proposal_index,
-        rationaleText: v.rationale_text,
+        rationaleText: v.meta_url,
       }));
 
       const scores = await scoreRationalesBatch(forScoring);
@@ -86,27 +150,25 @@ export const syncAlignment = inngest.createFunction(
 
       try {
         const s1 = Date.now();
-        const [
-          { data: rawProposals },
-          { data: drepRows },
-          { data: voteRows },
-          { data: classRows },
-        ] = await Promise.all([
-          sb.from('proposals').select('*'),
-          sb.from('dreps').select('id, info, score, participation_rate, rationale_rate, size_tier'),
-          sb
-            .from('drep_votes')
-            .select(
-              'drep_id, proposal_tx_hash, proposal_index, vote, block_time, meta_url, rationale_text, rationale_quality',
+        const [{ data: dbRows }, { data: drepRows }, { data: voteRows }, { data: classRows }] =
+          await Promise.all([
+            sb.from('proposals').select(DB_PROPOSAL_COLUMNS),
+            sb.from('dreps').select(
+              'id, info, score, participation_rate, rationale_rate, size_tier',
             ),
-          sb.from('proposal_classifications').select('*'),
-        ]);
+            sb
+              .from('drep_votes')
+              .select(
+                'drep_id, proposal_tx_hash, proposal_index, vote, block_time, meta_url, rationale_quality',
+              ),
+            sb.from('proposal_classifications').select('*'),
+          ]);
 
-        if (!rawProposals?.length || !drepRows?.length || !voteRows?.length) {
+        if (!dbRows?.length || !drepRows?.length || !voteRows?.length) {
           return { success: true, skipped: true, reason: 'insufficient data' };
         }
 
-        const proposals = rawProposals as unknown as ProposalInfo[];
+        const proposals = dbRows.map(mapDBProposal);
         phaseTiming.load_ms = Date.now() - s1;
 
         // Build classification map from DB
@@ -121,7 +183,7 @@ export const syncAlignment = inngest.createFunction(
             dimSecurity: c.dim_security,
             dimInnovation: c.dim_innovation,
             dimTransparency: c.dim_transparency,
-            aiSummary: c.reasoning ?? null,
+            aiSummary: c.ai_summary ?? null,
           });
         }
 
@@ -132,7 +194,13 @@ export const syncAlignment = inngest.createFunction(
           proposalTypeMap.set(key, p.proposal_type);
           const amount =
             p.withdrawal?.reduce(
-              (sum, w) => sum + Number(BigInt(w.amount || '0') / BigInt(1_000_000)),
+              (sum, w) => {
+                try {
+                  return sum + Number(BigInt(w.amount || '0') / BigInt(1_000_000));
+                } catch {
+                  return sum;
+                }
+              },
               0,
             ) ?? null;
           proposalAmountMap.set(key, amount);
@@ -156,7 +224,7 @@ export const syncAlignment = inngest.createFunction(
             return {
               vote: v.vote as 'Yes' | 'No' | 'Abstain',
               blockTime: v.block_time,
-              hasRationale: !!(v.meta_url || v.rationale_text),
+              hasRationale: !!v.meta_url,
               rationaleQuality: v.rationale_quality ?? null,
               proposalType: proposalTypeMap.get(key) || 'InfoAction',
               withdrawalAmountAda: proposalAmountMap.get(key) ?? null,
@@ -201,7 +269,13 @@ export const syncAlignment = inngest.createFunction(
           type: p.proposal_type,
           withdrawalAmountAda:
             p.withdrawal?.reduce(
-              (sum, w) => sum + Number(BigInt(w.amount || '0') / BigInt(1_000_000)),
+              (sum, w) => {
+                try {
+                  return sum + Number(BigInt(w.amount || '0') / BigInt(1_000_000));
+                } catch {
+                  return sum;
+                }
+              },
               0,
             ) ?? null,
         }));
@@ -325,21 +399,35 @@ export const syncAlignment = inngest.createFunction(
       }
     });
 
+    // Step 4: Finalize sync_log (memoized step ensures it only runs once)
     const skipped = 'skipped' in computeResult && computeResult.skipped;
     const success = computeResult.success && !skipped;
-    await logger.finalize(
-      success,
-      skipped
-        ? 'skipped: ' + (('reason' in computeResult && computeResult.reason) || 'unknown')
-        : null,
-      {
-        ...computeResult,
-        rationalesScored: rationaleResult.scored,
-        proposalsClassified: classifyResult.classified,
-      },
-    );
-    await emitPostHog(success, 'alignment', logger.elapsed, computeResult);
 
+    await step.run('finalize-sync-log', async () => {
+      if (!logId) return;
+      const sb = getSupabaseAdmin();
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          duration_ms: Date.now() - startTime,
+          success,
+          error_message: skipped
+            ? capMsg(
+                'skipped: ' +
+                  (('reason' in computeResult && computeResult.reason) || 'unknown'),
+              )
+            : null,
+          metrics: {
+            ...computeResult,
+            rationalesScored: rationaleResult.scored,
+            proposalsClassified: classifyResult.classified,
+          },
+        })
+        .eq('id', logId);
+    });
+
+    await emitPostHog(success, 'alignment', Date.now() - startTime, computeResult);
     console.log('[alignment] Sync complete:', JSON.stringify(computeResult, null, 2));
     return computeResult;
   },

--- a/lib/alignment/classifyProposals.ts
+++ b/lib/alignment/classifyProposals.ts
@@ -39,9 +39,17 @@ function buildClassifyPrompt(proposal: ProposalInfo): string {
   const motivation = proposal.meta_json?.body?.motivation || proposal.meta_json?.motivation || '';
   const type = proposal.proposal_type;
 
-  const withdrawalInfo = proposal.withdrawal?.length
-    ? `Withdrawal amount: ${proposal.withdrawal.reduce((sum, w) => sum + BigInt(w.amount || '0'), BigInt(0)) / BigInt(1_000_000)} ADA`
-    : '';
+  let withdrawalInfo = '';
+  if (proposal.withdrawal?.length) {
+    try {
+      const total =
+        proposal.withdrawal.reduce((sum, w) => sum + BigInt(w.amount || '0'), BigInt(0)) /
+        BigInt(1_000_000);
+      withdrawalInfo = `Withdrawal amount: ${total} ADA`;
+    } catch {
+      withdrawalInfo = 'Withdrawal amount: unknown';
+    }
+  }
 
   const paramInfo = proposal.param_proposal
     ? `Parameter changes: ${JSON.stringify(proposal.param_proposal).slice(0, 500)}`
@@ -167,19 +175,18 @@ export async function classifyProposalsAI(
     (p) => !existingMap.has(`${p.proposal_tx_hash}-${p.proposal_index}`),
   );
 
-  // Classify new proposals
+  // Classify new proposals in parallel batches to avoid step timeouts
   const newClassifications: ProposalClassification[] = [];
+  const AI_CONCURRENCY = 10;
 
-  for (const proposal of unclassified) {
-    let classification: ProposalClassification;
-
+  async function classifyOne(proposal: ProposalInfo): Promise<ProposalClassification> {
     const aiResult = await generateJSON<AIClassificationResponse>(buildClassifyPrompt(proposal), {
       system: CLASSIFY_SYSTEM,
       maxTokens: 256,
     });
 
     if (aiResult) {
-      classification = {
+      return {
         proposalTxHash: proposal.proposal_tx_hash,
         proposalIndex: proposal.proposal_index,
         dimTreasuryConservative: clamp01(aiResult.treasury_conservative),
@@ -190,16 +197,24 @@ export async function classifyProposalsAI(
         dimTransparency: clamp01(aiResult.transparency),
         aiSummary: aiResult.summary?.slice(0, 500) || null,
       };
-    } else {
-      const fallback = ruleBasedClassify(proposal);
-      classification = {
-        proposalTxHash: proposal.proposal_tx_hash,
-        proposalIndex: proposal.proposal_index,
-        ...fallback,
-      };
     }
 
-    newClassifications.push(classification);
+    const fallback = ruleBasedClassify(proposal);
+    return {
+      proposalTxHash: proposal.proposal_tx_hash,
+      proposalIndex: proposal.proposal_index,
+      ...fallback,
+    };
+  }
+
+  for (let i = 0; i < unclassified.length; i += AI_CONCURRENCY) {
+    const batch = unclassified.slice(i, i + AI_CONCURRENCY);
+    const results = await Promise.allSettled(batch.map(classifyOne));
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        newClassifications.push(result.value);
+      }
+    }
   }
 
   // Persist new classifications (archive to classification_history first)


### PR DESCRIPTION
## Summary

Fixes the alignment sync which has never succeeded (0/8 runs, all failures). Three compounding bugs were causing it:

1. **DB/Koios column mismatch**: `select('*')` on `proposals` table was cast to `ProposalInfo` (Koios type), but DB uses different column names (`tx_hash` vs `proposal_tx_hash`, `withdrawal_amount` vs `withdrawal` array, `param_changes` vs `param_proposal`). All classification writes silently failed with `proposal_tx_hash: undefined`.

2. **Missing `rationale_text` column**: `drep_votes` table has `rationale_quality` but not `rationale_text`. Steps 2 and 3 queried this non-existent column, causing Supabase to return null data and Step 3 to always early-return with "insufficient data".

3. **Sequential AI calls timeout**: 89 proposals x ~2-5s per Anthropic call = 200-450s total, exceeding Inngest step timeout. Replaced with batched parallel execution (10 concurrent).

Additionally fixed:
- SyncLogger ghost entries: moved `logger.start()` into a memoized Inngest step
- `c.reasoning` -> `c.ai_summary` column reference
- BigInt safety for withdrawal amount parsing

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `vitest run` — 255/255 tests pass
- [ ] After deploy, verify alignment sync completes via Inngest dashboard
- [ ] Verify `proposal_classifications` table gets populated
- [ ] Verify `alignment_snapshots` table gets populated
