### PR TITLE
feat: enrich Pulse tabs with governance intelligence (Chunk 5)

### DIFF
--- a/components/civica/pulse/CivicaGovernanceCalendar.tsx
+++ b/components/civica/pulse/CivicaGovernanceCalendar.tsx
@@ -9,6 +9,7 @@ import {
   useGovernancePulse,
   useGovernanceEpochRecap,
   useGovernanceCalendar,
+  useGovernanceSparklines,
 } from '@/hooks/queries';
 
 interface CalendarData {
@@ -112,6 +113,14 @@ function ProposalDeadline({ proposal }: { proposal: CalendarData['upcoming'][0] 
 
 function EpochRecapCard({ recap }: { recap: any }) {
   const [expanded, setExpanded] = useState(false);
+  const ratified = recap.proposalsRatified ?? recap.proposals_ratified ?? 0;
+  const submitted = recap.proposalsSubmitted ?? recap.proposals_submitted;
+  const dropped = recap.proposalsDropped ?? recap.proposals_dropped;
+  const expired = recap.proposalsExpired ?? recap.proposals_expired;
+  const adaWithdrawn =
+    recap.adaWithdrawn ?? recap.treasury_withdrawn_ada ?? recap.treasuryWithdrawnAda;
+  const participation = recap.drepParticipationPct ?? recap.drep_participation_pct;
+  const narrative = recap.summary ?? recap.ai_narrative ?? recap.aiNarrative;
 
   return (
     <div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -124,15 +133,28 @@ function EpochRecapCard({ recap }: { recap: any }) {
             {recap.epoch}
           </span>
           <div>
-            <p className="text-sm font-medium">
-              {recap.proposalsRatified ?? 0} ratified
-              {recap.adaWithdrawn ? ` · ₳${formatAda(recap.adaWithdrawn)} withdrawn` : ''}
-            </p>
-            {recap.ghiDelta != null && (
-              <p className="text-[11px] text-muted-foreground">
-                GHI {recap.ghiDelta > 0 ? `+${recap.ghiDelta}` : recap.ghiDelta}
-              </p>
-            )}
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-medium">{ratified} ratified</span>
+              {submitted != null && submitted > 0 && (
+                <span className="text-[11px] text-muted-foreground">{submitted} submitted</span>
+              )}
+              {adaWithdrawn ? (
+                <span className="text-[11px] text-emerald-400">₳{formatAda(adaWithdrawn)}</span>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2 mt-0.5">
+              {participation != null && (
+                <span className="text-[11px] text-muted-foreground">
+                  {Math.round(participation)}% participation
+                </span>
+              )}
+              {dropped != null && dropped > 0 && (
+                <span className="text-[11px] text-rose-400/70">{dropped} dropped</span>
+              )}
+              {expired != null && expired > 0 && (
+                <span className="text-[11px] text-amber-400/70">{expired} expired</span>
+              )}
+            </div>
           </div>
         </div>
         <ChevronDown
@@ -142,9 +164,9 @@ function EpochRecapCard({ recap }: { recap: any }) {
           )}
         />
       </button>
-      {expanded && recap.summary && (
-        <div className="px-4 pb-3 text-xs text-muted-foreground border-t border-border pt-2">
-          {recap.summary}
+      {expanded && narrative && (
+        <div className="px-4 pb-3 text-xs text-muted-foreground border-t border-border pt-2 leading-relaxed">
+          {narrative}
         </div>
       )}
     </div>
@@ -164,8 +186,12 @@ export function CivicaGovernanceCalendar() {
 
   const { data: rawPulse } = useGovernancePulse();
   const { data: rawRecap } = useGovernanceEpochRecap();
+  const { data: rawSparklines } = useGovernanceSparklines();
   const pulse = rawPulse as any;
   const recap = rawRecap as any;
+  const sparklines = rawSparklines as any;
+  const participationRows: { epoch: number; participation_rate: number; rationale_rate: number }[] =
+    sparklines?.participation ?? [];
 
   // Initialize countdown from server data, then tick locally
   const initialSeconds = calendar?.secondsRemaining ?? null;
@@ -209,6 +235,47 @@ export function CivicaGovernanceCalendar() {
       ) : calendar ? (
         <EpochProgressHero calendar={calendar} countdown={countdown} />
       ) : null}
+
+      {/* Participation trend mini-chart */}
+      {participationRows.length >= 4 && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
+              Participation Trend
+            </p>
+            <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-1 w-3 rounded-full bg-blue-400" />
+                Participation
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-1 w-3 rounded-full bg-emerald-400 opacity-70" />
+                Rationale
+              </span>
+            </div>
+          </div>
+          <div className="flex items-end gap-[2px] h-12">
+            {(() => {
+              const maxP = Math.max(...participationRows.map((r) => r.participation_rate), 1);
+              return participationRows.slice(-20).map((r) => (
+                <div key={r.epoch} className="flex-1 flex flex-col justify-end gap-[1px]">
+                  <div
+                    className="bg-blue-400/70 rounded-t-sm min-w-[2px]"
+                    style={{
+                      height: `${Math.max(2, (r.participation_rate / maxP) * 100)}%`,
+                    }}
+                    title={`Epoch ${r.epoch}: ${r.participation_rate.toFixed(1)}% participation`}
+                  />
+                </div>
+              ));
+            })()}
+          </div>
+          <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
+            <span>Ep {participationRows[Math.max(0, participationRows.length - 20)]?.epoch}</span>
+            <span>Ep {participationRows[participationRows.length - 1]?.epoch}</span>
+          </div>
+        </div>
+      )}
 
       {/* Upcoming proposal deadlines */}
       {calendar && calendar.upcoming.length > 0 && (

--- a/components/civica/pulse/CivicaObservatory.tsx
+++ b/components/civica/pulse/CivicaObservatory.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { Globe, TrendingUp, TrendingDown, Minus, Info } from 'lucide-react';
+import { Globe, TrendingUp, TrendingDown, Minus, Info, GitBranch } from 'lucide-react';
+import { scaleLinear } from 'd3-scale';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   useGovernanceBenchmarks,
   useGovernanceHealthIndex,
   useGovernanceDecentralization,
+  useGovernanceInterBody,
 } from '@/hooks/queries';
 import { getChainMetrics, GOVERNANCE_MODELS } from '@/lib/crossChain/chainMetrics';
 import type { ChainBenchmark } from '@/lib/crossChain';
@@ -118,6 +120,155 @@ function EDICard({ metric }: { metric: EDIMetric }) {
   );
 }
 
+function MiniSparkline({
+  data,
+  color,
+  height = 40,
+}: {
+  data: number[];
+  color: string;
+  height?: number;
+}) {
+  if (data.length < 2) return null;
+  const W = 200;
+  const PAD = 2;
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1;
+  const xScale = scaleLinear()
+    .domain([0, data.length - 1])
+    .range([PAD, W - PAD]);
+  const yScale = scaleLinear()
+    .domain([min - range * 0.1, max + range * 0.1])
+    .range([height - PAD, PAD]);
+  const pts = data.map((v, i) => `${xScale(i).toFixed(1)},${yScale(v).toFixed(1)}`).join(' ');
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${height}`}
+      preserveAspectRatio="none"
+      className="w-full"
+      style={{ height }}
+    >
+      <polyline fill="none" stroke={color} strokeWidth="2" strokeLinejoin="round" points={pts} />
+    </svg>
+  );
+}
+
+const DECENTRALIZATION_METRICS = [
+  {
+    key: 'nakamoto_coefficient',
+    label: 'Nakamoto Coefficient',
+    color: '#818cf8',
+    format: (v: number) => String(v),
+  },
+  { key: 'gini', label: 'Gini Coefficient', color: '#f472b6', format: (v: number) => v.toFixed(3) },
+  {
+    key: 'composite_score',
+    label: 'Composite Score',
+    color: '#34d399',
+    format: (v: number) => v.toFixed(1),
+  },
+  { key: 'hhi', label: 'HHI', color: '#fbbf24', format: (v: number) => v.toFixed(4) },
+] as const;
+
+function DecentralizationTrends({ history }: { history: any[] }) {
+  if (history.length < 3) return null;
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {DECENTRALIZATION_METRICS.map((m) => {
+        const values = history.map((h) => h[m.key]).filter((v) => v != null) as number[];
+        if (values.length < 2) return null;
+        const latest = values[values.length - 1];
+        const prev = values[values.length - 2];
+        const delta = latest - prev;
+        return (
+          <div key={m.key} className="rounded-xl border border-border bg-card p-3 space-y-1.5">
+            <div className="flex items-center justify-between">
+              <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
+                {m.label}
+              </p>
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-bold tabular-nums text-foreground">
+                  {m.format(latest)}
+                </span>
+                {delta !== 0 && (
+                  <span
+                    className={cn(
+                      'text-[10px] font-medium tabular-nums',
+                      delta > 0 ? 'text-emerald-400' : 'text-rose-400',
+                    )}
+                  >
+                    {delta > 0 ? '+' : ''}
+                    {m.format(delta)}
+                  </span>
+                )}
+              </div>
+            </div>
+            <MiniSparkline data={values} color={m.color} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function InterBodySummary({ interBody }: { interBody: any }) {
+  const pairs = [
+    { label: 'DRep ↔ SPO', value: interBody.drepSpoAgreement },
+    { label: 'DRep ↔ CC', value: interBody.drepCcAgreement },
+    { label: 'SPO ↔ CC', value: interBody.spoCcAgreement },
+  ].filter((p) => p.value != null && p.value > 0);
+
+  if (pairs.length === 0) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1">
+        <GitBranch className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-bold uppercase tracking-wider">Inter-Body Alignment</h3>
+      </div>
+      <p className="text-xs text-muted-foreground mb-4">
+        How often DReps, SPOs, and the Constitutional Committee vote the same way.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {pairs.map((p) => {
+          const pct = Math.round(p.value);
+          return (
+            <div key={p.label} className="rounded-xl border border-border bg-card p-4 space-y-2">
+              <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
+                {p.label}
+              </p>
+              <p
+                className={cn(
+                  'font-display text-2xl font-bold tabular-nums',
+                  pct >= 70 ? 'text-emerald-400' : pct >= 40 ? 'text-amber-400' : 'text-rose-400',
+                )}
+              >
+                {pct}%
+              </p>
+              <div className="w-full h-2 bg-border rounded-full overflow-hidden">
+                <div
+                  className={cn(
+                    'h-full rounded-full',
+                    pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-rose-500',
+                  )}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {interBody.proposalCount > 0 && (
+        <p className="text-[10px] text-muted-foreground mt-2">
+          Based on {interBody.proposalCount} proposal{interBody.proposalCount !== 1 ? 's' : ''} with
+          multi-body votes
+        </p>
+      )}
+    </div>
+  );
+}
+
 function ChainComparisonBar({ chain, benchmark }: { chain: string; benchmark: ChainBenchmark }) {
   const model = GOVERNANCE_MODELS[chain as keyof typeof GOVERNANCE_MODELS];
   const metrics = getChainMetrics(benchmark);
@@ -172,6 +323,7 @@ export function CivicaObservatory() {
   const { data: rawGHI, isLoading: ghiLoading } = useGovernanceHealthIndex(1);
   const { data: rawBenchmarks, isLoading: benchLoading } = useGovernanceBenchmarks();
   const { data: rawDecentralization } = useGovernanceDecentralization();
+  const { data: rawInterBody } = useGovernanceInterBody();
 
   const ghi = (rawGHI as any)?.current ?? rawGHI;
   const benchmarksObj = ((rawBenchmarks as any)?.benchmarks ?? {}) as Record<string, any>;
@@ -189,8 +341,10 @@ export function CivicaObservatory() {
       fetchedAt: row.fetched_at ?? row.fetchedAt ?? '',
     }));
   const decentralization = rawDecentralization as any;
+  const interBody = rawInterBody as any;
 
   const ediMetrics = buildEDIMetrics(ghi, decentralization);
+  const decHistory: any[] = decentralization?.history ?? [];
   const topDRepsByPower = (decentralization?.topDRepsByPower ?? []) as {
     drepId: string;
     name: string;
@@ -230,6 +384,12 @@ export function CivicaObservatory() {
           </div>
         )}
       </div>
+
+      {/* Decentralization trends */}
+      <DecentralizationTrends history={decHistory} />
+
+      {/* Inter-body alignment */}
+      {interBody && interBody.proposalCount > 0 && <InterBodySummary interBody={interBody} />}
 
       {/* Voting power treemap */}
       {topDRepsByPower.length > 0 && (

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -402,6 +402,90 @@ export function CivicaPulseOverview() {
             </div>
           )}
 
+          {/* ── Community vs DRep Sentiment Gap ─────────────────── */}
+          {pulse?.communityGap?.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Community vs DRep Sentiment
+              </p>
+              <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
+                {(pulse.communityGap as any[]).slice(0, 3).map((g: any) => {
+                  const pollTotal = g.pollTotal || 1;
+                  const yesPct = Math.round((g.pollYes / pollTotal) * 100);
+                  const noPct = Math.round((g.pollNo / pollTotal) * 100);
+                  return (
+                    <Link
+                      key={`${g.txHash}-${g.index}`}
+                      href={`/proposal/${g.txHash}/${g.index}`}
+                      className="block px-4 py-3 hover:bg-muted/20 transition-colors"
+                    >
+                      <p className="text-sm truncate mb-1.5">{g.title}</p>
+                      <div className="flex items-center gap-3 text-[11px]">
+                        <span className="text-muted-foreground">
+                          Community: <strong className="text-emerald-400">{yesPct}% Yes</strong>
+                          {' / '}
+                          <strong className="text-rose-400">{noPct}% No</strong>
+                          <span className="text-muted-foreground/60"> ({pollTotal} votes)</span>
+                        </span>
+                        <span className="text-muted-foreground">
+                          DReps: <strong className="text-foreground">{g.drepVotePct}%</strong> voted
+                        </span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* ── Treasury Health Components ─────────────────────── */}
+          {treasury?.healthComponents && (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Treasury Health Breakdown
+              </p>
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {(treasury.healthComponents as any[]).map((c: any) => (
+                  <div
+                    key={c.name ?? c.label}
+                    className="rounded-xl border border-border bg-card px-4 py-3 space-y-1.5"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium truncate">
+                        {c.name ?? c.label}
+                      </p>
+                      <span
+                        className={cn(
+                          'text-sm font-bold tabular-nums',
+                          (c.score ?? c.value ?? 0) >= 70
+                            ? 'text-emerald-400'
+                            : (c.score ?? c.value ?? 0) >= 40
+                              ? 'text-amber-400'
+                              : 'text-rose-400',
+                        )}
+                      >
+                        {Math.round(c.score ?? c.value ?? 0)}
+                      </span>
+                    </div>
+                    <div className="w-full h-1.5 bg-border rounded-full overflow-hidden">
+                      <div
+                        className={cn(
+                          'h-full rounded-full',
+                          (c.score ?? c.value ?? 0) >= 70
+                            ? 'bg-emerald-500'
+                            : (c.score ?? c.value ?? 0) >= 40
+                              ? 'bg-amber-500'
+                              : 'bg-rose-500',
+                        )}
+                        style={{ width: `${Math.min(100, c.score ?? c.value ?? 0)}%` }}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* ── ADA governed ────────────────────────────────────── */}
           {pulse?.totalAdaGoverned && (
             <div className="rounded-xl border border-border bg-muted/10 px-5 py-4 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- **Overview tab**: Surface community vs DRep sentiment gap (API returned it, frontend ignored it) + treasury health score component breakdown
- **Observatory tab**: Decentralization trend sparklines (Nakamoto coefficient, Gini, HHI, composite score — 20 epochs of history, previously invisible) + inter-body alignment summary (DRep/SPO/CC agreement percentages)
- **Calendar tab**: Participation trend bar chart (last 20 epochs) + enriched epoch recap cards showing submitted/dropped/expired/participation/AI narrative

## Test plan
- [ ] Overview: community sentiment cards render when poll data exists
- [ ] Overview: treasury health components show breakdown bars
- [ ] Observatory: 4 decentralization trend sparklines with values and deltas
- [ ] Observatory: inter-body alignment section shows DRep↔SPO, DRep↔CC, SPO↔CC
- [ ] Calendar: participation trend bar chart visible below epoch hero
- [ ] Calendar: past epoch cards show participation %, submitted count, dropped/expired
- [ ] All 306 tests pass, preflight clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)