### PR TITLE
feat: Civica Shell Foundation (Phase 1A)

### DIFF
--- a/.cursor/rules/workflow.md
+++ b/.cursor/rules/workflow.md
@@ -73,6 +73,23 @@ First-principles checklist:
 
 If the user's message is a question (not a change request), suggest Ask mode for cost efficiency.
 
+## Cost & Loop Risk Assessment
+
+Before attempting any high-effort autonomous action, evaluate whether it's worth trying vs. telling the user to do it themselves:
+
+**Stop and tell the user instead of attempting autonomously when:**
+
+- Writing or restoring a file > 300 lines — prefer StrReplace for targeted edits; if the whole file must be rewritten and Write fails once, stop and say why
+- A task requires recovering lost/uncommitted data — point to Cursor Timeline, git stash, or local history first; these are instant and free
+- You've already failed at the same action twice — looping costs more credits than asking
+- The user action is < 5 seconds (e.g., "right-click → Open Timeline → click restore") vs. your approach being 10+ tool calls
+
+**Pattern to follow:**
+
+1. Attempt once with the right tool
+2. If it fails, immediately explain the failure and offer the user-action alternative
+3. Never retry the same failed approach more than once without a different strategy
+
 ## Continuous Learning
 
 ### Lesson Lifecycle (on every correction)

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,8 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-civica-display);
+  --font-body: var(--font-civica-body);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -160,6 +162,85 @@
   --sidebar-accent-foreground: oklch(0.96 0.005 260);
   --sidebar-border: oklch(0.17 0.015 260);
   --sidebar-ring: oklch(0.72 0.14 200);
+}
+
+/* ============================================================
+   Tier Identity System — ambient color cascading
+   Each tier sets accent, glow, and border via CSS variables.
+   TierThemeProvider applies .tier-<name> class; components inherit.
+   ============================================================ */
+
+.tier-emerging {
+  --tier-accent: oklch(0.55 0.03 260);
+  --tier-accent-rgb: 120 120 140;
+  --tier-glow: oklch(0.55 0.03 260 / 0);
+  --tier-border: oklch(0.25 0.015 260);
+  --tier-bg-subtle: oklch(0.12 0.01 260);
+}
+
+.tier-bronze {
+  --tier-accent: oklch(0.65 0.12 55);
+  --tier-accent-rgb: 180 130 70;
+  --tier-glow: oklch(0.65 0.12 55 / 0.15);
+  --tier-border: oklch(0.45 0.08 55);
+  --tier-bg-subtle: oklch(0.14 0.03 55);
+}
+
+.tier-silver {
+  --tier-accent: oklch(0.75 0.02 260);
+  --tier-accent-rgb: 180 185 195;
+  --tier-glow: oklch(0.75 0.02 260 / 0.15);
+  --tier-border: oklch(0.5 0.015 260);
+  --tier-bg-subtle: oklch(0.15 0.01 260);
+}
+
+.tier-gold {
+  --tier-accent: oklch(0.78 0.15 85);
+  --tier-accent-rgb: 210 175 50;
+  --tier-glow: oklch(0.78 0.15 85 / 0.2);
+  --tier-border: oklch(0.55 0.1 85);
+  --tier-bg-subtle: oklch(0.15 0.04 85);
+}
+
+.tier-diamond {
+  --tier-accent: oklch(0.78 0.12 200);
+  --tier-accent-rgb: 80 210 230;
+  --tier-glow: oklch(0.78 0.12 200 / 0.25);
+  --tier-border: oklch(0.55 0.1 200);
+  --tier-bg-subtle: oklch(0.13 0.03 200);
+}
+
+.tier-legendary {
+  --tier-accent: oklch(0.65 0.2 310);
+  --tier-accent-rgb: 170 90 220;
+  --tier-glow: oklch(0.65 0.2 310 / 0.3);
+  --tier-border: oklch(0.45 0.15 310);
+  --tier-bg-subtle: oklch(0.13 0.05 310);
+}
+
+/* ============================================================
+   Motion tokens — consistent animation timing across Civica
+   ============================================================ */
+
+:root {
+  --duration-instant: 100ms;
+  --duration-fast: 150ms;
+  --duration-normal: 250ms;
+  --duration-enter: 300ms;
+  --duration-exit: 200ms;
+  --duration-celebration: 600ms;
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-spring: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ============================================================
+   Civica font variables — set by CivicaShell layout
+   ============================================================ */
+
+:root {
+  --font-civica-display: var(--font-geist-sans);
+  --font-civica-body: var(--font-geist-sans);
 }
 
 /* ============================================================

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,8 @@ import { ShortcutsHelpOverlay } from '@/components/ShortcutsHelpOverlay';
 import { InstallPrompt } from '@/components/InstallPrompt';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { EasterEggs } from '@/components/EasterEggs';
+import { CivicaShell } from '@/components/civica/CivicaShell';
+import { getFeatureFlag } from '@/lib/featureFlags';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -45,11 +47,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const civicaEnabled = await getFeatureFlag('civica_frontend', false);
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -66,19 +70,25 @@ export default function RootLayout({
               >
                 Skip to main content
               </a>
-              <HeaderClient />
-              <SyncFreshnessBanner />
-              <main id="main-content" className="min-h-screen pb-16 sm:pb-0" tabIndex={-1}>
-                {children}
-              </main>
-              <Footer />
-              <MobileBottomNav />
+              {civicaEnabled ? (
+                <CivicaShell>{children}</CivicaShell>
+              ) : (
+                <>
+                  <HeaderClient />
+                  <SyncFreshnessBanner />
+                  <main id="main-content" className="min-h-screen pb-16 sm:pb-0" tabIndex={-1}>
+                    {children}
+                  </main>
+                  <Footer />
+                  <MobileBottomNav />
+                </>
+              )}
               <CommandPalette />
               <KeyboardShortcuts />
               <ShortcutsHelpOverlay />
               <InstallPrompt />
               <OfflineBanner />
-              <EasterEggs />
+              {!civicaEnabled && <EasterEggs />}
             </NavDirectionProvider>
           </Providers>
         </ThemeProvider>

--- a/app/my-gov/page.tsx
+++ b/app/my-gov/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useFeatureFlag } from '@/components/FeatureGate';
+
+export default function MyGovPage() {
+  const civica = useFeatureFlag('civica_frontend');
+  const { segment, isLoading, drepId, poolId, delegatedDrep } = useSegment();
+
+  if (civica === null) return null;
+
+  if (!civica) {
+    return (
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+        <p className="text-muted-foreground">This page is not yet available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 sm:px-6 py-12">
+      <h1 className="font-display text-3xl font-bold tracking-tight mb-4">My Gov</h1>
+      <p className="text-muted-foreground mb-8">Your civic command center.</p>
+
+      <div className="rounded-lg border border-border bg-card p-6 space-y-2">
+        <p className="text-sm">
+          <span className="text-muted-foreground">Segment:</span>{' '}
+          <span className="font-medium">{isLoading ? 'Detecting...' : segment}</span>
+        </p>
+        {drepId && (
+          <p className="text-sm">
+            <span className="text-muted-foreground">DRep ID:</span>{' '}
+            <span className="font-mono text-xs">{drepId}</span>
+          </p>
+        )}
+        {poolId && (
+          <p className="text-sm">
+            <span className="text-muted-foreground">Pool ID:</span>{' '}
+            <span className="font-mono text-xs">{poolId}</span>
+          </p>
+        )}
+        {delegatedDrep && (
+          <p className="text-sm">
+            <span className="text-muted-foreground">Delegated to:</span>{' '}
+            <span className="font-mono text-xs">{delegatedDrep}</span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Home, Compass, Activity, Landmark } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const NAV_ITEMS = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/discover', label: 'Discover', icon: Compass },
+  { href: '/pulse', label: 'Pulse', icon: Activity },
+  { href: '/my-gov', label: 'My Gov', icon: Landmark },
+] as const;
+
+export function CivicaBottomNav() {
+  const pathname = usePathname();
+
+  const isActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  return (
+    <nav
+      className="fixed bottom-0 inset-x-0 z-40 sm:hidden bg-background/80 backdrop-blur-xl border-t border-border/50 pb-[env(safe-area-inset-bottom)]"
+      aria-label="Mobile navigation"
+    >
+      <div className="flex items-center justify-around h-14">
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+          const active = isActive(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors',
+                active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
+              )}
+              aria-current={active ? 'page' : undefined}
+            >
+              <Icon className="h-5 w-5" />
+              <span className="text-[10px] font-medium leading-tight">{label}</span>
+              {active && (
+                <span className="absolute bottom-[calc(env(safe-area-inset-bottom)+2px)] h-0.5 w-6 rounded-full bg-primary" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import { Home, Compass, Activity, Landmark, Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useWallet } from '@/utils/wallet';
+import { useSegment, type UserSegment } from '@/components/providers/SegmentProvider';
+import { Button } from '@/components/ui/button';
+
+const WalletConnectModal = dynamic(
+  () => import('@/components/WalletConnectModal').then((mod) => mod.WalletConnectModal),
+  { ssr: false },
+);
+
+const NAV_ITEMS = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/discover', label: 'Discover', icon: Compass },
+  { href: '/pulse', label: 'Pulse', icon: Activity },
+  { href: '/my-gov', label: 'My Gov', icon: Landmark },
+] as const;
+
+const SEGMENT_LABELS: Record<UserSegment, string> = {
+  anonymous: '',
+  citizen: 'Citizen',
+  drep: 'DRep',
+  spo: 'SPO',
+};
+
+export function CivicaHeader() {
+  const pathname = usePathname();
+  const { isAuthenticated, connected } = useWallet();
+  const { segment } = useSegment();
+
+  const isActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  return (
+    <header className="sticky top-0 z-50 hidden sm:block border-b border-border/50 bg-background/80 backdrop-blur-xl">
+      <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">
+        <div className="flex items-center gap-1">
+          <Link
+            href="/"
+            className="font-display text-lg font-bold tracking-tight mr-6 text-foreground"
+          >
+            Civica
+          </Link>
+
+          <nav className="flex items-center gap-1" aria-label="Main navigation">
+            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+              const active = isActive(href);
+              return (
+                <Link
+                  key={href}
+                  href={href}
+                  className={cn(
+                    'relative flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors',
+                    'hover:bg-accent hover:text-accent-foreground',
+                    active ? 'text-foreground' : 'text-muted-foreground',
+                  )}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                  {active && (
+                    <span className="absolute bottom-0 left-3 right-3 h-0.5 rounded-full bg-primary" />
+                  )}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
+            onClick={() =>
+              document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))
+            }
+            aria-label="Open command palette"
+          >
+            <Search className="h-4 w-4 mr-1.5" />
+            <kbd className="text-xs text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded">
+              ⌘K
+            </kbd>
+          </Button>
+
+          {isAuthenticated && segment !== 'anonymous' && (
+            <span className="text-xs font-medium text-muted-foreground bg-muted px-2 py-1 rounded-full">
+              {SEGMENT_LABELS[segment]}
+            </span>
+          )}
+
+          {!connected && <WalletConnectModal />}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { SegmentProvider } from '@/components/providers/SegmentProvider';
+import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
+import { CivicaHeader } from './CivicaHeader';
+import { CivicaBottomNav } from './CivicaBottomNav';
+
+/**
+ * Civica layout shell — wraps children with 4-tab nav + providers.
+ * Rendered by root layout when civica_frontend flag is on.
+ */
+export function CivicaShell({ children }: { children: React.ReactNode }) {
+  return (
+    <SegmentProvider>
+      <TierThemeProvider score={null}>
+        <CivicaHeader />
+        <main id="main-content" className="min-h-screen pb-16 sm:pb-0" tabIndex={-1}>
+          {children}
+        </main>
+        <CivicaBottomNav />
+      </TierThemeProvider>
+    </SegmentProvider>
+  );
+}

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useWallet } from '@/utils/wallet';
+
+export type UserSegment = 'anonymous' | 'citizen' | 'spo' | 'drep';
+
+export interface SegmentState {
+  segment: UserSegment;
+  isLoading: boolean;
+  stakeAddress: string | null;
+  drepId: string | null;
+  poolId: string | null;
+  delegatedDrep: string | null;
+  delegatedPool: string | null;
+}
+
+const STORAGE_KEY = 'civica_segment';
+
+const DEFAULT_STATE: SegmentState = {
+  segment: 'anonymous',
+  isLoading: false,
+  stakeAddress: null,
+  drepId: null,
+  poolId: null,
+  delegatedDrep: null,
+  delegatedPool: null,
+};
+
+const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
+
+function loadCached(stakeAddress: string): SegmentState | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const cached = JSON.parse(raw) as SegmentState & { _addr: string };
+    if (cached._addr === stakeAddress) return cached;
+  } catch {
+    // Ignore parse errors
+  }
+  return null;
+}
+
+function saveCache(state: SegmentState, stakeAddress: string) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...state, _addr: stakeAddress }));
+  } catch {
+    // Storage full or unavailable
+  }
+}
+
+export function SegmentProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated, address } = useWallet();
+  const [state, setState] = useState<SegmentState>(DEFAULT_STATE);
+
+  const detect = useCallback(async (stakeAddress: string) => {
+    const cached = loadCached(stakeAddress);
+    if (cached) {
+      setState(cached);
+      return;
+    }
+
+    setState((s) => ({ ...s, isLoading: true }));
+
+    try {
+      const res = await fetch(`/api/user/detect-segment?stakeAddress=${stakeAddress}`);
+      if (!res.ok) throw new Error('detect-segment failed');
+
+      const data = await res.json();
+      const next: SegmentState = {
+        segment: data.segment ?? 'citizen',
+        isLoading: false,
+        stakeAddress,
+        drepId: data.drepId ?? null,
+        poolId: data.poolId ?? null,
+        delegatedDrep: data.delegatedDrep ?? null,
+        delegatedPool: data.delegatedPool ?? null,
+      };
+      setState(next);
+      saveCache(next, stakeAddress);
+    } catch {
+      setState((s) => ({ ...s, isLoading: false, segment: 'citizen' }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated || !address) {
+      setState(DEFAULT_STATE);
+      return;
+    }
+    detect(address);
+  }, [isAuthenticated, address, detect]);
+
+  return <SegmentContext.Provider value={state}>{children}</SegmentContext.Provider>;
+}
+
+export function useSegment(): SegmentState {
+  return useContext(SegmentContext);
+}

--- a/components/providers/TierThemeProvider.tsx
+++ b/components/providers/TierThemeProvider.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { computeTier, type TierName } from '@/lib/scoring/tiers';
+
+export interface TierTheme {
+  tier: TierName;
+  className: string;
+  glowIntensity: number;
+}
+
+const TIER_GLOW: Record<TierName, number> = {
+  Emerging: 0,
+  Bronze: 0.15,
+  Silver: 0.2,
+  Gold: 0.3,
+  Diamond: 0.4,
+  Legendary: 0.5,
+};
+
+const TierThemeContext = createContext<TierTheme>({
+  tier: 'Emerging',
+  className: 'tier-emerging',
+  glowIntensity: 0,
+});
+
+function tierClassName(tier: TierName): string {
+  return `tier-${tier.toLowerCase()}`;
+}
+
+interface TierThemeProviderProps {
+  score: number | null | undefined;
+  children: ReactNode;
+}
+
+/**
+ * Sets tier-specific CSS variables via a class on the wrapping div.
+ * Components inside inherit --tier-accent, --tier-glow, etc.
+ * Pass score={null} for no tier ambient (e.g. anonymous users).
+ */
+export function TierThemeProvider({ score, children }: TierThemeProviderProps) {
+  const theme = useMemo<TierTheme>(() => {
+    if (score == null) {
+      return { tier: 'Emerging', className: 'tier-emerging', glowIntensity: 0 };
+    }
+    const tier = computeTier(score);
+    return {
+      tier,
+      className: tierClassName(tier),
+      glowIntensity: TIER_GLOW[tier],
+    };
+  }, [score]);
+
+  return (
+    <TierThemeContext.Provider value={theme}>
+      <div className={theme.className}>{children}</div>
+    </TierThemeContext.Provider>
+  );
+}
+
+export function useTierTheme(): TierTheme {
+  return useContext(TierThemeContext);
+}

--- a/docs/plans/civica-frontend-redesign.md
+++ b/docs/plans/civica-frontend-redesign.md
@@ -202,7 +202,7 @@ This is NOT just the score badge — it's the nav underline, the card borders, t
 
 For citizens viewing a DRep's profile: the profile page adopts that DRep's tier ambient. You walk into their tier world.
 
-  1.4 — **New `CivicaShell` layout**
+1.4 — **New `CivicaShell` layout**
 
 - `app/(civica)/layout.tsx` — the new layout group
 - Desktop: `CivicaHeader` with 4 nav items + wallet + ⌘K
@@ -321,7 +321,7 @@ Technical: the existing `ConstellationHero.tsx` already has expanded/contracted 
 
 **SPO matching toggle (scaffolded):** After DRep results render, a subtle toggle: "Also find an SPO aligned with your values." Same 3 answers, different result set via `/api/governance/quick-match-pool` (already built). Not prominent in Phase A — just scaffolded.
 
-  2.2 — **Home page — delegated citizen**
+2.2 — **Home page — delegated citizen**
 
 **VP1 contract:** Your DRep's name, score hex (tier-colored), and one-sentence verdict ("Voted on 4/5 proposals this epoch. Alignment: strong."). Below: one urgent action card if applicable, otherwise epoch recap CTA. The constellation shrinks to a decorative background element. VP1 answers: "Is my governance voice being used well?" in 3 seconds.
 

--- a/docs/plans/phase-b-growth-engagement.md
+++ b/docs/plans/phase-b-growth-engagement.md
@@ -7,6 +7,7 @@
 ## What Phase A Delivered (Prerequisites)
 
 ### Backend (Batches 0-8)
+
 - **SPO Score V2** — 4-pillar model with Governance Identity, momentum, percentile normalization (ADR-006)
 - **Score Tier System** — Emerging → Legendary, tier history, tier change detection, tier API
 - **Alignment Drift Detection** — 6D drift engine, Inngest function, drift API, re-delegation intelligence
@@ -21,6 +22,7 @@
 - **`spo_power_snapshots` table** — epoch-level snapshots of `delegator_count` + `live_stake_lovelace` per pool, mirroring `drep_power_snapshots`. Populated each `sync-spo-scores` run. Enables SPO delegator trend charts and temporal analysis.
 
 ### Frontend Plan (Batch 9)
+
 - Clean-sheet redesign plan in `docs/plans/civica-frontend-redesign.md`
 - 4-destination navigation, segment detection, action feed, celebration/sharing system, tier visual identity
 - The Civica frontend plan creates the **surfaces** Phase B fills with content
@@ -31,17 +33,18 @@
 
 Three workstreams, all building on Phase A infrastructure:
 
-| Workstream | Core Idea | Phase A Foundation |
-| --- | --- | --- |
-| **B1: Governance Wrapped** | Shareable civic identity cards | Epoch summaries, tier history, score snapshots, OG image infrastructure, share modal |
-| **B2: DRep-to-Citizen Communication** | Representative-constituent channel | Action feed, notification registry, DRep profiles, citizen inbox |
-| **B3: Notification-Driven Civic Life** | Return visits with purpose | Channel renderers, notification triggers, epoch summaries, deep-linking |
+| Workstream                             | Core Idea                          | Phase A Foundation                                                                   |
+| -------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------ |
+| **B1: Governance Wrapped**             | Shareable civic identity cards     | Epoch summaries, tier history, score snapshots, OG image infrastructure, share modal |
+| **B2: DRep-to-Citizen Communication**  | Representative-constituent channel | Action feed, notification registry, DRep profiles, citizen inbox                     |
+| **B3: Notification-Driven Civic Life** | Return visits with purpose         | Channel renderers, notification triggers, epoch summaries, deep-linking              |
 
 ---
 
 ## B1: Governance Wrapped & Shareable Moments
 
 ### Concept
+
 Every citizen, DRep, and SPO gets a "Wrapped" — a visual summary of their governance life over an epoch or a year. Every stat in the Wrapped generates a shareable card. This is the primary viral growth mechanic.
 
 ### Backend Tasks
@@ -49,17 +52,20 @@ Every citizen, DRep, and SPO gets a "Wrapped" — a visual summary of their gove
 **B1.1 — Wrapped Data Aggregation Engine**
 
 New Inngest function: `generate-governance-wrapped`
+
 - Triggers: end of each epoch + annually
 - Computes per-entity Wrapped data packages:
 
-*Citizen Wrapped:*
+_Citizen Wrapped:_
+
 - DRep accountability: how their DRep voted, score trend, tier changes
 - Alignment status: drift events, dimension shifts
 - Governance footprint: epoch participation, delegation duration
 - Civic engagement level progression
 - Top governance moments (achievements unlocked)
 
-*DRep Wrapped:*
+_DRep Wrapped:_
+
 - Score journey: start → end, tier changes, personal best
 - Votes cast, rationales written, rationale quality trend
 - Delegators: gained, lost, net, milestone
@@ -67,7 +73,8 @@ New Inngest function: `generate-governance-wrapped`
 - Most impactful votes (proposals where their vote was decisive)
 - Pillar breakdown comparison: start of period vs end
 
-*SPO Wrapped:*
+_SPO Wrapped:_
+
 - Governance participation rate vs SPO average
 - Score + tier journey
 - Voting consistency analysis
@@ -80,6 +87,7 @@ Storage: `governance_wrapped` table with `entity_type`, `entity_id`, `period_typ
 **B1.2 — Shareable Card Generation**
 
 Extend OG image infrastructure:
+
 - New OG routes per Wrapped stat type:
   - `/api/og/wrapped/citizen/[userId]/[period]`
   - `/api/og/wrapped/drep/[drepId]/[period]`
@@ -92,6 +100,7 @@ Extend OG image infrastructure:
 **B1.3 — "Your Staking Governance" Card**
 
 Special Wrapped card for stakers:
+
 - How their SPO voted this epoch/year
 - SPO governance score + tier
 - Participation rate vs SPO average
@@ -106,6 +115,7 @@ Special Wrapped card for stakers:
 **B1.4 — Wrapped Experience Flow**
 
 New route: `/my-gov/wrapped/[period]`
+
 - Full-screen, story-like presentation (swipe through stats)
 - Each stat is a screen with:
   - Visual (custom, animated)
@@ -115,12 +125,14 @@ New route: `/my-gov/wrapped/[period]`
 - Final screen: "Share your Governance Wrapped" with combined card
 
 **B1.5 — Wrapped Entry Points**
+
 - Notification on epoch end: "Your Governance Wrapped is ready"
 - My Gov action feed card: "View your epoch summary"
 - Profile badge: "Wrapped available" indicator
 - Home page highlight when Wrapped is new
 
 **B1.6 — Share Flow Enhancement**
+
 - Extend `ShareModal` from Phase A frontend plan:
   - Pre-filled tweet text with governance stats
   - Card preview with download option
@@ -158,6 +170,7 @@ VALUES ('governance_wrapped', false, 'Enable Governance Wrapped generation and d
 ## B2: DRep-to-Citizen Communication Loop
 
 ### Concept
+
 DReps can post position statements that their delegators see in their action feed. Citizens can see what their DRep thinks about active proposals. This creates the first direct representative-constituent communication channel in crypto governance.
 
 ### Backend Tasks
@@ -217,6 +230,7 @@ VALUES ('drep_communication', false, 'Enable DRep-to-citizen communication featu
 **B2.4 — Communication Notification Triggers**
 
 New Inngest function: `notify-drep-communication`
+
 - Trigger: new position statement published
 - Find all delegators of this DRep
 - Check notification preferences
@@ -224,6 +238,7 @@ New Inngest function: `notify-drep-communication`
 - Dispatch via existing channel renderers
 
 New event types in notification registry:
+
 - `drep-position-statement` — DRep publishes a position
 - `citizen-question` — citizen submits a question (notify DRep)
 - `question-upvote-milestone` — question reaches 5/10/25 upvotes (notify DRep)
@@ -233,12 +248,14 @@ New event types in notification registry:
 **B2.5 — DRep Profile: Communication Section**
 
 On DRep profile page (`/drep/[drepId]`):
+
 - "Statements" tab showing position statements
 - Pinned statement at top
 - Statement cards: title, preview, proposal link, timestamp
 - Expand to read full statement
 
 For the DRep themselves (authenticated):
+
 - "Write a Statement" button in My Gov action feed
 - Statement editor: rich text, proposal link, visibility toggle
 - Draft/publish flow
@@ -246,11 +263,13 @@ For the DRep themselves (authenticated):
 **B2.6 — Citizen Feed Integration**
 
 In My Gov action feed (delegated citizen):
+
 - Statement cards: "Your DRep posted about [Proposal]"
 - CTA: "Read their position" → expands or navigates to profile
 - Questions CTA: "Ask your DRep a question"
 
 On proposal detail page:
+
 - "What representatives are saying" section
 - Position statements from DReps who voted on this proposal
 - Your DRep's statement highlighted if they posted
@@ -258,6 +277,7 @@ On proposal detail page:
 **B2.7 — Questions Feed**
 
 On DRep profile:
+
 - "Questions from citizens" section
 - Sorted by upvotes + recency
 - Citizens can submit + upvote
@@ -268,6 +288,7 @@ On DRep profile:
 ## B3: Notification-Driven Civic Life
 
 ### Concept
+
 Notifications become the primary return-visit driver. Every notification has a specific purpose and deep-links to an action. Weekly digest gives citizens a reason to return even during quiet epochs.
 
 ### Backend Tasks
@@ -275,6 +296,7 @@ Notifications become the primary return-visit driver. Every notification has a s
 **B3.1 — Weekly Governance Digest**
 
 New Inngest scheduled function: `generate-weekly-digest`
+
 - Runs weekly (configurable day)
 - For each authenticated citizen:
   - DRep score change summary
@@ -288,6 +310,7 @@ New Inngest scheduled function: `generate-weekly-digest`
 **B3.2 — Epoch Recap Notification**
 
 New Inngest function: `notify-epoch-recap`
+
 - Triggers on epoch boundary (detected from sync pipeline)
 - For each citizen with notifications enabled:
   - "Epoch [N] Recap: Your government made [X] decisions"
@@ -297,6 +320,7 @@ New Inngest function: `notify-epoch-recap`
 **B3.3 — Deep-Link Resolution**
 
 Notification deep-links must resolve to specific actions, not just pages:
+
 - Tier change → My Gov with celebration overlay triggered
 - Alignment drift → My Gov with drift alert expanded
 - New proposal → Proposal detail page with DRep's expected impact highlighted
@@ -309,6 +333,7 @@ Frontend reads these on mount and triggers appropriate behavior.
 **B3.4 — Notification Scheduling & Rate Limiting**
 
 Prevent notification fatigue:
+
 - Maximum 3 push notifications per day per user
 - Batch low-priority notifications into daily summary
 - Priority system: tier changes > alignment drift > proposals > digest > achievements
@@ -316,6 +341,7 @@ Prevent notification fatigue:
 - Quiet hours: no push between 22:00-08:00 user local time (stored preference)
 
 Storage: `notification_preferences` table if not already sufficient. Add columns for:
+
 - `quiet_hours_start`, `quiet_hours_end`
 - `max_daily_push`
 - Per-category toggles
@@ -323,6 +349,7 @@ Storage: `notification_preferences` table if not already sufficient. Add columns
 **B3.5 — Notification Analytics**
 
 Track engagement to optimize:
+
 - `notification_events` table: sent, delivered, opened, action_taken
 - Weekly digest open rate
 - Push → app return rate
@@ -349,6 +376,7 @@ CREATE INDEX idx_notif_analytics_type ON notification_analytics (notification_ty
 **B3.6 — Digest Email Template**
 
 Rich HTML email:
+
 - Civica branded header
 - Personalized greeting with segment acknowledgment
 - Score/tier update section
@@ -360,6 +388,7 @@ Rich HTML email:
 **B3.7 — Push Notification Handling**
 
 Service worker updates:
+
 - Click handler routes to deep-linked URL
 - Badge count management
 - Notification grouping by category
@@ -375,16 +404,16 @@ Service worker updates:
 
 ## Build Sequence
 
-| Batch | Workstream | Scope | Depends On |
-| --- | --- | --- | --- |
-| B-0 | Infrastructure | Database migrations, feature flags, notification preferences schema | Phase A complete |
-| B-1 | B1 | Wrapped data aggregation engine + OG card generation | Epoch summary data (A), score snapshots |
-| B-2 | B2 | Position statements + questions backend (API, data model) | DRep profiles (A) |
-| B-3 | B3 | Weekly digest + epoch recap + deep-link resolution | Notification triggers (A), channel renderers |
-| B-4 | B1 | Wrapped frontend: story flow, share enhancement, public Wrapped page | B-1, Civica frontend (A7) |
-| B-5 | B2 | Communication frontend: statement editor, feed integration, questions | B-2, Civica frontend (A7) |
-| B-6 | B3 | Digest email template, push handling, in-app indicators, rate limiting | B-3, Civica frontend (A7) |
-| B-7 | All | Notification analytics, A/B testing hooks, polish | B-4, B-5, B-6 |
+| Batch | Workstream     | Scope                                                                  | Depends On                                   |
+| ----- | -------------- | ---------------------------------------------------------------------- | -------------------------------------------- |
+| B-0   | Infrastructure | Database migrations, feature flags, notification preferences schema    | Phase A complete                             |
+| B-1   | B1             | Wrapped data aggregation engine + OG card generation                   | Epoch summary data (A), score snapshots      |
+| B-2   | B2             | Position statements + questions backend (API, data model)              | DRep profiles (A)                            |
+| B-3   | B3             | Weekly digest + epoch recap + deep-link resolution                     | Notification triggers (A), channel renderers |
+| B-4   | B1             | Wrapped frontend: story flow, share enhancement, public Wrapped page   | B-1, Civica frontend (A7)                    |
+| B-5   | B2             | Communication frontend: statement editor, feed integration, questions  | B-2, Civica frontend (A7)                    |
+| B-6   | B3             | Digest email template, push handling, in-app indicators, rate limiting | B-3, Civica frontend (A7)                    |
+| B-7   | All            | Notification analytics, A/B testing hooks, polish                      | B-4, B-5, B-6                                |
 
 **Note:** Batches B-1, B-2, B-3 are backend-only and can proceed in parallel. Batches B-4, B-5, B-6 require the Civica frontend (Phase A7) to be at least partially shipped. B-7 is integration and polish.
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,7 @@ const CORS_HEADERS = {
   'Access-Control-Max-Age': '86400',
 };
 
-const AUTH_REQUIRED_PATHS = ['/dashboard'];
+const AUTH_REQUIRED_PATHS = ['/dashboard', '/my-gov'];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -55,5 +55,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/v1/:path*', '/dashboard/:path*'],
+  matcher: ['/api/v1/:path*', '/dashboard/:path*', '/my-gov/:path*'],
 };


### PR DESCRIPTION
﻿## Summary

Civica Shell Foundation (Phase 1A) -- the structural skeleton for the frontend redesign.

- **Feature flag**: civica_frontend (default off) gates the new shell in root layout
- **SegmentProvider**: detects user segment (anonymous/citizen/drep/spo) on wallet connect, caches in sessionStorage
- **TierThemeProvider**: sets tier-specific CSS variables (accent, glow, border) via class cascading
- **CivicaHeader**: desktop 4-tab nav (Home, Discover, Pulse, My Gov) + command palette trigger + segment badge
- **CivicaBottomNav**: mobile 4-tab nav with the same destinations
- **Design tokens**: tier color palette (Emerging through Legendary), motion tokens in globals.css
- **Root layout branching**: old shell when flag off, CivicaShell when on -- no breaking changes
- **/my-gov route**: new authenticated stub page, auth-gated in middleware

### What's NOT in this PR (deferred)
- Old route redirects (deferred to cutover -- all existing pages work fine with new shell)
- GovTerm component (Phase 1B)
- Metadata architecture (Phase 1B)
- New font pairing (fonts kept as Geist for now; CSS variables ready for swap)

## Test plan

- [ ] Toggle civica_frontend flag on via /admin/flags
- [ ] Verify 4-tab nav renders on desktop (Home, Discover, Pulse, My Gov)
- [ ] Verify mobile bottom nav shows 4 tabs
- [ ] Connect wallet and verify segment badge appears in header
- [ ] Navigate to /my-gov when authenticated -- stub page renders
- [ ] Toggle flag off -- old layout renders with no issues
- [ ] All existing pages continue working under both shells

## Plan Audit

Parent plan: docs/plans/civica-frontend-redesign.md Phase 1

| Task | Status |
|------|--------|
| 1.1 Design tokens (tier colors, motion) | **Done** -- tier palette + motion tokens added to globals.css |
| 1.2 SegmentProvider | **Done** -- wraps detect-segment API with caching |
| 1.3 TierThemeProvider | **Done** -- CSS variable cascading via tier classes |
| 1.4 CivicaShell layout | **Done** -- header + bottom nav + shell wrapper |
| 1.5 Redirect old routes | **Adapted** -- deferred to cutover (old routes work fine with new shell) |
| 1.6 Feature flag | **Done** -- civica_frontend in feature_flags table |
| 1.7 GovTerm | Deferred to Phase 1B |
| 1.8 Metadata | Deferred to Phase 1B |
