### PR TITLE
feat: backend hardening phase 2 — API handler generalization and input validation

### DIFF
--- a/__tests__/api/polls.test.ts
+++ b/__tests__/api/polls.test.ts
@@ -8,7 +8,10 @@ const mockEq = vi.fn();
 const mockSingle = vi.fn();
 const mockLimit = vi.fn();
 
+const mockRequireAuth = vi.fn();
+
 vi.mock('@/lib/supabaseAuth', () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
   validateSessionToken: vi.fn(),
 }));
 
@@ -46,8 +49,29 @@ vi.mock('@/lib/supabase', () => ({
   }),
 }));
 
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/api/response', () => ({
+  generateRequestId: () => 'req_test',
+  normalizeEndpoint: (p: string) => p.replace(/^\/api/, ''),
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  captureServerEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/koios', () => ({
+  blockTimeToEpoch: () => 500,
+}));
+
+vi.mock('@/lib/matching/userProfile', () => ({
+  updateUserProfile: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { NextResponse } from 'next/server';
 import { POST } from '@/app/api/polls/vote/route';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 
 describe('POST /api/polls/vote', () => {
   beforeEach(() => {
@@ -55,7 +79,9 @@ describe('POST /api/polls/vote', () => {
   });
 
   it('returns 401 without auth token', async () => {
-    vi.mocked(validateSessionToken).mockResolvedValue(null);
+    mockRequireAuth.mockResolvedValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
     const req = createRequest('/api/polls/vote', {
       method: 'POST',
       body: { proposalTxHash: 'abc', proposalIndex: 0, vote: 'yes' },
@@ -65,7 +91,7 @@ describe('POST /api/polls/vote', () => {
   });
 
   it('returns 400 when proposalTxHash is missing', async () => {
-    vi.mocked(validateSessionToken).mockResolvedValue({ walletAddress: 'addr1...' } as any);
+    mockRequireAuth.mockResolvedValue({ wallet: 'addr1test' });
     const req = createRequest('/api/polls/vote', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' },
@@ -76,7 +102,7 @@ describe('POST /api/polls/vote', () => {
   });
 
   it('returns 400 when vote is invalid', async () => {
-    vi.mocked(validateSessionToken).mockResolvedValue({ walletAddress: 'addr1...' } as any);
+    mockRequireAuth.mockResolvedValue({ wallet: 'addr1test' });
     const req = createRequest('/api/polls/vote', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' },
@@ -87,7 +113,7 @@ describe('POST /api/polls/vote', () => {
   });
 
   it('inserts a new vote for first-time voter', async () => {
-    vi.mocked(validateSessionToken).mockResolvedValue({ walletAddress: 'addr1test' } as any);
+    mockRequireAuth.mockResolvedValue({ wallet: 'addr1test' });
     mockSingle.mockResolvedValue({ data: null, error: null });
     mockInsert.mockResolvedValue({ error: null });
     mockSelect.mockReturnValue({

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
-export async function POST() {
+export const POST = withRouteHandler(async () => {
   const response = NextResponse.json({ ok: true });
 
   response.cookies.set('drepscore_session', '', {
@@ -12,4 +13,4 @@ export async function POST() {
   });
 
   return response;
-}
+});

--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -5,25 +5,21 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { verifyNonce } from '@/lib/nonce';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { ZodError } from 'zod';
+import { WalletAuthSchema } from '@/lib/api/schemas/auth';
 
 export const runtime = 'nodejs';
 
-interface AuthRequest {
-  address: string;
-  nonce: string;
-  nonceSignature: string;
-  signature: string;
-  key: string;
-}
-
 export async function POST(request: NextRequest) {
   try {
-    const body: AuthRequest = await request.json();
-    const { address, nonce, nonceSignature, signature, key } = body;
-
-    if (!address || !nonce || !nonceSignature || !signature || !key) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    let body;
+    try {
+      body = WalletAuthSchema.parse(await request.json());
+    } catch (e) {
+      if (e instanceof ZodError) return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+      throw e;
     }
+    const { address, nonce, nonceSignature, signature, key } = body;
 
     const nonceValid = await verifyNonce(nonce, nonceSignature);
     if (!nonceValid) {

--- a/app/api/briefs/generate/route.ts
+++ b/app/api/briefs/generate/route.ts
@@ -12,24 +12,13 @@ import {
 } from '@/lib/governanceBrief';
 import { notifyUser } from '@/lib/notifications';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const session = await validateSessionToken(authHeader.slice(7));
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const wallet = session.walletAddress;
+export const POST = withRouteHandler(async (request: NextRequest, ctx: RouteContext) => {
+  const wallet = ctx.wallet!;
   const supabase = getSupabaseAdmin();
 
   const { data: user } = await supabase
@@ -44,47 +33,42 @@ export async function POST(request: NextRequest) {
 
   const isDRep = !!user.claimed_drep_id;
 
-  try {
-    let brief;
-    if (isDRep) {
-      const ctx = await assembleDRepBriefContext(user.claimed_drep_id!, wallet);
-      if (!ctx)
-        return NextResponse.json({ error: 'Could not assemble DRep context' }, { status: 500 });
-      brief = generateDRepBrief(ctx);
-      await storeBrief(wallet, 'drep', brief, ctx.epoch);
-    } else {
-      const history = user.delegation_history as Array<{ drepId: string }> | null;
-      const currentDrep = history?.length ? history[history.length - 1].drepId : null;
-      const ctx = await assembleHolderBriefContext(wallet, currentDrep);
-      brief = generateHolderBrief(ctx);
-      await storeBrief(wallet, 'holder', brief, ctx.epoch);
-    }
-
-    await notifyUser(wallet, {
-      eventType: 'governance-brief',
-      fallback: {
-        title: 'Your Weekly Governance Brief',
-        body: brief.greeting,
-        url: '/dashboard',
-      },
-      data: {
-        briefType: isDRep ? 'drep' : 'holder',
-        greeting: brief.greeting,
-        sections: brief.sections,
-        ctaText: brief.ctaText,
-        ctaUrl: brief.ctaUrl,
-      },
-    });
-
-    captureServerEvent(
-      'brief_generation_requested',
-      { wallet_address: wallet, brief_type: isDRep ? 'drep' : 'holder' },
-      wallet,
-    );
-
-    return NextResponse.json({ ok: true, brief });
-  } catch (err) {
-    logger.error('Error', { context: 'briefgenerate', error: err });
-    return NextResponse.json({ error: 'Generation failed' }, { status: 500 });
+  let brief;
+  if (isDRep) {
+    const briefCtx = await assembleDRepBriefContext(user.claimed_drep_id!, wallet);
+    if (!briefCtx)
+      return NextResponse.json({ error: 'Could not assemble DRep context' }, { status: 500 });
+    brief = generateDRepBrief(briefCtx);
+    await storeBrief(wallet, 'drep', brief, briefCtx.epoch);
+  } else {
+    const history = user.delegation_history as Array<{ drepId: string }> | null;
+    const currentDrep = history?.length ? history[history.length - 1].drepId : null;
+    const briefCtx = await assembleHolderBriefContext(wallet, currentDrep);
+    brief = generateHolderBrief(briefCtx);
+    await storeBrief(wallet, 'holder', brief, briefCtx.epoch);
   }
-}
+
+  await notifyUser(wallet, {
+    eventType: 'governance-brief',
+    fallback: {
+      title: 'Your Weekly Governance Brief',
+      body: brief.greeting,
+      url: '/dashboard',
+    },
+    data: {
+      briefType: isDRep ? 'drep' : 'holder',
+      greeting: brief.greeting,
+      sections: brief.sections,
+      ctaText: brief.ctaText,
+      ctaUrl: brief.ctaUrl,
+    },
+  });
+
+  captureServerEvent(
+    'brief_generation_requested',
+    { wallet_address: wallet, brief_type: isDRep ? 'drep' : 'holder' },
+    wallet,
+  );
+
+  return NextResponse.json({ ok: true, brief });
+}, { auth: 'required', rateLimit: { max: 5, window: 60 } });

--- a/app/api/briefs/latest/route.ts
+++ b/app/api/briefs/latest/route.ts
@@ -5,22 +5,12 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getLatestBrief } from '@/lib/governanceBrief';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const session = await validateSessionToken(authHeader.slice(7));
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const brief = await getLatestBrief(session.walletAddress);
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const brief = await getLatestBrief(wallet!);
 
   if (!brief) {
     return NextResponse.json({ brief: null, message: 'No briefs yet' });
@@ -32,8 +22,8 @@ export async function GET(request: NextRequest) {
       brief_id: brief.id,
       source: 'api',
     },
-    session.walletAddress,
+    wallet!,
   );
 
   return NextResponse.json({ brief });
-}
+}, { auth: 'required' });

--- a/app/api/dashboard/inbox/route.ts
+++ b/app/api/dashboard/inbox/route.ts
@@ -15,18 +15,17 @@ import { calculateParticipationRate, applyRationaleCurve } from '@/utils/scoring
 import { getProposalPriority } from '@/utils/proposalPriority';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { getTreasuryBalance } from '@/lib/treasury';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
+export const GET = withRouteHandler(async (request: NextRequest, context: RouteContext) => {
   const drepId = request.nextUrl.searchParams.get('drepId');
   if (!drepId) {
     return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
   }
 
-  try {
-    const [drep, pendingProposals, totalProposalCount] = await Promise.all([
+  const [drep, pendingProposals, totalProposalCount] = await Promise.all([
       getDRepById(drepId),
       getOpenProposalsForDRep(drepId),
       getActualProposalCount(),
@@ -134,22 +133,18 @@ export async function GET(request: NextRequest) {
       drepId,
     );
 
-    return NextResponse.json({
-      pendingProposals: enriched,
-      pendingCount: enriched.length,
-      votedThisEpoch: votedThisEpochCount,
-      currentEpoch,
-      scoreImpact: {
-        currentScore: drep.drepScore,
-        simulatedScore: Math.min(100, drep.drepScore + scoreImpact),
-        potentialGain: Math.max(0, scoreImpact),
-        perProposalGain: perProposalImpact,
-      },
-      criticalCount,
-      urgentCount,
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'inbox-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    pendingProposals: enriched,
+    pendingCount: enriched.length,
+    votedThisEpoch: votedThisEpochCount,
+    currentEpoch,
+    scoreImpact: {
+      currentScore: drep.drepScore,
+      simulatedScore: Math.min(100, drep.drepScore + scoreImpact),
+      potentialGain: Math.max(0, scoreImpact),
+      perProposalGain: perProposalImpact,
+    },
+    criticalCount,
+    urgentCount,
+  });
+});

--- a/app/api/dashboard/milestones/route.ts
+++ b/app/api/dashboard/milestones/route.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { MILESTONES, getAchievedMilestones, checkAndAwardMilestones } from '@/lib/milestones';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
+export const GET = withRouteHandler(async (request: NextRequest) => {
   const drepId = request.nextUrl.searchParams.get('drepId');
   if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
 
-  try {
-    const achieved = await getAchievedMilestones(drepId);
+  const achieved = await getAchievedMilestones(drepId);
     const achievedKeys = new Set(achieved.map((a) => a.milestoneKey));
 
     const milestones = MILESTONES.map((m) => ({
@@ -19,23 +18,18 @@ export async function GET(request: NextRequest) {
       achievedAt: achieved.find((a) => a.milestoneKey === m.key)?.achievedAt || null,
     }));
 
-    return NextResponse.json({
-      milestones,
-      achievedCount: achieved.length,
-      totalCount: MILESTONES.length,
-    });
-  } catch (err) {
-    logger.error('Error', { context: 'milestones-api', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    milestones,
+    achievedCount: achieved.length,
+    totalCount: MILESTONES.length,
+  });
+});
 
-export async function POST(request: NextRequest) {
-  try {
-    const { drepId } = await request.json();
-    if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  const { drepId } = await request.json();
+  if (!drepId) return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
 
-    const newMilestones = await checkAndAwardMilestones(drepId);
+  const newMilestones = await checkAndAwardMilestones(drepId);
 
     captureServerEvent(
       'milestone_updated',
@@ -43,9 +37,5 @@ export async function POST(request: NextRequest) {
       drepId,
     );
 
-    return NextResponse.json({ newMilestones });
-  } catch (err) {
-    logger.error('Error', { context: 'milestones-post', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({ newMilestones });
+});

--- a/app/api/dashboard/onboarding/route.ts
+++ b/app/api/dashboard/onboarding/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { OnboardingSchema } from '@/lib/api/schemas/user';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,40 +22,35 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ checklist: data?.onboarding_checklist || {} });
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    const { sessionToken, item, completed } = await request.json();
-    if (!sessionToken || !item)
-      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const body = await request.json();
+  const { sessionToken, item, completed } = OnboardingSchema.parse(body);
 
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const supabase = getSupabaseAdmin();
-    const { data: user } = await supabase
-      .from('users')
-      .select('onboarding_checklist')
-      .eq('wallet_address', parsed.walletAddress)
-      .single();
-
-    const checklist = user?.onboarding_checklist || {};
-    checklist[item] = completed !== false;
-
-    await supabase
-      .from('users')
-      .update({ onboarding_checklist: checklist })
-      .eq('wallet_address', parsed.walletAddress);
-
-    captureServerEvent(
-      'onboarding_step_completed',
-      { item, completed: checklist[item], wallet_address: parsed.walletAddress },
-      parsed.walletAddress,
-    );
-
-    return NextResponse.json({ checklist });
-  } catch (err) {
-    logger.error('Error', { context: 'onboarding-api', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const supabase = getSupabaseAdmin();
+  const { data: user } = await supabase
+    .from('users')
+    .select('onboarding_checklist')
+    .eq('wallet_address', parsed.walletAddress)
+    .single();
+
+  const checklist = user?.onboarding_checklist || {};
+  checklist[item] = completed !== false;
+
+  await supabase
+    .from('users')
+    .update({ onboarding_checklist: checklist })
+    .eq('wallet_address', parsed.walletAddress);
+
+  captureServerEvent(
+    'onboarding_step_completed',
+    { item, completed: checklist[item], wallet_address: parsed.walletAddress },
+    parsed.walletAddress,
+  );
+
+  return NextResponse.json({ checklist });
+}, { auth: 'none', rateLimit: { max: 20, window: 60 } });

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -15,18 +15,17 @@ import {
   getDRepPercentile,
 } from '@/lib/data';
 import { getProposalDisplayTitle } from '@/utils/display';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
+export const GET = withRouteHandler(async (request: NextRequest, context: RouteContext) => {
   const drepId = request.nextUrl.searchParams.get('drepId');
   if (!drepId) {
     return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
   }
 
-  try {
-    const cachedDRep = await getDRepById(drepId);
+  const cachedDRep = await getDRepById(drepId);
     if (!cachedDRep) {
       return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
     }
@@ -87,41 +86,37 @@ export async function GET(request: NextRequest) {
 
     const brokenLinks = linkChecks.filter((c: any) => c.status === 'broken').map((c: any) => c.uri);
 
-    return NextResponse.json({
-      drep: {
-        drepId: cachedDRep.drepId,
-        drepHash: cachedDRep.drepHash,
-        handle: cachedDRep.handle,
-        name: cachedDRep.name,
-        ticker: cachedDRep.ticker,
-        description: cachedDRep.description,
-        votingPower: cachedDRep.votingPower,
-        votingPowerLovelace: cachedDRep.votingPowerLovelace,
-        delegatorCount: cachedDRep.delegatorCount,
-        sizeTier: cachedDRep.sizeTier,
-        drepScore: cachedDRep.drepScore,
-        isActive: cachedDRep.isActive,
-        participationRate: cachedDRep.participationRate,
-        rationaleRate: cachedDRep.rationaleRate,
-        effectiveParticipation: cachedDRep.effectiveParticipation,
-        deliberationModifier: cachedDRep.deliberationModifier,
-        reliabilityScore: cachedDRep.reliabilityScore,
-        reliabilityStreak: cachedDRep.reliabilityStreak,
-        reliabilityRecency: cachedDRep.reliabilityRecency,
-        reliabilityLongestGap: cachedDRep.reliabilityLongestGap,
-        reliabilityTenure: cachedDRep.reliabilityTenure,
-        profileCompleteness: cachedDRep.profileCompleteness,
-        anchorUrl: cachedDRep.anchorUrl,
-        metadata: cachedDRep.metadata,
-        votes,
-        brokenLinks,
-        updatedAt: cachedDRep.updatedAt,
-      },
-      scoreHistory,
-      percentile,
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'mydrep-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    drep: {
+      drepId: cachedDRep.drepId,
+      drepHash: cachedDRep.drepHash,
+      handle: cachedDRep.handle,
+      name: cachedDRep.name,
+      ticker: cachedDRep.ticker,
+      description: cachedDRep.description,
+      votingPower: cachedDRep.votingPower,
+      votingPowerLovelace: cachedDRep.votingPowerLovelace,
+      delegatorCount: cachedDRep.delegatorCount,
+      sizeTier: cachedDRep.sizeTier,
+      drepScore: cachedDRep.drepScore,
+      isActive: cachedDRep.isActive,
+      participationRate: cachedDRep.participationRate,
+      rationaleRate: cachedDRep.rationaleRate,
+      effectiveParticipation: cachedDRep.effectiveParticipation,
+      deliberationModifier: cachedDRep.deliberationModifier,
+      reliabilityScore: cachedDRep.reliabilityScore,
+      reliabilityStreak: cachedDRep.reliabilityStreak,
+      reliabilityRecency: cachedDRep.reliabilityRecency,
+      reliabilityLongestGap: cachedDRep.reliabilityLongestGap,
+      reliabilityTenure: cachedDRep.reliabilityTenure,
+      profileCompleteness: cachedDRep.profileCompleteness,
+      anchorUrl: cachedDRep.anchorUrl,
+      metadata: cachedDRep.metadata,
+      votes,
+      brokenLinks,
+      updatedAt: cachedDRep.updatedAt,
+    },
+    scoreHistory,
+    percentile,
+  });
+});

--- a/app/api/delegation/route.ts
+++ b/app/api/delegation/route.ts
@@ -1,17 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 const KOIOS_BASE_URL = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
 const KOIOS_API_KEY = process.env.KOIOS_API_KEY;
 
-export async function POST(request: NextRequest) {
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  const { stakeAddress } = await request.json();
+
+  if (!stakeAddress || typeof stakeAddress !== 'string') {
+    return NextResponse.json({ error: 'stakeAddress required' }, { status: 400 });
+  }
+
   try {
-    const { stakeAddress } = await request.json();
-
-    if (!stakeAddress || typeof stakeAddress !== 'string') {
-      return NextResponse.json({ error: 'stakeAddress required' }, { status: 400 });
-    }
-
     const headers: HeadersInit = {
       'Content-Type': 'application/json',
       ...(KOIOS_API_KEY && { Authorization: `Bearer ${KOIOS_API_KEY}` }),
@@ -42,4 +43,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ drepId: null });
   }
-}
+});

--- a/app/api/drep-claim/route.ts
+++ b/app/api/drep-claim/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { DrepClaimSchema } from '@/lib/api/schemas/drep';
 
 /**
  * GET: Check if a DRep is claimed by any user.
@@ -36,37 +38,27 @@ export async function GET(request: NextRequest) {
 /**
  * POST: Auto-claim a DRep profile when an authenticated wallet matches the DRep ID.
  */
-export async function POST(request: NextRequest) {
-  try {
-    const { sessionToken, drepId } = await request.json();
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const { sessionToken, drepId } = DrepClaimSchema.parse(await request.json());
 
-    if (!sessionToken || !drepId) {
-      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
-    }
-
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const walletAddress = parsed.walletAddress;
-    const supabase = getSupabaseAdmin();
-
-    // Idempotent upsert: set claimed_drep_id for this wallet
-    const { error } = await supabase
-      .from('users')
-      .update({ claimed_drep_id: drepId })
-      .eq('wallet_address', walletAddress);
-
-    if (error) {
-      logger.error('Error', { context: 'drepclaim', error: error?.message });
-      return NextResponse.json({ error: 'Failed to claim' }, { status: 500 });
-    }
-
-    captureServerEvent('drep_claimed', { drep_id: drepId }, walletAddress);
-    return NextResponse.json({ claimed: true, drepId });
-  } catch (err) {
-    logger.error('Error', { context: 'drepclaim', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const walletAddress = parsed.walletAddress;
+  const supabase = getSupabaseAdmin();
+
+  const { error } = await supabase
+    .from('users')
+    .update({ claimed_drep_id: drepId })
+    .eq('wallet_address', walletAddress);
+
+  if (error) {
+    logger.error('Error', { context: 'drepclaim', error: error?.message });
+    return NextResponse.json({ error: 'Failed to claim' }, { status: 500 });
+  }
+
+  captureServerEvent('drep_claimed', { drep_id: drepId }, walletAddress);
+  return NextResponse.json({ claimed: true, drepId });
+}, { auth: 'none', rateLimit: { max: 5, window: 60 } });

--- a/app/api/drep/[drepId]/explanations/route.ts
+++ b/app/api/drep/[drepId]/explanations/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { DrepExplanationSchema } from '@/lib/api/schemas/drep';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,62 +29,50 @@ export async function GET(
   return NextResponse.json(data || []);
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ drepId: string }> },
-) {
-  const { drepId } = await params;
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const drepId = request.nextUrl.pathname.split('/')[3];
+  const body = await request.json();
+  const { sessionToken, proposalTxHash, proposalIndex, explanationText, aiAssisted } =
+    DrepExplanationSchema.parse(body);
 
-  try {
-    const body = await request.json();
-    const { sessionToken, proposalTxHash, proposalIndex, explanationText, aiAssisted } = body;
-
-    if (!sessionToken || !proposalTxHash || proposalIndex == null || !explanationText) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
-    }
-
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const supabase = getSupabaseAdmin();
-
-    const { data: user } = await supabase
-      .from('users')
-      .select('claimed_drep_id')
-      .eq('wallet_address', parsed.walletAddress)
-      .single();
-
-    if (!user || user.claimed_drep_id !== drepId) {
-      return NextResponse.json({ error: 'Not authorized for this DRep' }, { status: 403 });
-    }
-
-    const { data, error } = await supabase
-      .from('vote_explanations')
-      .upsert(
-        {
-          drep_id: drepId,
-          proposal_tx_hash: proposalTxHash,
-          proposal_index: proposalIndex,
-          explanation_text: explanationText,
-          ai_assisted: aiAssisted || false,
-        },
-        { onConflict: 'drep_id,proposal_tx_hash,proposal_index' },
-      )
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Error', { context: 'explanations-post', error: error?.message });
-      return NextResponse.json({ error: 'Failed to save explanation' }, { status: 500 });
-    }
-
-    captureServerEvent('vote_explanation_created', { drep_id: drepId }, drepId);
-
-    return NextResponse.json(data);
-  } catch (err) {
-    logger.error('Error', { context: 'explanations-post', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: user } = await supabase
+    .from('users')
+    .select('claimed_drep_id')
+    .eq('wallet_address', parsed.walletAddress)
+    .single();
+
+  if (!user || user.claimed_drep_id !== drepId) {
+    return NextResponse.json({ error: 'Not authorized for this DRep' }, { status: 403 });
+  }
+
+  const { data, error } = await supabase
+    .from('vote_explanations')
+    .upsert(
+      {
+        drep_id: drepId,
+        proposal_tx_hash: proposalTxHash,
+        proposal_index: proposalIndex,
+        explanation_text: explanationText,
+        ai_assisted: aiAssisted || false,
+      },
+      { onConflict: 'drep_id,proposal_tx_hash,proposal_index' },
+    )
+    .select()
+    .single();
+
+  if (error) {
+    logger.error('Error', { context: 'explanations-post', error: error?.message });
+    return NextResponse.json({ error: 'Failed to save explanation' }, { status: 500 });
+  }
+
+  captureServerEvent('vote_explanation_created', { drep_id: drepId }, drepId);
+
+  return NextResponse.json(data);
+}, { auth: 'none', rateLimit: { max: 20, window: 60 } });

--- a/app/api/drep/[drepId]/philosophy/route.ts
+++ b/app/api/drep/[drepId]/philosophy/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { DrepPhilosophySchema } from '@/lib/api/schemas/drep';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,46 +23,39 @@ export async function GET(
   return NextResponse.json(data || { philosophy_text: null });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ drepId: string }> },
-) {
-  const { drepId } = await params;
-  try {
-    const { sessionToken, philosophyText } = await request.json();
-    if (!sessionToken || !philosophyText)
-      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const drepId = request.nextUrl.pathname.split('/')[3];
+  const body = await request.json();
+  const { sessionToken, philosophyText } = DrepPhilosophySchema.parse(body);
 
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const supabase = getSupabaseAdmin();
-    const { data: user } = await supabase
-      .from('users')
-      .select('claimed_drep_id')
-      .eq('wallet_address', parsed.walletAddress)
-      .single();
-
-    if (!user || user.claimed_drep_id !== drepId)
-      return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
-
-    const { data, error } = await supabase
-      .from('governance_philosophy')
-      .upsert({ drep_id: drepId, philosophy_text: philosophyText }, { onConflict: 'drep_id' })
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Error', { context: 'philosophy-post', error: error?.message });
-      return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
-    }
-
-    captureServerEvent('philosophy_updated', { drep_id: drepId }, drepId);
-
-    return NextResponse.json(data);
-  } catch (err) {
-    logger.error('Error', { context: 'philosophy-post', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const supabase = getSupabaseAdmin();
+  const { data: user } = await supabase
+    .from('users')
+    .select('claimed_drep_id')
+    .eq('wallet_address', parsed.walletAddress)
+    .single();
+
+  if (!user || user.claimed_drep_id !== drepId) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+
+  const { data, error } = await supabase
+    .from('governance_philosophy')
+    .upsert({ drep_id: drepId, philosophy_text: philosophyText }, { onConflict: 'drep_id' })
+    .select()
+    .single();
+
+  if (error) {
+    logger.error('Error', { context: 'philosophy-post', error: error?.message });
+    return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+  }
+
+  captureServerEvent('philosophy_updated', { drep_id: drepId }, drepId);
+
+  return NextResponse.json(data);
+}, { auth: 'none', rateLimit: { max: 20, window: 60 } });

--- a/app/api/drep/[drepId]/positions/route.ts
+++ b/app/api/drep/[drepId]/positions/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { DrepPositionSchema } from '@/lib/api/schemas/drep';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,55 +23,48 @@ export async function GET(
   return NextResponse.json(data || []);
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ drepId: string }> },
-) {
-  const { drepId } = await params;
-  try {
-    const { sessionToken, proposalTxHash, proposalIndex, statementText } = await request.json();
-    if (!sessionToken || !proposalTxHash || proposalIndex == null || !statementText) {
-      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
-    }
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const drepId = request.nextUrl.pathname.split('/')[3];
+  const body = await request.json();
+  const { sessionToken, proposalTxHash, proposalIndex, statementText } =
+    DrepPositionSchema.parse(body);
 
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed)
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const supabase = getSupabaseAdmin();
-    const { data: user } = await supabase
-      .from('users')
-      .select('claimed_drep_id')
-      .eq('wallet_address', parsed.walletAddress)
-      .single();
-
-    if (!user || user.claimed_drep_id !== drepId)
-      return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
-
-    const { data, error } = await supabase
-      .from('position_statements')
-      .upsert(
-        {
-          drep_id: drepId,
-          proposal_tx_hash: proposalTxHash,
-          proposal_index: proposalIndex,
-          statement_text: statementText,
-        },
-        { onConflict: 'drep_id,proposal_tx_hash,proposal_index' },
-      )
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Error', { context: 'positions-post', error: error?.message });
-      return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
-    }
-
-    captureServerEvent('position_statement_created', { drep_id: drepId }, drepId);
-
-    return NextResponse.json(data);
-  } catch (err) {
-    logger.error('Error', { context: 'positions-post', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const supabase = getSupabaseAdmin();
+  const { data: user } = await supabase
+    .from('users')
+    .select('claimed_drep_id')
+    .eq('wallet_address', parsed.walletAddress)
+    .single();
+
+  if (!user || user.claimed_drep_id !== drepId) {
+    return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
+  }
+
+  const { data, error } = await supabase
+    .from('position_statements')
+    .upsert(
+      {
+        drep_id: drepId,
+        proposal_tx_hash: proposalTxHash,
+        proposal_index: proposalIndex,
+        statement_text: statementText,
+      },
+      { onConflict: 'drep_id,proposal_tx_hash,proposal_index' },
+    )
+    .select()
+    .single();
+
+  if (error) {
+    logger.error('Error', { context: 'positions-post', error: error?.message });
+    return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+  }
+
+  captureServerEvent('position_statement_created', { drep_id: drepId }, drepId);
+
+  return NextResponse.json(data);
+}, { auth: 'none', rateLimit: { max: 20, window: 60 } });

--- a/app/api/governance/cohorts/route.ts
+++ b/app/api/governance/cohorts/route.ts
@@ -1,17 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
-
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
 
 interface CohortResult {
   userCohort: string;
@@ -45,15 +36,9 @@ function classifyVoter(treasuryYes: number, treasuryNo: number): string {
   return 'Balanced Voter';
 }
 
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
   const supabase = getSupabaseAdmin();
-
-  try {
     const { count: totalVoters } = await supabase
       .from('poll_responses')
       .select('wallet_address', { count: 'exact', head: true })
@@ -133,9 +118,5 @@ export async function GET(request: NextRequest) {
       },
     };
 
-    return NextResponse.json({ cohort: result });
-  } catch (error) {
-    logger.error('Error', { context: 'cohorts-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({ cohort: result });
+}, { auth: 'required' });

--- a/app/api/governance/epoch-review/route.ts
+++ b/app/api/governance/epoch-review/route.ts
@@ -1,18 +1,9 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
-
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
 
 function deriveGovernanceLevel(
   hasDelegation: boolean,
@@ -30,17 +21,12 @@ function deriveParticipationTier(pollCount: number, drepVotesCast: number): stri
   return 'passive';
 }
 
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
   const supabase = createClient();
   const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
 
-  try {
-    const [
+  const [
       statsRow,
       userRow,
       proposalsCreatedResult,
@@ -135,22 +121,18 @@ export async function GET(request: NextRequest) {
     );
     const participationTier = deriveParticipationTier(yourPollsTaken, drepVotesCast);
 
-    return NextResponse.json({
-      epoch,
-      stats: {
-        proposalsCreated,
-        drepVotesCast,
-        yourPollsTaken,
-        activeDReps,
-        yourDRepName,
-        yourDRepScore,
-        yourDRepScoreTrend,
-        governanceLevel,
-        participationTier,
-      },
-    });
-  } catch (err) {
-    logger.error('Error', { context: 'epoch-review', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    epoch,
+    stats: {
+      proposalsCreated,
+      drepVotesCast,
+      yourPollsTaken,
+      activeDReps,
+      yourDRepName,
+      yourDRepScore,
+      yourDRepScoreTrend,
+      governanceLevel,
+      participationTier,
+    },
+  });
+}, { auth: 'required' });

--- a/app/api/governance/footprint/route.ts
+++ b/app/api/governance/footprint/route.ts
@@ -1,38 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { buildGovernanceFootprint } from '@/lib/governanceFootprint';
 import { getFeatureFlag } from '@/lib/featureFlags';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-  try {
-    const enabled = await getFeatureFlag('governance_footprint', false);
-    if (!enabled) {
-      return NextResponse.json({ error: 'Feature not available' }, { status: 404 });
-    }
-
-    const authHeader = request.headers.get('Authorization');
-    if (!authHeader?.startsWith('Bearer ')) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const token = authHeader.slice(7);
-    const session = await validateSessionToken(token);
-    if (!session?.walletAddress) {
-      return NextResponse.json({ error: 'Invalid session' }, { status: 401 });
-    }
-
-    const stakeAddress = request.nextUrl.searchParams.get('stakeAddress');
-
-    const footprint = await buildGovernanceFootprint(session.walletAddress, stakeAddress);
-
-    return NextResponse.json(footprint, {
-      headers: { 'Cache-Control': 'private, s-maxage=300, stale-while-revalidate=600' },
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'governance/footprint', error: error });
-    return NextResponse.json({ error: 'Failed to build governance footprint' }, { status: 500 });
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const enabled = await getFeatureFlag('governance_footprint', false);
+  if (!enabled) {
+    return NextResponse.json({ error: 'Feature not available' }, { status: 404 });
   }
-}
+
+  const stakeAddress = request.nextUrl.searchParams.get('stakeAddress');
+
+  const footprint = await buildGovernanceFootprint(wallet!, stakeAddress);
+
+  return NextResponse.json(footprint, {
+    headers: { 'Cache-Control': 'private, s-maxage=300, stale-while-revalidate=600' },
+  });
+}, { auth: 'required' });

--- a/app/api/governance/for-you/route.ts
+++ b/app/api/governance/for-you/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { cosineSimilarity } from '@/lib/representationMatch';
 import type { AlignmentDimension, AlignmentScores } from '@/lib/drepIdentity';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
@@ -104,22 +103,9 @@ function topAligningDimension(
   return best ? { dim: best, strength: bestStrength } : null;
 }
 
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const supabase = createClient();
-  const walletAddress = session.walletAddress;
-
-  try {
+  const walletAddress = wallet!;
     const [profileResult, pollResult] = await Promise.all([
       supabase
         .from('user_governance_profiles')
@@ -278,12 +264,8 @@ export async function GET(request: NextRequest) {
       walletAddress,
     );
 
-    return NextResponse.json({
-      recommendations,
-      profileSource,
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'for-you-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    recommendations,
+    profileSource,
+  });
+}, { auth: 'required' });

--- a/app/api/governance/holder/route.ts
+++ b/app/api/governance/holder/route.ts
@@ -5,7 +5,6 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { getDRepById } from '@/lib/data';
@@ -13,7 +12,7 @@ import { blockTimeToEpoch } from '@/lib/koios';
 import { getProposalPriority } from '@/utils/proposalPriority';
 import { getDRepPrimaryName } from '@/utils/display';
 import { calculateRepresentationMatch, findBestMatchDReps } from '@/lib/representationMatch';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,25 +20,12 @@ function normalizeVote(vote: string): string {
   return vote.charAt(0).toUpperCase() + vote.slice(1).toLowerCase();
 }
 
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
-
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
 
   const delegatedDrepId = request.nextUrl.searchParams.get('drepId');
   const supabase = createClient();
   const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
-
-  try {
     const admin = getSupabaseAdmin();
 
     // Parallel fetch: user's poll votes, DRep data, open proposals, DRep votes, user profile
@@ -262,26 +248,22 @@ export async function GET(request: NextRequest) {
 
     const userProfile = userResult.data;
 
-    return NextResponse.json({
-      delegationHealth,
-      representationScore: {
-        score: repScore,
-        aligned: alignedCount,
-        misaligned: comparisons.length - alignedCount,
-        total: comparisons.length,
-        comparisons,
-      },
-      activeProposals,
-      pollHistory,
-      redelegationSuggestions,
-      currentEpoch,
-      repScoreDelta,
-      governanceLevel: userProfile?.governance_level ?? 'observer',
-      pollCount: userProfile?.poll_count ?? 0,
-      visitStreak: userProfile?.visit_streak ?? 0,
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'governance-dashboard-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    delegationHealth,
+    representationScore: {
+      score: repScore,
+      aligned: alignedCount,
+      misaligned: comparisons.length - alignedCount,
+      total: comparisons.length,
+      comparisons,
+    },
+    activeProposals,
+    pollHistory,
+    redelegationSuggestions,
+    currentEpoch,
+    repScoreDelta,
+    governanceLevel: userProfile?.governance_level ?? 'observer',
+    pollCount: userProfile?.poll_count ?? 0,
+    visitStreak: userProfile?.visit_streak ?? 0,
+  });
+}, { auth: 'required' });

--- a/app/api/governance/matches/detail/route.ts
+++ b/app/api/governance/matches/detail/route.ts
@@ -1,23 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { calculateRepresentationMatch } from '@/lib/representationMatch';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const drepId = request.nextUrl.searchParams.get('drepId');
   if (!drepId) {
     return NextResponse.json({ error: 'drepId required' }, { status: 400 });
@@ -28,7 +17,7 @@ export async function GET(request: NextRequest) {
   const { data: pollVotes } = await supabase
     .from('poll_responses')
     .select('proposal_tx_hash, proposal_index, vote')
-    .eq('wallet_address', session.walletAddress);
+    .eq('wallet_address', wallet!);
 
   if (!pollVotes || pollVotes.length === 0) {
     return NextResponse.json({ comparisons: [], agreed: 0, total: 0, matchScore: 0 });
@@ -59,7 +48,7 @@ export async function GET(request: NextRequest) {
       comparisons_count: result.comparisons.length,
       match_score: result.score,
     },
-    session.walletAddress,
+    wallet!,
   );
 
   return NextResponse.json({
@@ -73,4 +62,4 @@ export async function GET(request: NextRequest) {
       agreed: c.agreed,
     })),
   });
-}
+}, { auth: 'required' });

--- a/app/api/governance/matches/route.ts
+++ b/app/api/governance/matches/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { projectUserVector, cosineSimilarity } from '@/lib/representationMatch';
 import { loadActivePCA } from '@/lib/alignment/pca';
 import { calculateMatchConfidence } from '@/lib/matching/confidence';
@@ -15,7 +14,7 @@ import { extractAlignments } from '@/lib/drepIdentity';
 import type { AlignmentDimension, AlignmentScores } from '@/lib/drepIdentity';
 import { createClient } from '@/lib/supabase';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,27 +22,14 @@ function normalizeVote(vote: string): string {
   return vote.charAt(0).toUpperCase() + vote.slice(1).toLowerCase();
 }
 
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const excludeDrepId = request.nextUrl.searchParams.get('currentDrepId') || undefined;
-
-  try {
-    const supabase = createClient();
+  const supabase = createClient();
 
     const { data: pollVotes } = await supabase
       .from('poll_responses')
       .select('proposal_tx_hash, proposal_index, vote')
-      .eq('wallet_address', session.walletAddress);
+      .eq('wallet_address', wallet!);
 
     if (!pollVotes?.length) {
       return NextResponse.json({
@@ -242,21 +228,17 @@ export async function GET(request: NextRequest) {
         user_vote_count: pollVotes.length,
         overall_confidence: overallConfidence,
       },
-      session.walletAddress,
+      wallet!,
     );
 
-    return NextResponse.json({
-      matches,
-      currentDRepMatch,
-      overallConfidence,
-      matchMethod,
-      userAlignments,
-    });
-  } catch (error) {
-    logger.error('Error', { context: 'governance-matches-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    matches,
+    currentDRepMatch,
+    overallConfidence,
+    matchMethod,
+    userAlignments,
+  });
+}, { auth: 'required' });
 
 function rankByOverlap(overlapMap: Map<string, { agreed: number; total: number }>): string[] {
   return [...overlapMap.entries()]

--- a/app/api/governance/my-profile/route.ts
+++ b/app/api/governance/my-profile/route.ts
@@ -5,31 +5,19 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { updateUserProfile } from '@/lib/matching/userProfile';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  if (!session?.walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const supabase = createClient();
 
-  // Try to load existing profile
   const { data: existing } = await supabase
     .from('user_governance_profiles')
     .select('alignment_scores, personality_label, votes_used, confidence, updated_at')
-    .eq('wallet_address', session.walletAddress)
+    .eq('wallet_address', wallet!)
     .single();
 
   if (existing) {
@@ -42,8 +30,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // No profile yet — compute and store
-  const profile = await updateUserProfile(session.walletAddress);
+  const profile = await updateUserProfile(wallet!);
   if (!profile) {
     return NextResponse.json({
       alignmentScores: null,
@@ -61,4 +48,4 @@ export async function GET(request: NextRequest) {
     confidence: profile.confidence,
     updatedAt: new Date().toISOString(),
   });
-}
+}, { auth: 'required' });

--- a/app/api/governance/questions/[questionId]/respond/route.ts
+++ b/app/api/governance/questions/[questionId]/respond/route.ts
@@ -3,91 +3,75 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { QuestionRespondSchema } from '@/lib/api/schemas/governance';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ questionId: string }> },
-) {
-  try {
-    const { questionId } = await params;
-    const { sessionToken, responseText } = await request.json();
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const questionId = request.nextUrl.pathname.split('/')[4];
+  const body = await request.json();
+  const { sessionToken, responseText } = QuestionRespondSchema.parse(body);
 
-    if (!sessionToken || !responseText) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
-    }
-
-    if (responseText.length > 2000) {
-      return NextResponse.json({ error: 'Response too long (max 2000 chars)' }, { status: 400 });
-    }
-
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const supabase = getSupabaseAdmin();
-
-    // Verify the session user is the claimed DRep for this question
-    const { data: question } = await supabase
-      .from('drep_questions')
-      .select('drep_id, status')
-      .eq('id', questionId)
-      .single();
-
-    if (!question) {
-      return NextResponse.json({ error: 'Question not found' }, { status: 404 });
-    }
-
-    const { data: user } = await supabase
-      .from('users')
-      .select('claimed_drep_id')
-      .eq('wallet_address', parsed.walletAddress)
-      .single();
-
-    if (!user || user.claimed_drep_id !== question.drep_id) {
-      return NextResponse.json({ error: 'Only the claimed DRep can respond' }, { status: 403 });
-    }
-
-    // Check if already responded
-    const { count } = await supabase
-      .from('drep_responses')
-      .select('id', { count: 'exact', head: true })
-      .eq('question_id', questionId);
-
-    if ((count ?? 0) > 0) {
-      return NextResponse.json({ error: 'Already responded to this question' }, { status: 409 });
-    }
-
-    const { data, error } = await supabase
-      .from('drep_responses')
-      .insert({
-        question_id: questionId,
-        drep_id: question.drep_id,
-        response_text: responseText.trim(),
-      })
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Response insert error', { context: 'governance/questions/:questionId/respond', error: error?.message });
-      return NextResponse.json({ error: 'Failed to submit response' }, { status: 500 });
-    }
-
-    // Update question status
-    await supabase.from('drep_questions').update({ status: 'answered' }).eq('id', questionId);
-
-    captureServerEvent('question_responded', {
-      drep_id: question.drep_id,
-      question_id: questionId,
-      response_id: data.id,
-      wallet: parsed.walletAddress,
-    });
-
-    return NextResponse.json(data, { status: 201 });
-  } catch (error) {
-    logger.error('Respond POST error', { context: 'governance/questions/:questionId/respond', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: question } = await supabase
+    .from('drep_questions')
+    .select('drep_id, status')
+    .eq('id', questionId)
+    .single();
+
+  if (!question) {
+    return NextResponse.json({ error: 'Question not found' }, { status: 404 });
+  }
+
+  const { data: user } = await supabase
+    .from('users')
+    .select('claimed_drep_id')
+    .eq('wallet_address', parsed.walletAddress)
+    .single();
+
+  if (!user || user.claimed_drep_id !== question.drep_id) {
+    return NextResponse.json({ error: 'Only the claimed DRep can respond' }, { status: 403 });
+  }
+
+  const { count } = await supabase
+    .from('drep_responses')
+    .select('id', { count: 'exact', head: true })
+    .eq('question_id', questionId);
+
+  if ((count ?? 0) > 0) {
+    return NextResponse.json({ error: 'Already responded to this question' }, { status: 409 });
+  }
+
+  const { data, error } = await supabase
+    .from('drep_responses')
+    .insert({
+      question_id: questionId,
+      drep_id: question.drep_id,
+      response_text: responseText.trim(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    logger.error('Response insert error', { context: 'governance/questions/:questionId/respond', error: error?.message });
+    return NextResponse.json({ error: 'Failed to submit response' }, { status: 500 });
+  }
+
+  await supabase.from('drep_questions').update({ status: 'answered' }).eq('id', questionId);
+
+  captureServerEvent('question_responded', {
+    drep_id: question.drep_id,
+    question_id: questionId,
+    response_id: data.id,
+    wallet: parsed.walletAddress,
+  });
+
+  return NextResponse.json(data, { status: 201 });
+}, { auth: 'none', rateLimit: { max: 20, window: 60 } });

--- a/app/api/governance/questions/route.ts
+++ b/app/api/governance/questions/route.ts
@@ -3,6 +3,8 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { QuestionSchema } from '@/lib/api/schemas/governance';
 
 export const dynamic = 'force-dynamic';
 
@@ -54,66 +56,53 @@ export async function GET(request: NextRequest) {
   });
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    const { sessionToken, drepId, questionText } = await request.json();
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const body = await request.json();
+  const { sessionToken, drepId, questionText } = QuestionSchema.parse(body);
 
-    if (!sessionToken || !drepId || !questionText) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
-    }
-
-    if (questionText.length > 500) {
-      return NextResponse.json({ error: 'Question too long (max 500 chars)' }, { status: 400 });
-    }
-
-    const parsed = await validateSessionToken(sessionToken);
-    if (!parsed) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const wallet = parsed.walletAddress;
-    const supabase = getSupabaseAdmin();
-
-    // Rate limit: 3 questions per day per wallet per DRep
-    const dayAgo = new Date(Date.now() - 86400000).toISOString();
-    const { count } = await supabase
-      .from('drep_questions')
-      .select('id', { count: 'exact', head: true })
-      .eq('asker_wallet', wallet)
-      .eq('drep_id', drepId)
-      .gte('created_at', dayAgo);
-
-    if ((count ?? 0) >= 3) {
-      return NextResponse.json(
-        { error: 'Rate limit: max 3 questions per day per DRep' },
-        { status: 429 },
-      );
-    }
-
-    const { data, error } = await supabase
-      .from('drep_questions')
-      .insert({
-        drep_id: drepId,
-        asker_wallet: wallet,
-        question_text: questionText.trim(),
-      })
-      .select()
-      .single();
-
-    if (error) {
-      logger.error('Q&A insert error', { context: 'governance/questions', error: error?.message });
-      return NextResponse.json({ error: 'Failed to submit question' }, { status: 500 });
-    }
-
-    captureServerEvent('question_submitted', {
-      drep_id: drepId,
-      question_id: data.id,
-      wallet,
-    });
-
-    return NextResponse.json(data, { status: 201 });
-  } catch (error) {
-    logger.error('Q&A POST error', { context: 'governance/questions', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  const parsed = await validateSessionToken(sessionToken);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-}
+
+  const wallet = parsed.walletAddress;
+  const supabase = getSupabaseAdmin();
+
+  const dayAgo = new Date(Date.now() - 86400000).toISOString();
+  const { count } = await supabase
+    .from('drep_questions')
+    .select('id', { count: 'exact', head: true })
+    .eq('asker_wallet', wallet)
+    .eq('drep_id', drepId)
+    .gte('created_at', dayAgo);
+
+  if ((count ?? 0) >= 3) {
+    return NextResponse.json(
+      { error: 'Rate limit: max 3 questions per day per DRep' },
+      { status: 429 },
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('drep_questions')
+    .insert({
+      drep_id: drepId,
+      asker_wallet: wallet,
+      question_text: questionText.trim(),
+    })
+    .select()
+    .single();
+
+  if (error) {
+    logger.error('Q&A insert error', { context: 'governance/questions', error: error?.message });
+    return NextResponse.json({ error: 'Failed to submit question' }, { status: 500 });
+  }
+
+  captureServerEvent('question_submitted', {
+    drep_id: drepId,
+    question_id: data.id,
+    wallet,
+  });
+
+  return NextResponse.json(data, { status: 201 });
+}, { auth: 'none' });

--- a/app/api/governance/quick-match-pool/route.ts
+++ b/app/api/governance/quick-match-pool/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
@@ -124,7 +125,7 @@ function similarityToScore(sim: number): number {
   return Math.max(0, Math.min(100, Math.round(sim * 100)));
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withRouteHandler(async (request: NextRequest) => {
   let body: { treasury?: string; protocol?: string; transparency?: string };
   try {
     body = await request.json();
@@ -237,4 +238,4 @@ export async function POST(request: NextRequest) {
       voteCount: r.voteCount,
     })),
   });
-}
+}, { rateLimit: { max: 10, window: 60 } });

--- a/app/api/governance/since-visit/route.ts
+++ b/app/api/governance/since-visit/route.ts
@@ -1,24 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { createClient } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
-
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
 
   const since = request.nextUrl.searchParams.get('since');
   const drepId = request.nextUrl.searchParams.get('drepId');
@@ -36,8 +24,7 @@ export async function GET(request: NextRequest) {
   const sinceEpoch = blockTimeToEpoch(sinceBlockTime);
   const supabase = createClient();
 
-  try {
-    const [openedResult, closedResult] = await Promise.all([
+  const [openedResult, closedResult] = await Promise.all([
       supabase
         .from('proposals')
         .select('tx_hash', { count: 'exact', head: true })
@@ -129,17 +116,13 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    return NextResponse.json({
-      proposalsOpened,
-      proposalsClosed,
-      drepVotesCast,
-      drepScoreChange,
-      delegatorChange,
-      proposalOutcomes,
-      drepActivity,
-    });
-  } catch (err) {
-    logger.error('Error', { context: 'since-visit-api', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({
+    proposalsOpened,
+    proposalsClosed,
+    drepVotesCast,
+    drepScoreChange,
+    delegatorChange,
+    proposalOutcomes,
+    drepActivity,
+  });
+}, { auth: 'required' });

--- a/app/api/governance/timeline/route.ts
+++ b/app/api/governance/timeline/route.ts
@@ -1,18 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
-
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
 
 interface TimelineEvent {
   id: string;
@@ -25,15 +16,9 @@ interface TimelineEvent {
   createdAt: string;
 }
 
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
   const supabase = getSupabaseAdmin();
-
-  try {
     const [eventsResult, pollResult] = await Promise.all([
       supabase
         .from('governance_events')
@@ -113,9 +98,5 @@ export async function GET(request: NextRequest) {
       (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
 
-    return NextResponse.json({ events: allEvents.slice(0, 50) });
-  } catch (error) {
-    logger.error('Error', { context: 'governance-timeline-api', error: error });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
-  }
-}
+  return NextResponse.json({ events: allEvents.slice(0, 50) });
+}, { auth: 'required' });

--- a/app/api/polls/results/route.ts
+++ b/app/api/polls/results/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import type { PollResultsResponse } from '@/types/supabase';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
 function aggregateCounts(rows: { vote: string }[]): {
   yes: number;
@@ -19,7 +19,7 @@ function aggregateCounts(rows: { vote: string }[]): {
   return counts;
 }
 
-export async function GET(request: NextRequest) {
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const { searchParams } = new URL(request.url);
   const proposalTxHash = searchParams.get('proposalTxHash');
   const proposalIndexStr = searchParams.get('proposalIndex');
@@ -37,12 +37,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'proposalIndex must be a number' }, { status: 400 });
   }
 
-  let walletAddress: string | null = null;
-  const authHeader = request.headers.get('Authorization');
-  if (authHeader?.startsWith('Bearer ')) {
-    const session = await validateSessionToken(authHeader.slice(7));
-    walletAddress = session?.walletAddress ?? null;
-  }
+  const walletAddress = wallet ?? null;
 
   const supabase = getSupabaseAdmin();
 
@@ -78,4 +73,4 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json(result);
-}
+}, { auth: 'optional' });

--- a/app/api/polls/vote/route.ts
+++ b/app/api/polls/vote/route.ts
@@ -1,40 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
 import { updateUserProfile } from '@/lib/matching/userProfile';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
-
-const VALID_VOTES = ['yes', 'no', 'abstain'] as const;
-type Vote = (typeof VALID_VOTES)[number];
-
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX = 10;
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
-
-function checkRateLimit(walletAddress: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(walletAddress);
-
-  if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(walletAddress, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-
-  if (entry.count >= RATE_LIMIT_MAX) return false;
-  entry.count++;
-  return true;
-}
-
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { PollVoteSchema } from '@/lib/api/schemas/governance';
 
 async function lookupDelegation(stakeAddress: string): Promise<string | null> {
   try {
@@ -76,40 +47,10 @@ function aggregateCounts(rows: { vote: string }[]): {
   return counts;
 }
 
-export async function POST(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  if (!checkRateLimit(walletAddress)) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
-  let body: {
-    proposalTxHash?: string;
-    proposalIndex?: number;
-    vote?: string;
-    stakeAddress?: string;
-    delegatedDrepId?: string;
-  };
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-  }
-
-  const { proposalTxHash, proposalIndex, vote, stakeAddress, delegatedDrepId } = body;
-
-  if (!proposalTxHash || typeof proposalTxHash !== 'string') {
-    return NextResponse.json({ error: 'proposalTxHash required' }, { status: 400 });
-  }
-  if (proposalIndex === undefined || typeof proposalIndex !== 'number') {
-    return NextResponse.json({ error: 'proposalIndex required' }, { status: 400 });
-  }
-  if (!vote || !VALID_VOTES.includes(vote as Vote)) {
-    return NextResponse.json({ error: 'vote must be yes, no, or abstain' }, { status: 400 });
-  }
+export const POST = withRouteHandler(async (request: NextRequest, { requestId, wallet }: RouteContext) => {
+  const walletAddress = wallet!;
+  const { proposalTxHash, proposalIndex, vote, stakeAddress, delegatedDrepId } =
+    PollVoteSchema.parse(await request.json());
 
   const resolvedStakeAddress = stakeAddress || null;
   let resolvedDrepId = delegatedDrepId || null;
@@ -161,7 +102,6 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Write governance event for timeline (fire-and-forget, don't block the response)
   const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
   let proposalTitle: string | null = null;
   try {
@@ -190,7 +130,6 @@ export async function POST(request: NextRequest) {
       if (evtErr) logger.error('governance_event write failed', { context: 'poll-vote', error: evtErr?.message });
     });
 
-  // Update user governance profile (fire-and-forget, don't block response)
   updateUserProfile(walletAddress).catch((err) => {
     logger.error('Failed to update user profile', { context: 'poll-vote', error: err });
   });
@@ -214,4 +153,4 @@ export async function POST(request: NextRequest) {
     userVote: vote,
     hasVoted: true,
   });
-}
+}, { auth: 'required', rateLimit: { max: 10, window: 60 } });

--- a/app/api/proposals/explain/route.ts
+++ b/app/api/proposals/explain/route.ts
@@ -8,64 +8,62 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { generateText } from '@/lib/ai';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { ProposalExplainSchema } from '@/lib/api/schemas/governance';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
 
-export async function POST(request: NextRequest) {
-  try {
-    const { txHash, index } = await request.json();
-    if (!txHash || index == null) {
-      return NextResponse.json({ error: 'Missing txHash or index' }, { status: 400 });
-    }
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const { txHash, index } = ProposalExplainSchema.parse(await request.json());
 
-    const supabase = getSupabaseAdmin();
+  const supabase = getSupabaseAdmin();
 
-    const { data: proposal } = await supabase
-      .from('proposals')
-      .select('title, abstract, proposal_type, withdrawal_amount, ai_summary, meta_json')
-      .eq('tx_hash', txHash)
-      .eq('proposal_index', index)
-      .single();
+  const { data: proposal } = await supabase
+    .from('proposals')
+    .select('title, abstract, proposal_type, withdrawal_amount, ai_summary, meta_json')
+    .eq('tx_hash', txHash)
+    .eq('proposal_index', index)
+    .single();
 
-    if (!proposal) {
-      return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
-    }
+  if (!proposal) {
+    return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+  }
 
-    const metaJson = (proposal.meta_json as Record<string, unknown>) ?? {};
-    if (metaJson.ai_explanation) {
-      return NextResponse.json({ explanation: metaJson.ai_explanation, cached: true });
-    }
+  const metaJson = (proposal.meta_json as Record<string, unknown>) ?? {};
+  if (metaJson.ai_explanation) {
+    return NextResponse.json({ explanation: metaJson.ai_explanation, cached: true });
+  }
 
-    const { data: votingSummary } = await supabase
-      .from('proposal_voting_summary')
-      .select('drep_yes_votes_cast, drep_no_votes_cast, drep_abstain_votes_cast')
-      .eq('proposal_tx_hash', txHash)
-      .eq('proposal_index', index)
-      .single();
+  const { data: votingSummary } = await supabase
+    .from('proposal_voting_summary')
+    .select('drep_yes_votes_cast, drep_no_votes_cast, drep_abstain_votes_cast')
+    .eq('proposal_tx_hash', txHash)
+    .eq('proposal_index', index)
+    .single();
 
-    const { data: topRationales } = await supabase
-      .from('vote_rationales')
-      .select('rationale_text, ai_summary')
-      .eq('proposal_tx_hash', txHash)
-      .eq('proposal_index', index)
-      .not('rationale_text', 'is', null)
-      .limit(5);
+  const { data: topRationales } = await supabase
+    .from('vote_rationales')
+    .select('rationale_text, ai_summary')
+    .eq('proposal_tx_hash', txHash)
+    .eq('proposal_index', index)
+    .not('rationale_text', 'is', null)
+    .limit(5);
 
-    const rationaleContext = (topRationales ?? [])
-      .map((r) => r.ai_summary || r.rationale_text?.slice(0, 300))
-      .filter(Boolean)
-      .join('\n- ');
+  const rationaleContext = (topRationales ?? [])
+    .map((r) => r.ai_summary || r.rationale_text?.slice(0, 300))
+    .filter(Boolean)
+    .join('\n- ');
 
-    const voteContext = votingSummary
-      ? `Votes so far: ${votingSummary.drep_yes_votes_cast ?? 0} Yes, ${votingSummary.drep_no_votes_cast ?? 0} No, ${votingSummary.drep_abstain_votes_cast ?? 0} Abstain.`
-      : '';
+  const voteContext = votingSummary
+    ? `Votes so far: ${votingSummary.drep_yes_votes_cast ?? 0} Yes, ${votingSummary.drep_no_votes_cast ?? 0} No, ${votingSummary.drep_abstain_votes_cast ?? 0} Abstain.`
+    : '';
 
-    const withdrawalContext = proposal.withdrawal_amount
-      ? `This proposal requests ${(Number(proposal.withdrawal_amount) / 1_000_000).toLocaleString()} ADA from the Cardano treasury.`
-      : '';
+  const withdrawalContext = proposal.withdrawal_amount
+    ? `This proposal requests ${(Number(proposal.withdrawal_amount) / 1_000_000).toLocaleString()} ADA from the Cardano treasury.`
+    : '';
 
-    const prompt = `You are a governance analyst writing for DRepScore, a Cardano governance intelligence platform. Write a clear, informative explanation of this governance proposal for a crypto-literate audience.
+  const prompt = `You are a governance analyst writing for DRepScore, a Cardano governance intelligence platform. Write a clear, informative explanation of this governance proposal for a crypto-literate audience.
 
 PROPOSAL:
 Title: ${proposal.title || 'Untitled'}
@@ -83,23 +81,19 @@ Write exactly 3 paragraphs:
 
 Keep it under 250 words total. Be factual and balanced. Do not take a position. Output only the explanation text.`;
 
-    const explanation = await generateText(prompt, { maxTokens: 600 });
+  const explanation = await generateText(prompt, { maxTokens: 600 });
 
-    if (!explanation) {
-      return NextResponse.json({ error: 'AI explanation unavailable' }, { status: 503 });
-    }
-
-    await supabase
-      .from('proposals')
-      .update({ meta_json: { ...metaJson, ai_explanation: explanation } })
-      .eq('tx_hash', txHash)
-      .eq('proposal_index', index);
-
-    captureServerEvent('proposal_explained', { tx_hash: txHash, proposal_index: index });
-
-    return NextResponse.json({ explanation, cached: false });
-  } catch (error) {
-    logger.error('Error', { context: 'proposal-explainer', error: error });
-    return NextResponse.json({ error: 'Failed to generate explanation' }, { status: 500 });
+  if (!explanation) {
+    return NextResponse.json({ error: 'AI explanation unavailable' }, { status: 503 });
   }
-}
+
+  await supabase
+    .from('proposals')
+    .update({ meta_json: { ...metaJson, ai_explanation: explanation } })
+    .eq('tx_hash', txHash)
+    .eq('proposal_index', index);
+
+  captureServerEvent('proposal_explained', { tx_hash: txHash, proposal_index: index });
+
+  return NextResponse.json({ explanation, cached: false });
+}, { auth: 'none', rateLimit: { max: 10, window: 60 } });

--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -9,96 +9,92 @@ import { sendPushBroadcast, buildPushPayload } from '@/lib/push';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { type NotificationPayload } from '@/lib/channelRenderers';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { PushSendSchema } from '@/lib/api/schemas/user';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { type } = body as { type: string };
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const body = PushSendSchema.parse(await request.json());
+  const { type } = body;
 
-    const supabase = getSupabaseAdmin();
+  const supabase = getSupabaseAdmin();
 
-    const { data: users } = await supabase
-      .from('users')
-      .select('wallet_address, push_subscriptions, claimed_drep_id')
-      .not('push_subscriptions', 'eq', '{}');
+  const { data: users } = await supabase
+    .from('users')
+    .select('wallet_address, push_subscriptions, claimed_drep_id')
+    .not('push_subscriptions', 'eq', '{}');
 
-    if (!users || users.length === 0) {
-      return NextResponse.json({ sent: 0, message: 'No subscribed users' });
-    }
-
-    const subscribedUsers = users.filter(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (u: any) => u.push_subscriptions?.endpoint && u.push_subscriptions?.keys,
-    );
-
-    let payload: NotificationPayload;
-    let targetAddresses = subscribedUsers.map((u) => u.wallet_address);
-
-    switch (type) {
-      case 'critical-proposal-open': {
-        const { proposalTitle, txHash, index } = body;
-        payload = {
-          eventType: 'critical-proposal-open',
-          fallback: {
-            title: 'Critical Governance Proposal',
-            body: proposalTitle
-              ? `"${proposalTitle}" is open for voting. This is a high-impact proposal.`
-              : 'A critical governance proposal is now open for voting.',
-            url: txHash ? `/proposals/${txHash}/${index || 0}` : '/proposals',
-          },
-        };
-        break;
-      }
-
-      case 'drep-pending-proposals': {
-        const { pendingCount, criticalCount } = body;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        targetAddresses = subscribedUsers
-          .filter((u: any) => u.claimed_drep_id)
-          .map((u) => u.wallet_address);
-        payload = {
-          eventType: 'pending-proposals',
-          fallback: {
-            title:
-              criticalCount > 0
-                ? `${criticalCount} critical proposal${criticalCount !== 1 ? 's' : ''} need your vote`
-                : `${pendingCount} proposal${pendingCount !== 1 ? 's' : ''} awaiting your vote`,
-            body: 'Open your DRep dashboard to review and vote.',
-            url: '/dashboard/inbox',
-          },
-        };
-        break;
-      }
-
-      case 'test': {
-        payload = {
-          eventType: 'platform-announcement',
-          fallback: {
-            title: 'DRepScore Test Notification',
-            body: 'Push notifications are working!',
-            url: '/',
-          },
-        };
-        break;
-      }
-
-      default:
-        return NextResponse.json({ error: `Unknown type: ${type}` }, { status: 400 });
-    }
-
-    // Use buildPushPayload to verify the payload structure is correct
-    buildPushPayload(payload);
-
-    const result = await sendPushBroadcast(targetAddresses, payload);
-    return NextResponse.json({
-      sent: result.sent,
-      expired: result.expired,
-      total: targetAddresses.length,
-    });
-  } catch (err) {
-    logger.error('Error', { context: 'push-api', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  if (!users || users.length === 0) {
+    return NextResponse.json({ sent: 0, message: 'No subscribed users' });
   }
-}
+
+  const subscribedUsers = users.filter(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (u: any) => u.push_subscriptions?.endpoint && u.push_subscriptions?.keys,
+  );
+
+  let payload: NotificationPayload;
+  let targetAddresses = subscribedUsers.map((u) => u.wallet_address);
+
+  switch (type) {
+    case 'critical-proposal-open': {
+      const { proposalTitle, txHash, index } = body;
+      payload = {
+        eventType: 'critical-proposal-open',
+        fallback: {
+          title: 'Critical Governance Proposal',
+          body: proposalTitle
+            ? `"${proposalTitle}" is open for voting. This is a high-impact proposal.`
+            : 'A critical governance proposal is now open for voting.',
+          url: txHash ? `/proposals/${txHash}/${index || 0}` : '/proposals',
+        },
+      };
+      break;
+    }
+
+    case 'drep-pending-proposals': {
+      const { pendingCount, criticalCount } = body;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      targetAddresses = subscribedUsers
+        .filter((u: any) => u.claimed_drep_id)
+        .map((u) => u.wallet_address);
+      payload = {
+        eventType: 'pending-proposals',
+        fallback: {
+          title:
+            criticalCount && criticalCount > 0
+              ? `${criticalCount} critical proposal${criticalCount !== 1 ? 's' : ''} need your vote`
+              : `${pendingCount} proposal${pendingCount !== 1 ? 's' : ''} awaiting your vote`,
+          body: 'Open your DRep dashboard to review and vote.',
+          url: '/dashboard/inbox',
+        },
+      };
+      break;
+    }
+
+    case 'test': {
+      payload = {
+        eventType: 'platform-announcement',
+        fallback: {
+          title: 'DRepScore Test Notification',
+          body: 'Push notifications are working!',
+          url: '/',
+        },
+      };
+      break;
+    }
+
+    default:
+      return NextResponse.json({ error: `Unknown type: ${type}` }, { status: 400 });
+  }
+
+  buildPushPayload(payload);
+
+  const result = await sendPushBroadcast(targetAddresses, payload);
+  return NextResponse.json({
+    sent: result.sent,
+    expired: result.expired,
+    total: targetAddresses.length,
+  });
+}, { auth: 'none', rateLimit: { max: 10, window: 60 } });

--- a/app/api/rationale/draft/route.ts
+++ b/app/api/rationale/draft/route.ts
@@ -8,61 +8,58 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDRepById } from '@/lib/data';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { RationaleDraftSchema } from '@/lib/api/schemas/governance';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30;
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { drepId, proposalTitle, proposalAbstract, proposalType, aiSummary } = body;
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const { drepId, proposalTitle, proposalAbstract, proposalType, aiSummary } =
+    RationaleDraftSchema.parse(await request.json());
 
-    if (!drepId || !proposalTitle) {
-      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
-    }
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'AI features not configured' }, { status: 503 });
+  }
 
-    const apiKey = process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      return NextResponse.json({ error: 'AI features not configured' }, { status: 503 });
-    }
+  const drep = await getDRepById(drepId);
+  if (!drep) {
+    return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
+  }
 
-    const drep = await getDRepById(drepId);
-    if (!drep) {
-      return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
-    }
+  const metadata = drep.metadata || {};
+  const objectives = (metadata.objectives as string) || '';
+  const motivations = (metadata.motivations as string) || '';
+  const qualifications = (metadata.qualifications as string) || '';
 
-    const metadata = drep.metadata || {};
-    const objectives = (metadata.objectives as string) || '';
-    const motivations = (metadata.motivations as string) || '';
-    const qualifications = (metadata.qualifications as string) || '';
+  const drepContext = [
+    objectives && `Objectives: ${objectives}`,
+    motivations && `Motivations: ${motivations}`,
+    qualifications && `Qualifications: ${qualifications}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
 
-    const drepContext = [
-      objectives && `Objectives: ${objectives}`,
-      motivations && `Motivations: ${motivations}`,
-      qualifications && `Qualifications: ${qualifications}`,
-    ]
-      .filter(Boolean)
-      .join('\n');
+  const proposalContext = [
+    `Title: ${proposalTitle}`,
+    proposalType && `Type: ${proposalType}`,
+    proposalAbstract && `Abstract: ${proposalAbstract}`,
+    aiSummary && `Summary: ${aiSummary}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
 
-    const proposalContext = [
-      `Title: ${proposalTitle}`,
-      proposalType && `Type: ${proposalType}`,
-      proposalAbstract && `Abstract: ${proposalAbstract}`,
-      aiSummary && `Summary: ${aiSummary}`,
-    ]
-      .filter(Boolean)
-      .join('\n');
+  const { default: Anthropic } = await import('@anthropic-ai/sdk');
+  const anthropic = new Anthropic({ apiKey });
 
-    const { default: Anthropic } = await import('@anthropic-ai/sdk');
-    const anthropic = new Anthropic({ apiKey });
-
-    const message = await anthropic.messages.create({
-      model: 'claude-sonnet-4-20250514',
-      max_tokens: 1024,
-      messages: [
-        {
-          role: 'user',
-          content: `You are helping a Cardano DRep (Delegated Representative) write a CIP-100 compatible voting rationale for a governance proposal.
+  const message = await anthropic.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1024,
+    messages: [
+      {
+        role: 'user',
+        content: `You are helping a Cardano DRep (Delegated Representative) write a CIP-100 compatible voting rationale for a governance proposal.
 
 PROPOSAL:
 ${proposalContext}
@@ -77,17 +74,13 @@ Write a professional, structured voting rationale draft. The DRep will review an
 Keep it concise (under 300 words), factual, and neutral in tone. Do not make assumptions about the DRep's vote choice. Reference the DRep's stated objectives where relevant to help them frame their position.
 
 Output only the rationale text, no preamble.`,
-        },
-      ],
-    });
+      },
+    ],
+  });
 
-    const draft = message.content[0].type === 'text' ? message.content[0].text : '';
+  const draft = message.content[0].type === 'text' ? message.content[0].text : '';
 
-    captureServerEvent('rationale_ai_drafted', { drep_id: drepId }, drepId);
+  captureServerEvent('rationale_ai_drafted', { drep_id: drepId }, drepId);
 
-    return NextResponse.json({ draft });
-  } catch (error) {
-    logger.error('Error', { context: 'rationale-draft-api', error: error });
-    return NextResponse.json({ error: 'Failed to generate draft' }, { status: 500 });
-  }
-}
+  return NextResponse.json({ draft });
+}, { auth: 'none', rateLimit: { max: 10, window: 60 } });

--- a/app/api/telegram/connect/route.ts
+++ b/app/api/telegram/connect/route.ts
@@ -1,101 +1,82 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { requireAuth } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { TelegramConnectSchema } from '@/lib/api/schemas/user';
 
-/**
- * POST: Complete Telegram connect flow
- * Called from profile page when user visits with telegram_connect token
- */
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await requireAuth(request);
-    if (auth instanceof NextResponse) return auth;
+export const POST = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const body = await request.json();
+  const { token } = TelegramConnectSchema.parse(body);
 
-    const { token } = await request.json();
-    if (!token) {
-      return NextResponse.json({ error: 'Missing token' }, { status: 400 });
-    }
+  const supabase = getSupabaseAdmin();
 
-    const supabase = getSupabaseAdmin();
+  const { data: pending } = await supabase
+    .from('user_channels')
+    .select('*')
+    .eq('channel', 'telegram_pending')
+    .single();
 
-    // Find the pending connection
-    const { data: pending } = await supabase
-      .from('user_channels')
-      .select('*')
-      .eq('channel', 'telegram_pending')
-      .single();
-
-    if (!pending) {
-      return NextResponse.json({ error: 'No pending connection found' }, { status: 404 });
-    }
-
-    const config = pending.config as { token: string; chatId: number };
-    if (config.token !== token) {
-      return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
-    }
-
-    const chatId = String(config.chatId);
-    const wallet = auth.wallet;
-
-    // Create the actual connection
-    await supabase.from('user_channels').upsert(
-      {
-        user_wallet: wallet,
-        channel: 'telegram',
-        channel_identifier: chatId,
-        config: { chatId: config.chatId },
-        connected_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_wallet,channel' },
-    );
-
-    // Enable default notification preferences
-    const defaultEvents = [
-      'score-change',
-      'pending-proposals',
-      'urgent-deadline',
-      'critical-proposal-open',
-    ];
-    for (const eventType of defaultEvents) {
-      await supabase.from('notification_preferences').upsert(
-        {
-          user_wallet: wallet,
-          channel: 'telegram',
-          event_type: eventType,
-          enabled: true,
-        },
-        { onConflict: 'user_wallet,channel,event_type' },
-      );
-    }
-
-    captureServerEvent('telegram_connected', { chat_id: chatId }, wallet);
-
-    // Clean up pending
-    await supabase
-      .from('user_channels')
-      .delete()
-      .eq('channel', 'telegram_pending')
-      .eq('channel_identifier', chatId);
-
-    // Notify user on Telegram
-    const botToken = process.env.TELEGRAM_BOT_TOKEN;
-    if (botToken) {
-      await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          chat_id: config.chatId,
-          text: "✅ <b>Wallet Connected!</b>\n\nYour Telegram is now linked to your DRepScore account. You'll receive governance alerts here.",
-          parse_mode: 'HTML',
-        }),
-      }).catch(() => {});
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (err) {
-    logger.error('Error', { context: 'telegram-connect', error: err });
-    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  if (!pending) {
+    return NextResponse.json({ error: 'No pending connection found' }, { status: 404 });
   }
-}
+
+  const config = pending.config as { token: string; chatId: number };
+  if (config.token !== token) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 400 });
+  }
+
+  const chatId = String(config.chatId);
+
+  await supabase.from('user_channels').upsert(
+    {
+      user_wallet: wallet!,
+      channel: 'telegram',
+      channel_identifier: chatId,
+      config: { chatId: config.chatId },
+      connected_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_wallet,channel' },
+  );
+
+  const defaultEvents = [
+    'score-change',
+    'pending-proposals',
+    'urgent-deadline',
+    'critical-proposal-open',
+  ];
+  for (const eventType of defaultEvents) {
+    await supabase.from('notification_preferences').upsert(
+      {
+        user_wallet: wallet!,
+        channel: 'telegram',
+        event_type: eventType,
+        enabled: true,
+      },
+      { onConflict: 'user_wallet,channel,event_type' },
+    );
+  }
+
+  captureServerEvent('telegram_connected', { chat_id: chatId }, wallet!);
+
+  await supabase
+    .from('user_channels')
+    .delete()
+    .eq('channel', 'telegram_pending')
+    .eq('channel_identifier', chatId);
+
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  if (botToken) {
+    await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: config.chatId,
+        text: "✅ <b>Wallet Connected!</b>\n\nYour Telegram is now linked to your DRepScore account. You'll receive governance alerts here.",
+        parse_mode: 'HTML',
+      }),
+    }).catch(() => {});
+  }
+
+  return NextResponse.json({ ok: true });
+}, { auth: 'required', rateLimit: { max: 5, window: 60 } });

--- a/app/api/treasury/accountability/route.ts
+++ b/app/api/treasury/accountability/route.ts
@@ -2,13 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient, getSupabaseAdmin } from '@/lib/supabase';
 import { getSpendingEffectiveness } from '@/lib/treasury';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url);
     const txHash = searchParams.get('txHash');
     const index = searchParams.get('index');
 
@@ -36,17 +35,12 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    const effectiveness = await getSpendingEffectiveness();
-    return NextResponse.json(effectiveness);
-  } catch (error) {
-    logger.error('Error', { context: 'treasury/accountability', error: error });
-    return NextResponse.json({ error: 'Failed to fetch accountability data' }, { status: 500 });
-  }
-}
+  const effectiveness = await getSpendingEffectiveness();
+  return NextResponse.json(effectiveness);
+});
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
+export const POST = withRouteHandler(async (request: NextRequest) => {
+  const body = await request.json();
     const {
       txHash,
       index,
@@ -119,9 +113,5 @@ export async function POST(request: NextRequest) {
       userAddress,
     );
 
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    logger.error('POST error', { context: 'treasury/accountability', error: error });
-    return NextResponse.json({ error: 'Failed to submit vote' }, { status: 500 });
-  }
-}
+  return NextResponse.json({ success: true });
+});

--- a/app/api/user/channels/route.ts
+++ b/app/api/user/channels/route.ts
@@ -1,36 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { requireAuth } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { ChannelConnectSchema, ChannelDeleteSchema } from '@/lib/api/schemas/user';
 
-export async function GET(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const supabase = getSupabaseAdmin();
   const { data } = await supabase
     .from('user_channels')
     .select('channel, channel_identifier, config, connected_at')
-    .eq('user_wallet', wallet);
+    .eq('user_wallet', wallet!);
 
   return NextResponse.json(data || []);
-}
+}, { auth: 'required' });
 
-export async function POST(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
-  const { channel, channelIdentifier, config } = await request.json();
-  if (!channel || !channelIdentifier) {
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
-  }
+export const POST = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const body = await request.json();
+  const { channel, channelIdentifier, config } = ChannelConnectSchema.parse(body);
 
   const supabase = getSupabaseAdmin();
   const { error } = await supabase.from('user_channels').upsert(
     {
-      user_wallet: wallet,
+      user_wallet: wallet!,
       channel,
       channel_identifier: channelIdentifier,
       config: config || {},
@@ -43,21 +34,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  captureServerEvent('notification_channel_connected', { channel }, wallet);
+  captureServerEvent('notification_channel_connected', { channel }, wallet!);
   return NextResponse.json({ ok: true });
-}
+}, { auth: 'required', rateLimit: { max: 20, window: 60 } });
 
-export async function DELETE(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
-  const { channel } = await request.json();
-  if (!channel) return NextResponse.json({ error: 'Missing channel' }, { status: 400 });
+export const DELETE = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const body = await request.json();
+  const { channel } = ChannelDeleteSchema.parse(body);
 
   const supabase = getSupabaseAdmin();
-  await supabase.from('user_channels').delete().eq('user_wallet', wallet).eq('channel', channel);
+  await supabase.from('user_channels').delete().eq('user_wallet', wallet!).eq('channel', channel);
 
-  captureServerEvent('notification_channel_disconnected', { channel }, wallet);
+  captureServerEvent('notification_channel_disconnected', { channel }, wallet!);
   return NextResponse.json({ ok: true });
-}
+}, { auth: 'required', rateLimit: { max: 20, window: 60 } });

--- a/app/api/user/email/route.ts
+++ b/app/api/user/email/route.ts
@@ -10,17 +10,11 @@ import { sendEmail, generateVerificationUrl } from '@/lib/email';
 import { EmailVerificationEmail } from '@/lib/emailTemplates';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { requireAuth } from '@/lib/supabaseAuth';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { EmailSchema } from '@/lib/api/schemas/user';
 
-export async function POST(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
-  const { email } = await request.json();
-  if (!email || typeof email !== 'string' || !email.includes('@')) {
-    return NextResponse.json({ error: 'Invalid email' }, { status: 400 });
-  }
+export const POST = withRouteHandler(async (request: NextRequest, { requestId, wallet }: RouteContext) => {
+  const { email } = EmailSchema.parse(await request.json());
 
   const supabase = getSupabaseAdmin();
 
@@ -29,14 +23,14 @@ export async function POST(request: NextRequest) {
     .update({ email, email_verified: false })
     .eq('wallet_address', wallet);
 
-  const verifyUrl = generateVerificationUrl(wallet, email);
+  const verifyUrl = generateVerificationUrl(wallet!, email);
   const sent = await sendEmail(
     email,
     'Verify your email — DRepScore',
     React.createElement(EmailVerificationEmail, { verifyUrl }),
   );
 
-  captureServerEvent('email_subscribed', { digest_frequency: 'weekly' }, wallet);
+  captureServerEvent('email_subscribed', { digest_frequency: 'weekly' }, wallet!);
 
   return NextResponse.json({ ok: true, sent });
-}
+}, { auth: 'required', rateLimit: { max: 5, window: 60 } });

--- a/app/api/user/notification-prefs/route.ts
+++ b/app/api/user/notification-prefs/route.ts
@@ -1,36 +1,27 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { requireAuth } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { NotificationPrefSchema } from '@/lib/api/schemas/user';
 
-export async function GET(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
   const supabase = getSupabaseAdmin();
   const { data } = await supabase
     .from('notification_preferences')
     .select('channel, event_type, enabled')
-    .eq('user_wallet', wallet);
+    .eq('user_wallet', wallet!);
 
   return NextResponse.json(data || []);
-}
+}, { auth: 'required' });
 
-export async function POST(request: NextRequest) {
-  const auth = await requireAuth(request);
-  if (auth instanceof NextResponse) return auth;
-  const wallet = auth.wallet;
-
-  const { channel, eventType, enabled } = await request.json();
-  if (!channel || !eventType || typeof enabled !== 'boolean') {
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
-  }
+export const POST = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const body = await request.json();
+  const { channel, eventType, enabled } = NotificationPrefSchema.parse(body);
 
   const supabase = getSupabaseAdmin();
   const { error } = await supabase.from('notification_preferences').upsert(
     {
-      user_wallet: wallet,
+      user_wallet: wallet!,
       channel,
       event_type: eventType,
       enabled,
@@ -45,7 +36,7 @@ export async function POST(request: NextRequest) {
   captureServerEvent(
     'notification_pref_toggled',
     { channel, event_type: eventType, enabled },
-    wallet,
+    wallet!,
   );
   return NextResponse.json({ ok: true });
-}
+}, { auth: 'required', rateLimit: { max: 20, window: 60 } });

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,24 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { validateSessionToken } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { SupabaseUser, SupabaseUserUpdate } from '@/types/supabase';
 import { logger } from '@/lib/logger';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 
-async function authenticateRequest(request: NextRequest): Promise<string | null> {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7);
-  const session = await validateSessionToken(token);
-  return session?.walletAddress ?? null;
-}
-
-export async function GET(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const GET = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('users')
@@ -41,14 +28,10 @@ export async function GET(request: NextRequest) {
     ...data,
     previousVisitAt,
   } as SupabaseUser & { previousVisitAt: string | null });
-}
+}, { auth: 'required' });
 
-export async function PATCH(request: NextRequest) {
-  const walletAddress = await authenticateRequest(request);
-  if (!walletAddress) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+export const PATCH = withRouteHandler(async (request: NextRequest, { wallet }: RouteContext) => {
+  const walletAddress = wallet!;
   const updates: SupabaseUserUpdate = await request.json();
 
   const allowedFields: (keyof SupabaseUserUpdate)[] = [
@@ -81,4 +64,4 @@ export async function PATCH(request: NextRequest) {
   }
 
   return NextResponse.json(data as SupabaseUser);
-}
+}, { auth: 'required' });

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -2,43 +2,33 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { validateSessionToken } from '@/lib/supabaseAuth';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { ViewSchema } from '@/lib/api/schemas/governance';
 
-/**
- * POST: Record a profile view (non-blocking, fire-and-forget from client)
- */
-export async function POST(request: NextRequest) {
-  try {
-    const { drepId, sessionToken } = await request.json();
-    if (!drepId || typeof drepId !== 'string') {
-      return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
-    }
+export const POST = withRouteHandler(async (request: NextRequest, { requestId }: RouteContext) => {
+  const body = await request.json();
+  const { drepId, sessionToken } = ViewSchema.parse(body);
 
-    let viewerWallet: string | null = null;
-    if (sessionToken) {
-      const parsed = await validateSessionToken(sessionToken);
-      if (parsed) viewerWallet = parsed.walletAddress;
-    }
-
-    const supabase = getSupabaseAdmin();
-    await supabase.from('profile_views').insert({
-      drep_id: drepId,
-      viewer_wallet: viewerWallet,
-    });
-
-    captureServerEvent(
-      'profile_viewed',
-      { drep_id: drepId, authenticated: !!viewerWallet },
-      viewerWallet || 'anonymous',
-    );
-    return NextResponse.json({ ok: true });
-  } catch {
-    return NextResponse.json({ ok: false }, { status: 500 });
+  let viewerWallet: string | null = null;
+  if (sessionToken) {
+    const parsed = await validateSessionToken(sessionToken);
+    if (parsed) viewerWallet = parsed.walletAddress;
   }
-}
 
-/**
- * GET: Fetch view stats for a DRep (used by dashboard)
- */
+  const supabase = getSupabaseAdmin();
+  await supabase.from('profile_views').insert({
+    drep_id: drepId,
+    viewer_wallet: viewerWallet,
+  });
+
+  captureServerEvent(
+    'profile_viewed',
+    { drep_id: drepId, authenticated: !!viewerWallet },
+    viewerWallet || 'anonymous',
+  );
+  return NextResponse.json({ ok: true });
+}, { auth: 'none', rateLimit: { max: 60, window: 60 } });
+
 export async function GET(request: NextRequest) {
   const drepId = request.nextUrl.searchParams.get('drepId');
   if (!drepId) {

--- a/lib/api/handler.ts
+++ b/lib/api/handler.ts
@@ -56,7 +56,7 @@ export function withApiHandler(handler: ApiHandler, options: HandlerOptions = {}
       }
 
       if (options.requiredTier && tier === 'anon') {
-        return apiError('tier_required', { required: options.requiredTier }, { requestId });
+        return apiError('tier_insufficient', { required_tier: options.requiredTier, current_tier: tier }, { requestId });
       }
 
       const ipHash = hashIp(

--- a/lib/api/schemas/auth.ts
+++ b/lib/api/schemas/auth.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const WalletAuthSchema = z.object({
+  address: z.string().min(1, 'address is required'),
+  nonce: z.string().min(1, 'nonce is required'),
+  nonceSignature: z.string().min(1, 'nonceSignature is required'),
+  signature: z.string().min(1, 'signature is required'),
+  key: z.string().min(1, 'key is required'),
+});

--- a/lib/api/schemas/common.ts
+++ b/lib/api/schemas/common.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const DrepIdSchema = z.string().min(1, 'drepId is required');
+
+export const TxHashSchema = z.string().min(1, 'txHash is required');
+
+export const SessionTokenSchema = z.string().min(1, 'sessionToken is required');
+
+export const ProposalIndexSchema = z.coerce.number().int().min(0);
+
+export const PaginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});

--- a/lib/api/schemas/drep.ts
+++ b/lib/api/schemas/drep.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { DrepIdSchema, SessionTokenSchema, TxHashSchema, ProposalIndexSchema } from './common';
+
+export const DrepClaimSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  drepId: DrepIdSchema,
+});
+
+export const DrepPhilosophySchema = z.object({
+  sessionToken: SessionTokenSchema,
+  philosophyText: z.string().min(1, 'philosophyText is required').max(5000),
+});
+
+export const DrepPositionSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  proposalTxHash: TxHashSchema,
+  proposalIndex: ProposalIndexSchema,
+  statementText: z.string().min(1, 'statementText is required').max(5000),
+});
+
+export const DrepExplanationSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  proposalTxHash: TxHashSchema,
+  proposalIndex: ProposalIndexSchema,
+  explanationText: z.string().min(1, 'explanationText is required').max(5000),
+  aiAssisted: z.boolean().optional(),
+});

--- a/lib/api/schemas/governance.ts
+++ b/lib/api/schemas/governance.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { DrepIdSchema, SessionTokenSchema, TxHashSchema, ProposalIndexSchema } from './common';
+
+export const ProposalExplainSchema = z.object({
+  txHash: TxHashSchema,
+  index: ProposalIndexSchema,
+});
+
+export const RationaleDraftSchema = z.object({
+  drepId: DrepIdSchema,
+  proposalTitle: z.string().min(1, 'proposalTitle is required').max(500),
+  proposalAbstract: z.string().max(5000).optional(),
+  proposalType: z.string().max(200).optional(),
+  aiSummary: z.string().max(5000).optional(),
+});
+
+export const PollVoteSchema = z.object({
+  proposalTxHash: TxHashSchema,
+  proposalIndex: ProposalIndexSchema,
+  vote: z.enum(['yes', 'no', 'abstain']),
+  stakeAddress: z.string().optional(),
+  delegatedDrepId: z.string().optional(),
+});
+
+export const QuestionSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  drepId: DrepIdSchema,
+  questionText: z.string().min(1, 'questionText is required').max(500),
+});
+
+export const QuestionRespondSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  responseText: z.string().min(1, 'responseText is required').max(2000),
+});
+
+export const ViewSchema = z.object({
+  drepId: DrepIdSchema,
+  sessionToken: z.string().optional(),
+});

--- a/lib/api/schemas/user.ts
+++ b/lib/api/schemas/user.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { SessionTokenSchema } from './common';
+
+export const EmailSchema = z.object({
+  email: z.string().min(1, 'email is required').email('Invalid email address'),
+});
+
+export const ChannelConnectSchema = z.object({
+  channel: z.string().min(1, 'channel is required'),
+  channelIdentifier: z.string().min(1, 'channelIdentifier is required'),
+  config: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const ChannelDeleteSchema = z.object({
+  channel: z.string().min(1, 'channel is required'),
+});
+
+export const NotificationPrefSchema = z.object({
+  channel: z.string().min(1, 'channel is required'),
+  eventType: z.string().min(1, 'eventType is required'),
+  enabled: z.boolean(),
+});
+
+export const TelegramConnectSchema = z.object({
+  token: z.string().min(1, 'token is required'),
+});
+
+export const OnboardingSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  item: z.string().min(1, 'item is required'),
+  completed: z.boolean().optional(),
+});
+
+const PushCriticalProposalSchema = z.object({
+  type: z.literal('critical-proposal-open'),
+  proposalTitle: z.string().optional(),
+  txHash: z.string().optional(),
+  index: z.coerce.number().int().min(0).optional(),
+});
+
+const PushPendingProposalsSchema = z.object({
+  type: z.literal('drep-pending-proposals'),
+  pendingCount: z.coerce.number().int().min(0).optional(),
+  criticalCount: z.coerce.number().int().min(0).optional(),
+});
+
+const PushTestSchema = z.object({
+  type: z.literal('test'),
+});
+
+export const PushSendSchema = z.discriminatedUnion('type', [
+  PushCriticalProposalSchema,
+  PushPendingProposalsSchema,
+  PushTestSchema,
+]);

--- a/lib/api/withRouteHandler.ts
+++ b/lib/api/withRouteHandler.ts
@@ -1,0 +1,171 @@
+/**
+ * Lightweight API handler wrapper for internal (non-v1) routes.
+ *
+ * Provides: auth, rate limiting, Zod error handling, structured logging,
+ * and a catch-all error boundary. Does NOT require API keys.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import { logger } from '@/lib/logger';
+import { generateRequestId, normalizeEndpoint } from './response';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { createHash } from 'crypto';
+
+interface RateLimitConfig {
+  max: number;
+  /** Window in seconds */
+  window: number;
+  /** Custom key extractor. Defaults to wallet (if authed) or IP hash. */
+  key?: (req: NextRequest, wallet?: string) => string;
+}
+
+interface RouteOptions {
+  auth?: 'required' | 'optional' | 'none';
+  rateLimit?: RateLimitConfig;
+}
+
+export interface RouteContext {
+  requestId: string;
+  wallet?: string;
+}
+
+type HandlerFn = (
+  request: NextRequest,
+  context: RouteContext,
+) => Promise<NextResponse>;
+
+function hashIp(ip: string): string {
+  return createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+function getClientIp(request: NextRequest): string {
+  return request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+}
+
+// Simple in-process sliding window rate limiter.
+// Uses Upstash when available, falls back to in-memory.
+const memoryStore = new Map<string, { count: number; resetAt: number }>();
+
+async function checkLimit(
+  identifier: string,
+  config: RateLimitConfig,
+): Promise<{ allowed: boolean; remaining: number }> {
+  // Try Upstash first
+  try {
+    const { getRedis } = await import('@/lib/redis');
+    const redis = getRedis();
+    if (redis) {
+      const { Ratelimit } = await import('@upstash/ratelimit');
+      const limiter = new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(config.max, `${config.window} s`),
+        prefix: 'rl:route',
+      });
+      const result = await limiter.limit(identifier);
+      return { allowed: result.success, remaining: result.remaining };
+    }
+  } catch {
+    // Fall through to in-memory
+  }
+
+  const now = Date.now();
+  const windowMs = config.window * 1000;
+  const entry = memoryStore.get(identifier);
+
+  if (!entry || now > entry.resetAt) {
+    memoryStore.set(identifier, { count: 1, resetAt: now + windowMs });
+    return { allowed: true, remaining: config.max - 1 };
+  }
+
+  if (entry.count >= config.max) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  entry.count++;
+  return { allowed: true, remaining: config.max - entry.count };
+}
+
+export function withRouteHandler(handler: HandlerFn, options: RouteOptions = {}) {
+  const { auth = 'none' } = options;
+
+  return async (request: NextRequest): Promise<NextResponse> => {
+    const requestId = generateRequestId();
+    const startMs = Date.now();
+
+    try {
+      // --- Auth ---
+      let wallet: string | undefined;
+
+      if (auth === 'required') {
+        const result = await requireAuth(request);
+        if (result instanceof NextResponse) return result;
+        wallet = result.wallet;
+      } else if (auth === 'optional') {
+        const result = await requireAuth(request);
+        if (!(result instanceof NextResponse)) {
+          wallet = result.wallet;
+        }
+      }
+
+      // --- Rate limiting ---
+      if (options.rateLimit) {
+        const key = options.rateLimit.key
+          ? options.rateLimit.key(request, wallet)
+          : wallet || hashIp(getClientIp(request));
+
+        const rl = await checkLimit(key, options.rateLimit);
+        if (!rl.allowed) {
+          return NextResponse.json(
+            { error: 'Too many requests. Please try again later.' },
+            { status: 429 },
+          );
+        }
+      }
+
+      // --- Execute ---
+      const ctx: RouteContext = { requestId, wallet };
+      const response = await handler(request, ctx);
+
+      // --- Log ---
+      const durationMs = Date.now() - startMs;
+      logger.info('API request', {
+        context: normalizeEndpoint(request.nextUrl.pathname),
+        method: request.method,
+        status: response.status,
+        durationMs,
+        requestId,
+      });
+
+      return response;
+    } catch (err) {
+      const durationMs = Date.now() - startMs;
+
+      if (err instanceof ZodError) {
+        const fields = err.issues.map((e) => `${String(e.path.join('.'))}: ${e.message}`);
+        logger.warn('Validation error', {
+          context: normalizeEndpoint(request.nextUrl.pathname),
+          requestId,
+          fields,
+        });
+        return NextResponse.json(
+          { error: 'Validation failed', details: fields },
+          { status: 400 },
+        );
+      }
+
+      logger.error('Route error', {
+        context: normalizeEndpoint(request.nextUrl.pathname),
+        method: request.method,
+        durationMs,
+        requestId,
+        error: err,
+      });
+
+      return NextResponse.json(
+        { error: 'Internal server error' },
+        { status: 500 },
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Backend hardening Phase 2 — API handler generalization, Zod input validation, and rate limiting.

- **`withRouteHandler` wrapper** (`lib/api/withRouteHandler.ts`): Lightweight handler for non-v1 routes providing centralized auth, rate limiting (Upstash Redis w/ in-memory fallback), Zod error boundary (auto 400 on validation failure), and structured request logging.
- **Zod input schemas** (`lib/api/schemas/`): Type-safe validation for all POST request bodies across auth, DRep, governance, and user routes. 5 schema files covering 15+ schemas.
- **39 routes migrated** to `withRouteHandler`:
  - **Tier 1** (8 high-value): auth/wallet (Zod only), proposals/explain, rationale/draft, drep-claim, push/send, user/email, polls/vote
  - **Tier 2** (10 writes): DRep explanations/philosophy/positions, governance Q&A, user channels/prefs, telegram, views, onboarding
  - **Tier 3** (21 auth reads): dashboard, governance, briefs, polls/results, user profile
- **Rate limiting** added to 18 routes (auth, AI, writes) — replaced in-memory Map in polls/vote with shared Upstash mechanism
- **Error registry bug fixed**: `tier_required` → `tier_insufficient` in v1 handler
- **44 GET-only no-auth routes** left unwrapped — already have error boundaries from Phase 1 structured logging

## Plan Audit

| Plan Item | Status |
|---|---|
| Create withRouteHandler | **Done** |
| Fix error registry bug | **Done** |
| Create Zod schemas | **Done** — 5 files, 15+ schemas |
| Migrate Tier 1 (8 routes) | **Done** |
| Migrate Tier 2 (10 routes) | **Done** |
| Migrate Tier 3 reads | **Done** — 21 of 65 (auth-protected only, GET-only deferred) |
| Replace polls in-memory rate limit | **Done** |
| Write Phase 3 plan | **Deferred** — after merge |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 255/255 tests, 17/17 files
- [x] Updated polls test mocks for new `requireAuth`-based auth
- [ ] Railway deploy — verify boot and route responses
- [ ] Smoke test: auth flow, poll vote, DRep claim, admin panel
