### PR TITLE
feat: Chunk 3 — DRep Command Center enrichment

### DIFF
--- a/app/api/drep/[drepId]/votes/route.ts
+++ b/app/api/drep/[drepId]/votes/route.ts
@@ -1,11 +1,12 @@
 /**
  * DRep Votes API
- * Returns a DRep's vote choices keyed by proposal for client-side indicators.
+ * Returns a DRep's vote history enriched with proposal titles, type, epoch, and rationale status.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { createClient } from '@/lib/supabase';
+import { getProposalDisplayTitle } from '@/utils/display';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -17,10 +18,12 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
   }
 
   const supabase = createClient();
+
   const { data: votes, error } = await supabase
     .from('drep_votes')
-    .select('proposal_tx_hash, proposal_index, vote')
-    .eq('drep_id', drepId);
+    .select('proposal_tx_hash, proposal_index, vote, epoch_no, block_time, rationale_quality')
+    .eq('drep_id', drepId)
+    .order('block_time', { ascending: false });
 
   if (error) {
     logger.error('Failed to fetch DRep votes', {
@@ -32,11 +35,50 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
     return NextResponse.json({ error: 'Failed to fetch votes' }, { status: 500 });
   }
 
+  const allVotes = votes || [];
+  const txHashes = [...new Set(allVotes.map((v) => v.proposal_tx_hash))];
+
+  const [proposalsResult, rationalesResult] = await Promise.all([
+    txHashes.length > 0
+      ? supabase
+          .from('proposals')
+          .select('tx_hash, proposal_index, title, proposal_type')
+          .in('tx_hash', txHashes)
+      : Promise.resolve({ data: [] }),
+    supabase
+      .from('vote_rationales')
+      .select('proposal_tx_hash, proposal_index')
+      .eq('drep_id', drepId)
+      .not('rationale_text', 'is', null),
+  ]);
+
+  const proposalMap = new Map(
+    (proposalsResult.data ?? []).map((p: any) => [
+      `${p.tx_hash}:${p.proposal_index}`,
+      { title: p.title, proposalType: p.proposal_type },
+    ]),
+  );
+
+  const rationaleSet = new Set(
+    (rationalesResult.data ?? []).map((r: any) => `${r.proposal_tx_hash}:${r.proposal_index}`),
+  );
+
   return NextResponse.json({
-    votes: (votes || []).map((v: any) => ({
-      proposalTxHash: v.proposal_tx_hash,
-      proposalIndex: v.proposal_index,
-      vote: v.vote,
-    })),
+    votes: allVotes.map((v: any) => {
+      const key = `${v.proposal_tx_hash}:${v.proposal_index}`;
+      const proposal = proposalMap.get(key);
+      return {
+        proposalTxHash: v.proposal_tx_hash,
+        proposalIndex: v.proposal_index,
+        vote: v.vote,
+        epochNo: v.epoch_no,
+        proposalTitle: proposal
+          ? getProposalDisplayTitle(proposal.title, v.proposal_tx_hash, v.proposal_index)
+          : null,
+        proposalType: proposal?.proposalType ?? null,
+        hasRationale:
+          rationaleSet.has(key) || (v.rationale_quality != null && v.rationale_quality > 0),
+      };
+    }),
   });
 });

--- a/app/api/governance/report-card/route.ts
+++ b/app/api/governance/report-card/route.ts
@@ -117,6 +117,14 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       reliability: drep.reliability_v3,
       governanceIdentity: drep.governance_identity,
     },
+    alignment: {
+      treasuryConservative: drep.alignment_treasury_conservative ?? null,
+      treasuryGrowth: drep.alignment_treasury_growth ?? null,
+      decentralization: drep.alignment_decentralization ?? null,
+      security: drep.alignment_security ?? null,
+      innovation: drep.alignment_innovation ?? null,
+      transparency: drep.alignment_transparency ?? null,
+    },
     votingRecord: {
       totalVotes: voteCount ?? 0,
       rationalesProvided: rationaleCount ?? 0,

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -14,11 +14,24 @@ import {
   XCircle,
   Clock,
   Share2,
+  Target,
+  AlertTriangle,
+  FileText,
+  Shield,
+  Zap,
+  Eye,
+  Fingerprint,
 } from 'lucide-react';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useDRepReportCard, useGovernancePulse, useDRepVotes } from '@/hooks/queries';
+import {
+  useDRepReportCard,
+  useGovernancePulse,
+  useDRepVotes,
+  useDashboardCompetitive,
+  useDashboardUrgent,
+} from '@/hooks/queries';
 import {
   tierKey,
   TIER_SCORE_COLOR,
@@ -29,6 +42,22 @@ import {
 import { computeTier } from '@/lib/scoring/tiers';
 import { generateActions } from '@/lib/actionFeed';
 import { ActionFeed } from './ActionFeed';
+
+const PILLAR_META = [
+  { key: 'engagementQuality', label: 'Engagement', icon: Zap, weight: '35%' },
+  { key: 'effectiveParticipation', label: 'Participation', icon: Vote, weight: '25%' },
+  { key: 'reliability', label: 'Reliability', icon: Shield, weight: '25%' },
+  { key: 'governanceIdentity', label: 'Identity', icon: Fingerprint, weight: '15%' },
+] as const;
+
+const ALIGNMENT_META = [
+  { key: 'treasuryConservative', label: 'Treasury Conservative', color: 'bg-red-500' },
+  { key: 'treasuryGrowth', label: 'Treasury Growth', color: 'bg-emerald-500' },
+  { key: 'decentralization', label: 'Decentralization', color: 'bg-purple-500' },
+  { key: 'security', label: 'Security', color: 'bg-blue-500' },
+  { key: 'innovation', label: 'Innovation', color: 'bg-cyan-500' },
+  { key: 'transparency', label: 'Transparency', color: 'bg-amber-500' },
+] as const;
 
 function ScoreGauge({ score, tier }: { score: number; tier: string }) {
   const tKey = tierKey(tier);
@@ -66,16 +95,54 @@ function ScoreGauge({ score, tier }: { score: number; tier: string }) {
   );
 }
 
+function ScoreSparkline({ history }: { history: { snapshot_date: string; score: number }[] }) {
+  if (history.length < 2) return null;
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.snapshot_date).getTime() - new Date(b.snapshot_date).getTime(),
+  );
+  const scores = sorted.map((h) => h.score);
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const range = max - min || 1;
+  const width = 120;
+  const height = 32;
+  const points = scores
+    .map((s, i) => {
+      const x = (i / (scores.length - 1)) * width;
+      const y = height - ((s - min) / range) * (height - 4) - 2;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-[120px] h-8" preserveAspectRatio="none">
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-primary/60"
+      />
+    </svg>
+  );
+}
+
 export function DRepCommandCenter({ drepId }: { drepId: string }) {
   const [shareOpen, setShareOpen] = useState(false);
   const { data: rawCard, isLoading: summaryLoading } = useDRepReportCard(drepId);
   const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
   const { data: rawVotes, isLoading: votesLoading } = useDRepVotes(drepId);
+  const { data: rawCompetitive } = useDashboardCompetitive(drepId);
+  const { data: rawUrgent } = useDashboardUrgent(drepId);
 
   const card = rawCard as any;
   const pulse = rawPulse as any;
   const votes: any[] = (rawVotes as any)?.votes ?? rawVotes ?? [];
   const allVotes = Array.isArray(votes) ? votes : [];
+  const competitive = rawCompetitive as any;
+  const urgent = rawUrgent as any;
 
   const drepScore: number = card?.score ?? 0;
   const drepTier: string = card?.tier ?? computeTier(drepScore) ?? 'Emerging';
@@ -84,6 +151,11 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
   const scoreDelta: number | undefined = card?.momentum;
   const rationaleRate: number = card?.rationaleRate ?? card?.votingRecord?.rationaleRate ?? 0;
   const participationRate: number = card?.participationRate ?? 0;
+  const tierProgress = card?.tierProgress;
+  const pillars = card?.pillars;
+  const alignment = card?.alignment;
+  const scoreHistory: { snapshot_date: string; score: number }[] = card?.scoreHistory ?? [];
+  const votingRecord = card?.votingRecord;
 
   const activeProposals: number = pulse?.activeProposals ?? 0;
   const criticalProposals: number = pulse?.criticalProposals ?? 0;
@@ -91,6 +163,16 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
 
   const recentVotes = allVotes.slice(0, 5);
   const pendingVotesCount = activeProposals;
+
+  const urgentProposals: any[] = urgent?.proposals ?? [];
+  const unexplainedVotes: any[] = urgent?.unexplainedVotes ?? [];
+
+  const rank: number | null = competitive?.rank ?? null;
+  const totalActive: number = competitive?.totalActive ?? 0;
+  const nearbyAbove: any[] = competitive?.nearbyAbove ?? [];
+  const nearbyBelow: any[] = competitive?.nearbyBelow ?? [];
+  const top10FocusArea = competitive?.top10FocusArea ?? null;
+  const distanceToTop10: number = competitive?.distanceToTop10 ?? 0;
 
   const actions = generateActions({
     segment: 'drep',
@@ -118,6 +200,9 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
         ? 'text-emerald-400'
         : 'text-rose-400';
 
+  const hasAlignment =
+    alignment && ALIGNMENT_META.some((a) => alignment[a.key] != null && alignment[a.key] !== 50);
+
   return (
     <div className="space-y-6">
       {/* Score hero */}
@@ -131,18 +216,16 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
       ) : (
         <div className="relative">
           <ScoreGauge score={drepScore} tier={drepTier} />
-          {scoreDelta != null && (
-            <div
-              className={cn(
-                'absolute top-5 right-5 flex items-center gap-1 text-sm font-medium',
-                deltaColor,
-              )}
-            >
-              <DeltaIcon className="h-4 w-4" />
-              {scoreDelta > 0 ? '+' : ''}
-              {scoreDelta.toFixed(1)} this week
-            </div>
-          )}
+          <div className="absolute top-5 right-5 flex flex-col items-end gap-2">
+            {scoreDelta != null && (
+              <div className={cn('flex items-center gap-1 text-sm font-medium', deltaColor)}>
+                <DeltaIcon className="h-4 w-4" />
+                {scoreDelta > 0 ? '+' : ''}
+                {scoreDelta.toFixed(1)} this week
+              </div>
+            )}
+            <ScoreSparkline history={scoreHistory} />
+          </div>
           {!drepIsActive && (
             <div className="absolute bottom-5 right-5">
               <span className="text-xs text-rose-400 font-medium px-2 py-0.5 rounded-full border border-rose-900/40 bg-rose-950/20">
@@ -150,6 +233,30 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
               </span>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Tier progress */}
+      {!summaryLoading && tierProgress?.pointsToNext != null && (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Target className="h-4 w-4 text-primary" />
+            <div>
+              <p className="text-sm font-medium">
+                {tierProgress.pointsToNext} points to{' '}
+                <span className="text-primary font-bold">{tierProgress.nextTier}</span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
+              </p>
+            </div>
+          </div>
+          <div className="w-20 h-1.5 bg-border rounded-full overflow-hidden">
+            <div
+              className="h-full rounded-full bg-primary"
+              style={{ width: `${tierProgress.percentWithinTier}%` }}
+            />
+          </div>
         </div>
       )}
 
@@ -200,8 +307,121 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
         ))}
       </div>
 
+      {/* Pillar breakdown */}
+      {!summaryLoading && pillars && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Score Breakdown
+          </p>
+          <div className="space-y-2.5">
+            {PILLAR_META.map(({ key, label, icon: Icon, weight }) => {
+              const val = pillars[key] ?? 0;
+              return (
+                <div key={key} className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="text-sm font-medium">{label}</span>
+                      <span className="text-[10px] text-muted-foreground">{weight}</span>
+                    </div>
+                    <span className="text-sm font-bold tabular-nums">{val.toFixed(0)}</span>
+                  </div>
+                  <div className="h-1.5 bg-border rounded-full overflow-hidden">
+                    <motion.div
+                      className={cn(
+                        'h-full rounded-full',
+                        val >= 70 ? 'bg-emerald-500' : val >= 40 ? 'bg-amber-500' : 'bg-rose-500',
+                      )}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${Math.min(100, val)}%` }}
+                      transition={{ type: 'spring', stiffness: 60, damping: 20, delay: 0.2 }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {top10FocusArea && (
+            <p className="text-xs text-muted-foreground pt-1">
+              Focus area vs top 10:{' '}
+              <span className="font-medium text-foreground">{top10FocusArea.pillar}</span> (+
+              {Math.round(top10FocusArea.gap)} pts gap)
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* 6D Alignment */}
+      {!summaryLoading && hasAlignment && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Governance Alignment
+          </p>
+          <div className="space-y-2">
+            {ALIGNMENT_META.map(({ key, label, color }) => {
+              const val = alignment[key] ?? 50;
+              return (
+                <div key={key} className="flex items-center gap-3">
+                  <span className="text-xs text-muted-foreground w-32 shrink-0 truncate">
+                    {label}
+                  </span>
+                  <div className="flex-1 h-1.5 bg-border rounded-full overflow-hidden">
+                    <div
+                      className={cn('h-full rounded-full', color)}
+                      style={{ width: `${Math.min(100, val)}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-bold tabular-nums w-8 text-right">
+                    {Math.round(val)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Urgent votes */}
+      {urgentProposals.length > 0 && (
+        <div className="rounded-xl border border-amber-900/30 bg-amber-950/10 p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-400" />
+            <p className="text-sm font-medium text-amber-200">Expiring Soon</p>
+          </div>
+          {urgentProposals.slice(0, 3).map((p: any) => (
+            <Link
+              key={`${p.txHash}-${p.index}`}
+              href={`/proposal/${p.txHash}/${p.index}`}
+              className="flex items-center justify-between text-sm py-1.5 hover:text-primary transition-colors"
+            >
+              <span className="truncate flex-1">{p.title}</span>
+              <span className="text-xs text-amber-400 shrink-0 ml-2">
+                {p.epochsRemaining === 0 ? 'Last epoch!' : `${p.epochsRemaining}ep left`}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Unexplained votes nudge */}
+      {unexplainedVotes.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <FileText className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">
+                {unexplainedVotes.length} vote{unexplainedVotes.length > 1 ? 's' : ''} without
+                rationale
+              </p>
+              <p className="text-xs text-muted-foreground">Adding rationales boosts your score</p>
+            </div>
+          </div>
+          <Eye className="h-4 w-4 text-muted-foreground" />
+        </div>
+      )}
+
       {/* Pending votes widget */}
-      {!pulseLoading && activeProposals > 0 && (
+      {!pulseLoading && activeProposals > 0 && urgentProposals.length === 0 && (
         <Link href="/discover" className="block group">
           <div className="rounded-xl border border-amber-900/30 bg-amber-950/10 p-4 flex items-center justify-between hover:brightness-110 transition-all">
             <div className="flex items-center gap-3">
@@ -218,6 +438,73 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
             <ChevronRight className="h-4 w-4 text-amber-400 group-hover:translate-x-0.5 transition-transform" />
           </div>
         </Link>
+      )}
+
+      {/* Competitive context */}
+      {rank != null && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Leaderboard Position
+            </p>
+            <span className="text-xs text-muted-foreground">{totalActive} active DReps</span>
+          </div>
+          <div className="flex items-center gap-4">
+            <p className="font-display text-3xl font-bold tabular-nums text-primary">#{rank}</p>
+            {distanceToTop10 > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {distanceToTop10.toFixed(1)} pts to top 10
+              </p>
+            )}
+          </div>
+          {(nearbyAbove.length > 0 || nearbyBelow.length > 0) && (
+            <div className="divide-y divide-border/50 rounded-lg border overflow-hidden">
+              {nearbyAbove.map((d: any) => (
+                <Link
+                  key={d.drepId}
+                  href={`/drep/${d.drepId}`}
+                  className="px-3 py-2 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs font-bold text-muted-foreground tabular-nums w-6">
+                      #{d.rank}
+                    </span>
+                    <span className="text-sm truncate">{d.name}</span>
+                  </div>
+                  <span className="text-sm font-bold tabular-nums shrink-0">
+                    {d.score?.toFixed(1)}
+                  </span>
+                </Link>
+              ))}
+              <div className="px-3 py-2 flex items-center justify-between bg-primary/5">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-bold text-primary tabular-nums w-6">#{rank}</span>
+                  <span className="text-sm font-bold text-primary">You</span>
+                </div>
+                <span className="text-sm font-bold tabular-nums text-primary">
+                  {drepScore.toFixed(1)}
+                </span>
+              </div>
+              {nearbyBelow.map((d: any) => (
+                <Link
+                  key={d.drepId}
+                  href={`/drep/${d.drepId}`}
+                  className="px-3 py-2 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs font-bold text-muted-foreground tabular-nums w-6">
+                      #{d.rank}
+                    </span>
+                    <span className="text-sm truncate">{d.name}</span>
+                  </div>
+                  <span className="text-sm font-bold tabular-nums shrink-0">
+                    {d.score?.toFixed(1)}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {/* Recent votes */}
@@ -246,16 +533,40 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
                     ? 'text-rose-400'
                     : 'text-muted-foreground';
               return (
-                <div key={idx} className="px-4 py-3 flex items-center gap-3">
+                <Link
+                  key={idx}
+                  href={
+                    vote.proposalTxHash
+                      ? `/proposal/${vote.proposalTxHash}/${vote.proposalIndex}`
+                      : '#'
+                  }
+                  className="px-4 py-3 flex items-center gap-3 hover:bg-muted/20 transition-colors"
+                >
                   <VoteIcon className={cn('h-3.5 w-3.5 shrink-0', voteColor)} />
-                  <p className="text-sm truncate flex-1">
-                    {vote.proposalTitle ?? vote.title ?? 'Proposal'}
-                  </p>
-                  <span className={cn('text-xs font-bold shrink-0', voteColor)}>{voteDir}</span>
-                </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm truncate">
+                      {vote.proposalTitle ?? vote.title ?? 'Proposal'}
+                    </p>
+                    {vote.proposalType && (
+                      <p className="text-[10px] text-muted-foreground">{vote.proposalType}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {vote.hasRationale && (
+                      <span className="text-[10px] text-emerald-400/70">rationale</span>
+                    )}
+                    <span className={cn('text-xs font-bold', voteColor)}>{voteDir}</span>
+                  </div>
+                </Link>
               );
             })}
           </div>
+          {votingRecord && (
+            <p className="text-xs text-muted-foreground text-center">
+              {votingRecord.totalVotes} total votes &middot; {votingRecord.rationalesProvided}{' '}
+              rationales
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- **Votes API enriched**: `/api/drep/[id]/votes` now returns proposal titles, type, epoch, and rationale indicator (previously only tx hash + vote direction)
- **Report-card API**: added 6D alignment scores (treasury conservative/growth, decentralization, security, innovation, transparency)
- **DRepCommandCenter rewrite**: added 8 new sections — score sparkline, tier progress bar, 4-pillar breakdown, 6D alignment bars, competitive leaderboard with nearby DReps, urgent expiring vote callouts, unexplained vote nudge, and enriched recent votes with titles + type + rationale badges

## What was surfaced
| Data | Before | After |
|------|--------|-------|
| Score trend (14 days) | Hidden | Sparkline in hero |
| Tier progress | Hidden | "X pts to [Next Tier]" bar |
| 4 scoring pillars | Hidden | Animated bars with weights |
| 6D alignment | Not returned | Colored dimension bars |
| Leaderboard rank | Hidden | Rank + nearby DReps table |
| Top 10 focus area | Hidden | Coaching hint below pillars |
| Urgent proposals | Count only | Specific proposals + epochs left |
| Unexplained votes | Hidden | Nudge card with count |
| Vote titles | "Proposal" fallback | Real titles from DB |
| Vote rationale status | Hidden | "rationale" badge per vote |
| Proposal type | Hidden | Shown under vote title |

## Test plan
- [x] Preflight passes (306 tests, 0 errors)
- [ ] CI green
- [ ] Verify `/my-gov` page loads for DRep segment
- [ ] Verify `/api/drep/{id}/votes` returns enriched data
- [ ] Verify `/api/governance/report-card` returns alignment object

🤖 Generated with [Claude Code](https://claude.com/claude-code)