### PR TITLE
feat: UX narrative layer — plain-English labels, verdict card, nav fix

### DIFF
--- a/__tests__/components/DRepProfileHero.test.tsx
+++ b/__tests__/components/DRepProfileHero.test.tsx
@@ -50,7 +50,9 @@ describe('DRepProfileHero', () => {
   it('renders with valid props', () => {
     const { container } = render(<DRepProfileHero {...defaultProps} />);
     expect(container.textContent).toContain('TestDRep');
-    expect(screen.getByTestId('hex-score').textContent).toBe('85');
+    const hexScores = screen.getAllByTestId('hex-score');
+    expect(hexScores.length).toBe(2);
+    expect(hexScores[0].textContent).toBe('85');
   });
 
   it('renders with match score', () => {

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -304,14 +304,108 @@ async function getSpoAlignment(votes: VoteRecord[]): Promise<number | null> {
   }
 }
 
-/* ─── Key Facts Strip ─── */
-function KeyFact({ label, value, subtext }: { label: string; value: string; subtext?: string }) {
+/* ─── Delegation Verdict ─── */
+function DelegationVerdict({
+  score,
+  rank,
+  participationRate,
+  rationaleRate,
+  totalVotes,
+  isActive,
+  delegatorCount,
+  scoreMomentum,
+}: {
+  score: number;
+  rank: number | null;
+  participationRate: number;
+  rationaleRate: number;
+  totalVotes: number;
+  isActive: boolean;
+  delegatorCount: number;
+  scoreMomentum: number | null;
+}) {
+  if (totalVotes === 0) {
+    return (
+      <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 px-5 py-4">
+        <p className="text-sm font-medium">This DRep hasn&apos;t voted on any proposals yet.</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Check back after they participate in governance to see their track record.
+        </p>
+      </div>
+    );
+  }
+
+  const headline = !isActive
+    ? 'This DRep is currently inactive and not accepting new delegations.'
+    : score >= 80
+      ? 'A highly active and transparent representative with a strong governance track record.'
+      : score >= 60
+        ? 'A solid representative who participates regularly in governance.'
+        : score >= 40
+          ? 'A developing representative — participating but with room to improve.'
+          : 'An early-stage representative. Limited activity so far.';
+
+  const details: string[] = [];
+  if (participationRate >= 80) details.push('votes on most proposals');
+  else if (participationRate >= 50) details.push('votes on about half of proposals');
+  else details.push('votes selectively');
+
+  if (rationaleRate >= 80) details.push('almost always explains their reasoning');
+  else if (rationaleRate >= 50) details.push('explains their reasoning about half the time');
+  else if (rationaleRate > 0) details.push('rarely explains their reasoning');
+  else details.push("hasn't provided vote rationales yet");
+
+  if (scoreMomentum != null && scoreMomentum > 0.5) details.push('trending upward');
+  else if (scoreMomentum != null && scoreMomentum < -0.5) details.push('score declining recently');
+
+  const borderColor =
+    score >= 70
+      ? 'border-emerald-500/20 bg-emerald-500/5'
+      : score >= 40
+        ? 'border-primary/20 bg-primary/5'
+        : 'border-amber-500/20 bg-amber-500/5';
+
   return (
+    <div className={`rounded-xl border ${borderColor} px-5 py-4`}>
+      <p className="text-sm font-medium">{headline}</p>
+      <p className="text-xs text-muted-foreground mt-1 capitalize">{details.join(' · ')}</p>
+    </div>
+  );
+}
+
+/* ─── Key Facts Strip ─── */
+function KeyFact({
+  label,
+  value,
+  subtext,
+  tooltip,
+}: {
+  label: string;
+  value: string;
+  subtext?: string;
+  tooltip?: string;
+}) {
+  const content = (
     <div className="flex flex-col items-center text-center min-w-[80px]">
       <span className="text-xs text-muted-foreground">{label}</span>
       <span className="text-sm font-semibold font-mono tabular-nums">{value}</span>
       {subtext && <span className="text-[10px] text-muted-foreground">{subtext}</span>}
     </div>
+  );
+
+  if (!tooltip) return content;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="cursor-help">{content}</div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="text-xs max-w-[200px]">{tooltip}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 
@@ -506,22 +600,52 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         </div>
       )}
 
+      {/* 3b. Delegation Verdict */}
+      <DelegationVerdict
+        score={drep.drepScore}
+        rank={rank}
+        participationRate={drep.effectiveParticipation}
+        rationaleRate={drep.rationaleRate}
+        totalVotes={drep.totalVotes}
+        isActive={drep.isActive}
+        delegatorCount={drep.delegatorCount}
+        scoreMomentum={drep.scoreMomentum}
+      />
+
       {/* 4. Key Facts Strip */}
       <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 py-4 border-y border-border">
         <KeyFact
-          label="Score"
+          label="Governance Score"
           value={`${drep.drepScore}/100`}
           subtext={percentile > 0 ? `Top ${100 - percentile}%` : undefined}
+          tooltip="Overall quality score based on participation, rationale, reliability, and profile completeness"
         />
-        <KeyFact label="Participation" value={`${drep.effectiveParticipation}%`} />
-        <KeyFact label="Rationale" value={`${drep.rationaleRate}%`} />
-        <KeyFact label="Alignment" value={identityLabel} />
+        <KeyFact
+          label="Votes Cast"
+          value={`${drep.effectiveParticipation}%`}
+          tooltip="How often this DRep votes on proposals, adjusted for voting pattern diversity"
+        />
+        <KeyFact
+          label="Explains Votes"
+          value={`${drep.rationaleRate}%`}
+          tooltip="How often this DRep provides written reasoning for their votes"
+        />
+        <KeyFact
+          label="Governance Style"
+          value={identityLabel}
+          tooltip="Dominant governance philosophy based on voting patterns across 6 dimensions"
+        />
         {spoAlignPct !== null && (
-          <KeyFact label="SPO Alignment" value={`${spoAlignPct}%`} subtext="of the time" />
+          <KeyFact
+            label="Agrees with SPOs"
+            value={`${spoAlignPct}%`}
+            subtext="of the time"
+            tooltip="How often this DRep votes the same way as the SPO majority"
+          />
         )}
         {drep.totalVotes > 0 && (
           <div className="flex flex-col items-center text-center min-w-[100px]">
-            <span className="text-xs text-muted-foreground">Vote Split</span>
+            <span className="text-xs text-muted-foreground">Voting Pattern</span>
             <div className="flex items-center gap-1 mt-0.5">
               <div className="flex h-1.5 w-16 rounded-full overflow-hidden bg-border">
                 {drep.yesVotes > 0 && (
@@ -650,6 +774,9 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       {/* 7. Activity feed */}
       <ActivitySideWidget drepId={drep.drepId} limit={5} />
 
+      {/* 8. Similar DReps */}
+      <SimilarDReps drepId={drep.drepId} />
+
       {/* ════════════════════════════════════════════
           VP2 — "The Record" (below fold, tabbed)
           ════════════════════════════════════════════ */}
@@ -750,8 +877,6 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           </div>
         }
       />
-
-      <SimilarDReps drepId={drep.drepId} />
     </div>
   );
 

--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -139,6 +139,9 @@ export function DRepProfileHero({
             <div className="hidden sm:block">
               <HexScore score={score} alignments={alignments} size="hero" />
             </div>
+            <div className="block sm:hidden">
+              <HexScore score={score} alignments={alignments} size="card" />
+            </div>
           </motion.div>
         </motion.div>
       </div>

--- a/components/DRepVoteCallout.tsx
+++ b/components/DRepVoteCallout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import Link from 'next/link';
 import { useWallet } from '@/utils/wallet';
 import { useDRepVotes } from '@/hooks/queries';
 import { Card, CardContent } from '@/components/ui/card';
@@ -52,6 +53,12 @@ export function DRepVoteCallout({ txHash, proposalIndex }: DRepVoteCalloutProps)
         <CardContent className="p-3 flex items-center gap-2">
           <Icon className="h-4 w-4 shrink-0" />
           <span className="text-sm font-medium">{config.text}</span>
+          <Link
+            href={`/drep/${encodeURIComponent(delegatedDrepId)}`}
+            className="text-xs text-primary hover:underline ml-auto shrink-0"
+          >
+            View profile
+          </Link>
         </CardContent>
       </Card>
     );
@@ -64,6 +71,12 @@ export function DRepVoteCallout({ txHash, proposalIndex }: DRepVoteCalloutProps)
         <span className="text-sm text-muted-foreground">
           Your DRep has not voted on this proposal yet
         </span>
+        <Link
+          href={`/drep/${encodeURIComponent(delegatedDrepId)}`}
+          className="text-xs text-primary hover:underline ml-auto shrink-0"
+        >
+          View profile
+        </Link>
       </CardContent>
     </Card>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -32,7 +32,6 @@ import {
   Wallet,
   Info,
   Compass,
-  ScrollText,
   AlertTriangle,
   FileText,
   Vote,
@@ -208,10 +207,6 @@ export function Header() {
           <Link href="/discover" className={navLinkClass('/discover')}>
             <Compass className="h-4 w-4" />
             <span>Discover</span>
-          </Link>
-          <Link href="/discover" className={navLinkClass('/discover')}>
-            <ScrollText className="h-4 w-4" />
-            <span>Proposals</span>
           </Link>
           <Link href="/pulse" className={navLinkClass('/pulse')}>
             <Activity className="h-4 w-4" />

--- a/components/civica/MyGovClient.tsx
+++ b/components/civica/MyGovClient.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Bell, User, LayoutDashboard } from 'lucide-react';
+import { Bell, User, LayoutDashboard, ShieldCheck, Vote, TrendingUp } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { CitizenCommandCenter } from './mygov/CitizenCommandCenter';
 import { DRepCommandCenter } from './mygov/DRepCommandCenter';
@@ -44,15 +45,51 @@ function MyGovSubNav() {
 }
 
 function ConnectPrompt() {
+  const features = [
+    {
+      icon: ShieldCheck,
+      title: 'Delegation Health',
+      desc: 'See how your DRep is performing and if they are representing you well',
+    },
+    {
+      icon: Vote,
+      title: 'Open Proposals',
+      desc: 'Track active governance proposals and how your DRep voted',
+    },
+    {
+      icon: TrendingUp,
+      title: 'Action Recommendations',
+      desc: 'Get personalized suggestions to strengthen your governance participation',
+    },
+  ];
+
   return (
-    <div className="rounded-xl border border-border bg-card p-8 text-center space-y-4">
-      <p className="text-lg font-bold">Connect Your Wallet</p>
-      <p className="text-sm text-muted-foreground max-w-xs mx-auto">
-        Connect your Cardano wallet to access your personal governance command center.
-      </p>
-      <p className="text-xs text-muted-foreground">
-        View delegation health, track open proposals, and get personalised action recommendations.
-      </p>
+    <div className="space-y-6">
+      <div className="rounded-xl border border-border bg-card p-8 text-center space-y-4">
+        <p className="text-lg font-bold">Your Civic Command Center</p>
+        <p className="text-sm text-muted-foreground max-w-sm mx-auto">
+          Connect your Cardano wallet to see your personalized governance dashboard — delegation
+          health, voting activity, and action recommendations.
+        </p>
+        <Button
+          onClick={() => window.dispatchEvent(new CustomEvent('openWalletConnect', { detail: {} }))}
+        >
+          Connect Wallet
+        </Button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        {features.map(({ icon: Icon, title, desc }) => (
+          <div
+            key={title}
+            className="rounded-xl border border-border/50 bg-card/50 p-4 space-y-2 opacity-70"
+          >
+            <Icon className="h-5 w-5 text-primary" />
+            <p className="text-sm font-medium">{title}</p>
+            <p className="text-xs text-muted-foreground">{desc}</p>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/civica/proposals/ProposalHeroV1.tsx
+++ b/components/civica/proposals/ProposalHeroV1.tsx
@@ -139,6 +139,31 @@ export function ProposalHeroV1({
         <DeadlineBadge expirationEpoch={expirationEpoch} currentEpoch={currentEpoch} />
       </div>
 
+      {/* Urgency callout for proposals close to expiring */}
+      {expirationEpoch != null &&
+        !ratifiedEpoch &&
+        !enactedEpoch &&
+        !droppedEpoch &&
+        !expiredEpoch &&
+        (() => {
+          const remaining = Math.max(0, expirationEpoch - currentEpoch);
+          if (remaining > 2 || remaining === 0) return null;
+          const daysApprox = remaining * 5;
+          return (
+            <div
+              className={`rounded-lg px-4 py-2.5 text-sm font-medium ${
+                remaining <= 1
+                  ? 'bg-red-500/10 text-red-700 dark:text-red-400 border border-red-500/30'
+                  : 'bg-amber-500/10 text-amber-700 dark:text-amber-400 border border-amber-500/30'
+              }`}
+            >
+              {remaining <= 1
+                ? `Voting closes this epoch — roughly ${daysApprox} days remaining`
+                : `Voting closes in ${remaining} epochs (~${daysApprox} days)`}
+            </div>
+          );
+        })()}
+
       {/* Title */}
       <h1 className="text-2xl sm:text-3xl font-bold leading-tight">{title}</h1>
 


### PR DESCRIPTION
## Summary

- **DRep Profile**: Add tooltips to all Key Facts with plain-English explanations; rewrite labels (Score→Governance Score, Participation→Votes Cast, Rationale→Explains Votes, Alignment→Governance Style, SPO Alignment→Agrees with SPOs, Vote Split→Voting Pattern)
- **Delegation Verdict Card**: New component synthesizing DRep quality into a 2-line human-readable summary (above key facts strip)
- **Mobile HexScore**: Show compact HexScore on mobile (was `hidden sm:block`)
- **Nav fix**: Remove duplicate Proposals link that pointed to same URL as Discover
- **SimilarDReps**: Moved from after VP2 tabs to within VP1 for better discoverability
- **Proposal urgency**: Add prominent callout when proposals expire within 2 epochs
- **Cross-page intelligence**: DRepVoteCallout now links to DRep profile
- **My Gov preview**: Enhanced unauthenticated connect prompt with feature preview cards

## Test plan

- [x] Preflight passes (format, lint, type-check, 306 tests)
- [ ] CI passes
- [ ] DRep profile page: verify tooltips on Key Facts, verdict card renders, HexScore shows on mobile
- [ ] Proposal page: verify urgency callout for proposals close to expiry
- [ ] /my-gov unauthenticated: verify feature preview cards appear
- [ ] Header: verify no duplicate nav links

🤖 Generated with [Claude Code](https://claude.com/claude-code)