### PR TITLE
feat: SPO infrastructure globe V2

### DIFF
--- a/app/api/governance/constellation/route.ts
+++ b/app/api/governance/constellation/route.ts
@@ -60,7 +60,7 @@ export const GET = withRouteHandler(async (_request, { requestId }) => {
     supabase
       .from('pools')
       .select(
-        'pool_id, ticker, pool_name, governance_score, vote_count, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+        'pool_id, ticker, pool_name, governance_score, vote_count, relay_lat, relay_lon, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
       )
       .gt('vote_count', 0),
 
@@ -135,6 +135,9 @@ export const GET = withRouteHandler(async (_request, { requestId }) => {
       dominant: getDominantDimension(aligns),
       alignments: arr,
       nodeType: 'spo' as const,
+      ...(p.relay_lat != null && p.relay_lon != null
+        ? { geoLat: p.relay_lat, geoLon: p.relay_lon }
+        : {}),
     };
   });
 

--- a/components/GlobeConstellation.tsx
+++ b/components/GlobeConstellation.tsx
@@ -230,7 +230,6 @@ export const GlobeConstellation = forwardRef<
             />
             <ConstellationEdges edges={sceneState.edges} dimmed={sceneState.dimmed} />
           </TiltedGlobeGroup>
-          <ShootingStars />
 
           {quality !== 'low' && (
             <EffectComposer>
@@ -349,6 +348,23 @@ void main() {
 }
 `;
 
+// Diamond-shaped fragment shader for SPO infrastructure nodes
+const SPO_FRAG = /* glsl */ `
+varying vec3 vColor;
+varying float vAlpha;
+
+void main() {
+  vec2 p = gl_PointCoord - vec2(0.5);
+  // Diamond (rotated square) distance: |x| + |y|
+  float diamond = abs(p.x) + abs(p.y);
+  if (diamond > 0.5) discard;
+  float glow = 1.0 - smoothstep(0.0, 0.5, diamond);
+  float core = 1.0 - smoothstep(0.0, 0.15, diamond);
+  vec3 col = vColor * (1.0 + core * 2.0);
+  gl_FragColor = vec4(col, glow * vAlpha);
+}
+`;
+
 // --- Scene sub-components ---
 
 function RaycastConfig() {
@@ -423,6 +439,7 @@ function ConstellationNodes({
           onNodeClick={onNodeClick}
           getColor={getSpoColor}
           emissive={1.5}
+          fragmentShader={SPO_FRAG}
         />
       )}
       {groups.cc.length > 0 && (
@@ -450,6 +467,7 @@ function NodePoints({
   onNodeClick,
   getColor,
   emissive,
+  fragmentShader,
 }: {
   nodes: ConstellationNode3D[];
   highlightId: string | null;
@@ -459,6 +477,7 @@ function NodePoints({
   onNodeClick?: (node: ConstellationNode3D) => void;
   getColor: (node: ConstellationNode3D) => string;
   emissive: number;
+  fragmentShader?: string;
 }) {
   const tmpColor = useMemo(() => new THREE.Color(), []);
 
@@ -537,7 +556,7 @@ function NodePoints({
       <bufferGeometry ref={geoRef} />
       <shaderMaterial
         vertexShader={NODE_VERT}
-        fragmentShader={NODE_FRAG}
+        fragmentShader={fragmentShader ?? NODE_FRAG}
         transparent
         depthWrite={false}
         blending={THREE.AdditiveBlending}
@@ -547,7 +566,21 @@ function NodePoints({
   );
 }
 
-function ConstellationEdges({ edges, dimmed }: { edges: ConstellationEdge3D[]; dimmed: boolean }) {
+const EDGE_STYLES = {
+  proximity: { color: '#4488aa', opacity: 0.12, dimOpacity: 0.03 },
+  infrastructure: { color: '#06b6d4', opacity: 0.18, dimOpacity: 0.04 },
+  lastmile: { color: '#1a3a4a', opacity: 0.06, dimOpacity: 0.015 },
+} as const;
+
+function EdgeLayer({
+  edges,
+  dimmed,
+  edgeType,
+}: {
+  edges: ConstellationEdge3D[];
+  dimmed: boolean;
+  edgeType: keyof typeof EDGE_STYLES;
+}) {
   const geometry = useMemo(() => {
     if (edges.length === 0) return null;
     const positions: number[] = [];
@@ -560,16 +593,42 @@ function ConstellationEdges({ edges, dimmed }: { edges: ConstellationEdge3D[]; d
   }, [edges]);
 
   if (!geometry) return null;
+  const style = EDGE_STYLES[edgeType];
 
   return (
     <lineSegments geometry={geometry}>
       <lineBasicMaterial
-        color="#4488aa"
+        color={style.color}
         transparent
-        opacity={dimmed ? 0.03 : 0.12}
+        opacity={dimmed ? style.dimOpacity : style.opacity}
         toneMapped={false}
+        depthWrite={false}
       />
     </lineSegments>
+  );
+}
+
+function ConstellationEdges({ edges, dimmed }: { edges: ConstellationEdge3D[]; dimmed: boolean }) {
+  const layers = useMemo(() => {
+    const proximity: ConstellationEdge3D[] = [];
+    const infrastructure: ConstellationEdge3D[] = [];
+    const lastmile: ConstellationEdge3D[] = [];
+    for (const e of edges) {
+      if (e.edgeType === 'infrastructure') infrastructure.push(e);
+      else if (e.edgeType === 'lastmile') lastmile.push(e);
+      else proximity.push(e);
+    }
+    return { proximity, infrastructure, lastmile };
+  }, [edges]);
+
+  if (edges.length === 0) return null;
+
+  return (
+    <>
+      <EdgeLayer edges={layers.proximity} dimmed={dimmed} edgeType="proximity" />
+      <EdgeLayer edges={layers.infrastructure} dimmed={dimmed} edgeType="infrastructure" />
+      <EdgeLayer edges={layers.lastmile} dimmed={dimmed} edgeType="lastmile" />
+    </>
   );
 }
 
@@ -678,107 +737,6 @@ function GovernanceCore() {
         />
       </mesh>
       <pointLight color={CORE_COLOR} intensity={4} distance={12} decay={2} />
-    </group>
-  );
-}
-
-// --- Shooting stars (same as original) ---
-
-const METEOR_POOL = 4;
-const SPAWN_MIN_S = 4;
-const SPAWN_MAX_S = 10;
-
-function ShootingStars() {
-  const groupRef = useRef<THREE.Group>(null);
-  const stateRef = useRef({
-    meteors: Array.from({ length: METEOR_POOL }, () => ({
-      active: false,
-      start: new THREE.Vector3(),
-      end: new THREE.Vector3(),
-      progress: 0,
-      speed: 0,
-    })),
-    timer: SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S),
-  });
-
-  const _pos = useRef(new THREE.Vector3());
-  const _dir = useRef(new THREE.Vector3());
-  const _up = useRef(new THREE.Vector3(0, 1, 0));
-
-  useFrame((_, delta) => {
-    const group = groupRef.current;
-    if (!group) return;
-    const { meteors } = stateRef.current;
-
-    stateRef.current.timer -= delta;
-    if (stateRef.current.timer <= 0) {
-      stateRef.current.timer = SPAWN_MIN_S + Math.random() * (SPAWN_MAX_S - SPAWN_MIN_S);
-      const slot = meteors.find((m) => !m.active);
-      if (slot) {
-        const angle = Math.random() * Math.PI * 2;
-        const r = 15 + Math.random() * 5;
-        slot.start.set(Math.cos(angle) * r, Math.sin(angle) * r, (Math.random() - 0.5) * 10);
-        const endAngle = angle + Math.PI + (Math.random() - 0.5) * 0.8;
-        const endR = 1 + Math.random() * 6;
-        slot.end.set(
-          Math.cos(endAngle) * endR,
-          Math.sin(endAngle) * endR,
-          (Math.random() - 0.5) * 6,
-        );
-        slot.progress = 0;
-        slot.speed = 0.5 + Math.random() * 0.4;
-        slot.active = true;
-      }
-    }
-
-    for (let i = 0; i < METEOR_POOL; i++) {
-      const m = meteors[i];
-      const mesh = group.children[i] as THREE.Mesh;
-      if (!mesh) continue;
-
-      if (!m.active) {
-        mesh.visible = false;
-        continue;
-      }
-
-      m.progress += delta * m.speed;
-      if (m.progress >= 1) {
-        m.active = false;
-        mesh.visible = false;
-        continue;
-      }
-
-      _pos.current.lerpVectors(m.start, m.end, m.progress);
-      mesh.position.copy(_pos.current);
-
-      _dir.current.subVectors(m.end, m.start).normalize();
-      mesh.quaternion.setFromUnitVectors(_up.current, _dir.current);
-
-      const fadeIn = Math.min(1, m.progress * 8);
-      const fadeOut = 1 - m.progress * m.progress;
-      const opacity = fadeIn * fadeOut * 0.8;
-      mesh.scale.set(1, 0.4 + opacity * 0.8, 1);
-
-      (mesh.material as THREE.MeshBasicMaterial).opacity = opacity;
-      mesh.visible = true;
-    }
-  });
-
-  return (
-    <group ref={groupRef}>
-      {Array.from({ length: METEOR_POOL }, (_, i) => (
-        <mesh key={i} visible={false}>
-          <cylinderGeometry args={[0.03, 0.003, 1.5, 8]} />
-          <meshBasicMaterial
-            color="#e8dcc8"
-            transparent
-            opacity={0}
-            blending={THREE.AdditiveBlending}
-            depthWrite={false}
-            toneMapped={false}
-          />
-        </mesh>
-      ))}
     </group>
   );
 }

--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -75,6 +75,29 @@ interface KoiosPoolInfo {
 
 const KOIOS_BASE = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
 
+/** Check if an IPv4 address is private/reserved (RFC 1918, RFC 6598, link-local) */
+function isPrivateIP(ip: string): boolean {
+  if (
+    ip === '0.0.0.0' ||
+    ip.startsWith('127.') ||
+    ip.startsWith('10.') ||
+    ip.startsWith('192.168.') ||
+    ip.startsWith('169.254.')
+  )
+    return true;
+  // 172.16.0.0/12 — 172.16.x.x through 172.31.x.x
+  if (ip.startsWith('172.')) {
+    const second = parseInt(ip.split('.')[1], 10);
+    if (second >= 16 && second <= 31) return true;
+  }
+  // 100.64.0.0/10 — CGNAT (100.64.x.x through 100.127.x.x)
+  if (ip.startsWith('100.')) {
+    const second = parseInt(ip.split('.')[1], 10);
+    if (second >= 64 && second <= 127) return true;
+  }
+  return false;
+}
+
 export const syncSpoScores = inngest.createFunction(
   {
     id: 'sync-spo-scores',
@@ -617,6 +640,176 @@ export const syncSpoScores = inngest.createFunction(
       }
 
       return { refreshed };
+    });
+
+    // Geocode SPO relay IPs for globe visualization
+    await step.run('geocode-relay-ips', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Only geocode pools that haven't been processed yet
+      // Limit to 100 per run to stay well under Cloudflare's 100s timeout
+      const { data: poolsNeedingGeo } = await supabase
+        .from('pools')
+        .select('pool_id')
+        .is('relay_locations', null)
+        .gt('vote_count', 0)
+        .limit(100);
+
+      if (!poolsNeedingGeo?.length) return { geocoded: 0 };
+
+      const BATCH = 100;
+      let geocoded = 0;
+
+      for (let i = 0; i < poolsNeedingGeo.length; i += BATCH) {
+        const batch = poolsNeedingGeo.slice(i, i + BATCH);
+        const poolIds = batch.map((p: { pool_id: string }) => p.pool_id);
+
+        try {
+          // Fetch relay info from Koios
+          const relayRes = await fetch(`${KOIOS_BASE}/pool_relays`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ _pool_bech32_ids: poolIds }),
+            signal: AbortSignal.timeout(15_000),
+          });
+
+          if (!relayRes.ok) {
+            logger.warn('[sync-spo-scores] Koios pool_relays failed', { status: relayRes.status });
+            continue;
+          }
+
+          const relayData = (await relayRes.json()) as Array<{
+            pool_id_bech32: string;
+            relays: Array<{
+              dns?: string;
+              srv?: string;
+              ipv4?: string;
+              ipv6?: string;
+              port?: number;
+            }>;
+          }>;
+
+          // Collect all unique IPv4 addresses for batch geocoding
+          const ipToPoolMap = new Map<string, string[]>();
+          for (const pool of relayData) {
+            if (!pool.relays?.length) continue;
+            for (const relay of pool.relays) {
+              const ip = relay.ipv4;
+              if (!ip || isPrivateIP(ip)) continue;
+              const pools = ipToPoolMap.get(ip) ?? [];
+              pools.push(pool.pool_id_bech32);
+              ipToPoolMap.set(ip, pools);
+            }
+          }
+
+          if (ipToPoolMap.size === 0) {
+            // DNS-only relays or no public IPs — mark as processed (empty) so we don't re-query
+            for (const pool of relayData) {
+              if (!pool.relays?.length) continue;
+              await supabase
+                .from('pools')
+                .update({ relay_locations: [] })
+                .eq('pool_id', pool.pool_id_bech32);
+            }
+            continue;
+          }
+
+          // Batch geocode via ip-api.com (max 100 per request, free, no key needed)
+          const ips = [...ipToPoolMap.keys()].slice(0, 100);
+          const geoRes = await fetch(
+            'http://ip-api.com/batch?fields=query,status,lat,lon,country,city',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(ips.map((ip) => ({ query: ip }))),
+              signal: AbortSignal.timeout(10_000),
+            },
+          );
+
+          if (!geoRes.ok) {
+            logger.warn('[sync-spo-scores] ip-api.com batch failed', { status: geoRes.status });
+            continue;
+          }
+
+          const geoResults = (await geoRes.json()) as Array<{
+            query: string;
+            status: string;
+            lat?: number;
+            lon?: number;
+            country?: string;
+            city?: string;
+          }>;
+
+          // Build IP -> geo lookup
+          const ipGeo = new Map<
+            string,
+            { lat: number; lon: number; country: string; city: string }
+          >();
+          for (const g of geoResults) {
+            if (g.status === 'success' && g.lat != null && g.lon != null) {
+              ipGeo.set(g.query, {
+                lat: g.lat,
+                lon: g.lon,
+                country: g.country ?? '',
+                city: g.city ?? '',
+              });
+            }
+          }
+
+          // Update pools with geocoded relay data
+          const poolGeo = new Map<
+            string,
+            {
+              lats: number[];
+              lons: number[];
+              locations: Array<{
+                lat: number;
+                lon: number;
+                country: string;
+                city: string;
+                ip: string;
+              }>;
+            }
+          >();
+
+          for (const [ip, pools] of ipToPoolMap) {
+            const geo = ipGeo.get(ip);
+            if (!geo) continue;
+            for (const poolId of pools) {
+              const entry = poolGeo.get(poolId) ?? { lats: [], lons: [], locations: [] };
+              entry.lats.push(geo.lat);
+              entry.lons.push(geo.lon);
+              entry.locations.push({ ...geo, ip });
+              poolGeo.set(poolId, entry);
+            }
+          }
+
+          for (const [poolId, data] of poolGeo) {
+            // Use centroid of all relay locations as primary position
+            const avgLat = data.lats.reduce((a, b) => a + b, 0) / data.lats.length;
+            const avgLon = data.lons.reduce((a, b) => a + b, 0) / data.lons.length;
+            const { error } = await supabase
+              .from('pools')
+              .update({
+                relay_lat: avgLat,
+                relay_lon: avgLon,
+                relay_locations: data.locations,
+              })
+              .eq('pool_id', poolId);
+            if (!error) geocoded++;
+          }
+
+          // Rate limit: ip-api.com free tier allows 45 requests/minute
+          // Each batch is 1 request, so sleep 1.5s between batches
+          if (i + BATCH < poolsNeedingGeo.length) {
+            await new Promise((r) => setTimeout(r, 1500));
+          }
+        } catch (err) {
+          logger.warn('[sync-spo-scores] relay geocoding batch error', { error: errMsg(err) });
+        }
+      }
+
+      return { geocoded };
     });
 
     // Snapshot SPO power (delegator count + live stake) for trend tracking

--- a/lib/constellation/globe-layout.ts
+++ b/lib/constellation/globe-layout.ts
@@ -49,6 +49,8 @@ interface LayoutInput {
   dominant: AlignmentDimension;
   alignments: number[];
   nodeType: GovernanceNodeType;
+  geoLat?: number;
+  geoLon?: number;
 }
 
 export function computeGlobeLayout(inputs: LayoutInput[], nodeLimit: number): LayoutResult {
@@ -85,18 +87,37 @@ export function computeGlobeLayout(inputs: LayoutInput[], nodeLimit: number): La
     nodeMap.set(node.id, node);
   }
 
-  // SPOs — positioned on the surface for now, arcs computed as edges
+  // SPOs — positioned by real relay geolocation when available, hash fallback
   const spoNodes: ConstellationNode3D[] = [];
   for (let i = 0; i < spoInputs.length; i++) {
     const input = spoInputs[i];
-    const hash = simpleHash(input.id);
-    const lon = (i / spoInputs.length) * Math.PI * 2 - Math.PI;
-    const lat = (((hash % 140) - 70) / 70) * (Math.PI / 2) * 0.85; // spread across latitudes
+    let lat: number;
+    let lon: number;
+
+    if (input.geoLat != null && input.geoLon != null) {
+      // Real geolocation: convert degrees to radians
+      lat = (input.geoLat * Math.PI) / 180;
+      lon = (input.geoLon * Math.PI) / 180;
+    } else {
+      // Fallback: hash-based distribution
+      const hash = simpleHash(input.id);
+      lon = (i / spoInputs.length) * Math.PI * 2 - Math.PI;
+      lat = (((hash % 140) - 70) / 70) * (Math.PI / 2) * 0.85;
+    }
+
     const pos = sphereToCartesian(lat, lon, GLOBE_RADIUS);
     const scale =
       (MIN_VISIBLE_SCALE + input.power * (MAX_VISIBLE_SCALE - MIN_VISIBLE_SCALE)) *
       SPO_SCALE_FACTOR;
-    const node: ConstellationNode3D = { ...input, position: pos, scale };
+    // Score-based glow: higher governance score = brighter node
+    const scoreNorm = Math.max(0, Math.min(1, (input.score - 30) / 70));
+    const node: ConstellationNode3D = {
+      ...input,
+      position: pos,
+      scale: scale * (0.7 + scoreNorm * 0.6),
+      geoLat: input.geoLat,
+      geoLon: input.geoLon,
+    };
     spoNodes.push(node);
     nodes.push(node);
     nodeMap.set(node.id, node);
@@ -150,8 +171,10 @@ function computeSpherePosition(input: LayoutInput): [number, number] {
 }
 
 /**
- * Compute edges for the globe visualization.
- * SPO nodes become infrastructure arcs — great circle segments connecting nearby DRep/CC nodes.
+ * Compute edges for the globe visualization with three distinct layers:
+ * - proximity: DRep-DRep connections within same alignment dimension
+ * - infrastructure: SPO-SPO mesh backbone (nearest geo neighbors)
+ * - lastmile: faint SPO-to-nearest-DRep connections
  */
 function computeGlobeEdges(
   allNodes: ConstellationNode3D[],
@@ -160,7 +183,7 @@ function computeGlobeEdges(
   const edges: ConstellationEdge3D[] = [];
   const drepNodes = allNodes.filter((n) => n.nodeType === 'drep');
 
-  // Proximity edges among DReps in the same dimension (surface connections)
+  // Layer 1: Proximity edges among DReps in the same dimension (surface connections)
   const maxProximity = 200;
   for (let i = 0; i < drepNodes.length && edges.length < maxProximity; i++) {
     for (let j = i + 1; j < drepNodes.length && edges.length < maxProximity; j++) {
@@ -168,25 +191,49 @@ function computeGlobeEdges(
       const b = drepNodes[j];
       if (a.dominant !== b.dominant) continue;
       if (dist3D(a.position, b.position) > 3) continue;
-      edges.push({ from: a.position, to: b.position });
+      edges.push({ from: a.position, to: b.position, edgeType: 'proximity' });
     }
   }
 
-  // SPO infrastructure arcs — each SPO connects to its 2 nearest DRep nodes
-  const maxSpoEdges = 300;
-  for (const spo of spoNodes) {
-    if (edges.length >= maxProximity + maxSpoEdges) break;
-    const nearest = drepNodes
+  // Layer 2: SPO-to-SPO infrastructure mesh — each SPO connects to its 2-3 nearest SPO neighbors
+  const maxInfraEdges = 400;
+  let infraCount = 0;
+  for (let i = 0; i < spoNodes.length && infraCount < maxInfraEdges; i++) {
+    const spo = spoNodes[i];
+    const nearest = spoNodes
+      .filter((_, j) => j !== i)
       .map((n) => ({ node: n, dist: dist3D(spo.position, n.position) }))
       .sort((a, b) => a.dist - b.dist)
-      .slice(0, 2);
+      .slice(0, 3);
 
-    for (const { node } of nearest) {
-      // Create a great-circle arc as a series of segments
-      const arcPoints = greatCircleArc(spo.position, node.position, SPO_ARC_RADIUS, 8);
-      for (let i = 0; i < arcPoints.length - 1; i++) {
-        edges.push({ from: arcPoints[i], to: arcPoints[i + 1] });
+    for (const { node, dist } of nearest) {
+      if (dist > 6) continue; // only connect reasonably close SPOs
+      // Great-circle arc above the surface
+      const arcPoints = greatCircleArc(spo.position, node.position, SPO_ARC_RADIUS, 6);
+      for (let k = 0; k < arcPoints.length - 1; k++) {
+        edges.push({ from: arcPoints[k], to: arcPoints[k + 1], edgeType: 'infrastructure' });
+        infraCount++;
       }
+    }
+  }
+
+  // Layer 3: Last-mile connections — each SPO to its nearest DRep
+  const maxLastMile = 300;
+  let lastMileCount = 0;
+  for (const spo of spoNodes) {
+    if (lastMileCount >= maxLastMile) break;
+    if (drepNodes.length === 0) break;
+    const nearest = drepNodes
+      .map((n) => ({ node: n, dist: dist3D(spo.position, n.position) }))
+      .sort((a, b) => a.dist - b.dist)[0];
+
+    if (nearest && nearest.dist < 5) {
+      edges.push({
+        from: spo.position,
+        to: nearest.node.position,
+        edgeType: 'lastmile',
+      });
+      lastMileCount++;
     }
   }
 

--- a/lib/constellation/types.ts
+++ b/lib/constellation/types.ts
@@ -14,11 +14,18 @@ export interface ConstellationNode3D {
   scale: number;
   isAnchor?: boolean;
   nodeType: GovernanceNodeType;
+  /** Real-world latitude from relay geolocation (SPOs only) */
+  geoLat?: number;
+  /** Real-world longitude from relay geolocation (SPOs only) */
+  geoLon?: number;
 }
+
+export type EdgeType = 'proximity' | 'infrastructure' | 'lastmile';
 
 export interface ConstellationEdge3D {
   from: [number, number, number];
   to: [number, number, number];
+  edgeType?: EdgeType;
 }
 
 export interface FindMeTarget {
@@ -45,6 +52,8 @@ export interface ConstellationApiData {
     dominant: AlignmentDimension;
     alignments: number[];
     nodeType: GovernanceNodeType;
+    geoLat?: number;
+    geoLon?: number;
   }>;
   recentEvents: ConstellationEvent[];
   stats: {

--- a/types/database.ts
+++ b/types/database.ts
@@ -2187,6 +2187,9 @@ export type Database = {
           pledge_lovelace: number | null;
           pool_id: string;
           pool_name: string | null;
+          relay_lat: number | null;
+          relay_locations: Json | null;
+          relay_lon: number | null;
           reliability_pct: number | null;
           reliability_raw: number | null;
           score_momentum: number | null;
@@ -2226,6 +2229,9 @@ export type Database = {
           pledge_lovelace?: number | null;
           pool_id: string;
           pool_name?: string | null;
+          relay_lat?: number | null;
+          relay_locations?: Json | null;
+          relay_lon?: number | null;
           reliability_pct?: number | null;
           reliability_raw?: number | null;
           score_momentum?: number | null;
@@ -2265,6 +2271,9 @@ export type Database = {
           pledge_lovelace?: number | null;
           pool_id?: string;
           pool_name?: string | null;
+          relay_lat?: number | null;
+          relay_locations?: Json | null;
+          relay_lon?: number | null;
           reliability_pct?: number | null;
           reliability_raw?: number | null;
           score_momentum?: number | null;


### PR DESCRIPTION
## Summary
- **Relay geocoding pipeline**: New Inngest step geocodes SPO relay IPs via ip-api.com batch API, stores lat/lon in `pools` table (incremental, 100 pools/run)
- **Real-world SPO positioning**: Globe places SPOs at their actual relay locations instead of hash-based random positions
- **Visual differentiation**: Diamond-shaped SPO nodes (custom GLSL shader), three-layer edge system (proximity/infrastructure/last-mile) with distinct colors
- **Score-based sizing**: Higher governance score = larger, more prominent SPO nodes
- **Removed shooting stars**: They would clip through the solid globe
- **Hardened sync**: Comprehensive private IP filter (RFC 1918 + RFC 6598 + link-local), batch limit to stay under Cloudflare 100s timeout

## Files changed
- `inngest/functions/sync-spo-scores.ts` — relay geocoding step + `isPrivateIP` helper
- `app/api/governance/constellation/route.ts` — include `relay_lat`/`relay_lon` in SPO nodes
- `lib/constellation/types.ts` — `geoLat`/`geoLon` on nodes, `EdgeType` + `edgeType` on edges
- `lib/constellation/globe-layout.ts` — geo-based SPO positioning, SPO-to-SPO mesh, 3-layer edges
- `components/GlobeConstellation.tsx` — diamond shader, `EdgeLayer` component, removed `ShootingStars`
- `types/database.ts` — regenerated with new `relay_lat`/`relay_lon`/`relay_locations` columns

## Test plan
- [ ] Preflight passes (306 tests green, lint/types clean)
- [ ] Toggle `globe_constellation` flag on — verify globe renders with SPO diamond nodes
- [ ] Trigger `sync-spo-scores` — verify `geocode-relay-ips` step completes and pools get coordinates
- [ ] Verify SPOs with geo data cluster by real location, not random hash distribution
- [ ] Verify three edge layers visible with distinct colors (teal infrastructure, blue proximity, dark last-mile)
- [ ] PUT `/api/inngest` after deploy to register updated function

🤖 Generated with [Claude Code](https://claude.com/claude-code)