### PR TITLE
fix: harden dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Label major updates for manual review
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-        run: gh pr edit "$PR_URL" --add-label "major-update"
+        run: |
+          gh label create "major-update" --description "Dependabot major bump" --color "D93F0B" 2>/dev/null || true
+          gh pr edit "$PR_URL" --add-label "major-update"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Creates `major-update` label idempotently before applying it (prevents failure when label doesn't exist)
- Repo setting enabled: allow GitHub Actions to approve pull requests

Fixes both open dependabot PRs (#108, #88) failing on auto-merge.

## Test plan
- [x] Verified PR #108 failure: `GitHub Actions is not permitted to approve pull requests`
- [x] Verified PR #88 failure: `'major-update' not found`
- [x] Enabled repo setting via API
- [x] Created `major-update` label
- [ ] Re-run dependabot auto-merge on #108 and #88 after merge

Generated with [Claude Code](https://claude.com/claude-code)