### PR TITLE
feat: /learn hub + trajectory narrative + Wrapped CTA + flag cleanup

### DIFF
--- a/app/learn/LearnClient.tsx
+++ b/app/learn/LearnClient.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  BookOpen,
+  ChevronRight,
+  Users,
+  Vote,
+  Shield,
+  Landmark,
+  Scale,
+  Zap,
+  Search,
+  X,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import { GOV_TERMS, type GovTermDef } from '@/lib/microcopy';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+const GETTING_STARTED = [
+  {
+    title: 'What is Cardano governance?',
+    description:
+      'Cardano uses on-chain governance where ADA holders can vote on protocol changes, treasury spending, and constitutional amendments through elected representatives.',
+    icon: Scale,
+    color: 'text-violet-400 bg-violet-500/10',
+    link: '/discover',
+    linkLabel: 'Explore representatives',
+  },
+  {
+    title: 'How delegation works',
+    description:
+      "You delegate your ADA's voting power to a DRep (Delegated Representative) who votes on your behalf. Your ADA never leaves your wallet — you're lending governance weight, not money.",
+    icon: Users,
+    color: 'text-emerald-400 bg-emerald-500/10',
+    link: '/match',
+    linkLabel: 'Find your DRep',
+  },
+  {
+    title: 'Understanding proposals',
+    description:
+      'Governance actions include treasury withdrawals, parameter changes, hard forks, and constitutional updates. Each requires approval from DReps, stake pools, and the Constitutional Committee.',
+    icon: Vote,
+    color: 'text-sky-400 bg-sky-500/10',
+    link: '/discover?tab=proposals',
+    linkLabel: 'Browse proposals',
+  },
+  {
+    title: 'The three governance bodies',
+    description:
+      'Cardano governance has three pillars: DReps (citizen representatives), SPOs (stake pool operators), and the Constitutional Committee. Major decisions need approval from multiple bodies.',
+    icon: Shield,
+    color: 'text-amber-400 bg-amber-500/10',
+    link: '/discover?tab=committee',
+    linkLabel: 'View the Committee',
+  },
+  {
+    title: 'Treasury & funding',
+    description:
+      "The Cardano treasury is funded by transaction fees and monetary expansion. Governance proposals can request treasury withdrawals to fund ecosystem projects — your DRep's vote decides.",
+    icon: Landmark,
+    color: 'text-rose-400 bg-rose-500/10',
+    link: '/pulse',
+    linkLabel: 'See the Pulse',
+  },
+  {
+    title: 'Why your participation matters',
+    description:
+      'Governance quorum requirements mean your delegation matters. Without enough active participation, critical proposals can stall. Every delegated ADA strengthens the system.',
+    icon: Zap,
+    color: 'text-primary bg-primary/10',
+    link: '/match',
+    linkLabel: 'Get started',
+  },
+];
+
+function getWhyItMatters(term: GovTermDef, segment: string): string {
+  if (segment in term.whyItMatters) {
+    return (term.whyItMatters as Record<string, string>)[segment];
+  }
+  return term.whyItMatters.default;
+}
+
+export function LearnClient() {
+  const [search, setSearch] = useState('');
+  const { segment } = useSegment();
+
+  const termEntries = Object.entries(GOV_TERMS);
+  const filteredTerms = search.trim()
+    ? termEntries.filter(
+        ([key, term]) =>
+          term.label.toLowerCase().includes(search.toLowerCase()) ||
+          term.definition.toLowerCase().includes(search.toLowerCase()) ||
+          key.toLowerCase().includes(search.toLowerCase()),
+      )
+    : termEntries;
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-5 w-5 text-primary" />
+          <h1 className="text-2xl font-bold tracking-tight">Learn</h1>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Everything you need to understand Cardano governance — from delegation to treasury.
+        </p>
+      </div>
+
+      {/* Getting Started */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Getting Started</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {GETTING_STARTED.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div
+                key={item.title}
+                className="rounded-xl border border-border bg-card p-5 space-y-3"
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={cn(
+                      'w-9 h-9 rounded-full flex items-center justify-center shrink-0',
+                      item.color,
+                    )}
+                  >
+                    <Icon className="h-4.5 w-4.5" />
+                  </div>
+                  <h3 className="text-sm font-semibold">{item.title}</h3>
+                </div>
+                <p className="text-xs text-muted-foreground leading-relaxed">{item.description}</p>
+                <Link
+                  href={item.link}
+                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline font-medium"
+                >
+                  {item.linkLabel} <ChevronRight className="h-3 w-3" />
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Governance Glossary */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold">Governance Glossary</h2>
+          <span className="text-xs text-muted-foreground">{filteredTerms.length} terms</span>
+        </div>
+
+        <div className="relative mb-4">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+          <Input
+            placeholder="Search terms…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9 h-9"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
+          {filteredTerms.map(([key, term]) => (
+            <div key={key} className="px-5 py-4 space-y-1">
+              <h3 className="text-sm font-semibold text-foreground">{term.label}</h3>
+              <p className="text-xs text-muted-foreground leading-relaxed">{term.definition}</p>
+              <p className="text-xs text-primary/80 leading-relaxed">
+                {getWhyItMatters(term, segment)}
+              </p>
+            </div>
+          ))}
+          {filteredTerms.length === 0 && (
+            <div className="px-5 py-8 text-center text-sm text-muted-foreground">
+              No terms match your search.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+import { PageViewTracker } from '@/components/PageViewTracker';
+import { LearnClient } from './LearnClient';
+
+export const metadata: Metadata = {
+  title: 'Civica — Learn Governance',
+  description:
+    'Understand Cardano governance: DReps, delegation, proposals, treasury, and how your voice shapes the network.',
+  openGraph: {
+    title: 'Civica — Learn Governance',
+    description: 'Everything you need to understand Cardano on-chain governance.',
+    type: 'website',
+  },
+};
+
+export default function LearnPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <PageViewTracker event="learn_page_viewed" />
+      <LearnClient />
+    </div>
+  );
+}

--- a/components/AlignmentTrajectory.tsx
+++ b/components/AlignmentTrajectory.tsx
@@ -288,7 +288,55 @@ export function AlignmentTrajectory({ drepId }: AlignmentTrajectoryProps) {
             </div>
           ))}
         </div>
+
+        {/* Narrative summary */}
+        <TrajectoryNarrative snapshots={snapshots} />
       </CardContent>
     </Card>
+  );
+}
+
+function TrajectoryNarrative({ snapshots }: { snapshots: Snapshot[] }) {
+  if (snapshots.length < 3) return null;
+
+  const first = snapshots[0];
+  const last = snapshots[snapshots.length - 1];
+
+  interface Delta {
+    label: string;
+    delta: number;
+    end: number;
+  }
+
+  const deltas: Delta[] = [];
+  for (const { key, label } of DIMENSIONS) {
+    const start = first[key];
+    const end = last[key];
+    if (start != null && end != null) {
+      deltas.push({ label, delta: end - start, end });
+    }
+  }
+
+  if (deltas.length === 0) return null;
+
+  const biggest = deltas.reduce((a, b) => (Math.abs(b.delta) > Math.abs(a.delta) ? b : a));
+  const dominant = deltas.reduce((a, b) => (b.end > a.end ? b : a));
+  const stable = deltas.every((d) => Math.abs(d.delta) < 5);
+
+  let narrative: string;
+  if (stable) {
+    narrative = `Consistent ${dominant.label.toLowerCase()} alignment (${Math.round(dominant.end)}%) across ${snapshots.length} epochs — this DRep has a stable governance philosophy.`;
+  } else if (biggest.delta > 10) {
+    narrative = `${biggest.label} alignment rose ${Math.round(biggest.delta)} points over ${snapshots.length} epochs, now at ${Math.round(biggest.end)}%. Dominant dimension: ${dominant.label} (${Math.round(dominant.end)}%).`;
+  } else if (biggest.delta < -10) {
+    narrative = `${biggest.label} alignment dropped ${Math.round(Math.abs(biggest.delta))} points over ${snapshots.length} epochs. Current dominant dimension: ${dominant.label} (${Math.round(dominant.end)}%).`;
+  } else {
+    narrative = `Moderate shifts over ${snapshots.length} epochs. Strongest signal: ${dominant.label} at ${Math.round(dominant.end)}%.`;
+  }
+
+  return (
+    <p className="text-xs text-muted-foreground mt-3 leading-relaxed border-t border-border pt-3">
+      {narrative}
+    </p>
   );
 }

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -9,6 +9,7 @@ import {
   Compass,
   Activity,
   Landmark,
+  BookOpen,
   Search,
   User,
   LogOut,
@@ -45,6 +46,7 @@ const NAV_ITEMS = [
   { href: '/discover', label: 'Discover', icon: Compass },
   { href: '/pulse', label: 'Pulse', icon: Activity },
   { href: '/my-gov', label: 'My Gov', icon: Landmark },
+  { href: '/learn', label: 'Learn', icon: BookOpen },
 ] as const;
 
 const SEGMENT_LABELS: Record<UserSegment, string> = {

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -41,7 +41,6 @@ function DeepLinkHandler() {
 
 /**
  * Civica layout shell — wraps children with 4-tab nav + providers.
- * Rendered by root layout when civica_frontend flag is on.
  */
 export function CivicaShell({ children }: { children: React.ReactNode }) {
   return (

--- a/components/civica/mygov/CitizenCommandCenter.tsx
+++ b/components/civica/mygov/CitizenCommandCenter.tsx
@@ -13,6 +13,7 @@ import {
   AlertTriangle,
   XCircle,
   Calendar,
+  Gift,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -348,6 +349,24 @@ export function CitizenCommandCenter({
           </p>
         </div>
       ) : null}
+
+      {/* Wrapped CTA */}
+      {delegatedDrep && (
+        <Link href="/my-gov/wrapped/latest" className="block group">
+          <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between hover:border-primary/30 transition-colors">
+            <div className="flex items-center gap-3">
+              <Gift className="h-4 w-4 text-violet-400" />
+              <div>
+                <p className="text-sm font-medium">Your Governance Wrapped</p>
+                <p className="text-xs text-muted-foreground">
+                  See your governance journey — and share it
+                </p>
+              </div>
+            </div>
+            <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
+          </div>
+        </Link>
+      )}
     </div>
   );
 }

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -13,7 +13,6 @@
  * ---------------------------------------------------------------------------
  * ACTIVE FLAGS (in feature_flags table, toggleable via /admin/flags)
  * ---------------------------------------------------------------------------
- * civica_frontend          — Civica redesign master switch (shell, routes, home)
  * drep_communication       — DRep position statements / Phase B communication features
  * score_tiers              — Tier computation + change detection in sync pipeline
  * alignment_drift          — Citizen-DRep alignment drift detection


### PR DESCRIPTION
## Summary
Chunk C wow-factor improvements (+5 pts toward 90/100):

- **/learn governance education hub**: New route with 6 getting-started cards covering delegation, proposals, treasury, and governance bodies, plus searchable glossary of 12 governance terms with segment-aware "why it matters" framing. Added to main nav.
- **Alignment trajectory narrative**: Interpretive text below the D3 chart on DRep profiles describing trend direction, stability, and dominant alignment dimensions
- **Wrapped discoverability**: "Your Governance Wrapped" CTA in CitizenCommandCenter linking to existing wrapped feature that was previously undiscoverable
- **Feature flag cleanup**: Removed dead `civica_frontend` flag from docs (no conditional code existed)

## New files
- `app/learn/page.tsx` — Server component with metadata
- `app/learn/LearnClient.tsx` — Client component with glossary + guides

## Test plan
- [ ] Navigate to /learn → verify education cards render with correct links
- [ ] Search glossary terms → verify filtering works
- [ ] Verify "Learn" appears in header nav (desktop + mobile)
- [ ] Visit a DRep profile with trajectory data → verify narrative text appears below chart
- [ ] Visit /my-gov as citizen with delegation → verify "Your Governance Wrapped" CTA appears
- [ ] Click wrapped CTA → navigates to /my-gov/wrapped/latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)