### PR TITLE
fix: unify admin wallet check for feature flags

### DIFF
--- a/app/api/admin/check/route.ts
+++ b/app/api/admin/check/route.ts
@@ -1,49 +1,7 @@
 import { NextResponse } from 'next/server';
-import { bech32 } from 'bech32';
 import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
-
-function deriveStakeFromPaymentAddress(paymentAddress: string): string | null {
-  try {
-    const decoded = bech32.decode(paymentAddress, 256);
-    if (decoded.prefix !== 'addr' && decoded.prefix !== 'addr_test') return null;
-
-    const data = bech32.fromWords(decoded.words);
-    if (data.length !== 57) return null;
-
-    const headerByte = data[0];
-    const addrType = (headerByte & 0xf0) >> 4;
-    if (addrType > 3) return null;
-
-    const networkId = headerByte & 0x0f;
-    const stakeKeyHash = data.slice(29);
-
-    const stakeHeader = 0xe0 | networkId;
-    const stakeBytes = new Uint8Array(1 + stakeKeyHash.length);
-    stakeBytes[0] = stakeHeader;
-    stakeBytes.set(stakeKeyHash, 1);
-
-    const prefix = networkId === 1 ? 'stake' : 'stake_test';
-    return bech32.encode(prefix, bech32.toWords(stakeBytes), 256);
-  } catch {
-    return null;
-  }
-}
-
-function isAdminWallet(address: string): boolean {
-  const adminWallets = (process.env.ADMIN_WALLETS || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-
-  const lower = address.toLowerCase();
-  if (adminWallets.includes(lower)) return true;
-
-  const stakeAddr = deriveStakeFromPaymentAddress(lower);
-  if (stakeAddr && adminWallets.includes(stakeAddr.toLowerCase())) return true;
-
-  return false;
-}
 
 /**
  * POST: Check if the authenticated wallet is an admin.

--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -2,17 +2,10 @@ import { NextResponse } from 'next/server';
 import { getAllFlags, setFeatureFlag, invalidateFlagCache } from '@/lib/featureFlags';
 import { requireAuth } from '@/lib/supabaseAuth';
 import { logAdminAction } from '@/lib/adminAudit';
+import { isAdminWallet } from '@/lib/adminAuth';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
-
-function isAdminWallet(address: string): boolean {
-  const adminWallets = (process.env.ADMIN_WALLETS || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  return adminWallets.includes(address.toLowerCase());
-}
 
 /**
  * GET: Returns flag boolean map for all callers.

--- a/lib/adminAuth.ts
+++ b/lib/adminAuth.ts
@@ -1,0 +1,43 @@
+import { bech32 } from 'bech32';
+
+function deriveStakeFromPaymentAddress(paymentAddress: string): string | null {
+  try {
+    const decoded = bech32.decode(paymentAddress, 256);
+    if (decoded.prefix !== 'addr' && decoded.prefix !== 'addr_test') return null;
+
+    const data = bech32.fromWords(decoded.words);
+    if (data.length !== 57) return null;
+
+    const headerByte = data[0];
+    const addrType = (headerByte & 0xf0) >> 4;
+    if (addrType > 3) return null;
+
+    const networkId = headerByte & 0x0f;
+    const stakeKeyHash = data.slice(29);
+
+    const stakeHeader = 0xe0 | networkId;
+    const stakeBytes = new Uint8Array(1 + stakeKeyHash.length);
+    stakeBytes[0] = stakeHeader;
+    stakeBytes.set(stakeKeyHash, 1);
+
+    const prefix = networkId === 1 ? 'stake' : 'stake_test';
+    return bech32.encode(prefix, bech32.toWords(stakeBytes), 256);
+  } catch {
+    return null;
+  }
+}
+
+export function isAdminWallet(address: string): boolean {
+  const adminWallets = (process.env.ADMIN_WALLETS || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  const lower = address.toLowerCase();
+  if (adminWallets.includes(lower)) return true;
+
+  const stakeAddr = deriveStakeFromPaymentAddress(lower);
+  if (stakeAddr && adminWallets.includes(stakeAddr.toLowerCase())) return true;
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Extract shared `isAdminWallet` (with bech32 stake address derivation) into `lib/adminAuth.ts`
- Update `/api/admin/check` and `/api/admin/feature-flags` to use the shared module
- Fixes: admin feature flags page showing "No feature flags found" when `ADMIN_WALLETS` contains a stake address but the session has a payment address

## Test plan
- [ ] Connect admin wallet → navigate to Admin → Feature Flags
- [ ] Verify flags list loads with toggle switches
- [ ] Toggle a flag and confirm it persists after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)