### PR TITLE
feat: enrich DRep & SPO profile pages with rank, trends, vote distribution

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -85,6 +85,8 @@ import {
   getRationalesByVoteTxHashes,
   getScoreHistory,
   getDRepPercentile,
+  getDRepRank,
+  getDRepDelegationTrend,
   getSocialLinkChecks,
   isDRepClaimed,
 } from '@/lib/data';
@@ -324,15 +326,25 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
 
   const matchScore = match ? parseInt(match, 10) : null;
 
-  const [scoreHistory, percentile, linkChecks, isClaimed, spoAlignPct, drepCommunicationEnabled] =
-    await Promise.all([
-      getScoreHistory(drep.drepId),
-      getDRepPercentile(drep.drepScore),
-      getSocialLinkChecks(drep.drepId),
-      isDRepClaimed(drep.drepId),
-      getSpoAlignment(drep.votes),
-      getFeatureFlag('drep_communication', false),
-    ]);
+  const [
+    scoreHistory,
+    percentile,
+    rank,
+    delegationTrend,
+    linkChecks,
+    isClaimed,
+    spoAlignPct,
+    drepCommunicationEnabled,
+  ] = await Promise.all([
+    getScoreHistory(drep.drepId),
+    getDRepPercentile(drep.drepScore),
+    getDRepRank(drep.drepId),
+    getDRepDelegationTrend(drep.drepId),
+    getSocialLinkChecks(drep.drepId),
+    isDRepClaimed(drep.drepId),
+    getSpoAlignment(drep.votes),
+    getFeatureFlag('drep_communication', false),
+  ]);
 
   const brokenLinks = new Set(linkChecks.filter((c) => c.status === 'broken').map((c) => c.uri));
 
@@ -433,7 +445,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       <DRepProfileHero
         name={drepName}
         score={drep.drepScore}
-        rank={null}
+        rank={rank}
         delegatorCount={drep.delegatorCount}
         votingPowerFormatted={formatAda(drep.votingPower)}
         alignments={alignments}
@@ -452,7 +464,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           participationRate: drep.effectiveParticipation,
           rationaleRate: drep.rationaleRate,
           drepScore: drep.drepScore,
-          rank: null,
+          rank,
           delegatorCount: drep.delegatorCount,
           votingPower: drep.votingPower,
           alignments,
@@ -463,7 +475,38 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         accentColor={getIdentityColor(getDominantDimension(alignments)).hex}
       />
 
-      {/* 3. Key Facts Strip */}
+      {/* 3. Tier Progress + Momentum */}
+      {tierProgress.pointsToNext != null && (
+        <div className="flex items-center justify-between rounded-xl border border-border bg-card px-5 py-3">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-medium">
+              {tierProgress.pointsToNext} pts to{' '}
+              <span className="text-primary font-bold">{tierProgress.nextTier}</span>
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            {drep.scoreMomentum != null && drep.scoreMomentum !== 0 && (
+              <span
+                className={`text-xs font-medium tabular-nums ${drep.scoreMomentum > 0 ? 'text-emerald-400' : 'text-rose-400'}`}
+              >
+                {drep.scoreMomentum > 0 ? '+' : ''}
+                {drep.scoreMomentum.toFixed(1)} pts/day
+              </span>
+            )}
+            <div className="w-24 h-1.5 bg-border rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${tierProgress.percentWithinTier}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 4. Key Facts Strip */}
       <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 py-4 border-y border-border">
         <KeyFact
           label="Score"
@@ -475,6 +518,36 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <KeyFact label="Alignment" value={identityLabel} />
         {spoAlignPct !== null && (
           <KeyFact label="SPO Alignment" value={`${spoAlignPct}%`} subtext="of the time" />
+        )}
+        {drep.totalVotes > 0 && (
+          <div className="flex flex-col items-center text-center min-w-[100px]">
+            <span className="text-xs text-muted-foreground">Vote Split</span>
+            <div className="flex items-center gap-1 mt-0.5">
+              <div className="flex h-1.5 w-16 rounded-full overflow-hidden bg-border">
+                {drep.yesVotes > 0 && (
+                  <div
+                    className="h-full bg-emerald-500"
+                    style={{ width: `${(drep.yesVotes / drep.totalVotes) * 100}%` }}
+                  />
+                )}
+                {drep.noVotes > 0 && (
+                  <div
+                    className="h-full bg-rose-500"
+                    style={{ width: `${(drep.noVotes / drep.totalVotes) * 100}%` }}
+                  />
+                )}
+                {drep.abstainVotes > 0 && (
+                  <div
+                    className="h-full bg-muted-foreground/40"
+                    style={{ width: `${(drep.abstainVotes / drep.totalVotes) * 100}%` }}
+                  />
+                )}
+              </div>
+            </div>
+            <span className="text-[10px] text-muted-foreground">
+              {drep.yesVotes}Y {drep.noVotes}N {drep.abstainVotes}A
+            </span>
+          </div>
         )}
       </div>
 
@@ -535,10 +608,46 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <SocialProofBadge drepId={drep.drepId} variant="views" />
       </div>
 
-      {/* 5. Treasury Stance (compact in VP1) */}
+      {/* 5. Delegation Power Trend */}
+      {delegationTrend.length >= 2 && (
+        <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Delegation Trend
+            </span>
+            <span className="text-xs text-muted-foreground">{delegationTrend.length} epochs</span>
+          </div>
+          <div className="flex items-end gap-[2px] h-10">
+            {(() => {
+              const counts = delegationTrend.map((d) => d.delegatorCount);
+              const maxCount = Math.max(...counts, 1);
+              return delegationTrend.map((d, i) => (
+                <div
+                  key={d.epoch}
+                  className="flex-1 bg-primary/60 rounded-t-sm min-w-[3px]"
+                  style={{ height: `${Math.max(4, (d.delegatorCount / maxCount) * 100)}%` }}
+                  title={`Epoch ${d.epoch}: ${d.delegatorCount.toLocaleString()} delegators, ${d.votingPowerAda.toLocaleString()} ADA`}
+                />
+              ));
+            })()}
+          </div>
+          <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
+            <span>E{delegationTrend[0].epoch}</span>
+            <span>
+              {delegationTrend[delegationTrend.length - 1].delegatorCount.toLocaleString()}{' '}
+              delegators &middot;{' '}
+              {(delegationTrend[delegationTrend.length - 1].votingPowerAda / 1_000_000).toFixed(1)}M
+              ADA
+            </span>
+            <span>E{delegationTrend[delegationTrend.length - 1].epoch}</span>
+          </div>
+        </div>
+      )}
+
+      {/* 6. Treasury Stance (compact in VP1) */}
       <DRepTreasuryStance drepId={drep.drepId} compact />
 
-      {/* 6. Activity feed */}
+      {/* 7. Activity feed */}
       <ActivitySideWidget drepId={drep.drepId} limit={5} />
 
       {/* ════════════════════════════════════════════

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -558,7 +558,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
               </span>
             </div>
 
-            <div className="flex items-baseline gap-2">
+            <div className="flex items-baseline gap-2 flex-wrap">
               <span className={`text-4xl font-bold tabular-nums ${TIER_SCORE_COLOR[tk]}`}>
                 {governanceScore}
               </span>
@@ -566,6 +566,14 @@ export default async function PoolProfilePage({ params }: PageProps) {
               {scoreRank != null && (
                 <span className="ml-2 inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
                   Top {100 - scoreRank}% of governance-active SPOs
+                </span>
+              )}
+              {poolRow.score_momentum != null && (poolRow.score_momentum as number) !== 0 && (
+                <span
+                  className={`text-xs font-medium tabular-nums ${(poolRow.score_momentum as number) > 0 ? 'text-emerald-400' : 'text-rose-400'}`}
+                >
+                  {(poolRow.score_momentum as number) > 0 ? '+' : ''}
+                  {(poolRow.score_momentum as number).toFixed(1)} pts/day
                 </span>
               )}
             </div>
@@ -580,6 +588,25 @@ export default async function PoolProfilePage({ params }: PageProps) {
               </p>
             )}
           </div>
+
+          {/* Tier progress */}
+          {tierProgress.pointsToNext != null && (
+            <div className="flex items-center gap-3 text-sm">
+              <span>
+                {tierProgress.pointsToNext} pts to{' '}
+                <span className="text-primary font-bold">{tierProgress.nextTier}</span>
+              </span>
+              <div className="w-20 h-1.5 bg-border rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary"
+                  style={{ width: `${tierProgress.percentWithinTier}%` }}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
+              </span>
+            </div>
+          )}
 
           {/* Key fact chips */}
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2 py-4 border-y border-border">
@@ -618,6 +645,42 @@ export default async function PoolProfilePage({ params }: PageProps) {
                 <span className="text-xs text-muted-foreground">Agrees w/ CC</span>
                 <span className="text-sm font-semibold font-mono tabular-nums text-violet-400">
                   {interBody.ccPct}%
+                </span>
+              </div>
+            )}
+            {pledge != null && (
+              <div className="flex flex-col items-center text-center min-w-[80px]">
+                <span className="text-xs text-muted-foreground">Pledge</span>
+                <span className="text-sm font-semibold font-mono tabular-nums">
+                  {formatPledge(pledge)} ₳
+                </span>
+              </div>
+            )}
+            {totalVotes > 0 && (
+              <div className="flex flex-col items-center text-center min-w-[100px]">
+                <span className="text-xs text-muted-foreground">Vote Split</span>
+                <div className="flex h-1.5 w-16 rounded-full overflow-hidden bg-border mt-0.5">
+                  {yesCount > 0 && (
+                    <div
+                      className="h-full bg-emerald-500"
+                      style={{ width: `${(yesCount / totalVotes) * 100}%` }}
+                    />
+                  )}
+                  {noCount > 0 && (
+                    <div
+                      className="h-full bg-rose-500"
+                      style={{ width: `${(noCount / totalVotes) * 100}%` }}
+                    />
+                  )}
+                  {abstainCount > 0 && (
+                    <div
+                      className="h-full bg-muted-foreground/40"
+                      style={{ width: `${(abstainCount / totalVotes) * 100}%` }}
+                    />
+                  )}
+                </div>
+                <span className="text-[10px] text-muted-foreground">
+                  {yesCount}Y {noCount}N {abstainCount}A
                 </span>
               </div>
             )}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1164,6 +1164,51 @@ export async function getDRepPercentile(score: number): Promise<number> {
   }
 }
 
+/**
+ * Returns the 1-based rank of a DRep by score (1 = highest score).
+ */
+export async function getDRepRank(drepId: string): Promise<number | null> {
+  try {
+    const supabase = createClient();
+    const { data: drep } = await supabase.from('dreps').select('score').eq('id', drepId).single();
+    if (!drep?.score) return null;
+
+    const { count } = await supabase
+      .from('dreps')
+      .select('*', { count: 'exact', head: true })
+      .gt('score', drep.score);
+    return (count ?? 0) + 1;
+  } catch (err) {
+    logger.error('[Data] getDRepRank error', { error: err });
+    return null;
+  }
+}
+
+/**
+ * Returns epoch-by-epoch delegation power snapshots for a DRep.
+ */
+export async function getDRepDelegationTrend(
+  drepId: string,
+): Promise<{ epoch: number; votingPowerAda: number; delegatorCount: number }[]> {
+  try {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from('drep_power_snapshots')
+      .select('epoch_no, amount_lovelace, delegator_count')
+      .eq('drep_id', drepId)
+      .order('epoch_no', { ascending: true })
+      .limit(30);
+    return (data ?? []).map((s: any) => ({
+      epoch: s.epoch_no,
+      votingPowerAda: Math.round(Number(s.amount_lovelace) / 1_000_000),
+      delegatorCount: s.delegator_count ?? 0,
+    }));
+  } catch (err) {
+    logger.error('[Data] getDRepDelegationTrend error', { error: err });
+    return [];
+  }
+}
+
 // ============================================================================
 // SOCIAL LINK CHECKS
 // ============================================================================


### PR DESCRIPTION
## Summary
- **DRep profiles**: Real rank in hero (was always null), tier progress bar + score momentum, vote distribution stacked bar (Yes/No/Abstain), delegation power trend chart from `drep_power_snapshots`
- **SPO profiles**: Score momentum indicator, tier progress bar, pledge in key facts, vote distribution stacked bar
- **Data layer**: Added `getDRepRank` and `getDRepDelegationTrend` to `lib/data.ts`

## Test plan
- [ ] DRep profile shows rank badge in hero (e.g. "#12 of 800")
- [ ] Tier progress bar renders between narrative and key facts
- [ ] Vote distribution bar shows correct Yes/No/Abstain proportions
- [ ] Delegation trend chart renders epoch-by-epoch bars
- [ ] SPO profile shows momentum, pledge, and vote distribution
- [ ] All 306 tests pass, preflight clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)