### PR TITLE
feat: admin link in header dropdown

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -16,6 +16,7 @@ import {
   Sun,
   Moon,
   Eye,
+  Shield,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { useTheme } from 'next-themes';
@@ -177,6 +178,12 @@ export function CivicaHeader() {
                 {isAdmin && (
                   <>
                     <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                      <Link href="/admin">
+                        <Shield className="h-4 w-4" />
+                        Admin
+                      </Link>
+                    </DropdownMenuItem>
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger>
                         <Eye className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Adds "Admin" link with Shield icon to the profile dropdown menu, visible only when admin wallet is connected
- No impact on non-admin users

## Test plan
- [ ] Connect admin wallet, open profile dropdown, verify "Admin" link appears
- [ ] Click link, verify it navigates to /admin
- [ ] Connect non-admin wallet, verify link does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)