### PR TITLE
feat: UX intelligence layer

### DIFF
--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -7,14 +7,17 @@ import { Button } from '@/components/ui/button';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { PoolProfileClient } from '@/components/PoolProfileClient';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
-import { ArrowLeft, TrendingUp, BarChart3 } from 'lucide-react';
+import { ArrowLeft, BarChart3, MessageSquare, ExternalLink } from 'lucide-react';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import nextDynamic from 'next/dynamic';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
+import { generateSpoNarrative } from '@/lib/narratives';
+import { cn } from '@/lib/utils';
 
 const TierCelebrationManager = nextDynamic(() =>
   import('@/components/civica/shared/TierCelebrationManager').then((m) => m.TierCelebrationManager),
 );
+import { SpoProfileHero } from '@/components/civica/profiles/SpoProfileHero';
 import { SpoProfileTabsV1 } from '@/components/civica/profiles/SpoProfileTabsV1';
 import { computeTier, computeTierProgress } from '@/lib/scoring/tiers';
 import { tierKey, TIER_BADGE_BG, TIER_SCORE_COLOR } from '@/components/civica/cards/tierStyles';
@@ -26,18 +29,14 @@ interface PageProps {
 }
 
 function formatAda(lovelace: number | string | null | undefined): string {
-  if (lovelace == null) return '—';
+  if (lovelace == null) return '\u2014';
   const n = typeof lovelace === 'string' ? parseInt(lovelace, 10) : lovelace;
-  if (isNaN(n)) return '—';
+  if (isNaN(n)) return '\u2014';
   const ada = n / 1_000_000;
   if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(2)}B`;
   if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
   if (ada >= 1_000) return `${Math.round(ada / 1_000)}K`;
   return ada.toFixed(0);
-}
-
-function formatPledge(lovelace: number | string | null | undefined): string {
-  return formatAda(lovelace);
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -46,17 +45,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!poolRow) {
     const short = poolId.slice(0, 12);
     return {
-      title: `SPO ${short}… Governance Profile — Civica`,
-      description: `Governance participation and voting record for stake pool ${short}… on Cardano.`,
+      title: `SPO ${short}\u2026 Governance Profile \u2014 Civica`,
+      description: `Governance participation and voting record for stake pool ${short}\u2026 on Cardano.`,
     };
   }
-  const name = (poolRow.pool_name as string) || poolId.slice(0, 12) + '…';
+  const name = (poolRow.pool_name as string) || poolId.slice(0, 12) + '\u2026';
   const score = poolRow.governance_score as number | null;
   const tier = score != null ? computeTier(score) : null;
   const title =
     score != null && tier
-      ? `${name} — SPO Governance Score: ${score} (${tier}) — Civica`
-      : `${name} — SPO Governance Profile — Civica`;
+      ? `${name} \u2014 SPO Governance Score: ${score} (${tier}) \u2014 Civica`
+      : `${name} \u2014 SPO Governance Profile \u2014 Civica`;
   return {
     title,
     description: `SPO governance score, voting record, and alignment data for ${name} on Cardano.`,
@@ -69,7 +68,7 @@ async function getPoolRow(poolId: string) {
     const { data, error } = await supabase
       .from('pools')
       .select(
-        'pool_id, ticker, pool_name, pledge_lovelace, governance_score, participation_pct, deliberation_pct, consistency_pct, reliability_pct, governance_identity_pct, confidence, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, delegator_count, live_stake_lovelace, vote_count, governance_statement, current_tier, score_momentum',
+        'pool_id, ticker, pool_name, pledge_lovelace, governance_score, participation_pct, deliberation_pct, consistency_pct, reliability_pct, governance_identity_pct, confidence, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, delegator_count, live_stake_lovelace, vote_count, governance_statement, current_tier, score_momentum, homepage_url',
       )
       .eq('pool_id', poolId)
       .single();
@@ -156,6 +155,40 @@ async function getInterBodyAlignment(
   }
 }
 
+async function getSimilarPools(
+  poolId: string,
+  alignments: AlignmentScores,
+  score: number,
+): Promise<
+  Array<{
+    pool_id: string;
+    pool_name: string | null;
+    ticker: string | null;
+    governance_score: number;
+  }>
+> {
+  try {
+    const supabase = createClient();
+    const { data } = await supabase
+      .from('pools')
+      .select('pool_id, pool_name, ticker, governance_score')
+      .not('governance_score', 'is', null)
+      .neq('pool_id', poolId)
+      .gte('governance_score', Math.max(0, score - 15))
+      .lte('governance_score', Math.min(100, score + 15))
+      .order('governance_score', { ascending: false })
+      .limit(3);
+    return (data ?? []) as Array<{
+      pool_id: string;
+      pool_name: string | null;
+      ticker: string | null;
+      governance_score: number;
+    }>;
+  } catch {
+    return [];
+  }
+}
+
 function toAlignments(row: Record<string, unknown> | null): AlignmentScores {
   if (!row) {
     return {
@@ -175,6 +208,19 @@ function toAlignments(row: Record<string, unknown> | null): AlignmentScores {
     innovation: (row.alignment_innovation as number) ?? null,
     transparency: (row.alignment_transparency as number) ?? null,
   };
+}
+
+function getLastVotedText(votes: Array<{ block_time: number }>): string | null {
+  if (votes.length === 0) return null;
+  const latest = votes[0].block_time;
+  const now = Date.now() / 1000;
+  const diffDays = Math.floor((now - latest) / 86400);
+  if (diffDays === 0) return 'Voted today';
+  if (diffDays === 1) return 'Voted yesterday';
+  if (diffDays < 7) return `Voted ${diffDays} days ago`;
+  if (diffDays < 30) return `Voted ${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `Voted ${Math.floor(diffDays / 30)} months ago`;
+  return `Last voted ${Math.floor(diffDays / 365)}y ago`;
 }
 
 export default async function PoolProfilePage({ params }: PageProps) {
@@ -204,9 +250,6 @@ export default async function PoolProfilePage({ params }: PageProps) {
     proposals = data ?? [];
   }
 
-  const yesCount = safeVotes.filter((v) => v.vote === 'Yes').length;
-  const noCount = safeVotes.filter((v) => v.vote === 'No').length;
-  const abstainCount = safeVotes.filter((v) => v.vote === 'Abstain').length;
   const totalVotes = safeVotes.length;
 
   const { count: totalProposals } = await supabase
@@ -226,7 +269,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
           .select('epoch_no, governance_score, participation_rate')
           .eq('pool_id', poolId)
           .order('epoch_no', { ascending: false })
-          .limit(10)
+          .limit(20)
       : Promise.resolve({
           data: [] as Array<{
             epoch_no: number;
@@ -243,6 +286,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
   const scoreSnapshots = scoreHistoryRes.data ?? [];
   const sortedSnapshots = [...scoreSnapshots].reverse();
 
+  // Unscored pool fallback
   if (!hasScored) {
     return (
       <div className="container mx-auto px-4 py-8 space-y-8">
@@ -262,80 +306,29 @@ export default async function PoolProfilePage({ params }: PageProps) {
 
         {totalVotes === 0 ? (
           <Card>
-            <CardContent className="py-16 text-center">
+            <CardContent className="py-16 text-center space-y-3">
+              <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center">
+                <BarChart3 className="h-6 w-6 text-muted-foreground" />
+              </div>
               <p className="text-muted-foreground text-sm">
-                This pool has no recorded governance votes yet.
+                This pool hasn&apos;t participated in governance yet.
+              </p>
+              <p className="text-xs text-muted-foreground max-w-sm mx-auto">
+                Governance scores are calculated after a pool casts its first vote on a governance
+                proposal.
               </p>
             </CardContent>
           </Card>
         ) : (
-          <>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-muted-foreground">Total Votes</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-2xl font-bold">{totalVotes}</p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-muted-foreground">Participation</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-2xl font-bold">{participationRate}%</p>
-                  <p className="text-xs text-muted-foreground">
-                    {totalVotes} of {totalProposals ?? '?'} proposals
-                  </p>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-muted-foreground">Vote Split</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex gap-3 text-sm">
-                    <span className="text-green-500">{yesCount} Yes</span>
-                    <span className="text-red-500">{noCount} No</span>
-                    <span className="text-muted-foreground">{abstainCount} Abstain</span>
-                  </div>
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm text-muted-foreground">Most Active Epoch</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {(() => {
-                    const epochCounts = new Map<number, number>();
-                    for (const v of safeVotes) {
-                      epochCounts.set(v.epoch, (epochCounts.get(v.epoch) || 0) + 1);
-                    }
-                    const top = [...epochCounts.entries()].sort((a, b) => b[1] - a[1])[0];
-                    return top ? (
-                      <p className="text-2xl font-bold">
-                        Epoch {top[0]}{' '}
-                        <span className="text-sm font-normal text-muted-foreground">
-                          ({top[1]} votes)
-                        </span>
-                      </p>
-                    ) : (
-                      <p className="text-muted-foreground">—</p>
-                    );
-                  })()}
-                </CardContent>
-              </Card>
-            </div>
-
-            <PoolProfileClient votes={safeVotes} proposals={proposals} />
-          </>
+          <PoolProfileClient votes={safeVotes} proposals={proposals} />
         )}
       </div>
     );
   }
 
-  const displayName = (poolRow.pool_name as string) || poolId.slice(0, 16) + '…';
+  // ── Scored pool: full profile ──────────────────────────────────────────────
+
+  const displayName = (poolRow.pool_name as string) || poolId.slice(0, 16) + '\u2026';
   const ticker = (poolRow.ticker as string) || null;
   const governanceScore = (poolRow.governance_score as number) ?? 0;
   const delegatorCount = (poolRow.delegator_count as number) ?? 0;
@@ -348,21 +341,58 @@ export default async function PoolProfilePage({ params }: PageProps) {
   const governanceIdentityPillar = (poolRow.governance_identity_pct as number) ?? null;
   const poolConfidence = (poolRow.confidence as number) ?? null;
   const governanceStatement = (poolRow.governance_statement as string) ?? null;
+  const homepage = (poolRow.homepage_url as string) ?? null;
   const alignments = toAlignments(poolRow);
-
-  const hasAnyAlignment =
-    alignments.treasuryConservative != null ||
-    alignments.treasuryGrowth != null ||
-    alignments.decentralization != null ||
-    alignments.security != null ||
-    alignments.innovation != null ||
-    alignments.transparency != null;
+  const scoreMomentum = (poolRow.score_momentum as number) ?? null;
 
   const tier = computeTier(governanceScore);
   const tk = tierKey(tier);
   const tierProgress = computeTierProgress(governanceScore);
+  const lastVotedText = getLastVotedText(safeVotes);
 
-  // Score Analysis card (shared between civica and legacy paths)
+  // Generate narrative
+  const liveStakeAda =
+    liveStake != null
+      ? (typeof liveStake === 'string' ? parseInt(liveStake, 10) : (liveStake as number)) /
+        1_000_000
+      : 0;
+
+  const narrative = generateSpoNarrative({
+    poolName: displayName,
+    ticker,
+    governanceScore,
+    participationRate,
+    voteCount,
+    delegatorCount,
+    liveStakeAda,
+    alignments,
+    isClaimed: false,
+    governanceStatement,
+    scoreMomentum,
+  });
+
+  // Similar pools
+  const similarPools = await getSimilarPools(poolId, alignments, governanceScore);
+
+  // ── Score Analysis card ────────────────────────────────────────────────────
+
+  const PILLARS = [
+    { label: 'Participation', weight: '35%', value: participationPillar, color: 'bg-cyan-500/80' },
+    {
+      label: 'Deliberation Quality',
+      weight: '25%',
+      value: deliberationPillar,
+      color: 'bg-purple-500/80',
+    },
+    { label: 'Reliability', weight: '25%', value: reliabilityPillar, color: 'bg-amber-500/80' },
+    {
+      label: 'Governance Identity',
+      weight: '15%',
+      value: governanceIdentityPillar,
+      color: 'bg-emerald-500/80',
+    },
+  ];
+
   const scoreAnalysisCard = (
     <Card>
       <CardHeader>
@@ -375,148 +405,336 @@ export default async function PoolProfilePage({ params }: PageProps) {
         {poolConfidence != null && poolConfidence < 60 && (
           <div className="flex items-center gap-2 text-xs text-amber-500 bg-amber-500/10 rounded-md px-3 py-2">
             <span>
-              Provisional score — low confidence ({poolConfidence}%). More votes needed for full
-              tier assignment.
+              Provisional score \u2014 low confidence ({poolConfidence}%). More votes needed for
+              full tier assignment.
             </span>
           </div>
         )}
-        <div className="space-y-2">
-          <div className="flex justify-between text-sm">
-            <span>Participation · 35%</span>
-            <span className="font-mono tabular-nums">{participationPillar ?? '—'}%</span>
+        {PILLARS.map((p) => (
+          <div key={p.label} className="space-y-2">
+            <div className="flex justify-between text-sm">
+              <span>
+                {p.label} \u00B7 {p.weight}
+              </span>
+              <span className="font-mono tabular-nums">
+                {p.value != null ? `${p.value}%` : '\u2014'}
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className={cn('h-full rounded-full', p.color)}
+                style={{ width: `${Math.min(100, Math.max(0, p.value ?? 0))}%` }}
+              />
+            </div>
           </div>
-          <div className="h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full bg-cyan-500/80"
-              style={{ width: `${Math.min(100, Math.max(0, participationPillar ?? 0))}%` }}
-            />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <div className="flex justify-between text-sm">
-            <span>Deliberation Quality · 25%</span>
-            <span className="font-mono tabular-nums">
-              {deliberationPillar != null ? deliberationPillar : '—'}%
-            </span>
-          </div>
-          <div className="h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full bg-purple-500/80"
-              style={{ width: `${Math.min(100, Math.max(0, deliberationPillar ?? 0))}%` }}
-            />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <div className="flex justify-between text-sm">
-            <span>Reliability · 25%</span>
-            <span className="font-mono tabular-nums">
-              {reliabilityPillar != null ? reliabilityPillar : '—'}%
-            </span>
-          </div>
-          <div className="h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full bg-amber-500/80"
-              style={{ width: `${Math.min(100, Math.max(0, reliabilityPillar ?? 0))}%` }}
-            />
-          </div>
-        </div>
-        <div className="space-y-2">
-          <div className="flex justify-between text-sm">
-            <span>Governance Identity · 15%</span>
-            <span className="font-mono tabular-nums">
-              {governanceIdentityPillar != null ? `${governanceIdentityPillar}%` : '—'}
-            </span>
-          </div>
-          <div className="h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full rounded-full bg-emerald-500/80"
-              style={{
-                width: `${Math.min(100, Math.max(0, governanceIdentityPillar ?? 0))}%`,
-              }}
-            />
-          </div>
-          {governanceIdentityPillar == null && (
-            <p className="text-xs text-muted-foreground">
-              Governance identity scoring coming soon.
-            </p>
-          )}
-        </div>
+        ))}
         {tierProgress.recommendedAction && (
           <p className="text-xs text-muted-foreground border-t pt-3 mt-3">
-            💡 {tierProgress.recommendedAction}
+            {tierProgress.recommendedAction}
           </p>
         )}
       </CardContent>
     </Card>
   );
 
-  // Score History card
-  const scoreHistoryCard =
-    sortedSnapshots.length > 0 ? (
+  // ── Score History (chart-style) ────────────────────────────────────────────
+
+  const trajectoryContent = (
+    <div className="space-y-6">
+      {sortedSnapshots.length >= 2 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Score Trajectory</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {/* SVG sparkline chart */}
+              <div className="h-32">
+                <svg
+                  viewBox={`0 0 ${Math.max(200, sortedSnapshots.length * 30)} 100`}
+                  className="w-full h-full"
+                  preserveAspectRatio="none"
+                >
+                  {(() => {
+                    const scores = sortedSnapshots.map((s) => s.governance_score ?? 0);
+                    const min = Math.min(...scores) - 5;
+                    const max = Math.max(...scores) + 5;
+                    const range = max - min || 1;
+                    const w = Math.max(200, sortedSnapshots.length * 30);
+                    const points = sortedSnapshots
+                      .map((s, i) => {
+                        const x = 10 + (i / Math.max(1, sortedSnapshots.length - 1)) * (w - 20);
+                        const y = 90 - (((s.governance_score ?? 0) - min) / range) * 80;
+                        return `${x},${y}`;
+                      })
+                      .join(' ');
+                    const trending = scores.length >= 2 && scores[scores.length - 1] >= scores[0];
+                    return (
+                      <polyline
+                        points={points}
+                        fill="none"
+                        stroke={trending ? '#34d399' : '#fb7185'}
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    );
+                  })()}
+                </svg>
+              </div>
+              <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums px-2">
+                <span>Epoch {sortedSnapshots[0]?.epoch_no}</span>
+                <span>Epoch {sortedSnapshots[sortedSnapshots.length - 1]?.epoch_no}</span>
+              </div>
+              {/* Table below chart */}
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-muted-foreground">
+                      <th className="pb-2 pr-4">Epoch</th>
+                      <th className="pb-2 pr-4">Score</th>
+                      <th className="pb-2 pr-4">Participation</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...sortedSnapshots]
+                      .reverse()
+                      .slice(0, 10)
+                      .map((s) => (
+                        <tr key={s.epoch_no} className="border-b border-border/50">
+                          <td className="py-2 pr-4 font-mono">{s.epoch_no}</td>
+                          <td className="py-2 pr-4 font-mono tabular-nums">
+                            {s.governance_score ?? '\u2014'}
+                          </td>
+                          <td className="py-2 pr-4 font-mono tabular-nums">
+                            {s.participation_rate != null ? `${s.participation_rate}%` : '\u2014'}
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Score history builds over time. Check back after the next scoring epoch.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+
+  // ── Inter-body alignment content ───────────────────────────────────────────
+
+  const interBodyContent = (
+    <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <TrendingUp className="h-5 w-5" />
-            Score History
-          </CardTitle>
+          <CardTitle>Inter-Body Alignment</CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-muted-foreground">
-                  <th className="pb-2 pr-4">Epoch</th>
-                  <th className="pb-2 pr-4">Score</th>
-                  <th className="pb-2 pr-4">Participation</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedSnapshots.map((s) => (
-                  <tr key={s.epoch_no} className="border-b border-border/50">
-                    <td className="py-2 pr-4 font-mono">{s.epoch_no}</td>
-                    <td className="py-2 pr-4 font-mono tabular-nums">
-                      {s.governance_score ?? '—'}
-                    </td>
-                    <td className="py-2 pr-4 font-mono tabular-nums">
-                      {s.participation_rate != null ? `${s.participation_rate}%` : '—'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
-    ) : null;
-
-  // Inter-body card
-  const interBodyCard = (
-    <Card>
-      <CardHeader>
-        <CardTitle>Inter-Body Alignment</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-3">
+        <CardContent className="space-y-4">
           {interBody.drepPct != null && (
-            <div>
-              <span className="text-sm text-muted-foreground">Agrees with DRep majority</span>
-              <p className="text-xl font-bold tabular-nums">{interBody.drepPct}%</p>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span>Agrees with DRep majority</span>
+                <span className="font-mono tabular-nums font-bold text-cyan-400">
+                  {interBody.drepPct}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-cyan-500/80"
+                  style={{ width: `${interBody.drepPct}%` }}
+                />
+              </div>
             </div>
           )}
           {interBody.ccPct != null && (
-            <div>
-              <span className="text-sm text-muted-foreground">Agrees with CC majority</span>
-              <p className="text-xl font-bold tabular-nums">{interBody.ccPct}%</p>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span>Agrees with CC majority</span>
+                <span className="font-mono tabular-nums font-bold text-violet-400">
+                  {interBody.ccPct}%
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-violet-500/80"
+                  style={{ width: `${interBody.ccPct}%` }}
+                />
+              </div>
             </div>
           )}
           {interBody.drepPct == null && interBody.ccPct == null && (
             <p className="text-sm text-muted-foreground">
-              No inter-body alignment data for proposals this pool voted on.
+              Inter-body alignment data requires overlapping votes with DReps and CC members.
             </p>
           )}
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+
+      {/* Alignment Radar in inter-body context */}
+      {(alignments.treasuryConservative != null || alignments.decentralization != null) && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Governance Alignment</CardTitle>
+          </CardHeader>
+          <CardContent className="flex justify-center">
+            <GovernanceRadar alignments={alignments} size="full" />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+
+  // ── Community content ──────────────────────────────────────────────────────
+
+  const communityContent = (
+    <div className="space-y-6">
+      {/* Governance Statement */}
+      {governanceStatement && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MessageSquare className="h-5 w-5" />
+              Governance Statement
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-wrap">
+              {governanceStatement}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Pool info */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Pool Details</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            {pledge != null && (
+              <div>
+                <p className="text-xs text-muted-foreground">Pledge</p>
+                <p className="text-sm font-mono tabular-nums font-medium">
+                  {formatAda(pledge)} \u20B3
+                </p>
+              </div>
+            )}
+            <div>
+              <p className="text-xs text-muted-foreground">Live Stake</p>
+              <p className="text-sm font-mono tabular-nums font-medium">
+                {formatAda(liveStake)} \u20B3
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Delegators</p>
+              <p className="text-sm font-mono tabular-nums font-medium">
+                {delegatorCount.toLocaleString()}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Total Governance Votes</p>
+              <p className="text-sm font-mono tabular-nums font-medium">{voteCount}</p>
+            </div>
+          </div>
+          {homepage && (
+            <a
+              href={homepage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              Pool homepage
+            </a>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Similar SPOs */}
+      {similarPools.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Similar SPOs</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {similarPools.map((p) => {
+                const pTier = computeTier(p.governance_score);
+                const pTk = tierKey(pTier);
+                return (
+                  <Link
+                    key={p.pool_id}
+                    href={`/pool/${p.pool_id}`}
+                    className="flex items-center justify-between rounded-lg px-3 py-2.5 hover:bg-muted/30 transition-colors group"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-sm font-medium truncate">
+                        {p.pool_name || p.ticker || p.pool_id.slice(0, 12) + '\u2026'}
+                      </span>
+                      {p.ticker && (
+                        <Badge
+                          variant="outline"
+                          className="text-[10px] text-cyan-500 border-cyan-500/30 shrink-0"
+                        >
+                          {p.ticker.toUpperCase()}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0 ml-2">
+                      <span
+                        className={cn(
+                          'text-xs font-bold px-1.5 py-0.5 rounded-full',
+                          TIER_BADGE_BG[pTk],
+                        )}
+                      >
+                        {pTier}
+                      </span>
+                      <span
+                        className={cn(
+                          'font-mono tabular-nums text-sm font-bold',
+                          TIER_SCORE_COLOR[pTk],
+                        )}
+                      >
+                        {p.governance_score}
+                      </span>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+
+  // ── Tier progress bar (below hero) ─────────────────────────────────────────
+
+  const tierProgressBar = tierProgress.pointsToNext != null && (
+    <div className="flex items-center gap-3 text-sm">
+      <span>
+        {tierProgress.pointsToNext} pts to{' '}
+        <span className="text-primary font-bold">{tierProgress.nextTier}</span>
+      </span>
+      <div className="w-20 h-1.5 bg-border rounded-full overflow-hidden">
+        <div
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${tierProgress.percentWithinTier}%` }}
+        />
+      </div>
+      <span className="text-xs text-muted-foreground">
+        {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
+      </span>
+    </div>
   );
 
   return (
@@ -539,200 +757,33 @@ export default async function PoolProfilePage({ params }: PageProps) {
           </Button>
         </Link>
 
-        {/* VP1 Hero */}
-        <div className="space-y-6">
-          <div className="space-y-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="text-2xl font-bold tracking-tight">
-                {displayName.length > 40 ? displayName.slice(0, 40) + '…' : displayName}
-              </h1>
-              {ticker && (
-                <Badge variant="outline" className="text-cyan-500 border-cyan-500/40 font-mono">
-                  {ticker.toUpperCase()}
-                </Badge>
-              )}
-              <span
-                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${TIER_BADGE_BG[tk]}`}
-              >
-                {tier}
-              </span>
-            </div>
+        {/* VP1: The Story */}
+        <SpoProfileHero
+          name={displayName}
+          ticker={ticker}
+          score={governanceScore}
+          tier={tier}
+          rank={scoreRank}
+          delegatorCount={delegatorCount}
+          liveStakeFormatted={formatAda(liveStake)}
+          voteCount={voteCount}
+          participationRate={participationRate}
+          alignments={alignments}
+          narrative={narrative}
+          scoreMomentum={scoreMomentum}
+          lastVotedText={lastVotedText}
+        />
 
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className={`text-4xl font-bold tabular-nums ${TIER_SCORE_COLOR[tk]}`}>
-                {governanceScore}
-              </span>
-              <span className="text-muted-foreground text-sm">governance score</span>
-              {scoreRank != null && (
-                <span className="ml-2 inline-flex items-center rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
-                  Top {100 - scoreRank}% of governance-active SPOs
-                </span>
-              )}
-              {poolRow.score_momentum != null && (poolRow.score_momentum as number) !== 0 && (
-                <span
-                  className={`text-xs font-medium tabular-nums ${(poolRow.score_momentum as number) > 0 ? 'text-emerald-400' : 'text-rose-400'}`}
-                >
-                  {(poolRow.score_momentum as number) > 0 ? '+' : ''}
-                  {(poolRow.score_momentum as number).toFixed(1)} pts/day
-                </span>
-              )}
-            </div>
+        {tierProgressBar}
 
-            {governanceStatement && (
-              <p className="text-sm text-muted-foreground italic max-w-2xl">
-                &ldquo;
-                {governanceStatement.length > 150
-                  ? governanceStatement.slice(0, 150) + '…'
-                  : governanceStatement}
-                &rdquo;
-              </p>
-            )}
-          </div>
-
-          {/* Tier progress */}
-          {tierProgress.pointsToNext != null && (
-            <div className="flex items-center gap-3 text-sm">
-              <span>
-                {tierProgress.pointsToNext} pts to{' '}
-                <span className="text-primary font-bold">{tierProgress.nextTier}</span>
-              </span>
-              <div className="w-20 h-1.5 bg-border rounded-full overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-primary"
-                  style={{ width: `${tierProgress.percentWithinTier}%` }}
-                />
-              </div>
-              <span className="text-xs text-muted-foreground">
-                {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
-              </span>
-            </div>
-          )}
-
-          {/* Key fact chips */}
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 py-4 border-y border-border">
-            <div className="flex flex-col items-center text-center min-w-[80px]">
-              <span className="text-xs text-muted-foreground">Votes Cast</span>
-              <span className="text-sm font-semibold font-mono tabular-nums">{voteCount}</span>
-            </div>
-            <div className="flex flex-col items-center text-center min-w-[80px]">
-              <span className="text-xs text-muted-foreground">Participation</span>
-              <span className="text-sm font-semibold font-mono tabular-nums">
-                {participationRate}%
-              </span>
-            </div>
-            <div className="flex flex-col items-center text-center min-w-[80px]">
-              <span className="text-xs text-muted-foreground">Delegators</span>
-              <span className="text-sm font-semibold font-mono tabular-nums">
-                {delegatorCount.toLocaleString()}
-              </span>
-            </div>
-            <div className="flex flex-col items-center text-center min-w-[80px]">
-              <span className="text-xs text-muted-foreground">Live Stake</span>
-              <span className="text-sm font-semibold font-mono tabular-nums">
-                {formatAda(liveStake)} ₳
-              </span>
-            </div>
-            {interBody.drepPct != null && (
-              <div className="flex flex-col items-center text-center min-w-[100px]">
-                <span className="text-xs text-muted-foreground">Agrees w/ DReps</span>
-                <span className="text-sm font-semibold font-mono tabular-nums text-cyan-400">
-                  {interBody.drepPct}%
-                </span>
-              </div>
-            )}
-            {interBody.ccPct != null && (
-              <div className="flex flex-col items-center text-center min-w-[100px]">
-                <span className="text-xs text-muted-foreground">Agrees w/ CC</span>
-                <span className="text-sm font-semibold font-mono tabular-nums text-violet-400">
-                  {interBody.ccPct}%
-                </span>
-              </div>
-            )}
-            {pledge != null && (
-              <div className="flex flex-col items-center text-center min-w-[80px]">
-                <span className="text-xs text-muted-foreground">Pledge</span>
-                <span className="text-sm font-semibold font-mono tabular-nums">
-                  {formatPledge(pledge)} ₳
-                </span>
-              </div>
-            )}
-            {totalVotes > 0 && (
-              <div className="flex flex-col items-center text-center min-w-[100px]">
-                <span className="text-xs text-muted-foreground">Vote Split</span>
-                <div className="flex h-1.5 w-16 rounded-full overflow-hidden bg-border mt-0.5">
-                  {yesCount > 0 && (
-                    <div
-                      className="h-full bg-emerald-500"
-                      style={{ width: `${(yesCount / totalVotes) * 100}%` }}
-                    />
-                  )}
-                  {noCount > 0 && (
-                    <div
-                      className="h-full bg-rose-500"
-                      style={{ width: `${(noCount / totalVotes) * 100}%` }}
-                    />
-                  )}
-                  {abstainCount > 0 && (
-                    <div
-                      className="h-full bg-muted-foreground/40"
-                      style={{ width: `${(abstainCount / totalVotes) * 100}%` }}
-                    />
-                  )}
-                </div>
-                <span className="text-[10px] text-muted-foreground">
-                  {yesCount}Y {noCount}N {abstainCount}A
-                </span>
-              </div>
-            )}
-          </div>
-
-          {/* Governance Radar */}
-          {hasAnyAlignment && (
-            <Card>
-              <CardHeader>
-                <CardTitle>Alignment Radar</CardTitle>
-              </CardHeader>
-              <CardContent className="flex justify-center">
-                <GovernanceRadar alignments={alignments} size="full" />
-              </CardContent>
-            </Card>
-          )}
-        </div>
-
-        {/* VP2 Section */}
+        {/* VP2: The Record */}
         <SpoProfileTabsV1
           poolId={poolId}
           votingRecordContent={<PoolProfileClient votes={safeVotes} proposals={proposals} />}
           scoreAnalysisContent={scoreAnalysisCard}
-          trajectoryContent={
-            <div className="space-y-6">
-              {scoreHistoryCard ?? (
-                <Card>
-                  <CardContent className="py-8 text-center">
-                    <p className="text-sm text-muted-foreground">No score history yet.</p>
-                  </CardContent>
-                </Card>
-              )}
-              <p className="text-xs text-muted-foreground px-1">
-                Delegator trend data coming soon via /api/spo/{poolId}/trends.
-              </p>
-            </div>
-          }
-          interBodyContent={
-            <div className="space-y-6">
-              {interBodyCard}
-              {hasAnyAlignment && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle>Alignment Radar</CardTitle>
-                  </CardHeader>
-                  <CardContent className="flex justify-center">
-                    <GovernanceRadar alignments={alignments} size="full" />
-                  </CardContent>
-                </Card>
-              )}
-            </div>
-          }
+          trajectoryContent={trajectoryContent}
+          interBodyContent={interBodyContent}
+          communityContent={communityContent}
         />
       </div>
     </TierThemeProvider>

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -334,7 +334,7 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
           </Button>
         </div>
       ) : viewMode === 'cards' ? (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div key={page} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {pageItems.map((drep, i) => {
             let ms: number | null = null;
             if (sortMode === 'match' && matchProfile) {
@@ -349,12 +349,17 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
               ms = distanceToMatchScore(alignmentDistance(matchProfile.userAlignments, dAlign));
             }
             return (
-              <CivicaDRepCard
+              <div
                 key={drep.drepId}
-                drep={drep}
-                rank={sortMode === 'match' ? undefined : page * pageSize + i + 1}
-                matchScore={ms}
-              />
+                className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
+                style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
+              >
+                <CivicaDRepCard
+                  drep={drep}
+                  rank={sortMode === 'match' ? undefined : page * pageSize + i + 1}
+                  matchScore={ms}
+                />
+              </div>
             );
           })}
         </div>

--- a/components/civica/discover/CivicaSPOBrowse.tsx
+++ b/components/civica/discover/CivicaSPOBrowse.tsx
@@ -126,9 +126,15 @@ export function CivicaSPOBrowse() {
           No pools match your filters.
         </div>
       ) : (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div key={page} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {pageItems.map((pool: any, i: number) => (
-            <CivicaSPOCard key={pool.poolId} pool={pool} rank={page * PAGE_SIZE + i + 1} />
+            <div
+              key={pool.poolId}
+              className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
+              style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
+            >
+              <CivicaSPOCard pool={pool} rank={page * PAGE_SIZE + i + 1} />
+            </div>
           ))}
         </div>
       )}

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -111,6 +111,27 @@ function TriBodyMini({
   );
 }
 
+function getConsensusLabel(triBody: {
+  drep: { yes: number; no: number; abstain: number };
+  spo: { yes: number; no: number; abstain: number };
+  cc: { yes: number; no: number; abstain: number };
+}): { label: string; color: string } | null {
+  const bodies = [triBody.drep, triBody.spo, triBody.cc];
+  const activeBodies = bodies.filter((b) => b.yes + b.no + b.abstain > 0);
+  if (activeBodies.length < 2) return null;
+  const yesPcts = activeBodies.map((b) => {
+    const total = b.yes + b.no + b.abstain;
+    return total > 0 ? b.yes / total : 0;
+  });
+  const allHigh = yesPcts.every((p) => p >= 0.6);
+  const allLow = yesPcts.every((p) => p < 0.4);
+  const mixed = yesPcts.some((p) => p >= 0.6) && yesPcts.some((p) => p < 0.4);
+  if (allHigh) return { label: 'Consensus', color: 'text-emerald-400' };
+  if (allLow) return { label: 'Opposed', color: 'text-rose-400' };
+  if (mixed) return { label: 'Contested', color: 'text-amber-400' };
+  return null;
+}
+
 const PAGE_SIZE = 25;
 
 export function ProposalsBrowse() {
@@ -250,8 +271,11 @@ export function ProposalsBrowse() {
           No proposals match your search.
         </div>
       ) : (
-        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
-          {pageItems.map((p: any) => {
+        <div
+          key={page}
+          className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden"
+        >
+          {pageItems.map((p: any, i: number) => {
             const status = p.status ?? 'Open';
             const drepVote = drepVoteMap.get(`${p.txHash}:${p.index}`);
             const pill = drepVote ? VOTE_PILL[drepVote] : null;
@@ -264,7 +288,8 @@ export function ProposalsBrowse() {
               <Link
                 key={`${p.txHash}-${p.index}`}
                 href={`/proposal/${p.txHash}/${p.index}`}
-                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group"
+                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group animate-in fade-in duration-200 fill-mode-backwards"
+                style={{ animationDelay: `${Math.min(i, 14) * 20}ms` }}
               >
                 {/* Row 1: Type + Title + Status */}
                 <div className="flex items-center gap-3">
@@ -308,6 +333,16 @@ export function ProposalsBrowse() {
                     </span>
                   )}
                   {p.triBody && <TriBodyMini triBody={p.triBody} />}
+                  {p.triBody &&
+                    (() => {
+                      const consensus = getConsensusLabel(p.triBody);
+                      if (!consensus) return null;
+                      return (
+                        <span className={cn('text-[10px] font-semibold', consensus.color)}>
+                          {consensus.label}
+                        </span>
+                      );
+                    })()}
                   {pill && (
                     <span
                       className={cn(

--- a/components/civica/mygov/CitizenCommandCenter.tsx
+++ b/components/civica/mygov/CitizenCommandCenter.tsx
@@ -180,6 +180,106 @@ function TierProgressBar({
   );
 }
 
+// ── Intelligence Headline ────────────────────────────────────────────────────
+function IntelligenceHeadline({
+  delegatedDrep,
+  drepName,
+  drepScore,
+  drepIsActive,
+  scoreDelta,
+  activeProposals,
+  criticalProposals,
+  healthStatus,
+  loading,
+}: {
+  delegatedDrep: string | null | undefined;
+  drepName: string;
+  drepScore: number;
+  drepIsActive: boolean;
+  scoreDelta: number | undefined;
+  activeProposals: number;
+  criticalProposals: number;
+  healthStatus: 'green' | 'yellow' | 'red';
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <div className="space-y-1.5">
+        <Skeleton className="h-5 w-3/4" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+    );
+  }
+
+  let headline: string;
+  let subline: string;
+  let accent: 'emerald' | 'amber' | 'rose' | 'cyan' = 'cyan';
+
+  if (!delegatedDrep) {
+    headline =
+      activeProposals > 0
+        ? `${activeProposals} governance proposal${activeProposals > 1 ? 's' : ''} ${activeProposals > 1 ? 'are' : 'is'} live right now.`
+        : 'Cardano governance is active and evolving.';
+    subline = 'Connect your wallet to see how proposals affect your stake.';
+    accent = 'cyan';
+  } else if (healthStatus === 'red') {
+    headline = !drepIsActive
+      ? `${drepName} is currently inactive.`
+      : `${drepName} scored ${drepScore} — your delegation needs attention.`;
+    subline = 'Consider reviewing alternatives to protect your governance voice.';
+    accent = 'rose';
+  } else if (criticalProposals > 0) {
+    headline = `${criticalProposals} critical proposal${criticalProposals > 1 ? 's' : ''} ${criticalProposals > 1 ? 'need' : 'needs'} attention.`;
+    subline = `${drepName} is representing your vote — check their stance.`;
+    accent = 'amber';
+  } else if (scoreDelta != null && scoreDelta < -3) {
+    headline = `${drepName}'s score dropped ${Math.abs(scoreDelta).toFixed(1)} points this epoch.`;
+    subline = 'Review their recent voting activity to understand why.';
+    accent = 'amber';
+  } else if (scoreDelta != null && scoreDelta > 3) {
+    headline = `${drepName} is rising — up ${scoreDelta.toFixed(1)} points this epoch.`;
+    subline = 'Your governance position is strengthening.';
+    accent = 'emerald';
+  } else if (healthStatus === 'green') {
+    headline =
+      activeProposals > 0
+        ? `${drepName} is actively voting across ${activeProposals} open proposal${activeProposals > 1 ? 's' : ''}.`
+        : `${drepName} is up to date on all governance matters.`;
+    subline = 'Your delegation is healthy. No action required.';
+    accent = 'emerald';
+  } else {
+    headline = `${drepName} has a moderate governance score of ${drepScore}.`;
+    subline = 'Monitor their activity and compare with higher-scoring DReps.';
+    accent = 'amber';
+  }
+
+  const borderMap = {
+    emerald: 'border-emerald-800/30',
+    amber: 'border-amber-800/30',
+    rose: 'border-rose-800/30',
+    cyan: 'border-cyan-800/30',
+  };
+  const bgMap = {
+    emerald: 'bg-emerald-950/10',
+    amber: 'bg-amber-950/10',
+    rose: 'bg-rose-950/10',
+    cyan: 'bg-cyan-950/10',
+  };
+  const textMap = {
+    emerald: 'text-emerald-300',
+    amber: 'text-amber-300',
+    rose: 'text-rose-300',
+    cyan: 'text-cyan-300',
+  };
+
+  return (
+    <div className={cn('rounded-xl border px-5 py-4 space-y-1', borderMap[accent], bgMap[accent])}>
+      <p className={cn('text-sm font-semibold', textMap[accent])}>{headline}</p>
+      <p className="text-xs text-muted-foreground">{subline}</p>
+    </div>
+  );
+}
+
 // ── Main Component ───────────────────────────────────────────────────────────
 
 export function CitizenCommandCenter({
@@ -271,6 +371,19 @@ export function CitizenCommandCenter({
 
   return (
     <div className="space-y-6">
+      {/* Intelligence headline */}
+      <IntelligenceHeadline
+        delegatedDrep={delegatedDrep}
+        drepName={drepName}
+        drepScore={drepScore}
+        drepIsActive={drepIsActive}
+        scoreDelta={scoreDelta}
+        activeProposals={activeProposals}
+        criticalProposals={criticalProposals}
+        healthStatus={healthStatus}
+        loading={drepLoading || pulseLoading}
+      />
+
       {/* Delegation health card */}
       {delegatedDrep ? (
         <Link href={`/drep/${delegatedDrep}`} className="block group">

--- a/components/civica/profiles/SpoProfileHero.tsx
+++ b/components/civica/profiles/SpoProfileHero.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { motion, useScroll, useTransform } from 'framer-motion';
+import { useRef } from 'react';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import { HexScore } from '@/components/HexScore';
+import { AccentProvider } from '@/components/AccentProvider';
+import { Badge } from '@/components/ui/badge';
+import {
+  type AlignmentScores,
+  getDominantDimension,
+  getIdentityColor,
+  getIdentityGradient,
+  getPersonalityLabel,
+} from '@/lib/drepIdentity';
+import { fadeInUp, staggerContainer } from '@/lib/animations';
+import { cn } from '@/lib/utils';
+import { Users, TrendingUp, Award, Server, Clock } from 'lucide-react';
+import { tierKey, TIER_BADGE_BG, TIER_SCORE_COLOR } from '@/components/civica/cards/tierStyles';
+import type { TierName } from '@/lib/scoring/tiers';
+
+interface SpoProfileHeroProps {
+  name: string;
+  ticker: string | null;
+  score: number;
+  tier: TierName;
+  rank: number | null;
+  delegatorCount: number;
+  liveStakeFormatted: string;
+  voteCount: number;
+  participationRate: number;
+  alignments: AlignmentScores;
+  narrative: string | null;
+  scoreMomentum: number | null;
+  lastVotedText: string | null;
+  children?: React.ReactNode;
+}
+
+function formatMomentum(m: number): string {
+  const prefix = m > 0 ? '+' : '';
+  return `${prefix}${m.toFixed(1)} pts/epoch`;
+}
+
+export function SpoProfileHero({
+  name,
+  ticker,
+  score,
+  tier,
+  rank,
+  delegatorCount,
+  liveStakeFormatted,
+  voteCount,
+  participationRate,
+  alignments,
+  narrative,
+  scoreMomentum,
+  lastVotedText,
+  children,
+}: SpoProfileHeroProps) {
+  const hasAlignment =
+    alignments.treasuryConservative != null ||
+    alignments.treasuryGrowth != null ||
+    alignments.decentralization != null ||
+    alignments.security != null ||
+    alignments.innovation != null ||
+    alignments.transparency != null;
+
+  const dominant = getDominantDimension(alignments);
+  const identityColor = hasAlignment ? getIdentityColor(dominant) : null;
+  const gradient = hasAlignment ? getIdentityGradient(dominant) : undefined;
+  const personality = hasAlignment ? getPersonalityLabel(alignments) : null;
+  const tk = tierKey(tier);
+
+  const heroRef = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: heroRef, offset: ['start start', 'end start'] });
+  const bgY = useTransform(scrollYProgress, [0, 1], [0, 40]);
+
+  const inner = (
+    <div ref={heroRef}>
+      {/* Identity gradient background with parallax */}
+      {gradient && (
+        <motion.div
+          className="absolute inset-0 -mx-4 sm:-mx-6 lg:-mx-8 pointer-events-none"
+          style={{ background: gradient, y: bgY, willChange: 'transform' }}
+          aria-hidden
+        />
+      )}
+
+      <motion.div
+        className="relative grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-8 lg:gap-12 py-8 lg:py-12"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
+        {/* Left: Identity + stats */}
+        <motion.div className="space-y-4" variants={fadeInUp}>
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-3xl lg:text-4xl font-bold tracking-tight">
+                {name.length > 40 ? name.slice(0, 40) + '\u2026' : name}
+              </h1>
+              {ticker && (
+                <Badge variant="outline" className="text-cyan-500 border-cyan-500/40 font-mono">
+                  {ticker.toUpperCase()}
+                </Badge>
+              )}
+              <span
+                className={cn(
+                  'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold',
+                  TIER_BADGE_BG[tk],
+                )}
+              >
+                {tier}
+              </span>
+            </div>
+
+            {personality && (
+              <p
+                className="text-lg font-medium font-mono"
+                style={{ color: identityColor?.hex ?? 'inherit' }}
+              >
+                {personality}
+              </p>
+            )}
+          </div>
+
+          {/* Narrative */}
+          {narrative && (
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">{narrative}</p>
+          )}
+
+          {/* Key stats */}
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground pt-2">
+            {rank !== null && (
+              <span className="flex items-center gap-1.5">
+                <Award
+                  className="h-4 w-4"
+                  style={{ color: identityColor?.hex ?? 'currentColor' }}
+                />
+                <span className="font-mono font-medium text-foreground">Top {100 - rank}%</span>
+                of SPOs
+              </span>
+            )}
+            <span className="flex items-center gap-1.5">
+              <Users className="h-4 w-4" style={{ color: identityColor?.hex ?? 'currentColor' }} />
+              <span className="font-mono font-medium text-foreground">
+                {delegatorCount.toLocaleString()}
+              </span>
+              delegators
+            </span>
+            <span className="flex items-center gap-1.5">
+              <TrendingUp
+                className="h-4 w-4"
+                style={{ color: identityColor?.hex ?? 'currentColor' }}
+              />
+              <span className="font-mono font-medium text-foreground">{liveStakeFormatted}</span>
+              ADA
+            </span>
+            <span className="flex items-center gap-1.5">
+              <Server className="h-4 w-4" style={{ color: identityColor?.hex ?? 'currentColor' }} />
+              <span className="font-mono font-medium text-foreground">{voteCount}</span>
+              votes ({participationRate}%)
+            </span>
+            {scoreMomentum != null && scoreMomentum !== 0 && (
+              <span
+                className={cn(
+                  'flex items-center gap-1 text-xs font-medium tabular-nums',
+                  scoreMomentum > 0 ? 'text-emerald-400' : 'text-rose-400',
+                )}
+              >
+                {formatMomentum(scoreMomentum)}
+              </span>
+            )}
+            {lastVotedText && (
+              <span className="flex items-center gap-1.5">
+                <Clock className="h-4 w-4 text-muted-foreground" />
+                <span className="text-xs">{lastVotedText}</span>
+              </span>
+            )}
+          </div>
+
+          {/* Actions slot */}
+          {children && <div className="pt-2 flex flex-wrap gap-2">{children}</div>}
+        </motion.div>
+
+        {/* Right: Signature visuals */}
+        {hasAlignment && (
+          <motion.div
+            className="flex items-center gap-6 lg:gap-4 justify-center lg:justify-end"
+            variants={fadeInUp}
+          >
+            <GovernanceRadar alignments={alignments} size="full" />
+            <div className="hidden sm:block">
+              <HexScore score={score} alignments={alignments} size="hero" />
+            </div>
+          </motion.div>
+        )}
+
+        {/* Fallback when no alignment: just the score */}
+        {!hasAlignment && (
+          <motion.div
+            className="flex items-center justify-center lg:justify-end"
+            variants={fadeInUp}
+          >
+            <div className="text-center space-y-1">
+              <span
+                className={cn('font-display text-5xl font-bold tabular-nums', TIER_SCORE_COLOR[tk])}
+              >
+                {score}
+              </span>
+              <p className="text-xs text-muted-foreground">governance score</p>
+            </div>
+          </motion.div>
+        )}
+      </motion.div>
+    </div>
+  );
+
+  if (hasAlignment) {
+    return (
+      <AccentProvider dimension={dominant} className="relative">
+        {inner}
+      </AccentProvider>
+    );
+  }
+
+  return <div className="relative">{inner}</div>;
+}

--- a/components/civica/profiles/SpoProfileTabsV1.tsx
+++ b/components/civica/profiles/SpoProfileTabsV1.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnimatedTabs, type TabDefinition } from '@/components/AnimatedTabs';
-import { Vote, BarChart3, TrendingUp, Network } from 'lucide-react';
+import { Vote, BarChart3, TrendingUp, Network, Users } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 interface SpoProfileTabsV1Props {
@@ -10,6 +10,7 @@ interface SpoProfileTabsV1Props {
   scoreAnalysisContent: ReactNode;
   trajectoryContent: ReactNode;
   interBodyContent: ReactNode;
+  communityContent?: ReactNode;
 }
 
 export function SpoProfileTabsV1({
@@ -18,6 +19,7 @@ export function SpoProfileTabsV1({
   scoreAnalysisContent,
   trajectoryContent,
   interBodyContent,
+  communityContent,
 }: SpoProfileTabsV1Props) {
   const tabs: TabDefinition[] = [
     { id: 'voting', label: 'Voting Record', icon: Vote, content: votingRecordContent },
@@ -25,6 +27,10 @@ export function SpoProfileTabsV1({
     { id: 'trajectory', label: 'Trajectory', icon: TrendingUp, content: trajectoryContent },
     { id: 'inter-body', label: 'Inter-Body', icon: Network, content: interBodyContent },
   ];
+
+  if (communityContent) {
+    tabs.push({ id: 'community', label: 'Community', icon: Users, content: communityContent });
+  }
 
   return (
     <AnimatedTabs

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -20,29 +20,36 @@ import { useGovernancePulse } from '@/hooks/queries';
 import { useTreasuryCurrent } from '@/hooks/queries';
 import { useGovernanceLeaderboard } from '@/hooks/queries';
 import { CivicaEpochReport } from './CivicaEpochReport';
-import { CivicaTreasury } from './CivicaTreasury';
 import { CivicaGovernanceTrends } from './CivicaGovernanceTrends';
 import { CivicaObservatory } from './CivicaObservatory';
 import { CivicaGovernanceCalendar } from './CivicaGovernanceCalendar';
 import { StateOfGovernance } from './StateOfGovernance';
 
-type PulseTab = 'overview' | 'epoch' | 'treasury' | 'trends' | 'observatory' | 'calendar';
+type PulseTab = 'now' | 'history' | 'observatory';
 
 const TABS: { id: PulseTab; label: string }[] = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'epoch', label: 'Epoch' },
-  { id: 'treasury', label: 'Treasury' },
-  { id: 'trends', label: 'Trends' },
+  { id: 'now', label: 'Now' },
+  { id: 'history', label: 'History' },
   { id: 'observatory', label: 'Observatory' },
-  { id: 'calendar', label: 'Calendar' },
 ];
 
 const VALID_PULSE_TABS = new Set<PulseTab>(TABS.map((t) => t.id));
 
+// Legacy tab aliases for backwards compatibility with bookmarked URLs
+const TAB_ALIASES: Record<string, PulseTab> = {
+  overview: 'now',
+  epoch: 'history',
+  treasury: 'now',
+  trends: 'history',
+  calendar: 'history',
+};
+
 function resolvePulseTab(param: string | null): PulseTab {
-  if (!param) return 'overview';
-  const lower = param.toLowerCase() as PulseTab;
-  return VALID_PULSE_TABS.has(lower) ? lower : 'overview';
+  if (!param) return 'now';
+  const lower = param.toLowerCase();
+  if (VALID_PULSE_TABS.has(lower as PulseTab)) return lower as PulseTab;
+  if (lower in TAB_ALIASES) return TAB_ALIASES[lower];
+  return 'now';
 }
 
 function StatCard({
@@ -121,7 +128,7 @@ export function CivicaPulseOverview() {
   const setActiveTab = useCallback(
     (tab: PulseTab) => {
       const params = new URLSearchParams(searchParams.toString());
-      if (tab === 'overview') {
+      if (tab === 'now') {
         params.delete('tab');
       } else {
         params.set('tab', tab);
@@ -167,14 +174,19 @@ export function CivicaPulseOverview() {
         ))}
       </div>
 
-      {activeTab === 'epoch' && <CivicaEpochReport />}
-      {activeTab === 'treasury' && <CivicaTreasury />}
-      {activeTab === 'trends' && <CivicaGovernanceTrends />}
       {activeTab === 'observatory' && <CivicaObservatory />}
-      {activeTab === 'calendar' && <CivicaGovernanceCalendar />}
 
-      {/* ── Overview tab ────────────────────────────────────── */}
-      {activeTab === 'overview' && (
+      {/* ── History tab: epoch report + trends + calendar ───── */}
+      {activeTab === 'history' && (
+        <div className="space-y-8">
+          <CivicaEpochReport />
+          <CivicaGovernanceTrends />
+          <CivicaGovernanceCalendar />
+        </div>
+      )}
+
+      {/* ── Now tab ─────────────────────────────────────────── */}
+      {activeTab === 'now' && (
         <>
           {/* ── State of Governance narrative ───────────────────── */}
           <StateOfGovernance />


### PR DESCRIPTION
## Summary
- **SPO Profile Hero**: New parallax hero with GovernanceRadar, HexScore, identity-colored stats, narrative generation, score momentum, vote recency, and community tab
- **Pulse Tab Consolidation**: 6 tabs → 3 (Now/History/Observatory) with backwards-compatible URL aliases for bookmarked links
- **Command Center Intelligence Headline**: Contextual one-liner that adapts to delegation health, score momentum, critical proposals, and ecosystem state — tells users what matters right now
- **Discovery Stagger Animation**: Cards animate in with staggered fade+slide on page mount and pagination
- **Proposal Consensus Indicator**: Shows "Consensus", "Contested", or "Opposed" based on tri-body voting alignment across DRep/SPO/CC bodies

## Test plan
- [ ] Verify SPO profile page renders hero with radar, hex score, and narrative at `/pool/<poolId>`
- [ ] Verify Pulse page shows 3 tabs (Now, History, Observatory) and old bookmarked URLs redirect correctly
- [ ] Verify Command Center headline adapts when connected with/without delegation
- [ ] Verify DRep/SPO card grids animate in with stagger effect on discover page
- [ ] Verify proposal list shows consensus labels for proposals with tri-body data
- [ ] Preflight passes: format, lint, types, tests (306/306)

🤖 Generated with [Claude Code](https://claude.com/claude-code)