### PR TITLE
feat: replace window.prompt with searchable admin View As picker

### DIFF
--- a/components/civica/AdminViewAsPicker.tsx
+++ b/components/civica/AdminViewAsPicker.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Search } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { computeTier } from '@/lib/scoring/tiers';
+
+type PickerMode = 'drep' | 'spo';
+
+interface AdminViewAsPickerProps {
+  mode: PickerMode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (id: string) => void;
+  titleOverride?: string;
+  descriptionOverride?: string;
+}
+
+interface DRepItem {
+  drepId: string;
+  name?: string | null;
+  ticker?: string | null;
+  drepScore?: number | null;
+  isActive?: boolean;
+}
+
+interface PoolItem {
+  poolId: string;
+  poolName?: string | null;
+  ticker?: string | null;
+  governanceScore?: number | null;
+}
+
+function useDRepList(enabled: boolean) {
+  return useQuery({
+    queryKey: ['admin-view-as-dreps'],
+    queryFn: async () => {
+      const res = await fetch('/api/dreps');
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.allDReps ?? []) as DRepItem[];
+    },
+    enabled,
+    staleTime: 120_000,
+  });
+}
+
+function usePoolList(enabled: boolean) {
+  return useQuery({
+    queryKey: ['admin-view-as-pools'],
+    queryFn: async () => {
+      const res = await fetch('/api/governance/pools');
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.pools ?? []) as PoolItem[];
+    },
+    enabled,
+    staleTime: 120_000,
+  });
+}
+
+function truncateId(id: string) {
+  if (id.length <= 20) return id;
+  return `${id.slice(0, 12)}...${id.slice(-6)}`;
+}
+
+function ScoreBadge({ score }: { score: number | null | undefined }) {
+  if (score == null) return <span className="text-xs text-muted-foreground">--</span>;
+  const tier = computeTier(score);
+  const colors: Record<string, string> = {
+    Emerging: 'text-muted-foreground',
+    Bronze: 'text-amber-700 dark:text-amber-500',
+    Silver: 'text-slate-500 dark:text-slate-400',
+    Gold: 'text-yellow-600 dark:text-yellow-400',
+    Diamond: 'text-cyan-600 dark:text-cyan-400',
+    Legendary: 'text-purple-600 dark:text-purple-400',
+  };
+  return (
+    <span
+      className={`text-xs font-semibold tabular-nums ${colors[tier] ?? 'text-muted-foreground'}`}
+    >
+      {Math.round(score)}
+    </span>
+  );
+}
+
+export function AdminViewAsPicker({
+  mode,
+  open,
+  onOpenChange,
+  onSelect,
+  titleOverride,
+  descriptionOverride,
+}: AdminViewAsPickerProps) {
+  const [search, setSearch] = useState('');
+  const { data: dreps, isLoading: drepsLoading } = useDRepList(open && mode === 'drep');
+  const { data: pools, isLoading: poolsLoading } = usePoolList(open && mode === 'spo');
+
+  const isLoading = mode === 'drep' ? drepsLoading : poolsLoading;
+
+  const filteredDreps = useMemo(() => {
+    if (mode !== 'drep' || !dreps) return [];
+    const q = search.toLowerCase().trim();
+    if (!q) return dreps.slice(0, 100);
+    return dreps
+      .filter(
+        (d) =>
+          d.drepId.toLowerCase().includes(q) ||
+          d.name?.toLowerCase().includes(q) ||
+          d.ticker?.toLowerCase().includes(q),
+      )
+      .slice(0, 100);
+  }, [mode, dreps, search]);
+
+  const filteredPools = useMemo(() => {
+    if (mode !== 'spo' || !pools) return [];
+    const q = search.toLowerCase().trim();
+    if (!q) return pools.slice(0, 100);
+    return pools
+      .filter(
+        (p) =>
+          p.poolId.toLowerCase().includes(q) ||
+          p.poolName?.toLowerCase().includes(q) ||
+          p.ticker?.toLowerCase().includes(q),
+      )
+      .slice(0, 100);
+  }, [mode, pools, search]);
+
+  const handleSelect = (id: string) => {
+    onSelect(id);
+    onOpenChange(false);
+    setSearch('');
+  };
+
+  const title = titleOverride ?? (mode === 'drep' ? 'Select a DRep' : 'Select a Stake Pool');
+  const description =
+    descriptionOverride ??
+    (mode === 'drep'
+      ? 'View the app as this DRep. Sorted by score.'
+      : 'View the app as this SPO. Sorted by governance score.');
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        onOpenChange(v);
+        if (!v) setSearch('');
+      }}
+    >
+      <DialogContent className="sm:max-w-md max-h-[80vh] flex flex-col gap-3">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder={
+              mode === 'drep' ? 'Search by name or ID...' : 'Search by ticker, name, or ID...'
+            }
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+
+        <div className="overflow-y-auto min-h-0 max-h-[50vh] -mx-2 px-2">
+          {isLoading ? (
+            <div className="space-y-2 py-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-12 rounded-md bg-muted/50 animate-pulse" />
+              ))}
+            </div>
+          ) : mode === 'drep' ? (
+            filteredDreps.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-6 text-center">No DReps found.</p>
+            ) : (
+              <div className="space-y-0.5 py-1">
+                {filteredDreps.map((d) => (
+                  <button
+                    key={d.drepId}
+                    onClick={() => handleSelect(d.drepId)}
+                    className="w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-left hover:bg-accent transition-colors cursor-pointer"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">
+                        {d.name || d.ticker || truncateId(d.drepId)}
+                      </div>
+                      {(d.name || d.ticker) && (
+                        <div className="text-xs text-muted-foreground truncate">
+                          {truncateId(d.drepId)}
+                        </div>
+                      )}
+                    </div>
+                    <ScoreBadge score={d.drepScore} />
+                  </button>
+                ))}
+              </div>
+            )
+          ) : filteredPools.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6 text-center">No pools found.</p>
+          ) : (
+            <div className="space-y-0.5 py-1">
+              {filteredPools.map((p) => (
+                <button
+                  key={p.poolId}
+                  onClick={() => handleSelect(p.poolId)}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-md text-left hover:bg-accent transition-colors cursor-pointer"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">
+                      {p.ticker
+                        ? `[${p.ticker}] ${p.poolName || ''}`.trim()
+                        : p.poolName || truncateId(p.poolId)}
+                    </div>
+                    {(p.poolName || p.ticker) && (
+                      <div className="text-xs text-muted-foreground truncate">
+                        {truncateId(p.poolId)}
+                      </div>
+                    )}
+                  </div>
+                  <ScoreBadge score={p.governanceScore} />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -17,6 +17,7 @@ import {
   Moon,
   Eye,
 } from 'lucide-react';
+import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
 import { useWallet } from '@/utils/wallet-context';
@@ -59,13 +60,14 @@ const SEGMENT_LABELS: Record<UserSegment, string> = {
 export function CivicaHeader() {
   const pathname = usePathname();
   const { connected, disconnect } = useWallet();
-  const { segment, realSegment, stakeAddress, setOverride } = useSegment();
+  const { segment, realSegment, stakeAddress, delegatedDrep, setOverride } = useSegment();
   const { data: adminData } = useAdminCheck(connected);
   const isAdmin = adminData?.isAdmin === true;
   const hasOverride = segment !== realSegment;
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
   const { resolvedTheme, setTheme } = useTheme();
   const [walletModalOpen, setWalletModalOpen] = useState(false);
+  const [pickerMode, setPickerMode] = useState<'drep' | 'spo' | 'citizen-delegation' | null>(null);
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -143,7 +145,8 @@ export function CivicaHeader() {
             size="icon"
             className="h-8 w-8 text-muted-foreground hover:text-foreground"
             onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-            aria-label={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
+            aria-label="Toggle theme"
+            suppressHydrationWarning
           >
             <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
             <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
@@ -183,41 +186,33 @@ export function CivicaHeader() {
                         <DropdownMenuLabel className="text-xs text-muted-foreground">
                           Simulate segment
                         </DropdownMenuLabel>
-                        <DropdownMenuItem
-                          onClick={() =>
-                            setOverride(realSegment === 'citizen' ? null : { segment: 'citizen' })
-                          }
-                        >
-                          Citizen
-                          {realSegment === 'citizen' && ' (yours)'}
-                          {segment === 'citizen' && hasOverride && ' ✓'}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => {
-                            const id = window.prompt(
-                              'Enter DRep ID (drep1...):',
-                              realSegment === 'drep' ? '' : 'drep1...',
-                            );
-                            if (id?.trim()) {
-                              setOverride({ segment: 'drep', drepId: id.trim() });
-                            }
-                          }}
-                        >
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            Citizen
+                            {realSegment === 'citizen' && ' (yours)'}
+                            {segment === 'citizen' && hasOverride && ' ✓'}
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                setOverride({ segment: 'citizen', delegatedDrep: null })
+                              }
+                            >
+                              Undelegated
+                              {segment === 'citizen' && !delegatedDrep && hasOverride && ' ✓'}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => setPickerMode('citizen-delegation')}>
+                              Delegated to...
+                              {segment === 'citizen' && delegatedDrep && hasOverride && ' ✓'}
+                            </DropdownMenuItem>
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                        <DropdownMenuItem onClick={() => setPickerMode('drep')}>
                           DRep
                           {realSegment === 'drep' && ' (yours)'}
                           {segment === 'drep' && hasOverride && ' ✓'}
                         </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => {
-                            const id = window.prompt(
-                              'Enter Pool ID (pool1...):',
-                              realSegment === 'spo' ? '' : 'pool1...',
-                            );
-                            if (id?.trim()) {
-                              setOverride({ segment: 'spo', poolId: id.trim() });
-                            }
-                          }}
-                        >
+                        <DropdownMenuItem onClick={() => setPickerMode('spo')}>
                           SPO
                           {realSegment === 'spo' && ' (yours)'}
                           {segment === 'spo' && hasOverride && ' ✓'}
@@ -257,6 +252,28 @@ export function CivicaHeader() {
           )}
         </div>
       </div>
+      {isAdmin && pickerMode && (
+        <AdminViewAsPicker
+          mode={pickerMode === 'citizen-delegation' ? 'drep' : pickerMode}
+          open={!!pickerMode}
+          onOpenChange={(open) => {
+            if (!open) setPickerMode(null);
+          }}
+          onSelect={(id) => {
+            if (pickerMode === 'citizen-delegation') {
+              setOverride({ segment: 'citizen', delegatedDrep: id });
+            } else if (pickerMode === 'drep') {
+              setOverride({ segment: 'drep', drepId: id });
+            } else {
+              setOverride({ segment: 'spo', poolId: id });
+            }
+          }}
+          {...(pickerMode === 'citizen-delegation' && {
+            titleOverride: 'Delegate to a DRep',
+            descriptionOverride: 'View the app as a citizen delegated to this DRep.',
+          })}
+        />
+      )}
     </header>
   );
 }

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -9,6 +9,8 @@ export interface SegmentOverride {
   segment: UserSegment;
   drepId?: string;
   poolId?: string;
+  delegatedDrep?: string | null;
+  delegatedPool?: string | null;
 }
 
 export interface SegmentState {
@@ -148,6 +150,14 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
     realSegment: detectedSegment,
     drepId: override?.drepId ?? detected.drepId,
     poolId: override?.poolId ?? detected.poolId,
+    delegatedDrep:
+      override && 'delegatedDrep' in override
+        ? (override.delegatedDrep ?? null)
+        : detected.delegatedDrep,
+    delegatedPool:
+      override && 'delegatedPool' in override
+        ? (override.delegatedPool ?? null)
+        : detected.delegatedPool,
     setOverride,
   };
 


### PR DESCRIPTION
## Summary
- Replace ugly `window.prompt()` dialogs for DRep/SPO admin "View as" with a proper searchable dialog
- New `AdminViewAsPicker` component: searchable list with names, scores (tier-colored), sorted by score
- Extend citizen simulation: choose between undelegated and delegated-to-specific-DRep
- Extend `SegmentOverride` to support `delegatedDrep`/`delegatedPool` overrides

## Test plan
- [ ] Connect wallet with admin permissions
- [ ] Open user menu → View as → DRep: verify searchable dialog with scores appears
- [ ] Open user menu → View as → SPO: verify searchable dialog with governance scores appears
- [ ] Open user menu → View as → Citizen → Undelegated: verify delegation state clears
- [ ] Open user menu → View as → Citizen → Delegated to...: verify DRep picker opens with contextual title
- [ ] Verify search filtering works in all picker modes
- [ ] Verify Reset to [segment] still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)