### PR TITLE
fix: gate admin check on auth state

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -58,7 +58,7 @@ export function CivicaHeader() {
   const pathname = usePathname();
   const { connected, disconnect } = useWallet();
   const { segment, realSegment, stakeAddress, setOverride } = useSegment();
-  const { data: adminData } = useAdminCheck();
+  const { data: adminData } = useAdminCheck(connected);
   const isAdmin = adminData?.isAdmin === true;
   const hasOverride = segment !== realSegment;
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -314,9 +314,9 @@ export function useUser() {
   });
 }
 
-export function useAdminCheck() {
+export function useAdminCheck(isAuthenticated = false) {
   return useQuery({
-    queryKey: ['admin-check'],
+    queryKey: ['admin-check', isAuthenticated],
     queryFn: async () => {
       const { getStoredSession } = await import('@/lib/supabaseAuth');
       const token = getStoredSession();
@@ -331,6 +331,7 @@ export function useAdminCheck() {
       if (!res.ok) return { isAdmin: false };
       return res.json();
     },
+    enabled: isAuthenticated,
   });
 }
 


### PR DESCRIPTION
## Summary
- `useAdminCheck` was firing before wallet authentication, caching `{ isAdmin: false }`, and never invalidating
- Added `enabled: isAuthenticated` guard and included auth state in the query key
- Fixes admin segment switcher not appearing in the header dropdown

## Test plan
- [ ] Connect admin wallet on drepscore.io
- [ ] Open profile dropdown — "View as" submenu should appear
- [ ] Switch between Citizen/DRep/SPO segments
- [ ] Verify pill turns amber with eye icon when overriding

🤖 Generated with [Claude Code](https://claude.com/claude-code)