### PR TITLE
perf: Docker BuildKit cache mounts for faster builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ENV NEXT_TELEMETRY_DISABLED=1
 FROM base AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # ── Build ──
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 # ── Runtime ──
 FROM base AS runner


### PR DESCRIPTION
## Summary
- Add `--mount=type=cache` for npm download cache (`/root/.npm`) to skip re-downloading unchanged packages
- Add `--mount=type=cache` for Next.js build cache (`/app/.next/cache`) to skip recompiling unchanged routes

Expected to reduce incremental build times by 3-5 minutes once caches warm up.

## Test plan
- [ ] CI passes (Dockerfile-only change, no app logic affected)
- [ ] Railway build succeeds with BuildKit cache mounts
- [ ] Compare build time of next deploy against baseline (~18 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)