### PR TITLE
fix: wire globe flag into homepage + clean up flag categories

### DIFF
--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState, useCallback, useEffect } from 'react';
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { ChevronDown } from 'lucide-react';
 import { useWallet } from '@/utils/wallet';
@@ -12,27 +11,12 @@ import { ActivityTicker } from '@/components/ActivityTicker';
 import { PersonalizedStatsStrip } from '@/components/PersonalizedStatsStrip';
 import { ConstellationSearch } from '@/components/ConstellationSearch';
 import { ConstellationNodeDetail } from '@/components/ConstellationNodeDetail';
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 import type { UserSegment } from '@/components/PersonalGovernanceCard';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
 import type { ConstellationNode3D } from '@/lib/constellation/types';
 import type { AlignmentDimension } from '@/lib/drepIdentity';
-
-const GovernanceConstellation = dynamic(
-  () =>
-    import('@/components/GovernanceConstellation').then((m) => ({
-      default: m.GovernanceConstellation,
-    })),
-  { ssr: false },
-);
-
-const GlobeConstellation = dynamic(
-  () =>
-    import('@/components/GlobeConstellation').then((m) => ({
-      default: m.GlobeConstellation,
-    })),
-  { ssr: false },
-);
 
 interface PersonalCardData {
   segment: UserSegment;
@@ -71,8 +55,6 @@ export function ConstellationHero({
 
   const interactiveFlag = useFeatureFlag('interactive_constellation');
   const isInteractive = interactiveFlag === true;
-  const globeFlag = useFeatureFlag('globe_constellation');
-  const useGlobe = globeFlag === true;
   const [selectedNode, setSelectedNode] = useState<ConstellationNode3D | null>(null);
 
   useEffect(() => {
@@ -264,25 +246,14 @@ export function ConstellationHero({
       className={`relative w-full transition-all duration-700 -mt-16 ${contracted ? 'min-h-[calc(35vh+4rem)]' : 'min-h-[calc(65vh+4rem)]'}`}
       onMouseEnter={handleConstellationHover}
     >
-      {useGlobe ? (
-        <GlobeConstellation
-          ref={constellationRef}
-          interactive={isInteractive}
-          onReady={handleConstellationReady}
-          onContracted={handleConstellationContracted}
-          onNodeSelect={isInteractive ? handleNodeSelect : undefined}
-          className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
-        />
-      ) : (
-        <GovernanceConstellation
-          ref={constellationRef}
-          interactive={isInteractive}
-          onReady={handleConstellationReady}
-          onContracted={handleConstellationContracted}
-          onNodeSelect={isInteractive ? handleNodeSelect : undefined}
-          className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
-        />
-      )}
+      <ConstellationScene
+        ref={constellationRef}
+        interactive={isInteractive}
+        onReady={handleConstellationReady}
+        onContracted={handleConstellationContracted}
+        onNodeSelect={isInteractive ? handleNodeSelect : undefined}
+        className={contracted ? 'h-[35vh]' : 'h-[65vh]'}
+      />
 
       {/* SSR gradient fallback */}
       <div

--- a/components/ConstellationScene.tsx
+++ b/components/ConstellationScene.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { forwardRef } from 'react';
+import dynamic from 'next/dynamic';
+import { useFeatureFlag } from '@/components/FeatureGate';
+import type { ConstellationRef } from '@/components/GovernanceConstellation';
+import type { ConstellationNode3D } from '@/lib/constellation/types';
+
+const GovernanceConstellation = dynamic(
+  () =>
+    import('@/components/GovernanceConstellation').then((m) => ({
+      default: m.GovernanceConstellation,
+    })),
+  { ssr: false },
+);
+
+const GlobeConstellation = dynamic(
+  () =>
+    import('@/components/GlobeConstellation').then((m) => ({
+      default: m.GlobeConstellation,
+    })),
+  { ssr: false },
+);
+
+interface ConstellationSceneProps {
+  interactive?: boolean;
+  onReady?: () => void;
+  onContracted?: () => void;
+  onNodeSelect?: (node: ConstellationNode3D) => void;
+  className?: string;
+}
+
+/**
+ * Flag-gated constellation wrapper. Renders the globe variant when
+ * `globe_constellation` is enabled, otherwise the flat constellation.
+ */
+export const ConstellationScene = forwardRef<ConstellationRef, ConstellationSceneProps>(
+  function ConstellationScene(props, ref) {
+    const globeFlag = useFeatureFlag('globe_constellation');
+    const useGlobe = globeFlag === true;
+
+    if (useGlobe) {
+      return <GlobeConstellation ref={ref} {...props} />;
+    }
+    return <GovernanceConstellation ref={ref} {...props} />;
+  },
+);

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { ArrowRight, Users, ShieldCheck, Activity, Zap, Vote, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-
-const GovernanceConstellation = dynamic(
-  () =>
-    import('@/components/GovernanceConstellation').then((m) => ({
-      default: m.GovernanceConstellation,
-    })),
-  { ssr: false },
-);
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -38,7 +30,7 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
         aria-label="Governance constellation visualization"
       >
         <div className="absolute inset-0">
-          <GovernanceConstellation className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
 
         {/* Gradient fade at bottom */}

--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -20,15 +20,7 @@ import { computeTier } from '@/lib/scoring/tiers';
 import { useDRepReportCard } from '@/hooks/queries';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useWallet } from '@/utils/wallet';
-import dynamic from 'next/dynamic';
-
-const GovernanceConstellation = dynamic(
-  () =>
-    import('@/components/GovernanceConstellation').then((m) => ({
-      default: m.GovernanceConstellation,
-    })),
-  { ssr: false },
-);
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 const TIER_COLORS: Record<string, string> = {
   Emerging: 'text-muted-foreground',
@@ -80,7 +72,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
       {/* ── Constellation hero (~35vh) ─────────────────────────────── */}
       <section className="relative h-[35vh] min-h-[280px] sm:-mt-14 overflow-hidden">
         <div className="absolute inset-0">
-          <GovernanceConstellation className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
         <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-background to-transparent pointer-events-none" />
 
@@ -232,7 +224,7 @@ export function HomeCitizen({ pulseData, ssrHolderData, ssrWalletAddress }: Home
       {/* ── Constellation hero (28vh) — branded ambient with personal context ── */}
       <section className="relative h-[28vh] min-h-[200px] sm:-mt-14 overflow-hidden">
         <div className="absolute inset-0">
-          <GovernanceConstellation className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
         <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-background to-transparent pointer-events-none" />
 

--- a/components/civica/home/HomeDRep.tsx
+++ b/components/civica/home/HomeDRep.tsx
@@ -23,15 +23,7 @@ import {
   useDashboardDelegatorTrends,
 } from '@/hooks/queries';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import dynamic from 'next/dynamic';
-
-const GovernanceConstellation = dynamic(
-  () =>
-    import('@/components/GovernanceConstellation').then((m) => ({
-      default: m.GovernanceConstellation,
-    })),
-  { ssr: false },
-);
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 const TIER_COLORS: Record<string, string> = {
   Emerging: 'text-muted-foreground',
@@ -135,7 +127,7 @@ export function HomeDRep() {
       {/* ── Constellation hero (25vh) — "You are governance" ──────── */}
       <section className="relative h-[25vh] min-h-[180px] sm:-mt-14 overflow-hidden">
         <div className="absolute inset-0">
-          <GovernanceConstellation className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
         <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-background to-transparent pointer-events-none" />
 

--- a/components/civica/home/HomeSPO.tsx
+++ b/components/civica/home/HomeSPO.tsx
@@ -8,15 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { GovTerm } from '@/components/GovTerm';
 import { useSPOPoolCompetitive } from '@/hooks/queries';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import dynamic from 'next/dynamic';
-
-const GovernanceConstellation = dynamic(
-  () =>
-    import('@/components/GovernanceConstellation').then((m) => ({
-      default: m.GovernanceConstellation,
-    })),
-  { ssr: false },
-);
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 const TIER_COLORS: Record<string, string> = {
   Emerging: 'text-muted-foreground',
@@ -114,7 +106,7 @@ export function HomeSPO() {
       {/* ── Constellation hero (25vh) — "You help run this network" ── */}
       <section className="relative h-[25vh] min-h-[180px] sm:-mt-14 overflow-hidden">
         <div className="absolute inset-0">
-          <GovernanceConstellation className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
         <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-background to-transparent pointer-events-none" />
 


### PR DESCRIPTION
## Summary
- Create `ConstellationScene` wrapper that checks `globe_constellation` flag and renders either `GlobeConstellation` or `GovernanceConstellation`
- Replace hardcoded `GovernanceConstellation` in all 4 home variants (`HomeAnonymous`, `HomeCitizen`, `HomeDRep`, `HomeSPO`) + `ConstellationHero` with the new wrapper
- Delete dead `civica_frontend` flag from DB
- Normalize all flag categories to consistent lowercase grouping: `citizen`, `governance`, `scoring`, `spo`, `visualization`

## Test plan
- [ ] Toggle `globe_constellation` flag on in Admin → Feature Flags
- [ ] Hard refresh homepage — should show globe visualization
- [ ] Toggle flag off — should revert to flat constellation
- [ ] Verify Admin → Feature Flags page shows clean categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)