### PR TITLE
feat: delegation CTA on Quick Match + enriched proposal cards

### DIFF
--- a/app/api/proposals/route.ts
+++ b/app/api/proposals/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
@@ -10,13 +10,30 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
   const limit = Math.min(parseInt(searchParams.get('limit') || '100', 10), 500);
 
   const supabase = getSupabaseAdmin();
-  const { data, error } = await supabase
-    .from('proposals')
-    .select(
-      'tx_hash, proposal_index, title, proposal_type, expired_epoch, ratified_epoch, enacted_epoch, dropped_epoch',
-    )
-    .order('proposed_epoch', { ascending: false })
-    .limit(limit);
+
+  const [proposalsResult, votingSummaryResult, treasuryResult, epochResult] = await Promise.all([
+    supabase
+      .from('proposals')
+      .select(
+        'tx_hash, proposal_index, title, proposal_type, expired_epoch, ratified_epoch, enacted_epoch, dropped_epoch, expiration_epoch, proposed_epoch, withdrawal_amount, treasury_tier, block_time',
+      )
+      .order('proposed_epoch', { ascending: false })
+      .limit(limit),
+    supabase
+      .from('proposal_voting_summary')
+      .select(
+        'proposal_tx_hash, proposal_index, drep_yes_votes_cast, drep_no_votes_cast, drep_abstain_votes_cast, pool_yes_votes_cast, pool_no_votes_cast, pool_abstain_votes_cast, committee_yes_votes_cast, committee_no_votes_cast, committee_abstain_votes_cast',
+      ),
+    supabase
+      .from('treasury_balance')
+      .select('balance_ada')
+      .order('fetched_at', { ascending: false })
+      .limit(1)
+      .single(),
+    supabase.from('governance_stats').select('current_epoch').eq('id', 1).single(),
+  ]);
+
+  const { data, error } = proposalsResult;
 
   if (error) {
     logger.error('Failed to fetch proposals', {
@@ -27,20 +44,66 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
     return NextResponse.json({ error: 'Failed to fetch proposals' }, { status: 500 });
   }
 
+  // Build tri-body vote lookup
+  const triBodyMap = new Map<
+    string,
+    {
+      drep: { yes: number; no: number; abstain: number };
+      spo: { yes: number; no: number; abstain: number };
+      cc: { yes: number; no: number; abstain: number };
+    }
+  >();
+  if (votingSummaryResult.data) {
+    for (const s of votingSummaryResult.data) {
+      triBodyMap.set(`${s.proposal_tx_hash}-${s.proposal_index}`, {
+        drep: {
+          yes: s.drep_yes_votes_cast || 0,
+          no: s.drep_no_votes_cast || 0,
+          abstain: s.drep_abstain_votes_cast || 0,
+        },
+        spo: {
+          yes: s.pool_yes_votes_cast || 0,
+          no: s.pool_no_votes_cast || 0,
+          abstain: s.pool_abstain_votes_cast || 0,
+        },
+        cc: {
+          yes: s.committee_yes_votes_cast || 0,
+          no: s.committee_no_votes_cast || 0,
+          abstain: s.committee_abstain_votes_cast || 0,
+        },
+      });
+    }
+  }
+
+  const treasuryBalance = treasuryResult.data?.balance_ada ?? null;
+
   const proposals = (data || []).map((p) => {
     let status = 'active';
     if (p.enacted_epoch) status = 'enacted';
     else if (p.ratified_epoch) status = 'ratified';
     else if (p.expired_epoch) status = 'expired';
     else if (p.dropped_epoch) status = 'dropped';
+
+    const key = `${p.tx_hash}-${p.proposal_index}`;
+    const triBody = triBodyMap.get(key) ?? null;
+    const withdrawalAmount = p.withdrawal_amount != null ? Number(p.withdrawal_amount) : null;
+
     return {
       txHash: p.tx_hash,
       index: p.proposal_index,
       title: p.title,
       status,
       type: p.proposal_type,
+      withdrawalAmount,
+      treasuryTier: p.treasury_tier ?? null,
+      treasuryPct: withdrawalAmount && treasuryBalance ? withdrawalAmount / treasuryBalance : null,
+      expirationEpoch: p.expiration_epoch ?? null,
+      proposedEpoch: p.proposed_epoch ?? null,
+      triBody,
     };
   });
 
-  return NextResponse.json({ proposals });
+  const currentEpoch = epochResult.data?.current_epoch ?? null;
+
+  return NextResponse.json({ proposals, currentEpoch });
 });

--- a/components/DelegateButton.tsx
+++ b/components/DelegateButton.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useDelegation } from '@/hooks/useDelegation';
+import { Button } from '@/components/ui/button';
+import { Vote, Wallet, Loader2, CheckCircle, AlertTriangle, ExternalLink } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+const DelegationCeremony = dynamic(
+  () => import('./DelegationCeremony').then((m) => m.DelegationCeremony),
+  { ssr: false },
+);
+
+interface DelegateButtonProps {
+  drepId: string;
+  drepName: string;
+  size?: 'sm' | 'default' | 'lg';
+  className?: string;
+}
+
+const PHASE_LABELS: Record<string, string> = {
+  preflight: 'Checking...',
+  building: 'Preparing...',
+  signing: 'Sign in wallet...',
+  submitting: 'Submitting...',
+};
+
+export function DelegateButton({ drepId, drepName, size = 'sm', className }: DelegateButtonProps) {
+  const {
+    phase,
+    startDelegation,
+    confirmDelegation,
+    reset,
+    isProcessing,
+    delegatedDrepId,
+    canDelegate,
+  } = useDelegation();
+
+  const [showCeremony, setShowCeremony] = useState(false);
+  const [ceremonyScore, setCeremonyScore] = useState(0);
+  const [ceremonyAlignments, setCeremonyAlignments] = useState<AlignmentScores | undefined>();
+
+  const isAlreadyDelegated = !!delegatedDrepId && delegatedDrepId === drepId;
+
+  const handleDelegate = () => {
+    if (!canDelegate) {
+      window.dispatchEvent(new Event('openWalletConnect'));
+      return;
+    }
+    startDelegation(drepId);
+  };
+
+  const handleConfirm = async () => {
+    const result = await confirmDelegation(drepId);
+    if (result) {
+      fetch(`/api/dreps/${encodeURIComponent(drepId)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (data?.drepScore) setCeremonyScore(data.drepScore);
+          if (data?.alignmentTreasuryConservative != null) {
+            setCeremonyAlignments({
+              treasuryConservative: data.alignmentTreasuryConservative ?? 50,
+              treasuryGrowth: data.alignmentTreasuryGrowth ?? 50,
+              decentralization: data.alignmentDecentralization ?? 50,
+              security: data.alignmentSecurity ?? 50,
+              innovation: data.alignmentInnovation ?? 50,
+              transparency: data.alignmentTransparency ?? 50,
+            });
+          }
+        })
+        .catch(() => {});
+      setShowCeremony(true);
+    }
+  };
+
+  // Ceremony overlay
+  if (showCeremony) {
+    return (
+      <DelegationCeremony
+        drepId={drepId}
+        drepName={drepName}
+        score={ceremonyScore || 0}
+        alignments={ceremonyAlignments}
+        onContinue={() => setShowCeremony(false)}
+      />
+    );
+  }
+
+  // Already delegated
+  if (isAlreadyDelegated && phase.status !== 'success') {
+    return (
+      <Button variant="outline" size={size} className={cn('gap-1.5', className)} disabled>
+        <CheckCircle className="h-3.5 w-3.5 text-primary" />
+        Delegating
+      </Button>
+    );
+  }
+
+  // Success
+  if (phase.status === 'success') {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <Button variant="outline" size={size} className={cn('gap-1.5', className)} disabled>
+          <CheckCircle className="h-3.5 w-3.5 text-green-500" />
+          {phase.confirmed ? 'Delegated!' : 'Submitted!'}
+        </Button>
+        <a
+          href={`https://cardanoscan.io/transaction/${phase.txHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-primary transition-colors justify-center"
+        >
+          View tx <ExternalLink className="h-2.5 w-2.5" />
+        </a>
+      </div>
+    );
+  }
+
+  // Error
+  if (phase.status === 'error') {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <p className="text-[10px] text-destructive text-center">{phase.hint}</p>
+        <Button variant="outline" size={size} className={cn('gap-1.5', className)} onClick={reset}>
+          Try Again
+        </Button>
+      </div>
+    );
+  }
+
+  // Confirming — show fee and confirm/cancel
+  if (phase.status === 'confirming') {
+    return (
+      <div className="flex flex-col gap-2 p-3 rounded-lg border border-primary/20 bg-card">
+        <p className="text-xs font-medium">Delegate to {drepName}</p>
+        <div className="text-[10px] text-muted-foreground space-y-0.5">
+          <p>
+            Fee: <span className="font-medium text-foreground">{phase.preflight.estimatedFee}</span>
+          </p>
+          {phase.preflight.needsDeposit && (
+            <p className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+              <AlertTriangle className="h-2.5 w-2.5 shrink-0" />
+              +2 ADA refundable deposit
+            </p>
+          )}
+          <p>Your ADA stays in your wallet.</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" className="flex-1 h-7 text-xs" onClick={reset}>
+            Cancel
+          </Button>
+          <Button size="sm" className="flex-1 h-7 text-xs gap-1" onClick={handleConfirm}>
+            <Vote className="h-3 w-3" /> Confirm
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Processing
+  if (isProcessing) {
+    return (
+      <Button size={size} className={cn('gap-1.5', className)} disabled>
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        {PHASE_LABELS[phase.status] || 'Processing...'}
+      </Button>
+    );
+  }
+
+  // Default: delegate button
+  return (
+    <Button size={size} className={cn('gap-1.5', className)} onClick={handleDelegate}>
+      {canDelegate ? (
+        <>
+          <Vote className="h-3.5 w-3.5" />
+          {delegatedDrepId ? 'Switch DRep' : 'Delegate'}
+        </>
+      ) : (
+        <>
+          <Wallet className="h-3.5 w-3.5" />
+          Connect & Delegate
+        </>
+      )}
+    </Button>
+  );
+}

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Clock, Landmark, Users, Shield, Scale } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useProposals, useDRepVotes } from '@/hooks/queries';
@@ -52,12 +52,63 @@ const VOTE_PILL: Record<string, { label: string; color: string }> = {
   Abstain: { label: 'Abstain', color: 'text-amber-500 bg-amber-500/10 border-amber-500/20' },
 };
 
+function formatAdaShort(ada: number): string {
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toLocaleString();
+}
+
+function formatPct(pct: number): string {
+  if (pct < 0.01) return '<0.01%';
+  if (pct < 1) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(1)}%`;
+}
+
+function TriBodyMini({
+  triBody,
+}: {
+  triBody: {
+    drep: { yes: number; no: number; abstain: number };
+    spo: { yes: number; no: number; abstain: number };
+    cc: { yes: number; no: number; abstain: number };
+  };
+}) {
+  const bodies = [
+    { label: 'DRep', data: triBody.drep, icon: Users },
+    { label: 'SPO', data: triBody.spo, icon: Shield },
+    { label: 'CC', data: triBody.cc, icon: Scale },
+  ] as const;
+
+  return (
+    <div className="flex items-center gap-2">
+      {bodies.map(({ label, data, icon: Icon }) => {
+        const total = data.yes + data.no + data.abstain;
+        if (total === 0) return null;
+        const yesPct = Math.round((data.yes / total) * 100);
+        const color =
+          yesPct >= 60 ? 'text-green-500' : yesPct >= 40 ? 'text-amber-500' : 'text-red-500';
+        return (
+          <span
+            key={label}
+            className="flex items-center gap-0.5 text-[10px]"
+            title={`${label}: ${data.yes}Y / ${data.no}N / ${data.abstain}A`}
+          >
+            <Icon className="h-2.5 w-2.5 text-muted-foreground" />
+            <span className={cn('font-semibold tabular-nums', color)}>{yesPct}%</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 const PAGE_SIZE = 25;
 
 export function ProposalsBrowse() {
   const { data: rawData, isLoading } = useProposals(200);
   const data = rawData as any;
   const proposals: any[] = useMemo(() => data?.proposals ?? [], [data]);
+  const currentEpoch: number | null = data?.currentEpoch ?? null;
   const { delegatedDrepId } = useWallet();
   const { data: drepVotesRaw } = useDRepVotes(delegatedDrepId);
 
@@ -195,45 +246,79 @@ export function ProposalsBrowse() {
             const status = p.status ?? 'Open';
             const drepVote = drepVoteMap.get(`${p.txHash}:${p.index}`);
             const pill = drepVote ? VOTE_PILL[drepVote] : null;
+            const epochsLeft =
+              status === 'active' && currentEpoch && p.expirationEpoch
+                ? p.expirationEpoch - currentEpoch
+                : null;
+            const hasTreasury = p.type === 'TreasuryWithdrawals' && p.withdrawalAmount;
             return (
               <Link
                 key={`${p.txHash}-${p.index}`}
                 href={`/proposal/${p.txHash}/${p.index}`}
-                className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors group"
+                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group"
               >
-                {p.type && (
-                  <span
-                    className={cn(
-                      'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border shrink-0',
-                      TYPE_COLORS[p.type] ?? 'bg-muted text-muted-foreground',
-                    )}
-                  >
-                    {typeLabel(p.type)}
-                  </span>
-                )}
-                <span className="flex-1 text-sm text-foreground truncate min-w-0">
-                  {p.title || `${p.txHash?.slice(0, 16)}…`}
-                </span>
-                {pill && (
-                  <span
-                    className={cn(
-                      'text-[10px] font-semibold px-1.5 py-0.5 rounded border shrink-0 hidden sm:inline',
-                      pill.color,
-                    )}
-                    title={`Your DRep voted ${pill.label}`}
-                  >
-                    DRep: {pill.label}
-                  </span>
-                )}
-                <span
-                  className={cn(
-                    'text-xs font-medium shrink-0',
-                    STATUS_COLORS[status] ?? 'text-muted-foreground',
+                {/* Row 1: Type + Title + Status */}
+                <div className="flex items-center gap-3">
+                  {p.type && (
+                    <span
+                      className={cn(
+                        'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border shrink-0',
+                        TYPE_COLORS[p.type] ?? 'bg-muted text-muted-foreground',
+                      )}
+                    >
+                      {typeLabel(p.type)}
+                    </span>
                   )}
-                >
-                  {status}
-                </span>
-                <ChevronRight className="h-4 w-4 text-muted-foreground/70 shrink-0 group-hover:text-muted-foreground transition-colors" />
+                  <span className="flex-1 text-sm text-foreground truncate min-w-0">
+                    {p.title || `${p.txHash?.slice(0, 16)}…`}
+                  </span>
+                  <span
+                    className={cn(
+                      'text-xs font-medium shrink-0',
+                      STATUS_COLORS[status] ?? 'text-muted-foreground',
+                    )}
+                  >
+                    {status}
+                  </span>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground/70 shrink-0 group-hover:text-muted-foreground transition-colors" />
+                </div>
+
+                {/* Row 2: Metadata chips */}
+                <div className="flex items-center gap-3 pl-0 sm:pl-[calc(1.5rem+0.75rem)]">
+                  {hasTreasury && (
+                    <span className="flex items-center gap-1 text-[10px] text-emerald-500">
+                      <Landmark className="h-2.5 w-2.5" />
+                      <span className="font-semibold tabular-nums">
+                        {formatAdaShort(p.withdrawalAmount)} ADA
+                      </span>
+                      {p.treasuryPct != null && (
+                        <span className="text-muted-foreground">
+                          ({formatPct(p.treasuryPct * 100)})
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {p.triBody && <TriBodyMini triBody={p.triBody} />}
+                  {pill && (
+                    <span
+                      className={cn(
+                        'text-[10px] font-semibold px-1.5 py-0.5 rounded border shrink-0',
+                        pill.color,
+                      )}
+                      title={`Your DRep voted ${pill.label}`}
+                    >
+                      DRep: {pill.label}
+                    </span>
+                  )}
+                  {epochsLeft != null && epochsLeft > 0 && (
+                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                      <Clock className="h-2.5 w-2.5" />
+                      <span className="tabular-nums">
+                        {epochsLeft === 1 ? '1 epoch left' : `${epochsLeft} epochs left`}
+                      </span>
+                    </span>
+                  )}
+                </div>
               </Link>
             );
           })}

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -24,6 +24,7 @@ import { Badge } from '@/components/ui/badge';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
 import { RadarOverlay } from '@/components/matching/RadarOverlay';
 import { cn } from '@/lib/utils';
+import { DelegateButton } from '@/components/DelegateButton';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 
 /* ─── Types ─────────────────────────────────────────────── */
@@ -540,11 +541,19 @@ function QuickMatchResultCard({
               </p>
             )}
 
-            <Link href={`/drep/${encodeURIComponent(match.drepId)}`}>
-              <Button variant="outline" size="sm" className="text-xs gap-1 h-7 mt-1">
-                View Profile <ChevronRight className="h-3 w-3" />
-              </Button>
-            </Link>
+            <div className="flex gap-2 mt-1">
+              <DelegateButton
+                drepId={match.drepId}
+                drepName={displayName}
+                size="sm"
+                className="text-xs h-7"
+              />
+              <Link href={`/drep/${encodeURIComponent(match.drepId)}`}>
+                <Button variant="outline" size="sm" className="text-xs gap-1 h-7">
+                  View Profile <ChevronRight className="h-3 w-3" />
+                </Button>
+              </Link>
+            </div>
           </div>
         </div>
       </CardContent>

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -1,15 +1,15 @@
-# DRepScore: The Definitive Product Vision
+# Civica: The Definitive Product Vision
 
 > **Status:** Active north star -- all build decisions, monetization timing, and architecture choices should align with this document.
 > **Created:** March 2026
-> **Last updated:** March 2026 (Persona expansion)
+> **Last updated:** March 2026 (Multi-wallet identity, progress markers through Step 4)
 > **Supersedes:** `product-wow-plan-v2.md` as the primary product direction document.
 
 ---
 
 ## The Thesis
 
-DRepScore is not a dashboard. It is the **governance intelligence layer** for Cardano -- the single system that ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. The product moat is not code -- it is the compounding historical dataset that grows every epoch and becomes impossible to replicate.
+Civica is not a dashboard. It is the **governance intelligence layer** for Cardano -- the single system that ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. The product moat is not code -- it is the compounding historical dataset that grows every epoch and becomes impossible to replicate.
 
 The architectural insight that makes this possible: **every data point feeds every other data point.** A DRep's vote updates their alignment, their score, the GHI, the inter-body alignment, the treasury track record, and the epoch recap -- simultaneously. A delegator's quiz answer improves their match, their footprint, and the system's understanding of citizen preferences. Nothing exists in isolation. The product feels like magic because the dots are genuinely connected underneath.
 
@@ -17,7 +17,7 @@ The architectural insight that makes this possible: **every data point feeds eve
 
 ## Personas
 
-DRepScore serves seven distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data engine.
+Civica serves seven distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data engine.
 
 | Persona                                  | What DRepScore Does For Them                                                                                                                                                                  |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -28,6 +28,47 @@ DRepScore serves seven distinct personas. Each sees a product tailored to their 
 | **Treasury Proposal Teams**              | Showcase delivery track record, manage accountability polls, build proposer reputation for future funding requests. Monetized via Verified Project badges.                                    |
 | **Governance Researchers / Analysts**    | Academic-grade data exports, historical snapshots, EDI metrics, cross-chain comparison datasets. Citation-ready governance data. Monetized via Research API subscriptions.                    |
 | **Crypto Enthusiasts (Outside Cardano)** | See how sophisticated governance can be when done right. Cross-chain observatory, EDI comparison, and the sheer depth of the platform serve as a showcase for Cardano governance.             |
+
+### Segment Fluidity
+
+Most governance participants span multiple personas simultaneously. A DRep is also a delegator (to themselves or others). An SPO may also be a DRep. A CC member has personal delegation and may operate a pool. A treasury proposal team member is also an ADA holder tracking their own governance health.
+
+Civica treats segments as **additive facets of one identity**, not separate user types. The product adapts to the union of all segments detected across a user's linked wallets -- a user who links a DRep wallet and an SPO wallet sees a unified experience that surfaces both roles without mode-switching. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience) below and [ADR 007](../adr/007-multi-wallet-identity.md) for the technical model.
+
+---
+
+## Multi-Wallet Identity & Unified Experience
+
+Cardano governance participants routinely operate multiple wallets: cold storage for ADA holdings, an operational wallet for daily use, a governance key for DRep registration, a pool operator wallet. Under a single-wallet identity model, each wallet is a separate user -- fragmenting watchlists, engagement history, governance profiles, Wrapped summaries, and AI advisor context. This directly undermines the intelligence layer.
+
+### The Design
+
+- **One human = one profile**, anchored by a stable UUID, with many wallets linked via `user_wallets`
+- Each wallet contributes **segments** (DRep, SPO, Citizen) -- the user's effective segments are the union across all linked wallets
+- Wallet linking is **opt-in** with clear privacy controls: link anytime, unlink anytime, no on-chain footprint
+
+### Unified Experience Principles
+
+The product does not require mode-switching. All governance roles surface in one view, and the UI adapts to whatever segments the user's linked wallets reveal:
+
+- **Home screen adapts:** A DRep+SPO sees both scores, both inboxes, unified action items. A pure citizen sees delegation health and footprint. The same page, different facets.
+- **Matching adapts:** If you are already a DRep, the product surfaces "find an SPO aligned with your governance values" rather than "find your DRep." If you are both, matching focuses on delegation health.
+- **Wrapped spans all roles:** "As a DRep you voted on 47 proposals; as an SPO your pool participated in 40; as a citizen your delegation health is green." One shareable identity, not three separate cards.
+- **AI Advisor sees everything:** "Your DRep score dropped 3 points, but your SPO alignment with the DRep consensus improved. Your delegation to DRep X is still well-matched." Cross-role insights that no single-wallet system can generate.
+- **Navigation surfaces role-specific deep dives** (DRep management, SPO management, delegation health) from a unified top level. Depth is progressive -- the top layer is unified, the drill-downs are role-specific.
+
+### Cross-Segment Intelligence
+
+Multi-wallet identity unlocks intelligence that is impossible when each wallet is an island:
+
+- **Personal inter-body alignment:** "As a DRep, you voted Yes on Proposal X. As an SPO, your pool voted No. Here is why that is interesting."
+- **Aggregated governance footprint:** Total ADA governed across all wallets, total proposals touched across all roles, combined engagement level.
+- **Conflict detection:** "Your DRep delegation and your SPO operation have diverging alignment on treasury proposals -- here is where they split."
+- **Unified governance profile:** The PCA-based governance profile incorporates signal from all roles, producing a richer and more accurate representation of the user's governance values.
+
+### Privacy
+
+Wallet linking creates a server-side association between addresses. Privacy-sensitive users can choose to operate with a single wallet and lose nothing -- the core product works identically. Linking is purely additive. Unlinking removes the association completely. There is no on-chain record of linked wallets.
 
 ---
 
@@ -59,6 +100,7 @@ flowchart TB
   end
 
   subgraph personal [Personal Layer]
+    WalletUnion["Multi-Wallet Aggregation"]
     DRepMatch["DRep Matching"]
     SPOMatch["SPO Matching"]
     Footprint["Wallet Governance Footprint"]
@@ -95,6 +137,7 @@ flowchart TB
   ProposalAI --> DRepMatch & SPOMatch & DRepDiscover & Calendar & Trends
   Trends --> Calendar & Pulse
 
+  WalletUnion --> Footprint & DRepMatch & SPOMatch & Wrapped & Alerts
   DRepMatch --> Footprint & DRepDiscover
   SPOMatch --> Footprint & SPODiscover
   Footprint --> Wrapped & Alerts
@@ -109,6 +152,8 @@ flowchart TB
 Each step assumes the previous steps are complete. Complexity is rated Low / Medium / High. Detailed implementation plans for each step are linked where they exist.
 
 ### Step 0: Backend Metric Upgrades (HIGH complexity)
+
+> **Status: COMPLETE** -- All scoring, alignment, GHI, and observatory systems are live in production.
 
 The foundation. Everything downstream depends on the quality of these scores.
 
@@ -126,6 +171,8 @@ The foundation. Everything downstream depends on the quality of these scores.
 ---
 
 ### Step 1: DNA Quiz + Matching UX (MEDIUM complexity)
+
+> **Status: COMPLETE** -- Quick Match, PCA matching, user governance profiles, confidence scoring, dimension-level agreement all live.
 
 **What gets built:**
 
@@ -145,6 +192,8 @@ The foundation. Everything downstream depends on the quality of these scores.
 
 ### Step 2: Phase 1 Metrics Expansion (MEDIUM complexity)
 
+> **Status: COMPLETE** -- Treasury intelligence, SPO/CC votes, inter-body alignment, wallet footprint, governance calendar, proposal intelligence all live.
+
 **What gets built:**
 
 - Treasury Intelligence wiring -- API routes for `getDRepTreasuryTrackRecord()`, `getSpendingEffectiveness()`, `findSimilarProposals()`. Treasury % framing in proposal cards.
@@ -163,6 +212,8 @@ The foundation. Everything downstream depends on the quality of these scores.
 ---
 
 ### Step 2.5: SPO Governance Layer (MEDIUM-HIGH complexity)
+
+> **Status: COMPLETE** -- SPO scoring (4-pillar), SPO alignment, CC fidelity scoring (CIP-136), SPO matching all live.
 
 The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (SPO votes + metadata).
 
@@ -192,6 +243,8 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 
 ### Step 3: Frontend Reimagining (MEDIUM complexity)
 
+> **Status: SUBSTANTIALLY COMPLETE** -- All core surfaces live (homepage, discover, DRep/SPO/CC profiles, My Gov, Pulse, proposals, navigation). Delegation flow is wired into DRep profiles via `InlineDelegationCTA`. Remaining: treasury project pages (`/project/[txHash]`), `/learn` route, delegation CTA on Quick Match results, proposal browse card enrichment (treasury %, tri-body votes, expiration), Discover hero personalization, table view toggle, feature flag audit.
+
 **What gets built:**
 
 - Strip homepage to Constellation + Quick Match CTA + PersonalCard
@@ -209,6 +262,10 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 - **CC Members page** (`/committee`) -- listing of all current Constitutional Committee members with voting records, alignment, and transparency index.
 - **Treasury Project pages** (`/project/[txHash]`) -- funded proposal detail with delivery status, accountability poll results, team track record, similar proposals.
 - **Nav expansion** -- "Governance Bodies" section in navigation: DReps, SPOs, Committee. Unified information architecture for all three bodies.
+- **Production delegation flow** -- `InlineDelegationCTA` on DRep profiles (done), `DelegateButton` on Quick Match result cards, wallet connect → preflight → confirm → ceremony. The complete "90 seconds to delegation" path.
+- **Multi-wallet linking flow** in My Gov -- connect additional wallets, label them, view detected segments per wallet, manage linked wallets. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience).
+- **Unified multi-segment dashboard** -- the home screen adapts to the union of segments across all linked wallets. A DRep+SPO sees both scores and both inboxes. A pure citizen sees delegation health. No mode-switching.
+- **Role-aware navigation** -- DRep management and SPO management surface as deep dives from the unified home, not as separate products.
 
 **Why here (not earlier):** The backend upgrades, matching UX, and SPO scoring must be solid before we redesign the frontend. The reimagined homepage is JUST the Constellation + Quick Match -- if Quick Match is not world-class, the homepage is empty. If DRep and SPO scores are not trustworthy, the profile restructure means nothing. Build the engine first, then build the car around it.
 
@@ -220,6 +277,8 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 
 ### Step 4: Governance Wrapped + Shareable Moments (LOW-MEDIUM complexity)
 
+> **Status: IN PROGRESS** -- Wrapped generation and OG images live for all entity types (DRep, SPO, Citizen). Remaining: viral distribution UX (one-click social sharing with pre-composed text), animated share previews, multi-role Wrapped, embed enhancements.
+
 **What gets built:**
 
 - "Governance Wrapped" per-user and per-DRep -- annual or per-epoch summary of governance participation
@@ -229,6 +288,9 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 - Embed enhancements: interactive DRep card with live score, GHI gauge with sparkline
 - **SPO Wrapped** -- "Your pool operator voted on 47 proposals this year, scoring 85/100 on governance participation." SPOs share this to attract staking delegators.
 - **"Your Staking Governance" card** -- for staking delegators: not just delegation, but how their pool operator governs. "Your SPO voted on all treasury proposals and aligned with the DRep consensus 70% of the time."
+- **Multi-role Wrapped** -- for users who span segments, Wrapped tells the full story: "As a DRep you voted on 47 proposals. As an SPO your pool participated in 40. As a citizen your delegation health stayed green all year." One shareable identity card, not three separate summaries.
+
+**Future extension: Citizen Governance Impact Score.** A personal score for delegators based on: delegation duration, DRep activity level, quiz participation, proposal engagement, and governance footprint depth. This gives citizens a gamified reason to return and a sharable metric that drives virality. Natural fit for Step 6 Premium Delegator features.
 
 **Why here:** At this point every data layer exists for all three governance bodies. Wrapped is the viral growth engine -- users share their governance footprint, DReps share their score history, SPOs share their governance participation, and every share is a billboard for DRepScore. This step transforms all the data work into acquisition.
 
@@ -263,6 +325,8 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 
 **Why here (not earlier):** DReps and SPOs need to experience the free product's value before they will pay. By this point: their scores are sophisticated (Steps 0 + 2.5), their profile pages are beautiful (Step 3), delegators are finding them via Quick Match (Step 1), and their governance record is rich with treasury tracking, inter-body alignment, and temporal trajectories (Step 2). The Pro tier enhances what is already obviously valuable.
 
+**Open design question:** Pro tier pricing for multi-segment users (e.g., someone who is both a DRep and an SPO) -- bundle discount vs. unified "Gov Pro" tier. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience).
+
 **Monetization target:** $2,000-5,000/mo from DRep Pro (50-100 DReps) + SPO Pro (50-100 SPOs) + Verified Projects at $15-25/mo.
 
 ---
@@ -284,6 +348,8 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
 **Monetization target:** $750-2,000/mo from Premium Delegator (staking governance adds incremental value).
 
 **Dot connection highlight:** The AI advisor prompt has access to: the user's alignment profile, their DRep's 4-pillar score breakdown, their SPO's governance score, the DRep's treasury track record, inter-body alignment on recent proposals (including "your DRep voted Yes but your SPO voted No"), governance calendar deadlines, proposal trends, and GHI trajectory. No competitor can generate this insight because no competitor has this data.
+
+**Multi-wallet amplifier:** For users who span segments, the advisor sees the full picture across all linked wallets and all roles. Cross-role insights become possible: "Your DRep votes and your SPO votes diverged on treasury proposals this epoch -- your DRep approved 80% but your pool only voted on 60%." The advisor can also detect alignment drift between a user's own governance actions (as DRep/SPO) and their delegation choices (as citizen).
 
 ---
 
@@ -400,7 +466,7 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
   - Confidential delegation analytics
 - ENS/.ada integration for governance identity
 
-**Why last:** This is genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, DRepScore's reputation and data moat make it the natural home for governance identity.
+**Why last:** This is genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, Civica's reputation and data moat make it the natural home for governance identity.
 
 **Monetization angle:** This is the "Stripe for blockchain governance" play -- other chains and protocols pay to access governance reputation data.
 
@@ -434,9 +500,11 @@ The wow score is not a number we assign -- it is an emergent property of how wel
 
 **Scores that matter (not a vibe):** A DRep profile shows a score that reflects their actual governance behavior -- rationale quality assessed by AI, voting patterns weighted by importance, reliability measured by responsiveness, profile completeness scored by quality. The user trusts this score because it _means something specific and defensible_. (Step 0)
 
-**Matching that feels magic:** A user answers 3 questions about their governance values and sees a radar chart form in real-time, then 3 DReps appear with confidence scores and dimension-level explanations. They tap to delegate. 90 seconds, done. (Step 1)
+**Matching that feels magic:** A user answers 3 questions about their governance values and sees a radar chart form in real-time, then 3 DReps appear with confidence scores and dimension-level explanations. Each match card has a "Delegate" button. They tap it, their wallet confirms, confetti flies, and they are a governance participant. 90 seconds from first question to confirmed delegation. (Step 1 + Step 3)
 
 **Proposal cards that connect everything:** A treasury proposal card shows: "4.2M ADA (0.12% of treasury) -- Your DRep voted Yes -- SPOs voted 60% No -- Similar to 3 past proposals (2 delivered, 1 partial) -- Expires in 2 epochs." Every fact from a different system, unified into one glanceable card. (Steps 2+3)
+
+**Proposal browse cards that preview the intelligence:** Even before clicking into a proposal, the browse card on Discover shows: type badge, treasury amount and % (for withdrawals), tri-body vote indicators (DRep/SPO/CC), your DRep's vote, expiration countdown, and status. The user scans 25 proposals and already understands the governance landscape. Clicking in reveals the full story. (Steps 2+3)
 
 **An epoch that tells a story:** "Epoch 523: 4 proposals ratified, 12M ADA withdrawn, governance decentralization improved by 3%. Your DRep voted on all 4 and provided rationales for 3. Your governance alignment with DRep X grew 5% this epoch." Personal, contextual, narrative. (Steps 2+4)
 
@@ -448,6 +516,8 @@ The wow score is not a number we assign -- it is an emergent property of how wel
 
 **SPOs with a governance reputation:** A stake pool profile shows: SPO Score 88, voted on 95% of proposals, alignment radar showing strong decentralization conviction, inter-body alignment with DReps at 70%. Pool delegators see this and choose their SPO based on governance values, not just ROI. An entirely new decision dimension for staking. (Steps 2.5+3)
 
+**One identity, every role:** You connect your second wallet and suddenly your governance profile expands -- your SPO score appears alongside your DRep score, your Wrapped now includes pool governance, and the AI advisor spots that your DRep votes and SPO votes diverge on treasury proposals. You did not set anything up. You just linked a wallet. The product understood what you are and adapted. This is the "how does it know?" moment for power users -- and it is only possible because of the multi-wallet identity model underneath. (Multi-Wallet Identity + Steps 3-6)
+
 **An identity you want to share:** Governance Wrapped card: "You delegated 45,000 ADA to DRep X for 8 epochs. Your DRep voted on 47 proposals, provided rationales for 42, and approved 15M ADA in treasury spending -- 90% was rated as delivered. Your SPO voted on 40 proposals and aligned with your DRep 75% of the time." This is a badge of honor. Users share it unprompted. (Step 4)
 
 ---
@@ -456,22 +526,23 @@ The wow score is not a number we assign -- it is an emergent property of how wel
 
 This is the silent engine. Every day the product runs, the moat deepens.
 
-| Snapshot                    | Frequency        | Created At | Compounds Into                                          |
-| --------------------------- | ---------------- | ---------- | ------------------------------------------------------- |
-| `drep_score_snapshots`      | Per score change | Step 0     | Score history, momentum, Wrapped, alerts                |
-| `alignment_snapshots`       | Daily per epoch  | Step 0     | Temporal trajectories, shift detection, Wrapped         |
-| `ghi_snapshots`             | Daily            | Step 0     | GHI trends, epoch recaps, State of Gov                  |
-| `edi_snapshots`             | Daily            | Step 0     | Decentralization dashboard, cross-chain comparison      |
-| `treasury_snapshots`        | Daily            | Existing   | Treasury health, runway, epoch recaps                   |
-| `pools`                     | Per sync         | Step 2     | SPO profiles, SPO discovery, pool comparison            |
-| `inter_body_alignment`      | Per sync         | Step 2     | Proposal pages, DRep/SPO profiles, governance dynamics  |
-| `proposal_similarity_cache` | Per sync         | Step 2     | Related proposals, trend detection                      |
-| `epoch_recaps`              | Per epoch        | Step 2     | Calendar, Wrapped, AI advisor                           |
-| `governance_events`         | Per event        | Existing   | Footprint, timeline, Wrapped, notifications             |
-| `spo_score_snapshots`       | Per score change | Step 2.5   | SPO score history, momentum, SPO Wrapped, alerts        |
-| `spo_alignment_snapshots`   | Daily per epoch  | Step 2.5   | SPO temporal trajectories, shift detection, SPO Wrapped |
-| `user_governance_profiles`  | Per vote/quiz    | Step 1     | Matching (DRep + SPO), AI advisor, Premium features     |
-| `delegation_snapshots`      | Per epoch        | Step 8     | Network graph, migration analysis, influence            |
+| Snapshot                    | Frequency        | Created At   | Compounds Into                                                |
+| --------------------------- | ---------------- | ------------ | ------------------------------------------------------------- |
+| `drep_score_snapshots`      | Per score change | Step 0       | Score history, momentum, Wrapped, alerts                      |
+| `alignment_snapshots`       | Daily per epoch  | Step 0       | Temporal trajectories, shift detection, Wrapped               |
+| `ghi_snapshots`             | Daily            | Step 0       | GHI trends, epoch recaps, State of Gov                        |
+| `edi_snapshots`             | Daily            | Step 0       | Decentralization dashboard, cross-chain comparison            |
+| `treasury_snapshots`        | Daily            | Existing     | Treasury health, runway, epoch recaps                         |
+| `pools`                     | Per sync         | Step 2       | SPO profiles, SPO discovery, pool comparison                  |
+| `inter_body_alignment`      | Per sync         | Step 2       | Proposal pages, DRep/SPO profiles, governance dynamics        |
+| `proposal_similarity_cache` | Per sync         | Step 2       | Related proposals, trend detection                            |
+| `epoch_recaps`              | Per epoch        | Step 2       | Calendar, Wrapped, AI advisor                                 |
+| `governance_events`         | Per event        | Existing     | Footprint, timeline, Wrapped, notifications                   |
+| `spo_score_snapshots`       | Per score change | Step 2.5     | SPO score history, momentum, SPO Wrapped, alerts              |
+| `spo_alignment_snapshots`   | Daily per epoch  | Step 2.5     | SPO temporal trajectories, shift detection, SPO Wrapped       |
+| `user_governance_profiles`  | Per vote/quiz    | Step 1       | Matching (DRep + SPO), AI advisor, Premium features           |
+| `user_wallets`              | Per link event   | Multi-Wallet | Segment detection, cross-role intelligence, unified footprint |
+| `delegation_snapshots`      | Per epoch        | Step 8       | Network graph, migration analysis, influence                  |
 
 **The compounding insight:** A DRep who has been scored for 50 epochs has a richer profile than one scored for 5. An SPO who has been governance-tracked since day one has a story no latecomer can match. A delegator with 20 quiz answers has a better match than one with 3. An epoch recap for epoch 550 (built on 50 prior recaps) tells a richer story than epoch 500. Time is our advantage. Every day a competitor does NOT collect this data is a day they can never get back.
 
@@ -507,7 +578,7 @@ No governance product in crypto does what DRepScore will do after this vision is
 - **DRep.tools:** Basic Cardano DRep listing. No scoring, no matching, no AI, no analytics. DReps only, no SPOs or CC.
 - **PoolTool / ADApools:** Stake pool metrics (uptime, rewards, fees). Zero governance data. The SPO governance layer is a completely untapped opportunity that no pool comparison tool has touched.
 
-DRepScore's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the notification engine feeds the growth engine. Seven personas served by one interconnected data flywheel. No competitor can replicate this by copying one feature.
+Civica's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the notification engine feeds the growth engine. Seven personas served by one interconnected data flywheel. No competitor can replicate this by copying one feature.
 
 ---
 
@@ -520,3 +591,4 @@ DRepScore's advantage is not any single feature -- it is the system. The scoring
 5. **DReps and SPOs are the sales force.** Every DRep who shares their score and every SPO who shares their governance participation is marketing. Make sharing effortless and rewarding.
 6. **Vertical depth over horizontal breadth.** Be THE indispensable governance layer for Cardano. Depth wins.
 7. **Build in public.** Share the roadmap, the methodology, the decisions. Governance participants value transparency.
+8. **Intelligence demands action.** Every insight the product surfaces must connect to something the user can do. A score without a delegation button is just a number. A health warning without a "fix this" CTA is just anxiety. The product's job is not to inform -- it is to empower.


### PR DESCRIPTION
## Summary
- **DelegateButton component**: Reusable delegation CTA with full state machine (idle → preflight → confirm → sign → submit → success/error) and delegation ceremony overlay
- **Quick Match integration**: Users can now delegate directly from match results instead of navigating away to a DRep profile
- **Enriched proposal cards**: Two-row layout with tri-body vote indicators (DRep/SPO/CC), treasury withdrawal amounts (₳ + % of treasury), and epoch expiration countdowns
- **Vision doc refresh**: Renamed to Civica, added Principle #8 "Intelligence demands action", updated Step 3-4 status tracking

Wow factor audit Chunk A — closes the biggest gap between current app and vision (action over information).

## Test plan
- [ ] Navigate to Quick Match, complete flow → verify Delegate button appears on each result card
- [ ] Click Delegate on a match result → confirm full delegation flow works (preflight → confirm → sign → ceremony)
- [ ] Navigate to /discover → verify proposal cards show tri-body vote indicators for proposals with votes
- [ ] Verify treasury proposals show withdrawal amount and treasury percentage
- [ ] Verify active proposals show epoch countdown
- [ ] Verify DRep vote pill appears when wallet connected and delegated DRep has voted

🤖 Generated with [Claude Code](https://claude.com/claude-code)