### PR TITLE
feat: Discover hero + table toggle + Similar DReps + epoch context

### DIFF
--- a/app/api/dreps/[drepId]/similar/route.ts
+++ b/app/api/dreps/[drepId]/similar/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+import { loadActivePCA } from '@/lib/alignment/pca';
+import { cosineSimilarity } from '@/lib/representationMatch';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(async (request, { requestId }) => {
+  const url = new URL(request.url);
+  const drepId = decodeURIComponent(url.pathname.split('/dreps/')[1].split('/similar')[0]);
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '6', 10), 20);
+
+  const pca = await loadActivePCA();
+  if (!pca) {
+    return NextResponse.json({ similar: [] });
+  }
+
+  const supabase = createClient();
+
+  const { data: coordRows } = await supabase
+    .from('drep_pca_coordinates')
+    .select('drep_id, coordinates')
+    .eq('run_id', pca.runId);
+
+  if (!coordRows?.length) {
+    return NextResponse.json({ similar: [] });
+  }
+
+  const targetRow = coordRows.find((r) => r.drep_id === drepId);
+  if (!targetRow) {
+    return NextResponse.json({ similar: [] });
+  }
+
+  const targetCoords = targetRow.coordinates as number[];
+
+  const similarities = coordRows
+    .filter((r) => r.drep_id !== drepId)
+    .map((r) => ({
+      drepId: r.drep_id as string,
+      similarity: cosineSimilarity(targetCoords, r.coordinates as number[]),
+    }))
+    .sort((a, b) => b.similarity - a.similarity)
+    .slice(0, limit);
+
+  if (similarities.length === 0) {
+    return NextResponse.json({ similar: [] });
+  }
+
+  const { data: drepRows } = await supabase
+    .from('dreps')
+    .select('id, info, score, is_active, delegator_count')
+    .in(
+      'id',
+      similarities.map((s) => s.drepId),
+    );
+
+  const infoMap = new Map<
+    string,
+    { name: string | null; score: number; isActive: boolean; delegatorCount: number }
+  >();
+  if (drepRows) {
+    for (const d of drepRows) {
+      infoMap.set(d.id, {
+        name: ((d.info as Record<string, unknown>)?.name as string) || null,
+        score: Number(d.score) || 0,
+        isActive: d.is_active ?? true,
+        delegatorCount: d.delegator_count ?? 0,
+      });
+    }
+  }
+
+  const similar = similarities.map((s) => {
+    const info = infoMap.get(s.drepId);
+    return {
+      drepId: s.drepId,
+      similarity: Math.round(s.similarity * 100),
+      name: info?.name || null,
+      score: info?.score || 0,
+      isActive: info?.isActive ?? true,
+      delegatorCount: info?.delegatorCount ?? 0,
+    };
+  });
+
+  return NextResponse.json(
+    { similar },
+    { headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=3600' } },
+  );
+});

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -48,6 +48,10 @@ const MilestoneBadges = nextDynamic(
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
 );
 import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
+const SimilarDReps = nextDynamic(
+  () => import('@/components/civica/profiles/SimilarDReps').then((m) => m.SimilarDReps),
+  { loading: () => <div className="h-20 animate-pulse bg-muted rounded-lg" /> },
+);
 import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
@@ -638,13 +642,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         }
       />
 
-      {/* Similar DReps — placeholder for future PCA-based nearest neighbor query */}
-      <section className="border-t pt-8 mt-8">
-        <h3 className="text-lg font-semibold mb-4">Similar DReps</h3>
-        <p className="text-sm text-muted-foreground">
-          Coming soon — DReps with similar governance alignment profiles.
-        </p>
-      </section>
+      <SimilarDReps drepId={drep.drepId} />
     </div>
   );
 

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, LayoutGrid, TableProperties, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { CivicaDRepCard } from '@/components/civica/cards/CivicaDRepCard';
 import { computeTier } from '@/lib/scoring/tiers';
+import { TIER_SCORE_COLOR, TIER_BADGE_BG, tierKey } from '@/components/civica/cards/tierStyles';
 import type { EnrichedDRep } from '@/lib/koios';
 import { ScoreDistribution } from '@/components/civica/charts/ScoreDistribution';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
@@ -31,7 +34,20 @@ const ALIGNMENT_FIELD_MAP: Record<string, keyof EnrichedDRep> = {
   transparency: 'alignmentTransparency',
 };
 
-const PAGE_SIZE = 24;
+type ViewMode = 'cards' | 'table';
+const VIEW_MODE_KEY = 'civica_drep_view';
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === 'undefined') return 'cards';
+  try {
+    const stored = localStorage.getItem(VIEW_MODE_KEY);
+    if (stored === 'table' || stored === 'cards') return stored;
+  } catch {}
+  return window.innerWidth >= 768 ? 'cards' : 'cards';
+}
+
+const CARD_PAGE_SIZE = 24;
+const TABLE_PAGE_SIZE = 50;
 
 interface FilterState {
   search: string;
@@ -52,9 +68,54 @@ interface CivicaDRepBrowseProps {
   totalAvailable?: number;
 }
 
+function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
+  const score = drep.drepScore ?? 0;
+  const tier = tierKey(computeTier(score));
+  const displayName = drep.name || drep.ticker || drep.handle || `${drep.drepId.slice(0, 16)}…`;
+
+  return (
+    <Link
+      href={`/drep/${drep.drepId}`}
+      className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors group"
+    >
+      <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums w-6 text-right shrink-0">
+        #{rank}
+      </span>
+      <span className="flex-1 text-sm font-medium truncate min-w-0">{displayName}</span>
+      <span
+        className={cn(
+          'text-[10px] font-bold px-1.5 py-0.5 rounded-full shrink-0',
+          TIER_BADGE_BG[tier],
+          TIER_SCORE_COLOR[tier],
+        )}
+      >
+        {score}
+      </span>
+      <span className="text-[10px] text-muted-foreground tabular-nums w-14 text-right shrink-0">
+        {Math.round(drep.effectiveParticipation ?? 0)}% part.
+      </span>
+      <span className="text-[10px] text-muted-foreground tabular-nums w-12 text-right shrink-0">
+        {drep.delegatorCount.toLocaleString()}
+      </span>
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0 group-hover:text-primary transition-colors" />
+    </Link>
+  );
+}
+
 export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [page, setPage] = useState(0);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+
+  const pageSize = viewMode === 'table' ? TABLE_PAGE_SIZE : CARD_PAGE_SIZE;
+
+  const toggleViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    setPage(0);
+    try {
+      localStorage.setItem(VIEW_MODE_KEY, mode);
+    } catch {}
+  };
 
   const isDefaultFilters =
     filters.search === '' &&
@@ -117,8 +178,8 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
 
   const allScores = useMemo(() => dreps.map((d) => d.drepScore ?? 0), [dreps]);
 
-  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
-  const pageItems = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);
 
   return (
     <div className="space-y-4 pt-4">
@@ -165,7 +226,35 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
         pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
       />
 
-      {/* Card grid */}
+      {/* View mode toggle */}
+      <div className="flex items-center justify-end gap-1">
+        <button
+          onClick={() => toggleViewMode('cards')}
+          className={cn(
+            'p-1.5 rounded transition-colors',
+            viewMode === 'cards'
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          title="Card view"
+        >
+          <LayoutGrid className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => toggleViewMode('table')}
+          className={cn(
+            'p-1.5 rounded transition-colors',
+            viewMode === 'table'
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          title="Table view"
+        >
+          <TableProperties className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Content */}
       {pageItems.length === 0 ? (
         <div className="py-16 text-center space-y-2">
           <p className="text-muted-foreground text-sm">No DReps match your filters.</p>
@@ -174,10 +263,25 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
             Clear filters
           </Button>
         </div>
-      ) : (
+      ) : viewMode === 'cards' ? (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {pageItems.map((drep, i) => (
-            <CivicaDRepCard key={drep.drepId} drep={drep} rank={page * PAGE_SIZE + i + 1} />
+            <CivicaDRepCard key={drep.drepId} drep={drep} rank={page * pageSize + i + 1} />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
+          {/* Table header */}
+          <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+            <span className="w-6 text-right shrink-0">#</span>
+            <span className="flex-1">Name</span>
+            <span className="shrink-0">Score</span>
+            <span className="w-14 text-right shrink-0">Particip.</span>
+            <span className="w-12 text-right shrink-0">Deleg.</span>
+            <span className="w-3.5 shrink-0" />
+          </div>
+          {pageItems.map((drep, i) => (
+            <DRepTableRow key={drep.drepId} drep={drep} rank={page * pageSize + i + 1} />
           ))}
         </div>
       )}

--- a/components/civica/discover/CivicaDiscover.tsx
+++ b/components/civica/discover/CivicaDiscover.tsx
@@ -9,6 +9,7 @@ import { CivicaSPOBrowse } from './CivicaSPOBrowse';
 import { CivicaLeaderboard } from './CivicaLeaderboard';
 import { CommitteeDiscovery } from '@/components/CommitteeDiscovery';
 import { ProposalsBrowse } from './ProposalsBrowse';
+import { DiscoverHero } from './DiscoverHero';
 import type { EnrichedDRep } from '@/lib/koios';
 
 type TabId = 'dreps' | 'spos' | 'proposals' | 'committee' | 'rankings';
@@ -77,6 +78,9 @@ export function CivicaDiscover({ dreps, totalAvailable, proposalCount }: CivicaD
 
   return (
     <div className="space-y-0">
+      <div className="mb-4">
+        <DiscoverHero totalDreps={totalAvailable} proposalCount={proposalCount} />
+      </div>
       {/* ── Tab bar ──────────────────────────────────────────── */}
       <div className="border-b border-border sticky top-14 z-30 bg-background/90 backdrop-blur-sm -mx-4 px-4 sm:-mx-6 sm:px-6">
         <div className="flex gap-0 overflow-x-auto scrollbar-none max-w-4xl">

--- a/components/civica/discover/DiscoverHero.tsx
+++ b/components/civica/discover/DiscoverHero.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, Compass, Vote, Shield, Users } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useWallet } from '@/utils/wallet-context';
+
+interface DiscoverHeroProps {
+  totalDreps: number;
+  proposalCount: number;
+}
+
+export function DiscoverHero({ totalDreps, proposalCount }: DiscoverHeroProps) {
+  const { segment, delegatedDrep, isLoading } = useSegment();
+  const { connected } = useWallet();
+
+  if (isLoading) return null;
+
+  // Anonymous — encourage connection
+  if (!connected || segment === 'anonymous') {
+    return (
+      <div className="rounded-xl border border-primary/20 bg-gradient-to-r from-primary/5 to-transparent p-5 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+        <div className="flex items-center gap-3 shrink-0">
+          <div className="w-10 h-10 rounded-full bg-primary/15 flex items-center justify-center">
+            <Compass className="h-5 w-5 text-primary" />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold">
+            {totalDreps.toLocaleString()} DReps are shaping Cardano governance
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Find a DRep aligned with your values — it takes 60 seconds to delegate.
+          </p>
+        </div>
+        <Link
+          href="/match"
+          className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-xs font-bold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+        >
+          Quick Match <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    );
+  }
+
+  // Citizen — delegation context
+  if (segment === 'citizen') {
+    if (delegatedDrep) {
+      return (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+          <div className="w-9 h-9 rounded-full bg-emerald-500/10 flex items-center justify-center shrink-0">
+            <Vote className="h-4.5 w-4.5 text-emerald-500" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">
+              You&apos;re delegating — explore who else is governing
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Compare DReps, track proposals, and monitor committee members.
+            </p>
+          </div>
+          <Link
+            href="/my-gov"
+            className="text-xs text-primary hover:underline shrink-0 flex items-center gap-0.5"
+          >
+            My Gov <ChevronRight className="h-3 w-3" />
+          </Link>
+        </div>
+      );
+    }
+    return (
+      <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4 flex items-center gap-4">
+        <div className="w-9 h-9 rounded-full bg-amber-500/10 flex items-center justify-center shrink-0">
+          <Users className="h-4.5 w-4.5 text-amber-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">You&apos;re connected but not yet delegating</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Find the DRep that represents your governance values.
+          </p>
+        </div>
+        <Link
+          href="/match"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+        >
+          Match <ChevronRight className="h-3 w-3" />
+        </Link>
+      </div>
+    );
+  }
+
+  // DRep — peer context
+  if (segment === 'drep') {
+    return (
+      <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+        <div className="w-9 h-9 rounded-full bg-violet-500/10 flex items-center justify-center shrink-0">
+          <Shield className="h-4.5 w-4.5 text-violet-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">See how you compare to other DReps</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Browse peers, track proposals requiring your vote, and monitor your standing.
+          </p>
+        </div>
+        <Link
+          href="/my-gov"
+          className="text-xs text-primary hover:underline shrink-0 flex items-center gap-0.5"
+        >
+          Dashboard <ChevronRight className="h-3 w-3" />
+        </Link>
+      </div>
+    );
+  }
+
+  // SPO
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+      <div className="w-9 h-9 rounded-full bg-sky-500/10 flex items-center justify-center shrink-0">
+        <Shield className="h-4.5 w-4.5 text-sky-500" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">SPO governance view</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Track proposals requiring SPO votes and compare DRep alignment.
+        </p>
+      </div>
+      <Link
+        href="/my-gov"
+        className="text-xs text-primary hover:underline shrink-0 flex items-center gap-0.5"
+      >
+        Dashboard <ChevronRight className="h-3 w-3" />
+      </Link>
+    </div>
+  );
+}

--- a/components/civica/mygov/CitizenCommandCenter.tsx
+++ b/components/civica/mygov/CitizenCommandCenter.tsx
@@ -12,10 +12,16 @@ import {
   CheckCircle2,
   AlertTriangle,
   XCircle,
+  Calendar,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useDRepReportCard, useGovernancePulse, useDRepVotes } from '@/hooks/queries';
+import {
+  useDRepReportCard,
+  useGovernancePulse,
+  useDRepVotes,
+  useGovernanceEpochRecap,
+} from '@/hooks/queries';
 import {
   tierKey,
   TIER_SCORE_COLOR,
@@ -45,11 +51,13 @@ export function CitizenCommandCenter({
   const { data: rawCard, isLoading: drepLoading } = useDRepReportCard(delegatedDrep);
   const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
   const { data: rawVotes, isLoading: votesLoading } = useDRepVotes(delegatedDrep);
+  const { data: rawRecap } = useGovernanceEpochRecap();
 
   const card = rawCard as any;
   const pulse = rawPulse as any;
   const votes: any[] = (rawVotes as any)?.votes ?? rawVotes ?? [];
   const recentVotes = Array.isArray(votes) ? votes.slice(0, 3) : [];
+  const recap = rawRecap as any;
 
   const drepScore: number = card?.score ?? 0;
   const drepName: string = card?.name ?? delegatedDrep ?? '—';
@@ -214,6 +222,53 @@ export function CitizenCommandCenter({
               browse all DReps
             </Link>
           </p>
+        </div>
+      )}
+
+      {/* Epoch context */}
+      {recap?.epoch && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Epoch {recap.epoch}
+            </p>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {recap.proposals_submitted != null && (
+              <div>
+                <p className="text-lg font-bold tabular-nums">{recap.proposals_submitted}</p>
+                <p className="text-[10px] text-muted-foreground">Submitted</p>
+              </div>
+            )}
+            {recap.proposals_ratified != null && (
+              <div>
+                <p className="text-lg font-bold tabular-nums text-sky-400">
+                  {recap.proposals_ratified}
+                </p>
+                <p className="text-[10px] text-muted-foreground">Ratified</p>
+              </div>
+            )}
+            {recap.drep_participation_pct != null && (
+              <div>
+                <p className="text-lg font-bold tabular-nums">
+                  {Math.round(recap.drep_participation_pct)}%
+                </p>
+                <p className="text-[10px] text-muted-foreground">DRep Participation</p>
+              </div>
+            )}
+            {recap.treasury_withdrawn_ada != null && recap.treasury_withdrawn_ada > 0 && (
+              <div>
+                <p className="text-lg font-bold tabular-nums text-emerald-400">
+                  {(recap.treasury_withdrawn_ada / 1_000_000).toFixed(1)}M
+                </p>
+                <p className="text-[10px] text-muted-foreground">Treasury (ADA)</p>
+              </div>
+            )}
+          </div>
+          {recap.ai_narrative && (
+            <p className="text-xs text-muted-foreground leading-relaxed">{recap.ai_narrative}</p>
+          )}
         </div>
       )}
 

--- a/components/civica/profiles/SimilarDReps.tsx
+++ b/components/civica/profiles/SimilarDReps.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useSimilarDReps } from '@/hooks/queries';
+import { computeTier } from '@/lib/scoring/tiers';
+import { TIER_SCORE_COLOR, TIER_BADGE_BG, tierKey } from '@/components/civica/cards/tierStyles';
+
+interface SimilarDRepsProps {
+  drepId: string;
+}
+
+export function SimilarDReps({ drepId }: SimilarDRepsProps) {
+  const { data: raw, isLoading } = useSimilarDReps(drepId);
+  const similar: any[] = (raw as any)?.similar ?? [];
+
+  if (isLoading) {
+    return (
+      <section className="border-t pt-8 mt-8">
+        <h3 className="text-lg font-semibold mb-4">Similar DReps</h3>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 rounded-xl" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (similar.length === 0) {
+    return (
+      <section className="border-t pt-8 mt-8">
+        <h3 className="text-lg font-semibold mb-4">Similar DReps</h3>
+        <p className="text-sm text-muted-foreground">
+          No similar DReps found — alignment data may still be computing.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="border-t pt-8 mt-8">
+      <h3 className="text-lg font-semibold mb-4">Similar DReps</h3>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {similar.map((d: any) => {
+          const tier = tierKey(computeTier(d.score ?? 0));
+          const displayName = d.name || `${d.drepId.slice(0, 16)}…`;
+          return (
+            <Link
+              key={d.drepId}
+              href={`/drep/${encodeURIComponent(d.drepId)}`}
+              className="group flex items-center gap-3 rounded-xl border border-border p-3 hover:border-primary/30 transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{displayName}</p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span
+                    className={cn(
+                      'text-[10px] font-bold px-1.5 py-0.5 rounded-full',
+                      TIER_BADGE_BG[tier],
+                      TIER_SCORE_COLOR[tier],
+                    )}
+                  >
+                    {d.score}
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">{d.similarity}% similar</span>
+                </div>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 group-hover:text-primary transition-colors" />
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -366,6 +366,15 @@ export function useGovernanceEpochRecap() {
   });
 }
 
+export function useSimilarDReps(drepId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['similar-dreps', drepId],
+    queryFn: () => fetchJson(`/api/dreps/${encodeURIComponent(drepId!)}/similar`),
+    enabled: !!drepId,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
 export function useGovernanceDrepFeed() {
   return useQuery({
     queryKey: ['governance-drep-feed'],


### PR DESCRIPTION
## Summary
Chunk B wow-factor improvements (+8 pts toward 85/100):

- **Segment-aware Discover hero**: Personalized banner adapts based on user type — anonymous users see a Quick Match CTA, citizens see delegation context, DReps see peer comparison messaging, SPOs see governance view
- **Card/table view toggle**: DRep browse now supports both card grid and compact table view with localStorage persistence. Table shows rank, score, participation rate, and delegator count
- **Similar DReps**: PCA cosine similarity replaces the placeholder on DRep profiles — shows 6 nearest neighbors with tier badge, score, and similarity percentage
- **Epoch context in My Gov**: CitizenCommandCenter now shows current epoch stats (proposals submitted/ratified, DRep participation, treasury withdrawals) plus AI narrative summary

## New files
- `app/api/dreps/[drepId]/similar/route.ts` — PCA-based similar DReps API
- `components/civica/discover/DiscoverHero.tsx` — segment-aware hero banner
- `components/civica/profiles/SimilarDReps.tsx` — Similar DReps client component

## Test plan
- [ ] Visit /discover logged out → verify anonymous hero with Quick Match CTA
- [ ] Connect wallet → hero updates to citizen/DRep/SPO context
- [ ] On DRep tab, toggle between card and table views → verify both render correctly
- [ ] Reload page → table/card preference persists from localStorage
- [ ] Visit a DRep profile → scroll to Similar DReps section → verify 6 similar DReps load
- [ ] Click a similar DRep → navigates to their profile
- [ ] Visit /my-gov as citizen → verify Epoch context card shows current epoch stats
- [ ] Verify AI narrative appears if epoch_recaps has data

🤖 Generated with [Claude Code](https://claude.com/claude-code)