### PR TITLE
fix: SubSquare API + delegator snapshot timeout

### DIFF
--- a/inngest/functions/sync-data-moat.ts
+++ b/inngest/functions/sync-data-moat.ts
@@ -3,7 +3,7 @@
  * that compounds over time and becomes impossible for competitors to replicate.
  *
  * Streams (each as a separate Inngest step for durability):
- * 1. Delegator Snapshots (per-epoch delegation distribution)
+ * 1. Delegator Snapshots (per-epoch delegation distribution) — chunked to avoid timeout
  * 2. DRep Lifecycle Events (registration, updates, retirements)
  * 3. Epoch Governance Summaries (aggregate per-epoch stats)
  * 4. Committee Members (CC membership and terms)
@@ -15,12 +15,16 @@ import { logger } from '@/lib/logger';
 import { alertCritical, emitPostHog, errMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
 import {
-  syncDelegatorSnapshots,
+  prepareDelegatorSnapshot,
+  syncDelegatorSnapshotChunk,
+  finalizeDelegatorSnapshot,
   syncDRepLifecycleEvents,
   syncEpochGovernanceSummaries,
   syncCommitteeMembers,
   syncMetadataArchive,
 } from '@/lib/sync/data-moat';
+
+const DELEGATOR_CHUNK_SIZE = 100;
 
 export const syncDataMoat = inngest.createFunction(
   {
@@ -32,15 +36,57 @@ export const syncDataMoat = inngest.createFunction(
   async ({ step }) => {
     const checkInId = cronCheckIn('sync-data-moat', '15 3 * * *');
     try {
-      // Step 1: Delegator snapshots — highest value, most data
-      const delegatorResult = await step.run('snapshot-delegators', async () => {
+      // Step 1: Prepare delegator snapshot — check coverage, get remaining DRep IDs
+      const prep = await step.run('prepare-delegator-snapshot', async () => {
         try {
-          return await syncDelegatorSnapshots();
+          return await prepareDelegatorSnapshot();
         } catch (err) {
-          logger.error('[data-moat] Delegator snapshots failed', { error: err });
-          return { drepsProcessed: 0, delegatorsSnapshotted: 0, errors: [errMsg(err)] };
+          logger.error('[data-moat] Delegator snapshot prep failed', { error: err });
+          return null;
         }
       });
+
+      // Step 1b: Process delegators in chunks (each step < 60s)
+      let totalProcessed = 0;
+      let totalSnapshotted = 0;
+      const delegatorErrors: string[] = [];
+
+      if (prep) {
+        const chunks: string[][] = [];
+        for (let i = 0; i < prep.drepIds.length; i += DELEGATOR_CHUNK_SIZE) {
+          chunks.push(prep.drepIds.slice(i, i + DELEGATOR_CHUNK_SIZE));
+        }
+
+        for (let ci = 0; ci < chunks.length; ci++) {
+          const chunkResult = await step.run(`snapshot-delegators-${ci}`, async () => {
+            try {
+              return await syncDelegatorSnapshotChunk(chunks[ci], prep.epoch);
+            } catch (err) {
+              logger.error(`[data-moat] Delegator chunk ${ci} failed`, { error: err });
+              return { drepsProcessed: 0, delegatorsSnapshotted: 0, errors: [errMsg(err)] };
+            }
+          });
+          totalProcessed += chunkResult.drepsProcessed;
+          totalSnapshotted += chunkResult.delegatorsSnapshotted;
+          delegatorErrors.push(...chunkResult.errors);
+        }
+
+        // Step 1c: Finalize — write sync_log and completeness
+        await step.run('finalize-delegator-snapshot', async () => {
+          await finalizeDelegatorSnapshot(
+            prep.epoch,
+            totalProcessed,
+            totalSnapshotted,
+            delegatorErrors,
+          );
+        });
+      }
+
+      const delegatorResult = {
+        drepsProcessed: totalProcessed,
+        delegatorsSnapshotted: totalSnapshotted,
+        errors: delegatorErrors,
+      };
 
       // Step 2: DRep lifecycle events — incremental, only new events
       const lifecycleResult = await step.run('sync-lifecycle-events', async () => {

--- a/lib/crossChain.ts
+++ b/lib/crossChain.ts
@@ -249,45 +249,27 @@ async function subsquareFetch(path: string): Promise<unknown> {
 }
 
 export async function fetchPolkadotBenchmark(): Promise<ChainBenchmark | null> {
-  const [summaryData, referendaData] = await Promise.all([
-    withRetrySafe(() => subsquareFetch('/summary'), 'crossChain/subsquare/summary'),
-    withRetrySafe(
-      () => subsquareFetch('/gov2/referendums?page=1&page_size=20'),
-      'crossChain/subsquare/referenda',
-    ),
-  ]);
+  // SubSquare deprecated /gov2/referendums — use /summary only
+  const summaryData = await withRetrySafe(
+    () => subsquareFetch('/summary'),
+    'crossChain/subsquare/summary',
+  );
 
   const summary = summaryData as {
     gov2Referenda?: { all?: number; active?: number };
+    gov2ReferendaTracks?: { id: number; name: string; activeCount: number }[];
     fellowshipReferenda?: { all?: number };
   } | null;
 
-  const referenda = referendaData as {
-    items?: { state?: { name: string }; tally?: { ayes: string; nays: string } }[];
-    total?: number;
-  } | null;
+  if (!summary?.gov2Referenda) return null;
 
-  if (!summary && !referenda) return null;
+  const totalReferenda = summary.gov2Referenda.all ?? 0;
+  const activeReferenda = summary.gov2Referenda.active ?? 0;
+  const activeTracks = summary.gov2ReferendaTracks?.filter((t) => t.activeCount > 0).length ?? null;
 
-  const totalReferenda = summary?.gov2Referenda?.all ?? referenda?.total ?? 0;
-  const activeReferenda = summary?.gov2Referenda?.active ?? 0;
-
-  let proposalThroughput: number | null = null;
-  let participationRate: number | null = null;
-
-  if (referenda?.items?.length) {
-    const withVotes = referenda.items.filter((r) => {
-      const ayes = parseInt(r.tally?.ayes || '0', 10);
-      const nays = parseInt(r.tally?.nays || '0', 10);
-      return ayes + nays > 0;
-    });
-    proposalThroughput = Math.round((withVotes.length / referenda.items.length) * 100);
-
-    participationRate =
-      activeReferenda > 0
-        ? Math.min(100, Math.round((activeReferenda / Math.max(totalReferenda, 1)) * 100))
-        : null;
-  }
+  // Participation rate: active referenda as % of total (approximate engagement metric)
+  const participationRate =
+    totalReferenda > 0 ? Math.min(100, Math.round((activeReferenda / totalReferenda) * 100)) : null;
 
   const now = new Date();
   const periodLabel = `${now.getFullYear()}-W${String(getISOWeek(now)).padStart(2, '0')}`;
@@ -298,9 +280,9 @@ export async function fetchPolkadotBenchmark(): Promise<ChainBenchmark | null> {
     participationRate,
     delegateCount: null,
     proposalCount: totalReferenda,
-    proposalThroughput,
+    proposalThroughput: null,
     avgRationaleRate: null,
-    rawData: { summary, recentReferendaCount: referenda?.items?.length ?? 0 },
+    rawData: { summary, activeTracks },
     fetchedAt: now.toISOString(),
   };
 }

--- a/lib/sync/data-moat.ts
+++ b/lib/sync/data-moat.ts
@@ -32,114 +32,153 @@ const DREP_UPDATE_BATCH = 50;
 // 1. DRep Delegator Snapshots
 // ---------------------------------------------------------------------------
 
-export async function syncDelegatorSnapshots(): Promise<{
-  drepsProcessed: number;
-  delegatorsSnapshotted: number;
-  errors: string[];
-}> {
+/**
+ * Prepare delegator snapshot: check coverage and return DRep IDs that still need processing.
+ * Returns null if coverage is already sufficient (>= 95%).
+ */
+export async function prepareDelegatorSnapshot(): Promise<{
+  epoch: number;
+  drepIds: string[];
+} | null> {
   const supabase = getSupabaseAdmin();
-  const syncLog = new SyncLogger(supabase, 'delegator_snapshots');
-  await syncLog.start();
+  const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
 
+  // Get active DReps
+  const { data: dreps } = await supabase
+    .from('dreps')
+    .select('id')
+    .filter('info->>isActive', 'eq', 'true');
+
+  if (!dreps?.length) return null;
+
+  // Check coverage: how many DReps already have snapshots this epoch?
+  const { count: snappedDreps } = await supabase
+    .from('drep_delegator_snapshots')
+    .select('drep_id', { count: 'exact', head: true })
+    .eq('epoch_no', currentEpoch);
+
+  const coverage = (snappedDreps ?? 0) / dreps.length;
+  if (coverage >= 0.95) {
+    logger.info('[data-moat] Delegator snapshots already at sufficient coverage', {
+      epoch: currentEpoch,
+      snappedDreps,
+      totalDreps: dreps.length,
+      coverage: `${(coverage * 100).toFixed(1)}%`,
+    });
+    return null;
+  }
+
+  // If partially done, only return DReps not yet snapshotted
+  let drepIds = dreps.map((d) => d.id);
+  if ((snappedDreps ?? 0) > 0) {
+    const { data: existing } = await supabase
+      .from('drep_delegator_snapshots')
+      .select('drep_id')
+      .eq('epoch_no', currentEpoch);
+    const done = new Set((existing ?? []).map((r: any) => r.drep_id));
+    drepIds = drepIds.filter((id) => !done.has(id));
+  }
+
+  return { epoch: currentEpoch, drepIds };
+}
+
+/**
+ * Process a chunk of DReps for delegator snapshots.
+ * Designed to run within a single Inngest step (< 60s).
+ */
+export async function syncDelegatorSnapshotChunk(
+  drepIds: string[],
+  epoch: number,
+): Promise<{ drepsProcessed: number; delegatorsSnapshotted: number; errors: string[] }> {
+  const supabase = getSupabaseAdmin();
   const errors: string[] = [];
   let drepsProcessed = 0;
   let delegatorsSnapshotted = 0;
 
-  try {
-    const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+  for (let i = 0; i < drepIds.length; i += DELEGATOR_CONCURRENCY) {
+    const chunk = drepIds.slice(i, i + DELEGATOR_CONCURRENCY);
 
-    // Check if we already have snapshots for this epoch
-    const { count: existingCount } = await supabase
-      .from('drep_delegator_snapshots')
-      .select('id', { count: 'exact', head: true })
-      .eq('epoch_no', currentEpoch);
+    const results = await Promise.allSettled(
+      chunk.map(async (drepId) => {
+        try {
+          const delegators = await fetchDRepDelegatorsFull(drepId);
+          if (delegators.length === 0) return 0;
 
-    if ((existingCount ?? 0) > 100) {
-      logger.info('[data-moat] Delegator snapshots already exist for this epoch', {
-        epoch: currentEpoch,
-        existing: existingCount,
-      });
-      await syncLog.finalize(true, null, {
-        skipped: true,
-        epoch: currentEpoch,
-        existingRecords: existingCount,
-      });
-      return { drepsProcessed: 0, delegatorsSnapshotted: 0, errors: [] };
-    }
+          const rows = delegators.map((d) => ({
+            drep_id: drepId,
+            epoch_no: epoch,
+            stake_address: d.stake_address,
+            amount_lovelace: parseInt(d.amount || '0', 10),
+          }));
 
-    // Get active DReps with significant voting power (skip dust DReps)
-    const { data: dreps } = await supabase
-      .from('dreps')
-      .select('id, info')
-      .filter('info->>isActive', 'eq', 'true');
-
-    if (!dreps?.length) {
-      await syncLog.finalize(true, null, { drepsProcessed: 0 });
-      return { drepsProcessed: 0, delegatorsSnapshotted: 0, errors: [] };
-    }
-
-    // Process DReps in parallel chunks
-    for (let i = 0; i < dreps.length; i += DELEGATOR_CONCURRENCY) {
-      const chunk = dreps.slice(i, i + DELEGATOR_CONCURRENCY);
-
-      const results = await Promise.allSettled(
-        chunk.map(async (drep) => {
-          try {
-            const delegators = await fetchDRepDelegatorsFull(drep.id);
-            if (delegators.length === 0) return 0;
-
-            const rows = delegators.map((d) => ({
-              drep_id: drep.id,
-              epoch_no: currentEpoch,
-              stake_address: d.stake_address,
-              amount_lovelace: parseInt(d.amount || '0', 10),
-            }));
-
-            const result = await batchUpsert(
-              supabase,
-              'drep_delegator_snapshots',
-              rows,
-              'drep_id,epoch_no,stake_address',
-              `delegator-snap-${drep.id.slice(0, 12)}`,
-            );
-            return result.success;
-          } catch (err) {
-            errors.push(`${drep.id.slice(0, 16)}: ${errMsg(err)}`);
-            return 0;
-          }
-        }),
-      );
-
-      for (const r of results) {
-        if (r.status === 'fulfilled') {
-          delegatorsSnapshotted += r.value;
-          drepsProcessed++;
+          const result = await batchUpsert(
+            supabase,
+            'drep_delegator_snapshots',
+            rows,
+            'drep_id,epoch_no,stake_address',
+            `delegator-snap-${drepId.slice(0, 12)}`,
+          );
+          return result.success;
+        } catch (err) {
+          errors.push(`${drepId.slice(0, 16)}: ${errMsg(err)}`);
+          return 0;
         }
-      }
-    }
-
-    // Snapshot completeness tracking
-    await supabase.from('snapshot_completeness_log').upsert(
-      {
-        snapshot_type: 'delegator_snapshots',
-        epoch_no: currentEpoch,
-        snapshot_date: new Date().toISOString().slice(0, 10),
-        record_count: delegatorsSnapshotted,
-        expected_count: dreps.length,
-        coverage_pct:
-          dreps.length > 0 ? Math.round((drepsProcessed / dreps.length) * 10000) / 100 : 100,
-      },
-      { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
+      }),
     );
 
-    const metrics = { drepsProcessed, delegatorsSnapshotted, epoch: currentEpoch };
-    await syncLog.finalize(errors.length === 0, errors.length ? errors.join('; ') : null, metrics);
-    return { drepsProcessed, delegatorsSnapshotted, errors };
-  } catch (err) {
-    const msg = errMsg(err);
-    await syncLog.finalize(false, msg, { drepsProcessed, delegatorsSnapshotted });
-    throw err;
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        delegatorsSnapshotted += r.value;
+        drepsProcessed++;
+      }
+    }
   }
+
+  return { drepsProcessed, delegatorsSnapshotted, errors };
+}
+
+/**
+ * Finalize delegator snapshot: write completeness log and sync_log.
+ */
+export async function finalizeDelegatorSnapshot(
+  epoch: number,
+  totalProcessed: number,
+  totalSnapshotted: number,
+  allErrors: string[],
+): Promise<void> {
+  const supabase = getSupabaseAdmin();
+  const syncLog = new SyncLogger(supabase, 'delegator_snapshots');
+  await syncLog.start();
+
+  const { data: dreps } = await supabase
+    .from('dreps')
+    .select('id', { count: 'exact', head: true })
+    .filter('info->>isActive', 'eq', 'true');
+
+  const totalDreps = dreps?.length ?? totalProcessed;
+
+  await supabase.from('snapshot_completeness_log').upsert(
+    {
+      snapshot_type: 'delegator_snapshots',
+      epoch_no: epoch,
+      snapshot_date: new Date().toISOString().slice(0, 10),
+      record_count: totalSnapshotted,
+      expected_count: totalDreps,
+      coverage_pct: totalDreps > 0 ? Math.round((totalProcessed / totalDreps) * 10000) / 100 : 100,
+    },
+    { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
+  );
+
+  const metrics = {
+    drepsProcessed: totalProcessed,
+    delegatorsSnapshotted: totalSnapshotted,
+    epoch,
+  };
+  await syncLog.finalize(
+    allErrors.length === 0,
+    allErrors.length ? allErrors.join('; ') : null,
+    metrics,
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **SubSquare (Polkadot)**: Their `/gov2/referendums` endpoint now returns 404. Updated the adapter to use `/summary` only — still provides total/active referenda counts and track data
- **Delegator snapshots**: Timed out at 118s (Cloudflare 524 at 100s), leaving 297/868 DReps unsnapshotted. Refactored into chunked Inngest steps (100 DReps each, <60s per step) with coverage-based skip logic (95% threshold)
- **Treasury sync**: All 14 failures were deployment restarts ("Process terminated"), not code bugs — no fix needed

## Test plan
- [x] Preflight passes (0 errors, 306 tests)
- [ ] CI green
- [ ] Re-trigger benchmarks sync → verify Polkadot data populates
- [ ] Re-trigger data-moat sync → verify delegator snapshots complete without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)