### PR TITLE
feat: backend hardening phase 4 — resilience and monitoring

### DIFF
--- a/app/api/delegation/route.ts
+++ b/app/api/delegation/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
-
-const KOIOS_BASE_URL = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
-const KOIOS_API_KEY = process.env.KOIOS_API_KEY;
+import { fetchDelegatedDRep } from '@/utils/koios';
 
 export const POST = withRouteHandler(async (request: NextRequest) => {
   const { stakeAddress } = await request.json();
@@ -12,35 +10,13 @@ export const POST = withRouteHandler(async (request: NextRequest) => {
     return NextResponse.json({ error: 'stakeAddress required' }, { status: 400 });
   }
 
-  try {
-    const headers: HeadersInit = {
-      'Content-Type': 'application/json',
-      ...(KOIOS_API_KEY && { Authorization: `Bearer ${KOIOS_API_KEY}` }),
-    };
+  const drepId = await fetchDelegatedDRep(stakeAddress);
 
-    const res = await fetch(`${KOIOS_BASE_URL}/account_info`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ _stake_addresses: [stakeAddress] }),
-      cache: 'no-store',
-    });
+  captureServerEvent(
+    'delegation_updated',
+    { wallet_address: stakeAddress, drep_id: drepId },
+    stakeAddress,
+  );
 
-    if (!res.ok) {
-      return NextResponse.json({ drepId: null });
-    }
-
-    const data = await res.json();
-    const account = Array.isArray(data) ? data[0] : null;
-    const drepId = account?.vote_delegation || account?.delegated_drep || null;
-
-    captureServerEvent(
-      'delegation_updated',
-      { wallet_address: stakeAddress, drep_id: drepId },
-      stakeAddress,
-    );
-
-    return NextResponse.json({ drepId });
-  } catch {
-    return NextResponse.json({ drepId: null });
-  }
+  return NextResponse.json({ drepId });
 });

--- a/app/api/health/deep/route.ts
+++ b/app/api/health/deep/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { checkKoiosHealth } from '@/utils/koios';
+import { getRedis } from '@/lib/redis';
+
+export const dynamic = 'force-dynamic';
+
+type DepStatus = 'healthy' | 'unhealthy' | 'unavailable';
+
+interface DepResult {
+  status: DepStatus;
+  latencyMs: number;
+}
+
+async function probeSupabase(): Promise<DepResult> {
+  const start = Date.now();
+  try {
+    const supabase = getSupabaseAdmin();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5_000);
+
+    const { error } = await supabase
+      .from('dreps')
+      .select('id', { count: 'exact', head: true })
+      .limit(1)
+      .abortSignal(controller.signal);
+
+    clearTimeout(timer);
+    return { status: error ? 'unhealthy' : 'healthy', latencyMs: Date.now() - start };
+  } catch {
+    return { status: 'unhealthy', latencyMs: Date.now() - start };
+  }
+}
+
+async function probeKoios(): Promise<DepResult> {
+  const start = Date.now();
+  try {
+    const ok = await Promise.race([
+      checkKoiosHealth(),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 10_000)),
+    ]);
+    return { status: ok ? 'healthy' : 'unhealthy', latencyMs: Date.now() - start };
+  } catch {
+    return { status: 'unhealthy', latencyMs: Date.now() - start };
+  }
+}
+
+async function probeRedis(): Promise<DepResult> {
+  const start = Date.now();
+  try {
+    const redis = getRedis();
+    if (!redis) return { status: 'unavailable', latencyMs: Date.now() - start };
+    await redis.ping();
+    return { status: 'healthy', latencyMs: Date.now() - start };
+  } catch {
+    return { status: 'unhealthy', latencyMs: Date.now() - start };
+  }
+}
+
+export const GET = withRouteHandler(
+  async (_request: NextRequest) => {
+    const [supabase, koios, redis] = await Promise.all([
+      probeSupabase(),
+      probeKoios(),
+      probeRedis(),
+    ]);
+
+    const allHealthy =
+      supabase.status === 'healthy' &&
+      koios.status === 'healthy' &&
+      (redis.status === 'healthy' || redis.status === 'unavailable');
+
+    return NextResponse.json({
+      status: allHealthy ? 'healthy' : 'degraded',
+      dependencies: { supabase, koios, redis },
+      timestamp: new Date().toISOString(),
+    });
+  },
+  { auth: 'none' },
+);

--- a/app/api/polls/vote/route.ts
+++ b/app/api/polls/vote/route.ts
@@ -6,31 +6,7 @@ import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
 import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 import { PollVoteSchema } from '@/lib/api/schemas/governance';
-
-async function lookupDelegation(stakeAddress: string): Promise<string | null> {
-  try {
-    const baseUrl = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
-    const apiKey = process.env.KOIOS_API_KEY;
-    const headers: HeadersInit = {
-      'Content-Type': 'application/json',
-      ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
-    };
-
-    const res = await fetch(`${baseUrl}/account_info`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ _stake_addresses: [stakeAddress] }),
-      cache: 'no-store',
-    });
-
-    if (!res.ok) return null;
-    const data = await res.json();
-    const account = Array.isArray(data) ? data[0] : null;
-    return account?.vote_delegation || account?.delegated_drep || null;
-  } catch {
-    return null;
-  }
-}
+import { fetchDelegatedDRep } from '@/utils/koios';
 
 function aggregateCounts(rows: { vote: string }[]): {
   yes: number;
@@ -56,7 +32,7 @@ export const POST = withRouteHandler(async (request: NextRequest, { requestId, w
   let resolvedDrepId = delegatedDrepId || null;
 
   if (!resolvedDrepId && resolvedStakeAddress) {
-    resolvedDrepId = await lookupDelegation(resolvedStakeAddress);
+    resolvedDrepId = await fetchDelegatedDRep(resolvedStakeAddress);
   }
 
   const supabase = getSupabaseAdmin();

--- a/inngest/functions/check-snapshot-completeness.ts
+++ b/inngest/functions/check-snapshot-completeness.ts
@@ -8,7 +8,7 @@
 import { inngest } from '@/lib/inngest';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { alertDiscord, emitPostHog, type SyncType } from '@/lib/sync-utils';
+import { alertCritical, emitPostHog, type SyncType } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 interface CheckResult {
@@ -264,7 +264,7 @@ export const checkSnapshotCompleteness = inngest.createFunction(
       await step.run('alert-failures', async () => {
         const failureList = failures.map((f) => `- **${f.name}**: ${f.detail}`).join('\n');
 
-        await alertDiscord(
+        await alertCritical(
           'Snapshot Completeness Failed',
           `${failures.length} of ${checks.length} checks failed:\n${failureList}`,
         );

--- a/inngest/functions/sync-freshness-guard.ts
+++ b/inngest/functions/sync-freshness-guard.ts
@@ -6,7 +6,7 @@
 
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { alertDiscord, errMsg, emitPostHog, type SyncType } from '@/lib/sync-utils';
+import { alertDiscord, alertCritical, errMsg, emitPostHog, type SyncType } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 const FRESHNESS_THRESHOLDS: Record<string, { mins: number; event: string }> = {
@@ -127,10 +127,10 @@ export const syncFreshnessGuard = inngest.createFunction(
             recentTriggerCount,
             max: SELF_HEAL_MAX_TRIGGERS,
           });
-          await alertDiscord(
-            `Self-Heal Throttled: ${syncType}`,
-            `${recentTriggerCount} runs in last 2h but still stale (${staleMins}m). Possible persistent failure — needs manual investigation.`,
-          );
+        await alertCritical(
+          `Self-Heal Throttled: ${syncType}`,
+          `${recentTriggerCount} runs in last 2h but still stale (${staleMins}m). Possible persistent failure — needs manual investigation.`,
+        );
           return null;
         }
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -7,7 +7,7 @@ export async function register() {
     Sentry.init({
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
-      tracesSampleRate: 0.1,
+      tracesSampleRate: 0.25,
     });
   }
 
@@ -16,7 +16,7 @@ export async function register() {
     Sentry.init({
       dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
       enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
-      tracesSampleRate: 0.1,
+      tracesSampleRate: 0.25,
     });
   }
 }

--- a/lib/crossChain.ts
+++ b/lib/crossChain.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from '@/lib/logger';
+import { withRetry } from '@/lib/retry';
 
 export type Chain = 'cardano' | 'ethereum' | 'polkadot';
 
@@ -34,29 +35,23 @@ export const CHAIN_IDENTITIES: Record<Chain, ChainIdentity> = {
   polkadot: { chain: 'polkadot', name: 'Polkadot', color: '#ec4899', logo: '/chains/polkadot.svg' },
 };
 
-// ---------------------------------------------------------------------------
-// Retry helper — exponential backoff for transient failures
-// ---------------------------------------------------------------------------
-
-async function withRetry<T>(
+/**
+ * Wrapper that maps shared withRetry (throws on exhaustion) to the
+ * null-on-failure contract used by the cross-chain adapters.
+ */
+async function withRetrySafe<T>(
   fn: () => Promise<T>,
-  retries = 3,
-  initialDelay = 2000,
+  label: string,
 ): Promise<T | null> {
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      if (attempt === retries) {
-        logger.error('[crossChain] All retries exhausted', { error: err });
-        return null;
-      }
-      const delay = initialDelay * 2 ** attempt;
-      logger.warn('[crossChain] Attempt failed, retrying', { attempt: attempt + 1, delayMs: delay });
-      await new Promise((r) => setTimeout(r, delay));
-    }
+  try {
+    return await withRetry(fn, {
+      maxRetries: 3,
+      baseDelayMs: 2000,
+      label,
+    });
+  } catch {
+    return null;
   }
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +149,7 @@ async function tallyFetch(query: string, variables?: Record<string, unknown>): P
 }
 
 export async function fetchEthereumBenchmark(): Promise<ChainBenchmark | null> {
-  const orgsData = (await withRetry(() => tallyFetch(TALLY_ORGS_QUERY))) as {
+  const orgsData = (await withRetrySafe(() => tallyFetch(TALLY_ORGS_QUERY), 'crossChain/tally/orgs')) as {
     organizations?: { nodes: TallyOrgNode[] };
   } | null;
   if (!orgsData?.organizations?.nodes?.length) return null;
@@ -170,8 +165,9 @@ export async function fetchEthereumBenchmark(): Promise<ChainBenchmark | null> {
   let proposalThroughput: number | null = null;
 
   if (topSlug) {
-    const proposalsData = (await withRetry(() =>
-      tallyFetch(TALLY_ORG_PROPOSALS_QUERY, { slug: topSlug }),
+    const proposalsData = (await withRetrySafe(
+      () => tallyFetch(TALLY_ORG_PROPOSALS_QUERY, { slug: topSlug }),
+      'crossChain/tally/proposals',
     )) as {
       proposals?: { nodes: { status: string; voteStats: { votersCount: number }[] }[] };
     } | null;
@@ -248,8 +244,8 @@ async function subsquareFetch(path: string): Promise<unknown> {
 
 export async function fetchPolkadotBenchmark(): Promise<ChainBenchmark | null> {
   const [summaryData, referendaData] = await Promise.all([
-    withRetry(() => subsquareFetch('/summary')),
-    withRetry(() => subsquareFetch('/gov2/referendums?page=1&page_size=20')),
+    withRetrySafe(() => subsquareFetch('/summary'), 'crossChain/subsquare/summary'),
+    withRetrySafe(() => subsquareFetch('/gov2/referendums?page=1&page_size=20'), 'crossChain/subsquare/referenda'),
   ]);
 
   const summary = summaryData as {

--- a/lib/koios.ts
+++ b/lib/koios.ts
@@ -12,6 +12,7 @@ import {
   parseMetadataFields,
 } from '@/utils/koios';
 import { logger } from '@/lib/logger';
+import { withRetry } from '@/lib/retry';
 import type { DRepVotesResponse } from '@/types/koios';
 import {
   calculateParticipationRate,
@@ -245,13 +246,17 @@ export async function getEnrichedDReps(
       logger.info('[DRepScore] Epoch context', { currentEpoch, activeProposalEpochs: activeProposalEpochs.size, actualProposalCount });
     }
 
-    let drepList = await fetchAllDReps();
-    if (!drepList || drepList.length === 0) {
-      logger.warn('[DRepScore] Empty DRep list from Koios — retrying once after 3s');
-      await new Promise((r) => setTimeout(r, 3000));
-      drepList = await fetchAllDReps();
-    }
-    if (!drepList || drepList.length === 0) {
+    let drepList: Awaited<ReturnType<typeof fetchAllDReps>>;
+    try {
+      drepList = await withRetry(
+        async () => {
+          const result = await fetchAllDReps();
+          if (!result || result.length === 0) throw new Error('Empty DRep list');
+          return result;
+        },
+        { maxRetries: 1, baseDelayMs: 3000, label: 'getEnrichedDReps' },
+      );
+    } catch {
       logger.error('[DRepScore] No DReps found after retry');
       return { dreps: [], allDReps: [], error: true, totalAvailable: 0 };
     }

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared retry helper with exponential backoff.
+ */
+
+import { logger } from './logger';
+
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  /** Return true if the error is transient and should be retried. Defaults to always true. */
+  isTransient?: (err: unknown) => boolean;
+  onRetry?: (err: unknown, attempt: number) => void;
+  label?: string;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+function computeDelay(attempt: number, baseMs: number, maxMs: number): number {
+  const jitter = Math.random() * 0.3 + 0.85;
+  return Math.min(baseMs * Math.pow(2, attempt) * jitter, maxMs);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: RetryOptions,
+): Promise<T> {
+  const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const isTransient = options?.isTransient ?? (() => true);
+  const label = options?.label ?? 'retry';
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+
+      if (attempt >= maxRetries || !isTransient(err)) {
+        throw err;
+      }
+
+      const delayMs = computeDelay(attempt, baseDelayMs, maxDelayMs);
+
+      if (options?.onRetry) {
+        options.onRetry(err, attempt + 1);
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`[${label}] Retrying after transient error`, {
+          attempt: attempt + 1,
+          maxRetries,
+          delayMs: Math.round(delayMs),
+          error: msg,
+        });
+      }
+
+      await sleep(delayMs);
+    }
+  }
+
+  throw lastError;
+}

--- a/lib/sync-utils.ts
+++ b/lib/sync-utils.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
+import { withRetry } from '@/lib/retry';
 
 export type SyncType =
   | 'dreps'
@@ -27,10 +28,6 @@ export type SyncType =
 
 const BATCH_SIZE = 100;
 const MAX_UPSERT_RETRIES = 3;
-
-function upsertRetryDelay(attempt: number): number {
-  return Math.pow(2, attempt + 1) * 1000 + Math.random() * 500;
-}
 
 export function errMsg(e: unknown): string {
   if (e instanceof Error) return e.message;
@@ -78,29 +75,24 @@ export async function batchUpsert<T extends Record<string, unknown>>(
   const total = Math.ceil(rows.length / BATCH_SIZE);
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     const batch = rows.slice(i, i + BATCH_SIZE);
-    let lastError: string | null = null;
 
-    for (let attempt = 0; attempt < MAX_UPSERT_RETRIES; attempt++) {
-      const { error } = await supabase
-        .from(table)
-        .upsert(batch, { onConflict, ignoreDuplicates: false });
-      if (!error) {
-        success += batch.length;
-        lastError = null;
-        break;
-      }
-      lastError = error.message;
-      if (attempt < MAX_UPSERT_RETRIES - 1 && isTransientError(error.message)) {
-        const delay = upsertRetryDelay(attempt);
-        logger.warn(`[Sync] ${label} batch transient error, retrying`, { delayMs: Math.round(delay), attempt: attempt + 1, maxRetries: MAX_UPSERT_RETRIES, error: error.message });
-        await new Promise((r) => setTimeout(r, delay));
-      } else {
-        break;
-      }
-    }
-
-    if (lastError) {
-      logger.error(`[Sync] ${label} batch error`, { error: lastError });
+    try {
+      await withRetry(
+        async () => {
+          const { error } = await supabase
+            .from(table)
+            .upsert(batch, { onConflict, ignoreDuplicates: false });
+          if (error) throw error;
+        },
+        {
+          maxRetries: MAX_UPSERT_RETRIES - 1,
+          isTransient: (err) => isTransientError(errMsg(err)),
+          label: `Sync ${label} batch`,
+        },
+      );
+      success += batch.length;
+    } catch (err) {
+      logger.error(`[Sync] ${label} batch error`, { error: errMsg(err) });
       errors += batch.length;
     }
   }
@@ -286,31 +278,71 @@ export async function emitPostHog(
 
 /**
  * Send an alert to the configured Discord webhook.
- * Fire-and-forget — never throws, never blocks syncs.
+ * Retries once after 5s on failure. Never throws — alerting must not crash callers.
  */
 export async function alertDiscord(title: string, details: string): Promise<void> {
   const webhookUrl = process.env.DISCORD_WEBHOOK_URL;
   if (!webhookUrl) return;
+
+  await withRetry(
+    async () => {
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          embeds: [
+            {
+              title: `⚠️ ${title}`,
+              description: details,
+              color: 0xf59e0b,
+              footer: { text: 'DRepScore Sync Monitor' },
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        }),
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!res.ok) throw new Error(`Discord webhook returned ${res.status}`);
+    },
+    { maxRetries: 1, baseDelayMs: 5000, label: 'alertDiscord' },
+  ).catch(() => {
+    // swallow — alerting should not crash the caller
+  });
+}
+
+/**
+ * Send a critical alert email via Resend.
+ * Never throws — alerting must not crash callers.
+ */
+export async function alertEmail(subject: string, body: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return;
+
   try {
-    await fetch(webhookUrl, {
+    await fetch('https://api.resend.com/emails', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        embeds: [
-          {
-            title: `⚠️ ${title}`,
-            description: details,
-            color: 0xf59e0b,
-            footer: { text: 'DRepScore Sync Monitor' },
-            timestamp: new Date().toISOString(),
-          },
-        ],
+        from: 'DRepScore Alerts <alerts@drepscore.io>',
+        to: ['admin@drepscore.io'],
+        subject: `[DRepScore Alert] ${subject}`,
+        text: body,
       }),
-      signal: AbortSignal.timeout(5_000),
     });
-  } catch (e) {
-    logger.error('[alertDiscord] Failed', { error: errMsg(e) });
+  } catch {
+    // swallow — alerting should not crash the caller
   }
+}
+
+/**
+ * Send a critical alert to all channels (Discord + Email).
+ * Never throws — uses allSettled to ensure both channels are attempted.
+ */
+export async function alertCritical(title: string, details: string): Promise<void> {
+  await Promise.allSettled([
+    alertDiscord(title, details),
+    alertEmail(title, details),
+  ]);
 }
 
 /**

--- a/lib/sync/proposals.ts
+++ b/lib/sync/proposals.ts
@@ -6,6 +6,7 @@ import { fetchProposals, fetchVotesForProposals, fetchProposalVotingSummary } fr
 import { classifyProposals } from '@/lib/alignment';
 import { KoiosProposalSchema, validateArray } from '@/utils/koios-schemas';
 import type { ProposalListResponse } from '@/types/koios';
+import * as Sentry from '@sentry/nextjs';
 
 const BATCH_SIZE = 100;
 const SUMMARY_CONCURRENCY = 5;
@@ -16,6 +17,9 @@ const TAG = '[proposals]';
  * Throws on fatal errors (Inngest retries); returns result on success/degraded.
  */
 export async function executeProposalsSync(): Promise<Record<string, unknown>> {
+  return Sentry.startSpan(
+    { name: 'sync.proposals', op: 'task' },
+    async () => {
   const supabase = getSupabaseAdmin();
   const syncLog = new SyncLogger(supabase, 'proposals');
   await syncLog.start();
@@ -347,4 +351,6 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
     durationSeconds: (syncLog.elapsed / 1000).toFixed(1),
     timestamp: new Date().toISOString(),
   };
+    },
+  );
 }

--- a/lib/sync/secondary.ts
+++ b/lib/sync/secondary.ts
@@ -3,6 +3,7 @@ import { logger } from '@/lib/logger';
 import { SyncLogger, batchUpsert, errMsg, emitPostHog } from '@/lib/sync-utils';
 import { fetchDRepDelegatorCount } from '@/utils/koios';
 import { blockTimeToEpoch } from '@/lib/koios';
+import * as Sentry from '@sentry/nextjs';
 
 const BATCH_SIZE = 100;
 const DELEGATOR_CONCURRENCY = 20;
@@ -12,6 +13,9 @@ const DELEGATOR_CONCURRENCY = 20;
  * Throws on fatal errors (Inngest retries); returns result on success/degraded.
  */
 export async function executeSecondarySync(): Promise<Record<string, unknown>> {
+  return Sentry.startSpan(
+    { name: 'sync.secondary', op: 'task' },
+    async () => {
   const supabase = getSupabaseAdmin();
   const syncLog = new SyncLogger(supabase, 'secondary');
   await syncLog.start();
@@ -166,4 +170,6 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
     durationSeconds: (syncLog.elapsed / 1000).toFixed(1),
     timestamp: new Date().toISOString(),
   };
+    },
+  );
 }

--- a/lib/sync/slow.ts
+++ b/lib/sync/slow.ts
@@ -12,6 +12,7 @@ import { fetchDRepVotingPowerHistory, fetchDRepInfo } from '@/utils/koios';
 import { getProposalPriority } from '@/utils/proposalPriority';
 import { broadcastDiscord, broadcastEvent } from '@/lib/notifications';
 import { precomputeSimilarityCache } from '@/lib/proposalSimilarity';
+import * as Sentry from '@sentry/nextjs';
 
 const RATIONALE_FETCH_TIMEOUT_MS = 5000;
 const RATIONALE_MAX_CONTENT_SIZE = 50_000;
@@ -593,6 +594,9 @@ async function runCriticalProposalNotifications(supabase: SupabaseClient) {
  * Throws on fatal errors (Inngest retries); returns result on success/degraded.
  */
 export async function executeSlowSync(): Promise<Record<string, unknown>> {
+  return Sentry.startSpan(
+    { name: 'sync.slow', op: 'task' },
+    async () => {
   const supabase = getSupabaseAdmin();
   const syncLog = new SyncLogger(supabase, 'slow');
   await syncLog.start();
@@ -691,4 +695,6 @@ export async function executeSlowSync(): Promise<Record<string, unknown>> {
     errors: syncErrors.length > 0 ? syncErrors : undefined,
     timestamp: new Date().toISOString(),
   };
+    },
+  );
 }

--- a/lib/sync/votes.ts
+++ b/lib/sync/votes.ts
@@ -12,6 +12,7 @@ import {
   alertDiscord,
 } from '@/lib/sync-utils';
 import { KoiosVoteListSchema, validateArray } from '@/utils/koios-schemas';
+import * as Sentry from '@sentry/nextjs';
 
 interface SupabaseVoteRow {
   vote_tx_hash: string;
@@ -30,6 +31,9 @@ interface SupabaseVoteRow {
  * Throws on fatal errors (Inngest retries); returns result on success/degraded.
  */
 export async function executeVotesSync(): Promise<Record<string, unknown>> {
+  return Sentry.startSpan(
+    { name: 'sync.votes', op: 'task' },
+    async () => {
   const supabase = getSupabaseAdmin();
   const syncLog = new SyncLogger(supabase, 'votes');
   await syncLog.start();
@@ -188,4 +192,6 @@ export async function executeVotesSync(): Promise<Record<string, unknown>> {
     await emitPostHog(false, 'votes', syncLog.elapsed, metrics);
     throw err;
   }
+    },
+  );
 }

--- a/utils/koios.ts
+++ b/utils/koios.ts
@@ -16,6 +16,8 @@ import {
   CCVote,
   KoiosAccountInfo,
 } from '@/types/koios';
+import { logger } from '@/lib/logger';
+import * as Sentry from '@sentry/nextjs';
 
 const KOIOS_BASE_URL = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
 const KOIOS_API_KEY = process.env.KOIOS_API_KEY;
@@ -95,12 +97,10 @@ async function koiosFetch<T>(
 
   try {
     const startTime = Date.now();
-    const response = await fetch(url, {
-      ...options,
-      headers,
-      cache: 'no-store',
-      signal: controller.signal,
-    });
+    const response = await Sentry.startSpan(
+      { name: `koios${endpoint}`, op: 'http.client', attributes: { 'http.method': options.method || 'GET' } },
+      async () => fetch(url, { ...options, headers, cache: 'no-store', signal: controller.signal }),
+    );
     clearTimeout(timeoutId);
     const elapsed = Date.now() - startTime;
     _koiosCallCount++;
@@ -527,7 +527,7 @@ export async function fetchDelegatedDRep(stakeAddress: string): Promise<string |
     const account = Array.isArray(data) ? data[0] : null;
     return account?.vote_delegation || account?.delegated_drep || null;
   } catch (err) {
-    console.error('[Koios] Error fetching delegated DRep:', err);
+    logger.error('[Koios] Error fetching delegated DRep', { error: err });
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Backend hardening Phase 4 — resilience and monitoring. Final phase of the hardening project.

- **Koios call consolidation** (4A): Removed 2 raw `fetch` calls in `delegation/route.ts` and `polls/vote/route.ts`, replaced with `fetchDelegatedDRep` which uses `koiosFetch` (retry, 20s timeout, 503 circuit breaker)
- **Shared retry helper** (4B): Created `lib/retry.ts` with exponential backoff + jitter. Migrated `batchUpsert`, `getEnrichedDReps`, and `crossChain` adapters to use it
- **Deep health endpoint** (4C): New `/api/health/deep` with parallel probes for Supabase, Koios, and Redis — returns per-dependency status and latency
- **Sentry performance spans** (4D): Added spans to `koiosFetch` (individual requests) and all 4 sync functions (votes, proposals, slow, secondary). Bumped trace sample rate from 10% to 25%
- **Alerting consolidation** (4E): `alertDiscord` now retries once on failure. New `alertEmail` (via Resend) and `alertCritical` (Discord + email). Sync-freshness-guard and snapshot alerts routed through `alertCritical`

## Plan Audit

| Plan Item | Status |
|---|---|
| Route Koios calls through koiosFetch (4A) | **Done** |
| Create shared retry helper (4B) | **Done** |
| Migrate 3 retry patterns (4B) | **Done** |
| Health deep endpoint (4C) | **Done** |
| Sentry spans on koiosFetch + syncs (4D) | **Done** |
| Bump trace sample rate (4D) | **Done** — 0.1 → 0.25 |
| alertDiscord retry + alertCritical (4E) | **Done** |
| Route critical alerts (4E) | **Done** — freshness-guard + snapshot-completeness |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 255/255 tests, 17/17 files
- [ ] Railway deploy — verify boot
- [ ] Smoke test `/api/health/deep` endpoint
- [ ] Verify Sentry spans appear after next sync
