### PR TITLE
fix: correct column names in SPO profile query

### DIFF
--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -69,7 +69,7 @@ async function getPoolRow(poolId: string) {
     const { data, error } = await supabase
       .from('pools')
       .select(
-        'pool_id, ticker, pool_name, pledge, governance_score, participation_pct, deliberation_pct, consistency_pct, reliability_pct, governance_identity_pct, confidence, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, delegator_count, live_stake, vote_count, governance_statement, current_tier, score_momentum',
+        'pool_id, ticker, pool_name, pledge_lovelace, governance_score, participation_pct, deliberation_pct, consistency_pct, reliability_pct, governance_identity_pct, confidence, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, delegator_count, live_stake_lovelace, vote_count, governance_statement, current_tier, score_momentum',
       )
       .eq('pool_id', poolId)
       .single();
@@ -339,8 +339,8 @@ export default async function PoolProfilePage({ params }: PageProps) {
   const ticker = (poolRow.ticker as string) || null;
   const governanceScore = (poolRow.governance_score as number) ?? 0;
   const delegatorCount = (poolRow.delegator_count as number) ?? 0;
-  const liveStake = poolRow.live_stake;
-  const pledge = poolRow.pledge;
+  const liveStake = poolRow.live_stake_lovelace;
+  const pledge = poolRow.pledge_lovelace;
   const voteCount = (poolRow.vote_count as number) ?? totalVotes;
   const participationPillar = (poolRow.participation_pct as number) ?? participationRate;
   const deliberationPillar = (poolRow.deliberation_pct as number) ?? null;


### PR DESCRIPTION
## Summary
- `getPoolRow` selected `pledge` and `live_stake` but the actual DB columns are `pledge_lovelace` and `live_stake_lovelace`
- PostgREST returned 400 for every pool, making `getPoolRow` always return null
- **All 513 scored SPO profiles** showed the minimal unscored fallback view instead of the enriched governance profile (tier, score, alignment radar, tabs, etc.)

## Test plan
- [ ] Visit any scored SPO profile (e.g. `/pool/pool1xlfty06hg6q23qvcaxwv3p9ke7ff9n34qpr8tpxt2zflyq20ceh`) — should show full governance score, tier badge, alignment radar, and tabbed analysis
- [ ] Verify pledge and live stake values render correctly in the pool details section
- [ ] Verify unscored pools still show the minimal fallback view

🤖 Generated with [Claude Code](https://claude.com/claude-code)