### PR TITLE
fix: observatory tab crash — benchmarks object/array mismatch

### DIFF
--- a/components/civica/pulse/CivicaObservatory.tsx
+++ b/components/civica/pulse/CivicaObservatory.tsx
@@ -174,9 +174,20 @@ export function CivicaObservatory() {
   const { data: rawDecentralization } = useGovernanceDecentralization();
 
   const ghi = (rawGHI as any)?.current ?? rawGHI;
-  const benchmarks: ChainBenchmark[] = Array.isArray(rawBenchmarks)
-    ? rawBenchmarks
-    : ((rawBenchmarks as any)?.benchmarks ?? []);
+  const benchmarksObj = ((rawBenchmarks as any)?.benchmarks ?? {}) as Record<string, any>;
+  const benchmarks: ChainBenchmark[] = Object.values(benchmarksObj)
+    .filter(Boolean)
+    .map((row: any) => ({
+      chain: row.chain,
+      periodLabel: row.period_label ?? row.periodLabel ?? '',
+      participationRate: row.participation_rate ?? row.participationRate ?? null,
+      delegateCount: row.delegate_count ?? row.delegateCount ?? null,
+      proposalCount: row.proposal_count ?? row.proposalCount ?? null,
+      proposalThroughput: row.proposal_throughput ?? row.proposalThroughput ?? null,
+      avgRationaleRate: row.avg_rationale_rate ?? row.avgRationaleRate ?? null,
+      rawData: row.raw_data ?? row.rawData ?? {},
+      fetchedAt: row.fetched_at ?? row.fetchedAt ?? '',
+    }));
   const decentralization = rawDecentralization as any;
 
   const ediMetrics = buildEDIMetrics(ghi, decentralization);


### PR DESCRIPTION
## Summary
- The `/api/governance/benchmarks` endpoint returns benchmarks as `Record<string, BenchmarkRow>` (object keyed by chain), but `CivicaObservatory` treated it as `ChainBenchmark[]` (array)
- Calling `.find()`, `.filter()`, `.map()` on a plain object crashes the component with "is not a function"
- Additionally mapped snake_case DB fields (`participation_rate`) to camelCase (`participationRate`) expected by `ChainBenchmark`

## Test plan
- [x] Preflight passes (0 errors)
- [ ] CI green
- [ ] Visit `/pulse?tab=observatory` in production — verify Decentralization Index, Cross-Chain Comparison, and Voting Power Treemap render

🤖 Generated with [Claude Code](https://claude.com/claude-code)