### PR TITLE
feat: admin segment override switcher

### DIFF
--- a/components/AdminSimulateToggle.tsx
+++ b/components/AdminSimulateToggle.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { useWallet } from '@/utils/wallet';
 import { getStoredSession } from '@/lib/supabaseAuth';
+import { useSegment, type UserSegment } from '@/components/providers/SegmentProvider';
+
+const SEGMENTS: { value: UserSegment | null; label: string }[] = [
+  { value: null, label: 'Real' },
+  { value: 'anonymous', label: 'Anonymous' },
+  { value: 'citizen', label: 'Citizen' },
+  { value: 'drep', label: 'DRep' },
+  { value: 'spo', label: 'SPO' },
+];
 
 export function AdminSimulateToggle() {
   const { isAuthenticated } = useWallet();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
+  const { realSegment, segment, setOverride } = useSegment();
   const [isAdmin, setIsAdmin] = useState(false);
-
-  const isSimulating = searchParams.get('simulate') === 'true';
 
   useEffect(() => {
     const token = getStoredSession();
@@ -35,40 +39,35 @@ export function AdminSimulateToggle() {
 
   if (!isAdmin) return null;
 
-  const toggle = (simulate: boolean) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (simulate) {
-      params.set('simulate', 'true');
-    } else {
-      params.delete('simulate');
-    }
-    const qs = params.toString();
-    router.push(`${pathname}${qs ? `?${qs}` : ''}`);
-  };
+  // Current override: null means "real" (no override active)
+  const activeOverride = segment === realSegment ? null : segment;
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50">
-      <div className="flex items-center rounded-full border bg-background/90 backdrop-blur-md shadow-lg p-1 gap-0">
-        <button
-          onClick={() => toggle(false)}
-          className={`px-4 py-1.5 text-xs font-medium rounded-full transition-all ${
-            !isSimulating
-              ? 'bg-primary text-primary-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          ADA Holders
-        </button>
-        <button
-          onClick={() => toggle(true)}
-          className={`px-4 py-1.5 text-xs font-medium rounded-full transition-all ${
-            isSimulating
-              ? 'bg-primary text-primary-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          DReps
-        </button>
+      <div className="flex flex-col items-center gap-1.5">
+        {activeOverride !== null && (
+          <span className="text-[10px] text-muted-foreground bg-background/90 backdrop-blur-md rounded-full px-2 py-0.5 border">
+            Actual: {realSegment}
+          </span>
+        )}
+        <div className="flex items-center rounded-full border bg-background/90 backdrop-blur-md shadow-lg p-1 gap-0">
+          {SEGMENTS.map(({ value, label }) => {
+            const isActive = value === activeOverride;
+            return (
+              <button
+                key={label}
+                onClick={() => setOverride(value)}
+                className={`px-3 py-1.5 text-xs font-medium rounded-full transition-all ${
+                  isActive
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -7,7 +7,36 @@ export type UserSegment = 'anonymous' | 'citizen' | 'spo' | 'drep';
 
 export interface SegmentState {
   segment: UserSegment;
+  realSegment: UserSegment;
   isLoading: boolean;
+  stakeAddress: string | null;
+  drepId: string | null;
+  poolId: string | null;
+  delegatedDrep: string | null;
+  delegatedPool: string | null;
+  setOverride: (segment: UserSegment | null) => void;
+}
+
+const STORAGE_KEY = 'civica_segment';
+
+const noop = () => {};
+
+const DEFAULT_STATE: SegmentState = {
+  segment: 'anonymous',
+  realSegment: 'anonymous',
+  isLoading: false,
+  stakeAddress: null,
+  drepId: null,
+  poolId: null,
+  delegatedDrep: null,
+  delegatedPool: null,
+  setOverride: noop,
+};
+
+const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
+
+interface CachedSegment {
+  segment: UserSegment;
   stakeAddress: string | null;
   drepId: string | null;
   poolId: string | null;
@@ -15,25 +44,11 @@ export interface SegmentState {
   delegatedPool: string | null;
 }
 
-const STORAGE_KEY = 'civica_segment';
-
-const DEFAULT_STATE: SegmentState = {
-  segment: 'anonymous',
-  isLoading: false,
-  stakeAddress: null,
-  drepId: null,
-  poolId: null,
-  delegatedDrep: null,
-  delegatedPool: null,
-};
-
-const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
-
-function loadCached(stakeAddress: string): SegmentState | null {
+function loadCached(stakeAddress: string): CachedSegment | null {
   try {
     const raw = sessionStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
-    const cached = JSON.parse(raw) as SegmentState & { _addr: string };
+    const cached = JSON.parse(raw) as CachedSegment & { _addr: string };
     if (cached._addr === stakeAddress) return cached;
   } catch {
     // Ignore parse errors
@@ -41,7 +56,7 @@ function loadCached(stakeAddress: string): SegmentState | null {
   return null;
 }
 
-function saveCache(state: SegmentState, stakeAddress: string) {
+function saveCache(state: CachedSegment, stakeAddress: string) {
   try {
     sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ ...state, _addr: stakeAddress }));
   } catch {
@@ -51,24 +66,44 @@ function saveCache(state: SegmentState, stakeAddress: string) {
 
 export function SegmentProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated, address } = useWallet();
-  const [state, setState] = useState<SegmentState>(DEFAULT_STATE);
+  const [detected, setDetected] = useState<
+    Omit<SegmentState, 'segment' | 'realSegment' | 'setOverride'>
+  >({
+    isLoading: false,
+    stakeAddress: null,
+    drepId: null,
+    poolId: null,
+    delegatedDrep: null,
+    delegatedPool: null,
+  });
+  const [detectedSegment, setDetectedSegment] = useState<UserSegment>('anonymous');
+  const [override, setOverride] = useState<UserSegment | null>(null);
 
   const detect = useCallback(async (stakeAddress: string) => {
     const cached = loadCached(stakeAddress);
     if (cached) {
-      setState(cached);
+      setDetectedSegment(cached.segment);
+      setDetected({
+        isLoading: false,
+        stakeAddress: cached.stakeAddress,
+        drepId: cached.drepId,
+        poolId: cached.poolId,
+        delegatedDrep: cached.delegatedDrep,
+        delegatedPool: cached.delegatedPool,
+      });
       return;
     }
 
-    setState((s) => ({ ...s, isLoading: true }));
+    setDetected((s) => ({ ...s, isLoading: true }));
 
     try {
       const res = await fetch(`/api/user/detect-segment?stakeAddress=${stakeAddress}`);
       if (!res.ok) throw new Error('detect-segment failed');
 
       const data = await res.json();
-      const next: SegmentState = {
-        segment: data.segment ?? 'citizen',
+      const seg: UserSegment = data.segment ?? 'citizen';
+      setDetectedSegment(seg);
+      const next = {
         isLoading: false,
         stakeAddress,
         drepId: data.drepId ?? null,
@@ -76,22 +111,39 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
         delegatedDrep: data.delegatedDrep ?? null,
         delegatedPool: data.delegatedPool ?? null,
       };
-      setState(next);
-      saveCache(next, stakeAddress);
+      setDetected(next);
+      saveCache({ ...next, segment: seg }, stakeAddress);
     } catch {
-      setState((s) => ({ ...s, isLoading: false, segment: 'citizen' }));
+      setDetected((s) => ({ ...s, isLoading: false }));
+      setDetectedSegment('citizen');
     }
   }, []);
 
   useEffect(() => {
     if (!isAuthenticated || !address) {
-      setState(DEFAULT_STATE);
+      setDetected({
+        isLoading: false,
+        stakeAddress: null,
+        drepId: null,
+        poolId: null,
+        delegatedDrep: null,
+        delegatedPool: null,
+      });
+      setDetectedSegment('anonymous');
+      setOverride(null);
       return;
     }
     detect(address);
   }, [isAuthenticated, address, detect]);
 
-  return <SegmentContext.Provider value={state}>{children}</SegmentContext.Provider>;
+  const value: SegmentState = {
+    ...detected,
+    segment: override ?? detectedSegment,
+    realSegment: detectedSegment,
+    setOverride,
+  };
+
+  return <SegmentContext.Provider value={value}>{children}</SegmentContext.Provider>;
 }
 
 export function useSegment(): SegmentState {


### PR DESCRIPTION
## Summary
- Adds `realSegment` and `setOverride()` to `SegmentProvider` context — override when set, real detected segment otherwise
- Upgrades `AdminSimulateToggle` from binary "ADA Holders / DReps" to a 5-option pill bar: Real | Anonymous | Citizen | DRep | SPO
- Shows "Actual: {role}" indicator when override is active
- All 15 components using `useSegment()` automatically get the overridden segment — zero consumer changes needed
- Override clears on wallet disconnect, uses React state (no URL param leakage)

## Test plan
- [ ] Connect admin wallet, verify pill bar appears at bottom of screen
- [ ] Click each segment option, verify home page and /my-gov switch correctly
- [ ] Verify "Actual: drep" label shows when overriding
- [ ] Click "Real" to return to detected segment
- [ ] Verify non-admin wallets don't see the toggle
- [ ] Disconnect wallet, verify override clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)