### PR TITLE
fix: add cache IDs to Docker cache mounts for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ENV NEXT_TELEMETRY_DISABLED=1
 FROM base AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN --mount=type=cache,id=npm,target=/root/.npm npm ci
 
 # ── Build ──
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN --mount=type=cache,target=/app/.next/cache npm run build
+RUN --mount=type=cache,id=nextjs,target=/app/.next/cache npm run build
 
 # ── Runtime ──
 FROM base AS runner


### PR DESCRIPTION
## Summary
- Railway requires explicit `id=` on `--mount=type=cache` directives
- Fixes failed build from #97

## Test plan
- [ ] Railway build succeeds with `id=npm` and `id=nextjs` cache mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)