### PR TITLE
feat: enrich discover cards with backend data (Chunk 1)

### DIFF
--- a/app/api/governance/pools/route.ts
+++ b/app/api/governance/pools/route.ts
@@ -11,7 +11,7 @@ export const GET = withRouteHandler(async (_request, { requestId }) => {
   const { data: poolRows } = await supabase
     .from('pools')
     .select(
-      'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, current_tier, delegator_count, live_stake_lovelace, claimed_by, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+      'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, current_tier, delegator_count, live_stake_lovelace, claimed_by, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, governance_statement',
     )
     .gt('vote_count', 0)
     .order('governance_score', { ascending: false, nullsFirst: false })
@@ -37,6 +37,7 @@ export const GET = withRouteHandler(async (_request, { requestId }) => {
         ? Math.round(Number(p.live_stake_lovelace) / 1_000_000)
         : 0,
       claimedBy: p.claimed_by ?? null,
+      governanceStatement: p.governance_statement ?? null,
     }));
 
     return NextResponse.json(

--- a/app/api/proposals/route.ts
+++ b/app/api/proposals/route.ts
@@ -15,7 +15,7 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
     supabase
       .from('proposals')
       .select(
-        'tx_hash, proposal_index, title, proposal_type, expired_epoch, ratified_epoch, enacted_epoch, dropped_epoch, expiration_epoch, proposed_epoch, withdrawal_amount, treasury_tier, block_time',
+        'tx_hash, proposal_index, title, proposal_type, expired_epoch, ratified_epoch, enacted_epoch, dropped_epoch, expiration_epoch, proposed_epoch, withdrawal_amount, treasury_tier, block_time, relevant_prefs',
       )
       .order('proposed_epoch', { ascending: false })
       .limit(limit),
@@ -99,6 +99,7 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
       treasuryPct: withdrawalAmount && treasuryBalance ? withdrawalAmount / treasuryBalance : null,
       expirationEpoch: p.expiration_epoch ?? null,
       proposedEpoch: p.proposed_epoch ?? null,
+      relevantPrefs: p.relevant_prefs ?? [],
       triBody,
     };
   });

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { TrendingUp, TrendingDown, Minus, CheckCircle2, XCircle, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import { computeTier } from '@/lib/scoring/tiers';
 import {
   TIER_SCORE_COLOR,
@@ -15,26 +13,26 @@ import {
   tierKey,
 } from './tierStyles';
 import type { EnrichedDRep } from '@/lib/koios';
+import { getDRepTraitTags } from '@/lib/alignment';
+import {
+  extractAlignments,
+  getPersonalityLabel,
+  getDominantDimension,
+  getIdentityColor,
+} from '@/lib/drepIdentity';
 
-const ALIGNMENT_LABELS: [
-  keyof Pick<
-    EnrichedDRep,
-    | 'alignmentTreasuryConservative'
-    | 'alignmentTreasuryGrowth'
-    | 'alignmentDecentralization'
-    | 'alignmentSecurity'
-    | 'alignmentInnovation'
-    | 'alignmentTransparency'
-  >,
-  string,
-][] = [
-  ['alignmentTreasuryConservative', 'Fiscal'],
-  ['alignmentTreasuryGrowth', 'Growth'],
-  ['alignmentDecentralization', 'Decent.'],
-  ['alignmentSecurity', 'Security'],
-  ['alignmentInnovation', 'Innov.'],
-  ['alignmentTransparency', 'Transp.'],
-];
+function formatRecency(lastVoteTime: number | null): string | null {
+  if (!lastVoteTime) return null;
+  const now = Date.now() / 1000;
+  const diff = now - lastVoteTime;
+  if (diff < 0) return null;
+  const days = Math.floor(diff / 86400);
+  if (days === 0) return 'today';
+  if (days === 1) return '1d ago';
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
 
 interface CivicaDRepCardProps {
   drep: EnrichedDRep;
@@ -43,17 +41,20 @@ interface CivicaDRepCardProps {
 }
 
 export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) {
-  const [hovered, setHovered] = useState(false);
-
   const score = drep.drepScore ?? 0;
   const tier = tierKey(computeTier(score));
   const momentum = drep.scoreMomentum ?? null;
   const displayName = drep.name || drep.ticker || drep.handle || `${drep.drepId.slice(0, 12)}…`;
-  const hasAlignmentData = drep.alignmentDecentralization !== null;
 
-  const allAlignmentNull = ALIGNMENT_LABELS.every(
-    ([key]) => (drep as any)[key] === null || (drep as any)[key] === undefined,
-  );
+  const alignments = extractAlignments(drep);
+  const hasAlignment = drep.alignmentDecentralization !== null;
+  const personalityLabel = hasAlignment ? getPersonalityLabel(alignments) : null;
+  const dominantDim = hasAlignment ? getDominantDimension(alignments) : null;
+  const identityColor = dominantDim ? getIdentityColor(dominantDim) : null;
+  const traitTags = getDRepTraitTags(drep);
+
+  const recency = formatRecency(drep.lastVoteTime);
+  const rationaleRate = Math.round(drep.rationaleRate ?? 0);
 
   return (
     <Link
@@ -65,11 +66,9 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
         TIER_BORDER[tier],
         TIER_GLOW[tier],
       )}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
     >
       {/* ── Header row ─────────────────────────────────────── */}
-      <div className="flex items-start justify-between gap-2 mb-3">
+      <div className="flex items-start justify-between gap-2 mb-2">
         <div className="min-w-0 flex-1">
           {rank && (
             <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums mb-0.5 block">
@@ -79,7 +78,7 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
           <h3 className="font-semibold text-sm text-foreground truncate leading-tight">
             {displayName}
           </h3>
-          <div className="flex items-center gap-1.5 mt-0.5">
+          <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
             {drep.isActive ? (
               <span className="flex items-center gap-0.5 text-[10px] text-emerald-400 font-medium">
                 <CheckCircle2 className="h-3 w-3" /> Active
@@ -93,6 +92,9 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
               <span className="text-[10px] text-muted-foreground">
                 · {drep.delegatorCount.toLocaleString()} delegators
               </span>
+            )}
+            {recency && (
+              <span className="text-[10px] text-muted-foreground">· Voted {recency}</span>
             )}
           </div>
         </div>
@@ -132,62 +134,72 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
         </div>
       </div>
 
-      {/* ── Alignment mini-bars ─────────────────────────────── */}
-      {!allAlignmentNull && (
-        <div className="grid grid-cols-3 gap-x-3 gap-y-1.5 mb-3">
-          {ALIGNMENT_LABELS.map(([key, label]) => {
-            const v = (drep as any)[key] as number | null;
-            if (v === null || v === undefined) return null;
-            const pct = Math.round(v);
-            return (
-              <div key={key} className="space-y-0.5">
-                <div className="flex justify-between text-[9px] text-muted-foreground/70">
-                  <span>{label}</span>
-                  <span className="tabular-nums">{pct}</span>
-                </div>
-                <div className="h-0.5 rounded-full bg-muted overflow-hidden">
-                  <div className="h-full rounded-full bg-primary/50" style={{ width: `${pct}%` }} />
-                </div>
-              </div>
-            );
-          })}
+      {/* ── Governance identity ───────────────────────────────── */}
+      {(personalityLabel || traitTags.length > 0) && (
+        <div className="flex items-center gap-1.5 flex-wrap mb-2">
+          {personalityLabel && identityColor && (
+            <span
+              className="inline-flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full border"
+              style={{
+                borderColor: `${identityColor.hex}40`,
+                backgroundColor: `${identityColor.hex}10`,
+                color: identityColor.hex,
+              }}
+            >
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: identityColor.hex }}
+              />
+              {personalityLabel}
+            </span>
+          )}
+          {traitTags.slice(0, 2).map((tag) => (
+            <span
+              key={tag}
+              className="text-[9px] text-muted-foreground bg-muted/60 px-1.5 py-0.5 rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
         </div>
       )}
 
-      {/* ── Hover expansion: rationale + momentum ──────────── */}
-      <div
-        className={cn(
-          'overflow-hidden transition-all duration-200',
-          hovered ? 'max-h-16 opacity-100' : 'max-h-0 opacity-0',
-        )}
-      >
-        <div className="flex items-center justify-between text-xs text-muted-foreground pt-2 border-t border-border/40 mb-3">
-          <span>
-            Rationale rate:{' '}
-            <span className="font-medium text-foreground">
-              {Math.round(drep.rationaleRate ?? 0)}%
-            </span>
-          </span>
-          <span className="flex items-center gap-1">
-            Trend:{' '}
-            {momentum !== null && momentum > 0.5 ? (
-              <TrendingUp className="h-3 w-3 text-emerald-400" />
-            ) : momentum !== null && momentum < -0.5 ? (
-              <TrendingDown className="h-3 w-3 text-rose-400" />
-            ) : (
-              <Minus className="h-3 w-3 text-muted-foreground" />
+      {/* ── Key stats (always visible) ────────────────────────── */}
+      <div className="flex items-center justify-between text-[10px] text-muted-foreground border-t border-border/30 pt-2 mb-2">
+        <span>
+          Rationale{' '}
+          <span
+            className={cn(
+              'font-medium tabular-nums',
+              rationaleRate >= 70
+                ? 'text-emerald-400'
+                : rationaleRate >= 40
+                  ? 'text-foreground'
+                  : 'text-muted-foreground',
             )}
+          >
+            {rationaleRate}%
           </span>
-        </div>
+        </span>
+        <span>
+          Participation{' '}
+          <span className="font-medium text-foreground tabular-nums">
+            {drep.effectiveParticipation ? `${Math.round(drep.effectiveParticipation)}%` : '—'}
+          </span>
+        </span>
+        <span className="flex items-center gap-0.5">
+          {momentum !== null && momentum > 0.5 ? (
+            <TrendingUp className="h-3 w-3 text-emerald-400" />
+          ) : momentum !== null && momentum < -0.5 ? (
+            <TrendingDown className="h-3 w-3 text-rose-400" />
+          ) : (
+            <Minus className="h-3 w-3 text-muted-foreground" />
+          )}
+        </span>
       </div>
 
       {/* ── CTA ────────────────────────────────────────────── */}
-      <div className="mt-auto pt-2 flex items-center justify-between">
-        <span className="text-[10px] text-muted-foreground/70">
-          {drep.effectiveParticipation
-            ? `${Math.round(drep.effectiveParticipation)}% participation`
-            : 'No participation data'}
-        </span>
+      <div className="mt-auto flex items-center justify-end">
         <span
           className={cn(
             'flex items-center gap-0.5 text-xs font-medium transition-colors',

--- a/components/civica/cards/CivicaSPOCard.tsx
+++ b/components/civica/cards/CivicaSPOCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ShieldCheck, ChevronRight } from 'lucide-react';
+import { ShieldCheck, ChevronRight, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { computeTier } from '@/lib/scoring/tiers';
 import {
@@ -22,9 +22,13 @@ export interface CivicaSPOData {
   participationPct: number | null;
   consistencyPct?: number | null;
   reliabilityPct?: number | null;
+  deliberationPct?: number | null;
+  governanceIdentityPct?: number | null;
+  confidence?: number | null;
   delegatorCount: number;
   liveStakeAda: number;
   claimedBy?: string | null;
+  governanceStatement?: string | null;
 }
 
 function formatAda(ada: number): string {
@@ -44,12 +48,20 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
   const tier = tierKey(computeTier(score));
   const displayName = pool.ticker || pool.poolName || pool.poolId.slice(0, 12);
   const isClaimed = !!pool.claimedBy;
+  const isProvisional = pool.confidence != null && pool.confidence < 60;
 
-  const pillars: { label: string; value: number | null | undefined }[] = [
-    { label: 'Participation', value: pool.participationPct },
-    { label: 'Consistency', value: pool.consistencyPct },
-    { label: 'Reliability', value: pool.reliabilityPct },
+  const pillars: { label: string; value: number | null | undefined; weight: string }[] = [
+    { label: 'Participation', value: pool.participationPct, weight: '35%' },
+    { label: 'Deliberation', value: pool.deliberationPct, weight: '25%' },
+    { label: 'Reliability', value: pool.reliabilityPct, weight: '25%' },
+    { label: 'Identity', value: pool.governanceIdentityPct, weight: '15%' },
   ];
+
+  const statementPreview = pool.governanceStatement
+    ? pool.governanceStatement.length > 80
+      ? `${pool.governanceStatement.slice(0, 80)}…`
+      : pool.governanceStatement
+    : null;
 
   return (
     <Link
@@ -63,7 +75,7 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
       )}
     >
       {/* ── Header ──────────────────────────────────────────── */}
-      <div className="flex items-start justify-between gap-2 mb-3">
+      <div className="flex items-start justify-between gap-2 mb-2">
         <div className="min-w-0 flex-1">
           {rank && (
             <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums mb-0.5 block">
@@ -114,27 +126,43 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
           >
             {score}
           </div>
-          <span
-            className={cn(
-              'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full mt-1 inline-block',
-              TIER_BADGE_BG[tier],
+          <div className="flex items-center justify-end gap-1 mt-1">
+            <span
+              className={cn(
+                'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full inline-block',
+                TIER_BADGE_BG[tier],
+              )}
+            >
+              {tier}
+            </span>
+            {isProvisional && (
+              <span className="inline-flex items-center gap-0.5 text-[9px] text-amber-500 font-medium">
+                <AlertTriangle className="h-2.5 w-2.5" />
+              </span>
             )}
-          >
-            {tier}
-          </span>
+          </div>
         </div>
       </div>
 
-      {/* ── Pillar bars ──────────────────────────────────────── */}
+      {/* ── Governance statement preview ────────────────────── */}
+      {statementPreview && (
+        <p className="text-[10px] text-muted-foreground/80 italic leading-relaxed mb-2 line-clamp-2">
+          &ldquo;{statementPreview}&rdquo;
+        </p>
+      )}
+
+      {/* ── 4-Pillar bars ──────────────────────────────────────── */}
       {pillars.some((p) => p.value != null) && (
-        <div className="space-y-1.5 mb-3">
-          {pillars.map(({ label, value }) => {
+        <div className="space-y-1.5 mb-2">
+          {pillars.map(({ label, value, weight }) => {
             if (value == null) return null;
             const pct = Math.round(value);
             return (
               <div key={label} className="space-y-0.5">
                 <div className="flex justify-between text-[10px] text-muted-foreground/70">
-                  <span>{label}</span>
+                  <span>
+                    {label} <span className="opacity-50">({weight})</span>
+                  </span>
                   <span className="tabular-nums">{pct}%</span>
                 </div>
                 <div className="h-0.5 rounded-full bg-muted overflow-hidden">
@@ -156,6 +184,7 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
       <div className="mt-auto pt-2 flex items-center justify-between">
         <span className="text-[10px] text-muted-foreground/70 tabular-nums">
           {pool.voteCount} governance votes
+          {isProvisional && <span className="text-amber-500/80 ml-1">· Provisional</span>}
         </span>
         <span
           className={cn(

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { ChevronRight, Clock, Landmark, Users, Shield, Scale } from 'lucide-react';
+import { ChevronRight, Clock, Landmark, Users, Shield, Scale, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useProposals, useDRepVotes } from '@/hooks/queries';
@@ -63,6 +63,15 @@ function formatPct(pct: number): string {
   if (pct < 1) return `${pct.toFixed(2)}%`;
   return `${pct.toFixed(1)}%`;
 }
+
+const PREF_LABELS: Record<string, { label: string; color: string }> = {
+  'treasury-conservative': { label: 'Treasury', color: 'text-red-400 bg-red-500/10' },
+  'smart-treasury-growth': { label: 'Growth', color: 'text-emerald-400 bg-emerald-500/10' },
+  'strong-decentralization': { label: 'Decentral', color: 'text-purple-400 bg-purple-500/10' },
+  'protocol-security-first': { label: 'Security', color: 'text-blue-400 bg-blue-500/10' },
+  'innovation-defi-growth': { label: 'Innovation', color: 'text-cyan-400 bg-cyan-500/10' },
+  'responsible-governance': { label: 'Transparency', color: 'text-amber-400 bg-amber-500/10' },
+};
 
 function TriBodyMini({
   triBody,
@@ -284,7 +293,7 @@ export function ProposalsBrowse() {
                 </div>
 
                 {/* Row 2: Metadata chips */}
-                <div className="flex items-center gap-3 pl-0 sm:pl-[calc(1.5rem+0.75rem)]">
+                <div className="flex items-center gap-3 pl-0 sm:pl-[calc(1.5rem+0.75rem)] flex-wrap">
                   {hasTreasury && (
                     <span className="flex items-center gap-1 text-[10px] text-emerald-500">
                       <Landmark className="h-2.5 w-2.5" />
@@ -311,13 +320,35 @@ export function ProposalsBrowse() {
                     </span>
                   )}
                   {epochsLeft != null && epochsLeft > 0 && (
-                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                      <Clock className="h-2.5 w-2.5" />
+                    <span
+                      className={cn(
+                        'flex items-center gap-1 text-[10px]',
+                        epochsLeft <= 2 ? 'text-amber-400 font-semibold' : 'text-muted-foreground',
+                      )}
+                    >
+                      {epochsLeft <= 2 && <AlertTriangle className="h-2.5 w-2.5" />}
+                      {epochsLeft > 2 && <Clock className="h-2.5 w-2.5" />}
                       <span className="tabular-nums">
                         {epochsLeft === 1 ? '1 epoch left' : `${epochsLeft} epochs left`}
                       </span>
                     </span>
                   )}
+                  {p.relevantPrefs?.length > 0 &&
+                    p.relevantPrefs.slice(0, 2).map((pref: string) => {
+                      const info = PREF_LABELS[pref];
+                      if (!info) return null;
+                      return (
+                        <span
+                          key={pref}
+                          className={cn(
+                            'text-[10px] font-medium px-1.5 py-0.5 rounded',
+                            info.color,
+                          )}
+                        >
+                          {info.label}
+                        </span>
+                      );
+                    })}
                 </div>
               </Link>
             );

--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -117,7 +117,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
               Find the <GovTerm term="drep">DRep</GovTerm> who thinks like you
             </h2>
             <p className="text-sm text-muted-foreground">
-              Answer 5 quick questions and we&apos;ll match you to DReps who share your governance
+              Answer 3 quick questions and we&apos;ll match you to DReps who share your governance
               priorities — or browse and compare them yourself.
             </p>
           </div>
@@ -125,7 +125,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
             <Button asChild size="lg" className="flex-1">
               <Link href="/match">
                 <Zap className="mr-2 h-4 w-4" />
-                Find My DRep
+                Find My DRep — 60 Seconds
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary

- **DRep card**: personality label from 6D alignment, trait tags, rationale rate always visible, activity recency ("Voted 3d ago"), momentum indicator
- **SPO card**: V3 4-pillar model (Participation 35%, Deliberation 25%, Reliability 25%, Identity 15%) with weight labels, confidence/provisional flag, governance statement preview
- **Proposal card**: governance dimension tags (Treasury, Security, etc.), urgency indicator with amber alert for proposals expiring within 2 epochs
- **Pools API**: surface `governance_statement` field
- **Proposals API**: surface `relevant_prefs` field
- **HomeCitizen**: fix stale "5 questions" → "3 questions" copy

This is the first chunk of the frontend overhaul — surfacing ~70% of backend data that was previously invisible on discover cards.

## Test plan

- [ ] Verify DRep cards show personality label and trait tags on /discover
- [ ] Verify SPO cards show 4-pillar bars with weights and governance statement preview
- [ ] Verify proposal rows show dimension tags and urgency indicator for open proposals
- [ ] Confirm preflight passes (format, lint, types, 306 tests)
- [ ] Visual check on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)