### PR TITLE
perf: backend hardening phase 3 — database and query optimization

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -771,14 +771,25 @@ export async function getVotesByProposal(
 
     if (error || !votes) return [];
 
-    // Fetch DRep names and alignment data
+    // Fetch DRep names/alignment and vote rationales in parallel (both depend only on votes)
     const drepIds = [...new Set(votes.map((v) => v.drep_id))];
-    const { data: dreps } = await supabase
-      .from('dreps')
-      .select(
-        'id, info, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
-      )
-      .in('id', drepIds);
+    const voteTxHashes = votes.map((v) => v.vote_tx_hash);
+
+    const [drepsResult, rationalesResult] = await Promise.all([
+      supabase
+        .from('dreps')
+        .select(
+          'id, info, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+        )
+        .in('id', drepIds),
+      supabase
+        .from('vote_rationales')
+        .select('vote_tx_hash, rationale_text, ai_summary, hash_verified')
+        .in('vote_tx_hash', voteTxHashes),
+    ]);
+
+    const dreps = drepsResult.data;
+    const rationales = rationalesResult.data;
 
     const drepNameMap = new Map<string, string | null>();
     const drepAlignmentMap = new Map<string, ProposalVoteDetail['alignments']>();
@@ -795,13 +806,6 @@ export async function getVotesByProposal(
         });
       }
     }
-
-    // Fetch rationale text and AI summaries
-    const voteTxHashes = votes.map((v) => v.vote_tx_hash);
-    const { data: rationales } = await supabase
-      .from('vote_rationales')
-      .select('vote_tx_hash, rationale_text, ai_summary, hash_verified')
-      .in('vote_tx_hash', voteTxHashes);
 
     const rationaleMap = new Map<
       string,
@@ -1222,12 +1226,19 @@ export async function getVotingPowerSummary(
   }
 
   // Fallback: sum from per-vote data (less accurate, missing system auto-DReps)
-  const { data: votes } = await supabase
-    .from('drep_votes')
-    .select('vote, voting_power_lovelace')
-    .eq('proposal_tx_hash', txHash)
-    .eq('proposal_index', proposalIndex)
-    .not('voting_power_lovelace', 'is', null);
+  // Run drep_votes and dreps in parallel (independent queries)
+  const [votesResult, activeDrepsResult] = await Promise.all([
+    supabase
+      .from('drep_votes')
+      .select('vote, voting_power_lovelace')
+      .eq('proposal_tx_hash', txHash)
+      .eq('proposal_index', proposalIndex)
+      .not('voting_power_lovelace', 'is', null),
+    supabase.from('dreps').select('info').eq('info->>isActive', 'true'),
+  ]);
+
+  const votes = votesResult.data;
+  const activeDreps = activeDrepsResult.data;
 
   let yesPower = 0,
     noPower = 0,
@@ -1251,11 +1262,6 @@ export async function getVotingPowerSummary(
       }
     }
   }
-
-  const { data: activeDreps } = await supabase
-    .from('dreps')
-    .select('info')
-    .eq('info->>isActive', 'true');
 
   let totalActivePower = 0;
   if (activeDreps) {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -24,9 +24,12 @@ export function createClient() {
 }
 
 /**
- * Admin Supabase client for writes
- * Uses service role key - SERVER-ONLY, never expose to client
- * Full write access, bypasses RLS
+ * Admin Supabase client for writes.
+ * Uses service role key - SERVER-ONLY, never expose to client.
+ * Full write access, bypasses RLS.
+ *
+ * Not a singleton: Supabase JS is HTTP-based so client creation is cheap.
+ * Profiled at <0.1ms per call — no measurable benefit from caching.
  */
 export function getSupabaseAdmin() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/lib/sync/proposals.ts
+++ b/lib/sync/proposals.ts
@@ -238,18 +238,21 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
             );
 
           if (summaries?.length) {
+            const txHashes = [...new Set(summaries.map((s) => s.proposal_tx_hash))];
+            const { data: existing } = await supabase
+              .from('proposal_vote_snapshots')
+              .select('proposal_tx_hash, proposal_index')
+              .eq('epoch', epoch)
+              .in('proposal_tx_hash', txHashes);
+            const existingKeys = new Set(
+              (existing ?? []).map((r) => `${r.proposal_tx_hash}|${r.proposal_index}`),
+            );
+            const toInsert = summaries.filter(
+              (s) => !existingKeys.has(`${s.proposal_tx_hash}|${s.proposal_index}`),
+            );
             let inserted = 0;
-            for (const s of summaries) {
-              const { data: existing } = await supabase
-                .from('proposal_vote_snapshots')
-                .select('epoch')
-                .eq('epoch', epoch)
-                .eq('proposal_tx_hash', s.proposal_tx_hash)
-                .eq('proposal_index', s.proposal_index)
-                .maybeSingle();
-              if (existing) continue;
-
-              const { error } = await supabase.from('proposal_vote_snapshots').insert({
+            for (let i = 0; i < toInsert.length; i += BATCH_SIZE) {
+              const batch = toInsert.slice(i, i + BATCH_SIZE).map((s) => ({
                 epoch,
                 proposal_tx_hash: s.proposal_tx_hash,
                 proposal_index: s.proposal_index,
@@ -264,8 +267,9 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
                 cc_yes_count: s.committee_yes_votes_cast ?? 0,
                 cc_no_count: s.committee_no_votes_cast ?? 0,
                 cc_abstain_count: s.committee_abstain_votes_cast ?? 0,
-              });
-              if (!error) inserted++;
+              }));
+              const { error } = await supabase.from('proposal_vote_snapshots').insert(batch);
+              if (!error) inserted += batch.length;
             }
             voteSnapshotCount = inserted;
             if (inserted > 0) {

--- a/lib/sync/secondary.ts
+++ b/lib/sync/secondary.ts
@@ -35,20 +35,22 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
         let updated = 0;
         for (let i = 0; i < dreps.length; i += DELEGATOR_CONCURRENCY) {
           const chunk = dreps.slice(i, i + DELEGATOR_CONCURRENCY);
-          const settled = await Promise.allSettled(
+          const chunkUpdates: Record<string, unknown>[] = [];
+          await Promise.allSettled(
             chunk.map(async (drep) => {
               const count = await fetchDRepDelegatorCount(drep.id);
               const existing = (drep.info as Record<string, unknown>) ?? {};
-              if (existing.delegatorCount === count) return false;
-              const { error } = await supabase
-                .from('dreps')
-                .update({ info: { ...existing, delegatorCount: count } })
-                .eq('id', drep.id);
-              if (error) throw new Error(error.message);
-              return true;
+              if (existing.delegatorCount === count) return;
+              chunkUpdates.push({
+                id: drep.id,
+                info: { ...existing, delegatorCount: count },
+              });
             }),
           );
-          updated += settled.filter((r) => r.status === 'fulfilled' && r.value).length;
+          if (chunkUpdates.length > 0) {
+            const result = await batchUpsert(supabase, 'dreps', chunkUpdates, 'id', 'DelegatorCounts');
+            updated += result.success;
+          }
         }
         return updated;
       })(),

--- a/lib/sync/slow.ts
+++ b/lib/sync/slow.ts
@@ -174,6 +174,7 @@ async function runAiSummaries(supabase: SupabaseClient) {
     .neq('abstract', '')
     .limit(10);
 
+  const proposalUpdates: { tx_hash: string; proposal_index: number; ai_summary: string }[] = [];
   for (const row of unsummarized || []) {
     try {
       const amountCtx = row.withdrawal_amount
@@ -192,16 +193,15 @@ async function runAiSummaries(supabase: SupabaseClient) {
       const raw = msg.content[0]?.type === 'text' ? msg.content[0].text.trim() : null;
       const summary = raw ? truncateToWordBoundary(stripUrls(raw), 160) : null;
       if (summary) {
-        await supabase
-          .from('proposals')
-          .update({ ai_summary: summary })
-          .eq('tx_hash', row.tx_hash)
-          .eq('proposal_index', row.proposal_index);
+        proposalUpdates.push({ tx_hash: row.tx_hash, proposal_index: row.proposal_index, ai_summary: summary });
         proposalSummaries++;
       }
     } catch (e) {
       log.error('[SlowSync] AI proposal summary error', { error: errMsg(e) });
     }
+  }
+  if (proposalUpdates.length > 0) {
+    await batchUpsert(supabase, 'proposals', proposalUpdates, 'tx_hash,proposal_index', 'AI proposal summary');
   }
 
   const { data: unsumRationales } = await supabase
@@ -232,6 +232,7 @@ async function runAiSummaries(supabase: SupabaseClient) {
     const dirs = new Map<string, string>();
     for (const v of vRows || []) dirs.set(v.vote_tx_hash, v.vote);
 
+    const rationaleUpdates: { vote_tx_hash: string; ai_summary: string }[] = [];
     for (const row of unsumRationales) {
       try {
         const title =
@@ -250,15 +251,15 @@ async function runAiSummaries(supabase: SupabaseClient) {
         const raw = msg.content[0]?.type === 'text' ? msg.content[0].text.trim() : null;
         const summary = raw ? truncateToWordBoundary(stripUrls(raw), 160) : null;
         if (summary) {
-          await supabase
-            .from('vote_rationales')
-            .update({ ai_summary: summary })
-            .eq('vote_tx_hash', row.vote_tx_hash);
+          rationaleUpdates.push({ vote_tx_hash: row.vote_tx_hash, ai_summary: summary });
           rationaleSummaries++;
         }
       } catch (e) {
         log.error('[SlowSync] AI rationale summary error', { error: errMsg(e) });
       }
+    }
+    if (rationaleUpdates.length > 0) {
+      await batchUpsert(supabase, 'vote_rationales', rationaleUpdates, 'vote_tx_hash', 'AI rationale summary');
     }
   }
 
@@ -312,7 +313,7 @@ async function runSocialLinkChecks(supabase: SupabaseClient) {
     .filter((l) => !freshSet.has(`${l.drep_id}|${l.uri}`))
     .slice(0, LINK_CHECK_LIMIT);
 
-  let checked = 0;
+  const linkResults: Record<string, unknown>[] = [];
   for (const link of toCheck) {
     let status = 'broken';
     let httpStatus: number | null = null;
@@ -332,22 +333,20 @@ async function runSocialLinkChecks(supabase: SupabaseClient) {
       /* stays broken */
     }
 
-    const { error: linkErr } = await supabase.from('social_link_checks').upsert(
-      {
-        drep_id: link.drep_id,
-        uri: link.uri,
-        status,
-        http_status: httpStatus,
-        last_checked_at: new Date().toISOString(),
-      },
-      { onConflict: 'drep_id,uri' },
-    );
-    if (linkErr) log.error('[SlowSync] social_link_checks upsert error', { error: linkErr.message });
-    checked++;
+    linkResults.push({
+      drep_id: link.drep_id,
+      uri: link.uri,
+      status,
+      http_status: httpStatus,
+      last_checked_at: new Date().toISOString(),
+    });
   }
 
-  if (checked > 0) log.info('[SlowSync] Social links checked', { count: checked });
-  return { checked };
+  if (linkResults.length > 0) {
+    await batchUpsert(supabase, 'social_link_checks', linkResults, 'drep_id,uri', 'Social link check');
+    log.info('[SlowSync] Social links checked', { count: linkResults.length });
+  }
+  return { checked: linkResults.length };
 }
 
 // ── Operation 4: Vote power backfill ────────────────────────────────────────
@@ -393,17 +392,22 @@ async function runVotePowerBackfill(supabase: SupabaseClient) {
       if (snapErr)
         log.error('[SlowSync] power_snapshots upsert error', { drepId, error: snapErr.message });
 
-      for (const snap of snapRows) {
-        const { count } = await supabase
-          .from('drep_votes')
-          .update(
-            { voting_power_lovelace: snap.amount_lovelace, power_source: 'exact' },
-            { count: 'exact' },
-          )
-          .eq('drep_id', drepId)
-          .eq('epoch_no', snap.epoch_no)
-          .is('voting_power_lovelace', null);
-        exactCount += count || 0;
+      const epochPowerMap = new Map(snapRows.map((s) => [s.epoch_no, s.amount_lovelace]));
+      const { data: exactVotes } = await supabase
+        .from('drep_votes')
+        .select('vote_tx_hash, epoch_no')
+        .eq('drep_id', drepId)
+        .in('epoch_no', snapRows.map((s) => s.epoch_no))
+        .is('voting_power_lovelace', null);
+
+      const exactUpdates = (exactVotes || []).map((v: { vote_tx_hash: string; epoch_no: number }) => ({
+        vote_tx_hash: v.vote_tx_hash,
+        voting_power_lovelace: epochPowerMap.get(v.epoch_no)!,
+        power_source: 'exact',
+      }));
+      exactCount += exactUpdates.length;
+      if (exactUpdates.length > 0) {
+        await batchUpsert(supabase, 'drep_votes', exactUpdates, 'vote_tx_hash', 'Power exact');
       }
 
       const { data: remaining } = await supabase
@@ -413,15 +417,19 @@ async function runVotePowerBackfill(supabase: SupabaseClient) {
         .is('voting_power_lovelace', null)
         .not('epoch_no', 'is', null);
 
-      for (const vote of remaining || []) {
+      const nearestUpdates = (remaining || []).map((vote: { vote_tx_hash: string; epoch_no: number }) => {
         const nearest = history.reduce((best, h) =>
           Math.abs(h.epoch_no - vote.epoch_no) < Math.abs(best.epoch_no - vote.epoch_no) ? h : best,
         );
-        await supabase
-          .from('drep_votes')
-          .update({ voting_power_lovelace: parseInt(nearest.amount, 10), power_source: 'nearest' })
-          .eq('vote_tx_hash', vote.vote_tx_hash);
-        nearestCount++;
+        return {
+          vote_tx_hash: vote.vote_tx_hash,
+          voting_power_lovelace: parseInt(nearest.amount, 10),
+          power_source: 'nearest',
+        };
+      });
+      nearestCount += nearestUpdates.length;
+      if (nearestUpdates.length > 0) {
+        await batchUpsert(supabase, 'drep_votes', nearestUpdates, 'vote_tx_hash', 'Power nearest');
       }
     } catch (err) {
       log.warn('[SlowSync] Power backfill error', { drepId: drepId.slice(0, 20), error: errMsg(err) });
@@ -457,6 +465,7 @@ async function runRationaleHashVerification(supabase: SupabaseClient) {
   let verified = 0;
   let failed = 0;
 
+  const hashUpdates: { vote_tx_hash: string; hash_verified: boolean }[] = [];
   for (const row of unchecked) {
     const expectedHash = hashMap.get(row.vote_tx_hash);
     if (!expectedHash) continue;
@@ -471,15 +480,15 @@ async function runRationaleHashVerification(supabase: SupabaseClient) {
       const rawBytes = new Uint8Array(await res.arrayBuffer());
       const computedHash = blake2bHex(rawBytes, undefined, 32);
       const matches = computedHash === expectedHash;
-      await supabase
-        .from('vote_rationales')
-        .update({ hash_verified: matches })
-        .eq('vote_tx_hash', row.vote_tx_hash);
+      hashUpdates.push({ vote_tx_hash: row.vote_tx_hash, hash_verified: matches });
       if (matches) verified++;
       else failed++;
     } catch {
       /* skip */
     }
+  }
+  if (hashUpdates.length > 0) {
+    await batchUpsert(supabase, 'vote_rationales', hashUpdates, 'vote_tx_hash', 'Rationale hash');
   }
 
   log.info('[SlowSync] Rationale hash verification', { verified, mismatch: failed });
@@ -509,6 +518,7 @@ async function runDRepMetadataHashVerification(supabase: SupabaseClient) {
   let verified = 0;
   let failed = 0;
 
+  const metaHashUpdates: { id: string; metadata_hash_verified: boolean }[] = [];
   for (const id of drepIds) {
     const anchor = anchorMap.get(id);
     if (!anchor) continue;
@@ -523,12 +533,15 @@ async function runDRepMetadataHashVerification(supabase: SupabaseClient) {
       const rawBytes = new Uint8Array(await res.arrayBuffer());
       const computedHash = blake2bHex(rawBytes, undefined, 32);
       const matches = computedHash === anchor.hash;
-      await supabase.from('dreps').update({ metadata_hash_verified: matches }).eq('id', id);
+      metaHashUpdates.push({ id, metadata_hash_verified: matches });
       if (matches) verified++;
       else failed++;
     } catch {
       /* skip */
     }
+  }
+  if (metaHashUpdates.length > 0) {
+    await batchUpsert(supabase, 'dreps', metaHashUpdates, 'id', 'DRep metadata hash');
   }
 
   if (verified + failed > 0) {

--- a/lib/sync/votes.ts
+++ b/lib/sync/votes.ts
@@ -130,6 +130,7 @@ export async function executeVotesSync(): Promise<Record<string, unknown>> {
       }
     }
 
+    const reconUpdates: Record<string, unknown>[] = [];
     for (const [drepId, counts] of computedCounts) {
       const info = allCurrentInfo.get(drepId);
       if (!info) continue;
@@ -141,19 +142,21 @@ export async function executeVotesSync(): Promise<Record<string, unknown>> {
       )
         continue;
 
-      await supabase
-        .from('dreps')
-        .update({
-          info: {
-            ...info,
-            totalVotes: counts.total,
-            yesVotes: counts.yes,
-            noVotes: counts.no,
-            abstainVotes: counts.abstain,
-          },
-        })
-        .eq('id', drepId);
-      reconciled++;
+      reconUpdates.push({
+        id: drepId,
+        info: {
+          ...info,
+          totalVotes: counts.total,
+          yesVotes: counts.yes,
+          noVotes: counts.no,
+          abstainVotes: counts.abstain,
+        },
+      });
+    }
+
+    if (reconUpdates.length > 0) {
+      const result = await batchUpsert(supabase, 'dreps', reconUpdates, 'id', 'VoteReconciliation');
+      reconciled = result.success;
     }
 
     if (reconciled > 0) {

--- a/supabase/migrations/041_phase3_performance_indexes.sql
+++ b/supabase/migrations/041_phase3_performance_indexes.sql
@@ -1,0 +1,25 @@
+-- Phase 3A: Performance indexes for hot query paths
+-- All IF NOT EXISTS — safe to run idempotently
+
+-- poll_responses: governance/matches lookup, polls/vote upsert check
+CREATE INDEX IF NOT EXISTS idx_poll_responses_wallet
+  ON poll_responses (wallet_address);
+
+CREATE INDEX IF NOT EXISTS idx_poll_responses_proposal
+  ON poll_responses (proposal_tx_hash, proposal_index);
+
+-- drep_score_history: dashboard + score-history (every DRep page view)
+CREATE INDEX IF NOT EXISTS idx_drep_score_history_drep
+  ON drep_score_history (drep_id);
+
+-- social_link_checks: DRep profile display + slow sync
+CREATE INDEX IF NOT EXISTS idx_social_link_checks_drep_uri
+  ON social_link_checks (drep_id, uri);
+
+-- drep_pca_coordinates: governance/matches PCA similarity lookups
+CREATE INDEX IF NOT EXISTS idx_drep_pca_run
+  ON drep_pca_coordinates (run_id);
+
+-- sync_log: sync-freshness-guard Inngest cron checks
+CREATE INDEX IF NOT EXISTS idx_sync_log_type_time
+  ON sync_log (sync_type, started_at DESC);


### PR DESCRIPTION
## Summary

Backend hardening Phase 3 — database and query optimization.

- **6 performance indexes** applied to production via SQL migration (poll_responses, drep_score_history, social_link_checks, drep_pca_coordinates, sync_log)
- **N+1 elimination** across 4 sync files:
  - `votes.ts`: reconciliation loop batched (per-DRep update → `batchUpsert`)
  - `proposals.ts`: vote snapshot inserts batched (per-row select+insert → bulk existence check + bulk insert)
  - `slow.ts`: 6 loops batched (AI summaries, rationale summaries, social link checks, hash verification, power backfill, metadata verification — all collect-then-upsert)
  - `secondary.ts`: delegator count updates batched per-chunk
- **Query parallelization** in `lib/data.ts`:
  - `getVotesByProposal`: dreps + vote_rationales queries now run in `Promise.all()`
  - `getVotingPowerSummary`: fallback drep_votes + dreps queries now run in parallel
- **Supabase client profiled**: HTTP-based, <0.1ms overhead per call — singleton not warranted

## Plan Audit

| Plan Item | Status |
|---|---|
| Index migration (3A) | **Done** — 6 indexes applied live |
| Batch votes.ts (3B P1) | **Done** |
| Batch proposals.ts (3B P2) | **Done** |
| Batch slow.ts 6 loops (3B P3) | **Done** |
| Batch secondary.ts (3B P4) | **Done** |
| Parallelize getVotesByProposal (3C) | **Done** |
| Parallelize getVotingPowerSummary (3C) | **Done** |
| Supabase client optimization (3D) | **Done** — profiled, no action needed |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 255/255 tests, 17/17 files
- [x] Indexes verified live via `pg_indexes` query
- [ ] Railway deploy — verify boot and sync routes
- [ ] Monitor next vote/drep sync for duration improvement
