### PR TITLE
fix: default to dark theme, no system override

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         suppressHydrationWarning
       >
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
           <Providers>
             <NavDirectionProvider>
               <BrandedLoader />


### PR DESCRIPTION
## Summary
- Remove `enableSystem` from ThemeProvider — always default to dark mode
- Users can switch to light via the header toggle; choice persists in localStorage

## Test plan
- [ ] New visitor lands on dark mode regardless of OS preference
- [ ] Toggle to light mode works and persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)