### PR TITLE
feat: globe constellation prototype (flag-gated)

### DIFF
--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -26,6 +26,14 @@ const GovernanceConstellation = dynamic(
   { ssr: false },
 );
 
+const GlobeConstellation = dynamic(
+  () =>
+    import('@/components/GlobeConstellation').then((m) => ({
+      default: m.GlobeConstellation,
+    })),
+  { ssr: false },
+);
+
 interface PersonalCardData {
   segment: UserSegment;
   [key: string]: any;
@@ -63,6 +71,8 @@ export function ConstellationHero({
 
   const interactiveFlag = useFeatureFlag('interactive_constellation');
   const isInteractive = interactiveFlag === true;
+  const globeFlag = useFeatureFlag('globe_constellation');
+  const useGlobe = globeFlag === true;
   const [selectedNode, setSelectedNode] = useState<ConstellationNode3D | null>(null);
 
   useEffect(() => {
@@ -254,14 +264,25 @@ export function ConstellationHero({
       className={`relative w-full transition-all duration-700 -mt-16 ${contracted ? 'min-h-[calc(35vh+4rem)]' : 'min-h-[calc(65vh+4rem)]'}`}
       onMouseEnter={handleConstellationHover}
     >
-      <GovernanceConstellation
-        ref={constellationRef}
-        interactive={isInteractive}
-        onReady={handleConstellationReady}
-        onContracted={handleConstellationContracted}
-        onNodeSelect={isInteractive ? handleNodeSelect : undefined}
-        className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
-      />
+      {useGlobe ? (
+        <GlobeConstellation
+          ref={constellationRef}
+          interactive={isInteractive}
+          onReady={handleConstellationReady}
+          onContracted={handleConstellationContracted}
+          onNodeSelect={isInteractive ? handleNodeSelect : undefined}
+          className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
+        />
+      ) : (
+        <GovernanceConstellation
+          ref={constellationRef}
+          interactive={isInteractive}
+          onReady={handleConstellationReady}
+          onContracted={handleConstellationContracted}
+          onNodeSelect={isInteractive ? handleNodeSelect : undefined}
+          className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
+        />
+      )}
 
       {/* SSR gradient fallback */}
       <div

--- a/components/GlobeConstellation.tsx
+++ b/components/GlobeConstellation.tsx
@@ -1,0 +1,841 @@
+'use client';
+
+import {
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  useState,
+  useMemo,
+  useCallback,
+} from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { useGovernanceConstellation } from '@/hooks/queries';
+import { CameraControls } from '@react-three/drei';
+import { EffectComposer, Bloom } from '@react-three/postprocessing';
+import * as THREE from 'three';
+import { computeGlobeLayout } from '@/lib/constellation/globe-layout';
+import type {
+  ConstellationApiData,
+  FindMeTarget,
+  ConstellationNode3D,
+  ConstellationEdge3D,
+} from '@/lib/constellation/types';
+
+export type { ConstellationRef } from '@/components/GovernanceConstellation';
+
+const DREP_COLOR = '#2dd4bf';
+const SPO_COLOR = '#06b6d4';
+const CC_COLOR = '#fbbf24';
+const CORE_COLOR = '#fff0d4';
+const GLOBE_LINE_COLOR = '#334488';
+
+interface GlobeConstellationProps {
+  interactive?: boolean;
+  onReady?: () => void;
+  onContracted?: () => void;
+  onNodeSelect?: (node: ConstellationNode3D) => void;
+  className?: string;
+}
+
+interface SceneState {
+  nodes: ConstellationNode3D[];
+  edges: ConstellationEdge3D[];
+  nodeMap: Map<string, ConstellationNode3D>;
+  highlightId: string | null;
+  dimmed: boolean;
+  pulseId: string | null;
+  animating: boolean;
+}
+
+// Earth-like axial tilt: 23.4 degrees
+const AXIAL_TILT = 23.4 * (Math.PI / 180);
+const INITIAL_CAMERA: [number, number, number] = [0, -12, 14];
+const INITIAL_TARGET: [number, number, number] = [0, 0, 0];
+const ROTATION_SPEED = 0.04; // slightly slower than flat — globe needs to be readable
+
+export const GlobeConstellation = forwardRef<
+  import('@/components/GovernanceConstellation').ConstellationRef,
+  GlobeConstellationProps
+>(function GlobeConstellation(
+  { interactive, onReady, onContracted, onNodeSelect, className },
+  ref,
+) {
+  const cameraControlsRef = useRef<CameraControls>(null);
+  const rotationAngleRef = useRef(0);
+  const [ready, setReady] = useState(false);
+  const [sceneState, setSceneState] = useState<SceneState>({
+    nodes: [],
+    edges: [],
+    nodeMap: new Map(),
+    highlightId: null,
+    dimmed: false,
+    pulseId: null,
+    animating: false,
+  });
+  const [quality, setQuality] = useState<'low' | 'mid' | 'high'>('high');
+
+  const onNodeSelectRef = useRef(onNodeSelect);
+  useEffect(() => {
+    onNodeSelectRef.current = onNodeSelect;
+  }, [onNodeSelect]);
+
+  const flyToNodeImpl = async (nodeId: string): Promise<ConstellationNode3D | null> => {
+    const controls = cameraControlsRef.current;
+    if (!controls || sceneState.nodes.length === 0) return null;
+
+    const node = sceneState.nodes.find((n) => n.id === nodeId || n.fullId === nodeId);
+    if (!node || node.isAnchor) return null;
+
+    setSceneState((prev) => ({ ...prev, animating: true, highlightId: node.id, dimmed: true }));
+
+    const [x, y, z] = rotateAroundY(node.position, rotationAngleRef.current);
+    await controls.setLookAt(x * 1.5, y * 1.5, z * 1.5 + 3, x, y, z, true);
+
+    onNodeSelectRef.current?.(node);
+    return node;
+  };
+
+  useImperativeHandle(ref, () => ({
+    findMe: async (target: FindMeTarget) => {
+      const controls = cameraControlsRef.current;
+      if (!controls || sceneState.nodes.length === 0) return;
+      setSceneState((prev) => ({ ...prev, animating: true }));
+
+      if (target.type === 'undelegated') {
+        // Place user node on the globe surface at a visible spot
+        const edgePos: [number, number, number] = [7, -4, 2];
+        setSceneState((prev) => ({
+          ...prev,
+          highlightId: '__user__',
+          dimmed: true,
+          nodes: [
+            ...prev.nodes,
+            {
+              id: '__user__',
+              fullId: '__user__',
+              name: 'You',
+              power: 0,
+              score: 50,
+              dominant: 'transparency',
+              alignments: [50, 50, 50, 50, 50, 50],
+              position: edgePos,
+              scale: 0.08,
+              nodeType: 'drep',
+            },
+          ],
+        }));
+        const rotated = rotateAroundY(edgePos, rotationAngleRef.current);
+        await controls.setLookAt(rotated[0], rotated[1], 16, rotated[0], rotated[1], 0, true);
+        await sleep(2000);
+        setSceneState((prev) => ({ ...prev, animating: false }));
+        onContracted?.();
+        return;
+      }
+
+      const drepId = target.drepId;
+      if (!drepId) {
+        setSceneState((prev) => ({ ...prev, animating: false }));
+        onContracted?.();
+        return;
+      }
+
+      const node = sceneState.nodeMap.get(drepId);
+      if (!node) {
+        setSceneState((prev) => ({ ...prev, animating: false }));
+        onContracted?.();
+        return;
+      }
+
+      setSceneState((prev) => ({ ...prev, highlightId: drepId, dimmed: true }));
+
+      const [x, y, z] = rotateAroundY(node.position, rotationAngleRef.current);
+      await controls.setLookAt(x * 1.5, y * 1.5, z * 1.5 + 3, x, y, z, true);
+      await sleep(2000);
+
+      setSceneState((prev) => ({ ...prev, highlightId: null, dimmed: false }));
+      await controls.setLookAt(...INITIAL_CAMERA, ...INITIAL_TARGET, true);
+      await sleep(800);
+      setSceneState((prev) => ({ ...prev, animating: false }));
+      onContracted?.();
+    },
+
+    flyToNode: flyToNodeImpl,
+
+    pulseNode: (drepId: string) => {
+      setSceneState((prev) => ({ ...prev, pulseId: drepId }));
+      setTimeout(() => setSceneState((prev) => ({ ...prev, pulseId: null })), 1200);
+    },
+
+    resetCamera: () => {
+      cameraControlsRef.current?.setLookAt(...INITIAL_CAMERA, ...INITIAL_TARGET, true);
+      setSceneState((prev) => ({
+        ...prev,
+        highlightId: null,
+        dimmed: false,
+        animating: false,
+      }));
+    },
+  }));
+
+  const { data: apiData } = useGovernanceConstellation();
+
+  useEffect(() => {
+    if (!apiData) return;
+    const gpu = estimateGPUTier();
+    setQuality(gpu);
+    const nodeLimit = gpu === 'low' ? 200 : gpu === 'mid' ? 500 : 800;
+    const typedData = apiData as ConstellationApiData;
+    const { nodes, edges, nodeMap } = computeGlobeLayout(typedData.nodes, nodeLimit);
+    setSceneState((prev) => ({ ...prev, nodes, edges, nodeMap }));
+    setReady(true);
+    onReady?.();
+  }, [apiData, onReady]);
+
+  const dpr =
+    quality === 'low' ? 1 : quality === 'mid' ? 1.5 : Math.min(window.devicePixelRatio, 2);
+
+  return (
+    <div className={`relative z-0 w-full ${className || ''}`} style={{ background: '#0a0b14' }}>
+      {ready && (
+        <Canvas
+          dpr={dpr}
+          camera={{ position: INITIAL_CAMERA, fov: 60 }}
+          gl={{ antialias: false, alpha: false, powerPreference: 'high-performance' }}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            pointerEvents: interactive ? 'auto' : 'none',
+          }}
+          role="img"
+          aria-label="Interactive 3D globe visualization of Cardano governance"
+        >
+          <color attach="background" args={['#0a0b14']} />
+          <ambientLight intensity={0.05} />
+
+          <AmbientStarfield count={quality === 'low' ? 200 : 400} />
+          <TiltedGlobeGroup enabled={!sceneState.animating} rotationRef={rotationAngleRef}>
+            <GovernanceCore />
+            <GlobeWireframe radius={8} opacity={0.12} />
+            <GlobeWireframe radius={3.5} opacity={0.06} />
+            <ConstellationNodes
+              nodes={sceneState.nodes}
+              highlightId={sceneState.highlightId}
+              dimmed={sceneState.dimmed}
+              pulseId={sceneState.pulseId}
+              interactive={interactive}
+              onNodeClick={interactive ? (node) => flyToNodeImpl(node.id) : undefined}
+            />
+            <ConstellationEdges edges={sceneState.edges} dimmed={sceneState.dimmed} />
+          </TiltedGlobeGroup>
+          <ShootingStars />
+
+          {quality !== 'low' && (
+            <EffectComposer>
+              <Bloom
+                mipmapBlur
+                intensity={1.6}
+                luminanceThreshold={0.15}
+                luminanceSmoothing={0.9}
+                radius={0.95}
+              />
+            </EffectComposer>
+          )}
+
+          <CameraControls
+            ref={cameraControlsRef}
+            makeDefault
+            smoothTime={0.8}
+            mouseButtons={{ left: 0, middle: 0, right: 0, wheel: 0 }}
+            touches={{ one: 0, two: 0, three: 0 }}
+          />
+        </Canvas>
+      )}
+    </div>
+  );
+});
+
+// --- Globe wireframe (lat/lon lines) ---
+
+function GlobeWireframe({ radius, opacity }: { radius: number; opacity: number }) {
+  const geometry = useMemo(() => {
+    const points: number[] = [];
+    const segments = 64;
+
+    // Latitude lines at 30° intervals: -60, -30, 0, 30, 60
+    for (let latDeg = -60; latDeg <= 60; latDeg += 30) {
+      const lat = (latDeg * Math.PI) / 180;
+      const r = radius * Math.cos(lat);
+      const z = radius * Math.sin(lat);
+      for (let i = 0; i < segments; i++) {
+        const a1 = (i / segments) * Math.PI * 2;
+        const a2 = ((i + 1) / segments) * Math.PI * 2;
+        points.push(r * Math.cos(a1), r * Math.sin(a1), z);
+        points.push(r * Math.cos(a2), r * Math.sin(a2), z);
+      }
+    }
+
+    // Longitude lines at 30° intervals (12 meridians)
+    for (let lonDeg = 0; lonDeg < 360; lonDeg += 30) {
+      const lon = (lonDeg * Math.PI) / 180;
+      for (let i = 0; i < segments; i++) {
+        const lat1 = (i / segments) * Math.PI - Math.PI / 2;
+        const lat2 = ((i + 1) / segments) * Math.PI - Math.PI / 2;
+        points.push(
+          radius * Math.cos(lat1) * Math.cos(lon),
+          radius * Math.cos(lat1) * Math.sin(lon),
+          radius * Math.sin(lat1),
+        );
+        points.push(
+          radius * Math.cos(lat2) * Math.cos(lon),
+          radius * Math.cos(lat2) * Math.sin(lon),
+          radius * Math.sin(lat2),
+        );
+      }
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(points, 3));
+    return geo;
+  }, [radius]);
+
+  return (
+    <lineSegments geometry={geometry}>
+      <lineBasicMaterial
+        color={GLOBE_LINE_COLOR}
+        transparent
+        opacity={opacity}
+        toneMapped={false}
+        depthWrite={false}
+      />
+    </lineSegments>
+  );
+}
+
+// --- Point sprite shaders (same as original constellation) ---
+
+const POINT_SCALE = 3.0;
+
+const NODE_VERT = /* glsl */ `
+attribute float aSize;
+attribute float aDimmed;
+attribute vec3 aNodeColor;
+varying vec3 vColor;
+varying float vAlpha;
+
+void main() {
+  vColor = aNodeColor;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = aSize * 600.0 / -mvPosition.z;
+  gl_PointSize = clamp(gl_PointSize, 1.0, 128.0);
+  vAlpha = aDimmed < 0.5 ? 1.0 : 0.15;
+  gl_Position = projectionMatrix * mvPosition;
+}
+`;
+
+const NODE_FRAG = /* glsl */ `
+varying vec3 vColor;
+varying float vAlpha;
+
+void main() {
+  float dist = length(gl_PointCoord - vec2(0.5));
+  if (dist > 0.5) discard;
+  float glow = 1.0 - smoothstep(0.0, 0.5, dist);
+  float core = 1.0 - smoothstep(0.0, 0.15, dist);
+  vec3 col = vColor * (1.0 + core * 1.5);
+  gl_FragColor = vec4(col, glow * vAlpha);
+}
+`;
+
+// --- Scene sub-components ---
+
+function RaycastConfig() {
+  const raycaster = useThree((s) => s.raycaster);
+  useEffect(() => {
+    raycaster.params.Points = { threshold: 0.35 };
+  }, [raycaster]);
+  return null;
+}
+
+function ConstellationNodes({
+  nodes,
+  highlightId,
+  dimmed,
+  pulseId,
+  interactive,
+  onNodeClick,
+}: {
+  nodes: ConstellationNode3D[];
+  highlightId: string | null;
+  dimmed: boolean;
+  pulseId: string | null;
+  interactive?: boolean;
+  onNodeClick?: (node: ConstellationNode3D) => void;
+}) {
+  const [frameReady, setFrameReady] = useState(false);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setFrameReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const groups = useMemo(() => {
+    const drep: ConstellationNode3D[] = [];
+    const spo: ConstellationNode3D[] = [];
+    const cc: ConstellationNode3D[] = [];
+    for (const n of nodes) {
+      if (n.isAnchor) continue;
+      if (n.nodeType === 'spo') spo.push(n);
+      else if (n.nodeType === 'cc') cc.push(n);
+      else drep.push(n);
+    }
+    return { drep, spo, cc };
+  }, [nodes]);
+
+  const getDrepColor = useCallback(() => DREP_COLOR, []);
+  const getSpoColor = useCallback(() => SPO_COLOR, []);
+  const getCcColor = useCallback(() => CC_COLOR, []);
+
+  if (nodes.length === 0 || !frameReady) return null;
+
+  return (
+    <>
+      {interactive && <RaycastConfig />}
+      <NodePoints
+        nodes={groups.drep}
+        highlightId={highlightId}
+        dimmed={dimmed}
+        pulseId={pulseId}
+        interactive={interactive}
+        onNodeClick={onNodeClick}
+        getColor={getDrepColor}
+        emissive={2.0}
+      />
+      {groups.spo.length > 0 && (
+        <NodePoints
+          nodes={groups.spo}
+          highlightId={highlightId}
+          dimmed={dimmed}
+          pulseId={pulseId}
+          interactive={interactive}
+          onNodeClick={onNodeClick}
+          getColor={getSpoColor}
+          emissive={1.5}
+        />
+      )}
+      {groups.cc.length > 0 && (
+        <NodePoints
+          nodes={groups.cc}
+          highlightId={highlightId}
+          dimmed={dimmed}
+          pulseId={pulseId}
+          interactive={interactive}
+          onNodeClick={onNodeClick}
+          getColor={getCcColor}
+          emissive={3.0}
+        />
+      )}
+    </>
+  );
+}
+
+function NodePoints({
+  nodes,
+  highlightId,
+  dimmed,
+  pulseId,
+  interactive,
+  onNodeClick,
+  getColor,
+  emissive,
+}: {
+  nodes: ConstellationNode3D[];
+  highlightId: string | null;
+  dimmed: boolean;
+  pulseId: string | null;
+  interactive?: boolean;
+  onNodeClick?: (node: ConstellationNode3D) => void;
+  getColor: (node: ConstellationNode3D) => string;
+  emissive: number;
+}) {
+  const tmpColor = useMemo(() => new THREE.Color(), []);
+
+  const buffers = useMemo(() => {
+    const count = nodes.length;
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    const sizes = new Float32Array(count);
+    const dimmedArr = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      const node = nodes[i];
+      positions[i * 3] = node.position[0];
+      positions[i * 3 + 1] = node.position[1];
+      positions[i * 3 + 2] = node.position[2];
+
+      tmpColor.set(getColor(node));
+      colors[i * 3] = tmpColor.r * emissive;
+      colors[i * 3 + 1] = tmpColor.g * emissive;
+      colors[i * 3 + 2] = tmpColor.b * emissive;
+
+      const isHighlighted = highlightId === node.id;
+      const isPulsing = pulseId === node.id;
+      sizes[i] =
+        (isPulsing ? node.scale * 1.8 : isHighlighted ? node.scale * 1.5 : node.scale) *
+        POINT_SCALE;
+      dimmedArr[i] = dimmed && !isHighlighted && !isPulsing ? 1.0 : 0.0;
+    }
+
+    return { positions, colors, sizes, dimmedArr };
+  }, [nodes, highlightId, dimmed, pulseId, getColor, emissive, tmpColor]);
+
+  const geoRef = useRef<THREE.BufferGeometry>(null);
+
+  useEffect(() => {
+    const geo = geoRef.current;
+    if (!geo) return;
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(buffers.positions, 3));
+    geo.setAttribute('aNodeColor', new THREE.Float32BufferAttribute(buffers.colors, 3));
+    geo.setAttribute('aSize', new THREE.Float32BufferAttribute(buffers.sizes, 1));
+    geo.setAttribute('aDimmed', new THREE.Float32BufferAttribute(buffers.dimmedArr, 1));
+    geo.computeBoundingSphere();
+  }, [buffers]);
+
+  if (nodes.length === 0) return null;
+
+  return (
+    <points
+      frustumCulled={false}
+      onPointerDown={
+        interactive
+          ? (e: any) => {
+              e.stopPropagation();
+              const idx = e.index as number | undefined;
+              if (idx !== undefined && idx < nodes.length) {
+                onNodeClick?.(nodes[idx]);
+              }
+            }
+          : undefined
+      }
+      onPointerEnter={
+        interactive
+          ? () => {
+              document.body.style.cursor = 'pointer';
+            }
+          : undefined
+      }
+      onPointerLeave={
+        interactive
+          ? () => {
+              document.body.style.cursor = '';
+            }
+          : undefined
+      }
+    >
+      <bufferGeometry ref={geoRef} />
+      <shaderMaterial
+        vertexShader={NODE_VERT}
+        fragmentShader={NODE_FRAG}
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        toneMapped={false}
+      />
+    </points>
+  );
+}
+
+function ConstellationEdges({ edges, dimmed }: { edges: ConstellationEdge3D[]; dimmed: boolean }) {
+  const geometry = useMemo(() => {
+    if (edges.length === 0) return null;
+    const positions: number[] = [];
+    for (const { from, to } of edges) {
+      positions.push(...from, ...to);
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    return geo;
+  }, [edges]);
+
+  if (!geometry) return null;
+
+  return (
+    <lineSegments geometry={geometry}>
+      <lineBasicMaterial
+        color="#4488aa"
+        transparent
+        opacity={dimmed ? 0.03 : 0.12}
+        toneMapped={false}
+      />
+    </lineSegments>
+  );
+}
+
+// --- Ambient starfield (same as original) ---
+
+function seededRandom(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+function makeCircleTexture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 32;
+  canvas.height = 32;
+  const ctx = canvas.getContext('2d')!;
+  const g = ctx.createRadialGradient(16, 16, 0, 16, 16, 16);
+  g.addColorStop(0, 'rgba(255,255,255,1)');
+  g.addColorStop(0.5, 'rgba(255,255,255,0.4)');
+  g.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, 32, 32);
+  return new THREE.CanvasTexture(canvas);
+}
+
+function AmbientStarfield({ count }: { count: number }) {
+  const circleMap = useMemo(() => makeCircleTexture(), []);
+
+  const points = useMemo(() => {
+    const rand = seededRandom(42);
+    const positions = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+      const r = 20 + rand() * 30;
+      const theta = rand() * Math.PI * 2;
+      const phi = Math.acos(2 * rand() - 1);
+      positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i * 3 + 2] = r * Math.cos(phi);
+    }
+    return positions;
+  }, [count]);
+
+  const ref = useRef<THREE.Points>(null);
+
+  useFrame((_, delta) => {
+    if (ref.current) {
+      ref.current.rotation.y += delta * 0.005;
+    }
+  });
+
+  return (
+    <points ref={ref}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[points, 3]} />
+      </bufferGeometry>
+      <pointsMaterial
+        size={0.06}
+        map={circleMap}
+        color="#c0d0ff"
+        transparent
+        opacity={0.5}
+        sizeAttenuation
+        toneMapped={false}
+        blending={THREE.AdditiveBlending}
+        depthWrite={false}
+      />
+    </points>
+  );
+}
+
+// --- Core sun (same as original) ---
+
+function GovernanceCore() {
+  const coreRef = useRef<THREE.Mesh>(null);
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime();
+    if (coreRef.current) {
+      const breath = 0.95 + 0.05 * Math.sin(t * 1.57);
+      coreRef.current.scale.setScalar(breath);
+    }
+  });
+
+  return (
+    <group>
+      <mesh ref={coreRef}>
+        <sphereGeometry args={[0.7, 32, 32]} />
+        <meshStandardMaterial
+          emissive={CORE_COLOR}
+          emissiveIntensity={3}
+          color={CORE_COLOR}
+          toneMapped={false}
+        />
+      </mesh>
+      <mesh>
+        <sphereGeometry args={[2.0, 16, 16]} />
+        <meshBasicMaterial
+          color={CORE_COLOR}
+          transparent
+          opacity={0.06}
+          blending={THREE.AdditiveBlending}
+          depthWrite={false}
+          toneMapped={false}
+        />
+      </mesh>
+      <pointLight color={CORE_COLOR} intensity={4} distance={12} decay={2} />
+    </group>
+  );
+}
+
+// --- Shooting stars (same as original) ---
+
+const METEOR_POOL = 4;
+const SPAWN_MIN_S = 4;
+const SPAWN_MAX_S = 10;
+
+function ShootingStars() {
+  const groupRef = useRef<THREE.Group>(null);
+  const stateRef = useRef({
+    meteors: Array.from({ length: METEOR_POOL }, () => ({
+      active: false,
+      start: new THREE.Vector3(),
+      end: new THREE.Vector3(),
+      progress: 0,
+      speed: 0,
+    })),
+    timer: SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S),
+  });
+
+  const _pos = useRef(new THREE.Vector3());
+  const _dir = useRef(new THREE.Vector3());
+  const _up = useRef(new THREE.Vector3(0, 1, 0));
+
+  useFrame((_, delta) => {
+    const group = groupRef.current;
+    if (!group) return;
+    const { meteors } = stateRef.current;
+
+    stateRef.current.timer -= delta;
+    if (stateRef.current.timer <= 0) {
+      stateRef.current.timer = SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S);
+      const slot = meteors.find((m) => !m.active);
+      if (slot) {
+        const angle = Math.random() * Math.PI * 2;
+        const r = 15 + Math.random() * 5;
+        slot.start.set(Math.cos(angle) * r, Math.sin(angle) * r, (Math.random() - 0.5) * 10);
+        const endAngle = angle + Math.PI + (Math.random() - 0.5) * 0.8;
+        const endR = 1 + Math.random() * 6;
+        slot.end.set(
+          Math.cos(endAngle) * endR,
+          Math.sin(endAngle) * endR,
+          (Math.random() - 0.5) * 6,
+        );
+        slot.progress = 0;
+        slot.speed = 0.5 + Math.random() * 0.4;
+        slot.active = true;
+      }
+    }
+
+    for (let i = 0; i < METEOR_POOL; i++) {
+      const m = meteors[i];
+      const mesh = group.children[i] as THREE.Mesh;
+      if (!mesh) continue;
+
+      if (!m.active) {
+        mesh.visible = false;
+        continue;
+      }
+
+      m.progress += delta * m.speed;
+      if (m.progress >= 1) {
+        m.active = false;
+        mesh.visible = false;
+        continue;
+      }
+
+      _pos.current.lerpVectors(m.start, m.end, m.progress);
+      mesh.position.copy(_pos.current);
+
+      _dir.current.subVectors(m.end, m.start).normalize();
+      mesh.quaternion.setFromUnitVectors(_up.current, _dir.current);
+
+      const fadeIn = Math.min(1, m.progress * 8);
+      const fadeOut = 1 - m.progress * m.progress;
+      const opacity = fadeIn * fadeOut * 0.8;
+      mesh.scale.set(1, 0.4 + opacity * 0.8, 1);
+
+      (mesh.material as THREE.MeshBasicMaterial).opacity = opacity;
+      mesh.visible = true;
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      {Array.from({ length: METEOR_POOL }, (_, i) => (
+        <mesh key={i} visible={false}>
+          <cylinderGeometry args={[0.03, 0.003, 1.5, 8]} />
+          <meshBasicMaterial
+            color="#e8dcc8"
+            transparent
+            opacity={0}
+            blending={THREE.AdditiveBlending}
+            depthWrite={false}
+            toneMapped={false}
+          />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+// --- Globe rotation group: Y-axis with Earth-like axial tilt ---
+
+function TiltedGlobeGroup({
+  enabled,
+  rotationRef,
+  children,
+}: {
+  enabled: boolean;
+  rotationRef: React.MutableRefObject<number>;
+  children: React.ReactNode;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  useFrame((_, delta) => {
+    if (groupRef.current) {
+      if (enabled) {
+        rotationRef.current += delta * ROTATION_SPEED;
+      }
+      // Apply axial tilt on X, then spin on Y (local)
+      groupRef.current.rotation.x = AXIAL_TILT;
+      groupRef.current.rotation.y = rotationRef.current;
+    }
+  });
+
+  return <group ref={groupRef}>{children}</group>;
+}
+
+// --- Helpers ---
+
+function rotateAroundY(pos: [number, number, number], angle: number): [number, number, number] {
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  // Also account for axial tilt
+  const x1 = pos[0] * c + pos[2] * s;
+  const z1 = -pos[0] * s + pos[2] * c;
+  // Apply tilt
+  const y2 = pos[1] * Math.cos(AXIAL_TILT) - z1 * Math.sin(AXIAL_TILT);
+  const z2 = pos[1] * Math.sin(AXIAL_TILT) + z1 * Math.cos(AXIAL_TILT);
+  return [x1, y2, z2];
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function estimateGPUTier(): 'low' | 'mid' | 'high' {
+  if (typeof window === 'undefined') return 'mid';
+  const canvas = document.createElement('canvas');
+  const gl = canvas.getContext('webgl');
+  if (!gl) return 'low';
+  const ext = gl.getExtension('WEBGL_debug_renderer_info');
+  const renderer = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL).toLowerCase() : '';
+  if (/swiftshader|llvmpipe|mesa/i.test(renderer)) return 'low';
+  if (window.innerWidth < 768) return 'mid';
+  return 'high';
+}

--- a/lib/constellation/globe-layout.ts
+++ b/lib/constellation/globe-layout.ts
@@ -1,0 +1,249 @@
+/**
+ * Globe-based layout engine for the governance constellation.
+ *
+ * Maps governance participants onto a sphere:
+ *   - Core (origin) = governance engine
+ *   - CC members = inner mantle shell (radius ~3.5)
+ *   - DReps = surface of the globe (radius ~8), positioned by alignment dimensions → lat/lon
+ *   - SPOs = infrastructure arcs connecting surface nodes
+ *
+ * Alignment dimensions map to 6 longitude bands (60° each).
+ * Specialization strength maps to latitude spread.
+ */
+
+import type {
+  ConstellationNode3D,
+  ConstellationEdge3D,
+  LayoutResult,
+  GovernanceNodeType,
+} from './types';
+import type { AlignmentDimension } from '@/lib/drepIdentity';
+import { getDimensionOrder } from '@/lib/drepIdentity';
+
+const DIMS = getDimensionOrder();
+
+// 6 dimensions → 6 longitude sectors, 60° each
+const DIM_LONGITUDES: Record<string, number> = (() => {
+  const map: Record<string, number> = {};
+  DIMS.forEach((dim, i) => {
+    map[dim] = (i / DIMS.length) * Math.PI * 2 - Math.PI;
+  });
+  return map;
+})();
+
+const GLOBE_RADIUS = 8;
+const CC_RADIUS = 3.5;
+const SPO_ARC_RADIUS = GLOBE_RADIUS + 0.3; // slightly above surface
+const MIN_VISIBLE_SCALE = 0.06;
+const MAX_VISIBLE_SCALE = 0.25;
+const SPO_SCALE_FACTOR = 0.6;
+const CC_SCALE_FACTOR = 1.15;
+const SPO_LIMIT = 400;
+
+interface LayoutInput {
+  id: string;
+  fullId: string;
+  name: string | null;
+  power: number;
+  score: number;
+  dominant: AlignmentDimension;
+  alignments: number[];
+  nodeType: GovernanceNodeType;
+}
+
+export function computeGlobeLayout(inputs: LayoutInput[], nodeLimit: number): LayoutResult {
+  const drepInputs = inputs.filter((n) => n.nodeType === 'drep');
+  const spoInputs = inputs.filter((n) => n.nodeType === 'spo').slice(0, SPO_LIMIT);
+  const ccInputs = inputs.filter((n) => n.nodeType === 'cc');
+
+  const sorted = [...drepInputs].sort((a, b) => b.power - a.power);
+  const active = sorted.slice(0, nodeLimit);
+
+  const nodes: ConstellationNode3D[] = [];
+  const nodeMap = new Map<string, ConstellationNode3D>();
+
+  // DReps on globe surface
+  for (const input of active) {
+    const [lon, lat] = computeSpherePosition(input);
+    const pos = sphereToCartesian(lat, lon, GLOBE_RADIUS);
+    const scale = MIN_VISIBLE_SCALE + input.power * (MAX_VISIBLE_SCALE - MIN_VISIBLE_SCALE);
+    const node: ConstellationNode3D = { ...input, position: pos, scale };
+    nodes.push(node);
+    nodeMap.set(node.id, node);
+  }
+
+  // CC members — inner mantle shell
+  for (let i = 0; i < ccInputs.length; i++) {
+    const input = ccInputs[i];
+    const lon = (i / Math.max(ccInputs.length, 1)) * Math.PI * 2 - Math.PI;
+    // Slight latitude variation so they're not all on the equator
+    const lat = ((simpleHash(input.id) % 60) - 30) * (Math.PI / 180);
+    const pos = sphereToCartesian(lat, lon, CC_RADIUS);
+    const scale = MAX_VISIBLE_SCALE * CC_SCALE_FACTOR;
+    const node: ConstellationNode3D = { ...input, position: pos, scale };
+    nodes.push(node);
+    nodeMap.set(node.id, node);
+  }
+
+  // SPOs — positioned on the surface for now, arcs computed as edges
+  const spoNodes: ConstellationNode3D[] = [];
+  for (let i = 0; i < spoInputs.length; i++) {
+    const input = spoInputs[i];
+    const hash = simpleHash(input.id);
+    const lon = (i / spoInputs.length) * Math.PI * 2 - Math.PI;
+    const lat = (((hash % 140) - 70) / 70) * (Math.PI / 2) * 0.85; // spread across latitudes
+    const pos = sphereToCartesian(lat, lon, GLOBE_RADIUS);
+    const scale =
+      (MIN_VISIBLE_SCALE + input.power * (MAX_VISIBLE_SCALE - MIN_VISIBLE_SCALE)) *
+      SPO_SCALE_FACTOR;
+    const node: ConstellationNode3D = { ...input, position: pos, scale };
+    spoNodes.push(node);
+    nodes.push(node);
+    nodeMap.set(node.id, node);
+  }
+
+  const edges = computeGlobeEdges(nodes, spoNodes);
+  return { nodes, edges, nodeMap };
+}
+
+/**
+ * Map alignment scores to longitude/latitude on the globe.
+ * - Dominant dimension → base longitude sector
+ * - Weighted average of all dimensions → fine-tuned longitude
+ * - Specialization strength → latitude (generalists near equator, specialists toward poles)
+ */
+function computeSpherePosition(input: LayoutInput): [number, number] {
+  const scores = input.alignments;
+  const hash = simpleHash(input.id);
+  const hashNorm = (hash % 10000) / 10000;
+
+  // Weighted direction from alignment scores
+  let wx = 0,
+    wy = 0,
+    totalWeight = 0;
+  for (let i = 0; i < DIMS.length; i++) {
+    const score = scores[i] ?? 50;
+    const weight = Math.abs(score - 50);
+    const angle = DIM_LONGITUDES[DIMS[i]];
+    wx += Math.cos(angle) * weight;
+    wy += Math.sin(angle) * weight;
+    totalWeight += weight;
+  }
+
+  // Longitude: weighted direction + jitter
+  let lon: number;
+  if (totalWeight < 1) {
+    lon = hashNorm * Math.PI * 2 - Math.PI;
+  } else {
+    const dirAngle = Math.atan2(wy, wx);
+    const jitter = (hashNorm - 0.5) * (Math.PI / 3); // ±30° fan
+    lon = dirAngle + jitter;
+  }
+
+  // Latitude: specialization pushes toward poles, generalists near equator
+  const specialization = Math.min(1, totalWeight / (DIMS.length * 30));
+  const hashLat = (((hash >> 8) % 1000) / 1000 - 0.5) * 2;
+  const latSign = hashLat >= 0 ? 1 : -1;
+  const lat = latSign * specialization * (Math.PI / 2) * 0.8 + (hashLat * 0.2 * Math.PI) / 2;
+
+  return [lon, clamp(lat, -Math.PI / 2 + 0.1, Math.PI / 2 - 0.1)];
+}
+
+/**
+ * Compute edges for the globe visualization.
+ * SPO nodes become infrastructure arcs — great circle segments connecting nearby DRep/CC nodes.
+ */
+function computeGlobeEdges(
+  allNodes: ConstellationNode3D[],
+  spoNodes: ConstellationNode3D[],
+): ConstellationEdge3D[] {
+  const edges: ConstellationEdge3D[] = [];
+  const drepNodes = allNodes.filter((n) => n.nodeType === 'drep');
+
+  // Proximity edges among DReps in the same dimension (surface connections)
+  const maxProximity = 200;
+  for (let i = 0; i < drepNodes.length && edges.length < maxProximity; i++) {
+    for (let j = i + 1; j < drepNodes.length && edges.length < maxProximity; j++) {
+      const a = drepNodes[i];
+      const b = drepNodes[j];
+      if (a.dominant !== b.dominant) continue;
+      if (dist3D(a.position, b.position) > 3) continue;
+      edges.push({ from: a.position, to: b.position });
+    }
+  }
+
+  // SPO infrastructure arcs — each SPO connects to its 2 nearest DRep nodes
+  const maxSpoEdges = 300;
+  for (const spo of spoNodes) {
+    if (edges.length >= maxProximity + maxSpoEdges) break;
+    const nearest = drepNodes
+      .map((n) => ({ node: n, dist: dist3D(spo.position, n.position) }))
+      .sort((a, b) => a.dist - b.dist)
+      .slice(0, 2);
+
+    for (const { node } of nearest) {
+      // Create a great-circle arc as a series of segments
+      const arcPoints = greatCircleArc(spo.position, node.position, SPO_ARC_RADIUS, 8);
+      for (let i = 0; i < arcPoints.length - 1; i++) {
+        edges.push({ from: arcPoints[i], to: arcPoints[i + 1] });
+      }
+    }
+  }
+
+  return edges;
+}
+
+/**
+ * Generate points along a great-circle arc between two positions,
+ * lifted to a given radius (so arcs float above the surface).
+ */
+function greatCircleArc(
+  a: [number, number, number],
+  b: [number, number, number],
+  radius: number,
+  segments: number,
+): [number, number, number][] {
+  const points: [number, number, number][] = [];
+  for (let i = 0; i <= segments; i++) {
+    const t = i / segments;
+    // Slerp between the two positions
+    const x = a[0] * (1 - t) + b[0] * t;
+    const y = a[1] * (1 - t) + b[1] * t;
+    const z = a[2] * (1 - t) + b[2] * t;
+    // Normalize to sphere surface at the given radius
+    const len = Math.sqrt(x * x + y * y + z * z);
+    if (len < 0.001) {
+      points.push([x, y, z]);
+    } else {
+      points.push([(x / len) * radius, (y / len) * radius, (z / len) * radius]);
+    }
+  }
+  return points;
+}
+
+function sphereToCartesian(lat: number, lon: number, radius: number): [number, number, number] {
+  return [
+    radius * Math.cos(lat) * Math.cos(lon),
+    radius * Math.cos(lat) * Math.sin(lon),
+    radius * Math.sin(lat),
+  ];
+}
+
+function dist3D(a: [number, number, number], b: [number, number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  const dz = a[2] - b[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function simpleHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}

--- a/supabase/migrations/048_globe_constellation_flag.sql
+++ b/supabase/migrations/048_globe_constellation_flag.sql
@@ -1,0 +1,4 @@
+-- Globe constellation visualization (admin-only prototype)
+INSERT INTO feature_flags (key, enabled, description, category)
+VALUES ('globe_constellation', false, 'Globe-based constellation visualization (prototype)', 'visualization')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds globe-based governance visualization as a feature-flagged alternative to the flat constellation
- Toggle via `globe_constellation` flag in Admin → Feature Flags (defaults OFF, zero prod impact)
- DReps mapped to sphere surface by alignment dimensions, CC on inner mantle, SPOs as great-circle infrastructure arcs
- Earth-like Y-axis rotation with 23.4° axial tilt, wireframe lat/lon grid

## New files
- `components/GlobeConstellation.tsx` — R3F globe scene
- `lib/constellation/globe-layout.ts` — sphere surface layout engine
- `supabase/migrations/048_globe_constellation_flag.sql` — feature flag

## Modified
- `components/ConstellationHero.tsx` — conditional render based on flag (original constellation untouched)

## Test plan
- [ ] Deploy to prod, verify original constellation renders normally (flag OFF)
- [ ] Enable `globe_constellation` in Admin → Feature Flags
- [ ] Verify globe visualization renders with tilted rotation, wireframe, and layered nodes
- [ ] Disable flag, verify instant revert to original constellation
- [ ] Verify Find Me / fly-to-node / search still work on both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)