### PR TITLE
feat: Step 4 — Citizen Experience & Acquisition Funnel

### DIFF
--- a/app/api/briefing/citizen/route.ts
+++ b/app/api/briefing/citizen/route.ts
@@ -1,0 +1,476 @@
+/**
+ * GET /api/briefing/citizen
+ *
+ * Assembles a structured epoch briefing for a citizen (ADA holder).
+ * Aggregates governance stats, epoch recap, DRep performance, treasury,
+ * and active proposals into a single response.
+ *
+ * Optional query params:
+ *   - drepId: override DRep lookup (useful for unauthenticated preview)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type HealthStatus = 'green' | 'yellow' | 'red';
+type TreasuryTrend = 'growing' | 'shrinking' | 'stable';
+type HeadlineType = 'proposal' | 'treasury' | 'governance';
+
+interface Headline {
+  title: string;
+  description: string;
+  type: HeadlineType;
+}
+
+interface DRepPerformance {
+  name: string;
+  id: string;
+  votesCast: number;
+  rationalesProvided: number;
+  scoreChange: number;
+  score: number;
+  tier: string;
+  participationRate: number;
+  verdict: string;
+}
+
+interface BriefingResponse {
+  epoch: number;
+
+  status: {
+    health: HealthStatus;
+    headline: string;
+    delegatedTo: { name: string; id: string; score: number; tier: string } | null;
+  };
+
+  headlines: Headline[];
+
+  drepPerformance: DRepPerformance | null;
+
+  treasury: {
+    balanceAda: number;
+    trend: TreasuryTrend;
+    withdrawnThisEpoch: number;
+    pendingProposals: number;
+  };
+
+  upcoming: {
+    activeProposals: number;
+    criticalProposals: number;
+  };
+
+  recap: {
+    proposalsSubmitted: number;
+    proposalsRatified: number;
+    drepParticipationPct: number;
+    narrative: string | null;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CRITICAL_PROPOSAL_TYPES = [
+  'HardForkInitiation',
+  'NoConfidence',
+  'NewCommittee',
+  'NewConstitution',
+];
+
+function extractDRepName(info: Record<string, unknown> | null, drepId: string): string {
+  if (info && typeof info === 'object') {
+    const given = (info as Record<string, unknown>).givenName;
+    if (typeof given === 'string' && given.length > 0) return given;
+  }
+  // Truncate bech32 ID for display
+  return drepId.length > 20 ? `${drepId.slice(0, 12)}...${drepId.slice(-6)}` : drepId;
+}
+
+function computeVerdict(participationRate: number, rationaleRate: number): string {
+  if (participationRate >= 0.8 && rationaleRate >= 0.5) return 'Representing you well';
+  if (participationRate >= 0.5) return 'Moderately active';
+  return 'Low activity \u2014 consider reviewing alternatives';
+}
+
+function computeHealth(
+  drepId: string | null,
+  score: number | null,
+  votedThisEpoch: boolean,
+  scoreMomentum: number | null,
+): { health: HealthStatus; headline: string } {
+  if (!drepId) {
+    return { health: 'yellow', headline: "You're not represented in governance yet" };
+  }
+  const s = score ?? 0;
+  if (s >= 70 && votedThisEpoch) {
+    return { health: 'green', headline: "Everything's fine. Your DRep is active." };
+  }
+  if (s >= 40) {
+    if (!votedThisEpoch) {
+      return { health: 'yellow', headline: "Your DRep hasn't voted on proposals this epoch" };
+    }
+    if ((scoreMomentum ?? 0) < 0) {
+      return { health: 'yellow', headline: "Your DRep's score is trending down" };
+    }
+    return { health: 'yellow', headline: 'Your DRep could be more active' };
+  }
+  return { health: 'red', headline: 'Your DRep needs attention' };
+}
+
+function buildHeadlines(
+  recap: {
+    proposals_submitted: number | null;
+    proposals_ratified: number | null;
+    proposals_expired: number | null;
+    proposals_dropped: number | null;
+    drep_participation_pct: number | null;
+    treasury_withdrawn_ada: number | null;
+    ai_narrative: string | null;
+  } | null,
+): Headline[] {
+  const headlines: Headline[] = [];
+  if (!recap) return headlines;
+
+  if (recap.proposals_ratified && recap.proposals_ratified > 0) {
+    headlines.push({
+      title: `${recap.proposals_ratified} proposal${recap.proposals_ratified > 1 ? 's were' : ' was'} approved this epoch`,
+      description: recap.proposals_submitted
+        ? `Out of ${recap.proposals_submitted} submitted proposals`
+        : 'Governance proposals were ratified on-chain',
+      type: 'proposal',
+    });
+  }
+
+  if (recap.treasury_withdrawn_ada && recap.treasury_withdrawn_ada > 0) {
+    const formattedAda = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(
+      recap.treasury_withdrawn_ada,
+    );
+    headlines.push({
+      title: `${formattedAda} ADA withdrawn from treasury`,
+      description: 'Approved treasury withdrawal proposals were executed',
+      type: 'treasury',
+    });
+  }
+
+  if (recap.drep_participation_pct != null) {
+    const pct = Math.round(recap.drep_participation_pct);
+    if (pct >= 70) {
+      headlines.push({
+        title: `DRep participation reached ${pct}%`,
+        description: 'A strong majority of DReps voted on governance proposals',
+        type: 'governance',
+      });
+    } else if (pct < 50) {
+      headlines.push({
+        title: `DRep participation was only ${pct}%`,
+        description: 'Less than half of DReps voted — governance engagement is low',
+        type: 'governance',
+      });
+    }
+  }
+
+  if (recap.ai_narrative && headlines.length < 4) {
+    headlines.push({
+      title: 'Epoch summary',
+      description: recap.ai_narrative,
+      type: 'governance',
+    });
+  }
+
+  // If we somehow have nothing, add a generic headline from expired/dropped
+  if (headlines.length === 0) {
+    if (recap.proposals_expired && recap.proposals_expired > 0) {
+      headlines.push({
+        title: `${recap.proposals_expired} proposal${recap.proposals_expired > 1 ? 's' : ''} expired`,
+        description: 'These proposals did not receive enough support before their deadline',
+        type: 'proposal',
+      });
+    }
+    if (recap.proposals_dropped && recap.proposals_dropped > 0) {
+      headlines.push({
+        title: `${recap.proposals_dropped} proposal${recap.proposals_dropped > 1 ? 's were' : ' was'} dropped`,
+        description: 'These proposals were withdrawn or removed from consideration',
+        type: 'proposal',
+      });
+    }
+  }
+
+  return headlines;
+}
+
+function determineTreasuryTrend(
+  currentBalance: number,
+  previousBalance: number | null,
+): TreasuryTrend {
+  if (previousBalance == null) return 'stable';
+  const delta = currentBalance - previousBalance;
+  const pctChange = previousBalance > 0 ? Math.abs(delta / previousBalance) : 0;
+  // Consider < 1% change as stable
+  if (pctChange < 0.01) return 'stable';
+  return delta > 0 ? 'growing' : 'shrinking';
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, ctx: RouteContext) => {
+    const supabase = createClient();
+    const drepIdOverride = request.nextUrl.searchParams.get('drepId');
+
+    // -----------------------------------------------------------------------
+    // 1. Current epoch
+    // -----------------------------------------------------------------------
+    const { data: stats } = await supabase
+      .from('governance_stats')
+      .select('current_epoch')
+      .eq('id', 1)
+      .single();
+
+    const currentEpoch = stats?.current_epoch ?? 0;
+
+    // -----------------------------------------------------------------------
+    // 2. Epoch recap
+    // -----------------------------------------------------------------------
+    const { data: recap } = await supabase
+      .from('epoch_recaps')
+      .select(
+        'proposals_submitted, proposals_ratified, proposals_expired, proposals_dropped, drep_participation_pct, treasury_withdrawn_ada, ai_narrative',
+      )
+      .eq('epoch', currentEpoch)
+      .maybeSingle();
+
+    // -----------------------------------------------------------------------
+    // 3. Resolve DRep ID (authenticated user or query param override)
+    // -----------------------------------------------------------------------
+    let drepId: string | null = drepIdOverride;
+
+    if (!drepId && ctx.wallet) {
+      // Try user_wallets first (has on-chain drep_id from stake address)
+      const { data: walletRow } = await supabase
+        .from('user_wallets')
+        .select('drep_id')
+        .eq('payment_address', ctx.wallet)
+        .maybeSingle();
+
+      if (walletRow?.drep_id) {
+        drepId = walletRow.drep_id;
+      } else if (ctx.userId) {
+        // Fall back to users table: claimed_drep_id or delegation_history
+        const { data: user } = await supabase
+          .from('users')
+          .select('claimed_drep_id, delegation_history')
+          .eq('id', ctx.userId)
+          .single();
+
+        if (user?.claimed_drep_id) {
+          drepId = user.claimed_drep_id;
+        } else if (Array.isArray(user?.delegation_history) && user.delegation_history.length > 0) {
+          const last = user.delegation_history[user.delegation_history.length - 1] as {
+            drepId?: string;
+          };
+          drepId = last?.drepId ?? null;
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. DRep performance (if DRep found)
+    // -----------------------------------------------------------------------
+    let drepPerformance: DRepPerformance | null = null;
+    let drepScore: number | null = null;
+    let drepScoreMomentum: number | null = null;
+    let votedThisEpoch = false;
+
+    if (drepId) {
+      // Fetch DRep profile
+      const { data: drep } = await supabase
+        .from('dreps')
+        .select('id, score, current_tier, score_momentum, info, participation_rate, rationale_rate')
+        .eq('id', drepId)
+        .maybeSingle();
+
+      if (drep) {
+        drepScore = drep.score;
+        drepScoreMomentum = drep.score_momentum;
+
+        // Count votes this epoch
+        const { count: voteCount } = await supabase
+          .from('drep_votes')
+          .select('vote_tx_hash', { count: 'exact', head: true })
+          .eq('drep_id', drepId)
+          .eq('epoch_no', currentEpoch);
+
+        const votesCast = voteCount ?? 0;
+        votedThisEpoch = votesCast > 0;
+
+        // Count rationales for this epoch's votes
+        let rationalesProvided = 0;
+        if (votesCast > 0) {
+          const { data: epochVotes } = await supabase
+            .from('drep_votes')
+            .select('vote_tx_hash')
+            .eq('drep_id', drepId)
+            .eq('epoch_no', currentEpoch);
+
+          if (epochVotes && epochVotes.length > 0) {
+            const voteTxHashes = epochVotes.map((v) => v.vote_tx_hash);
+            const { count: rationaleCount } = await supabase
+              .from('vote_rationales')
+              .select('vote_tx_hash', { count: 'exact', head: true })
+              .in('vote_tx_hash', voteTxHashes);
+            rationalesProvided = rationaleCount ?? 0;
+          }
+        }
+
+        // Score delta from last 2 history entries
+        const { data: scoreHistory } = await supabase
+          .from('drep_score_history')
+          .select('score')
+          .eq('drep_id', drepId)
+          .order('snapshot_date', { ascending: false })
+          .limit(2);
+
+        let scoreChange = 0;
+        if (scoreHistory && scoreHistory.length >= 2) {
+          scoreChange = (scoreHistory[0].score ?? 0) - (scoreHistory[1].score ?? 0);
+        }
+
+        const info = drep.info as Record<string, unknown> | null;
+        const name = extractDRepName(info, drepId);
+        const participationRate = drep.participation_rate ?? 0;
+        const rationaleRate = drep.rationale_rate ?? 0;
+
+        drepPerformance = {
+          name,
+          id: drepId,
+          votesCast,
+          rationalesProvided,
+          scoreChange: Math.round(scoreChange * 100) / 100,
+          score: drep.score ?? 0,
+          tier: drep.current_tier ?? 'Unknown',
+          participationRate,
+          verdict: computeVerdict(participationRate, rationaleRate),
+        };
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Treasury data
+    // -----------------------------------------------------------------------
+    const [treasuryResult, previousTreasuryResult, pendingTreasuryResult] = await Promise.all([
+      // Latest treasury snapshot
+      supabase
+        .from('treasury_snapshots')
+        .select('epoch_no, balance_lovelace')
+        .order('epoch_no', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      // Previous treasury snapshot (for trend)
+      supabase
+        .from('treasury_snapshots')
+        .select('balance_lovelace')
+        .order('epoch_no', { ascending: false })
+        .range(1, 1)
+        .maybeSingle(),
+      // Count pending treasury withdrawal proposals
+      supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .like('proposal_type', '%TreasuryWithdrawals%')
+        .is('ratified_epoch', null)
+        .is('expired_epoch', null)
+        .is('dropped_epoch', null),
+    ]);
+
+    const latestBalance = treasuryResult.data?.balance_lovelace ?? 0;
+    const previousBalance = previousTreasuryResult.data?.balance_lovelace ?? null;
+    const balanceAda = latestBalance / 1_000_000;
+    const trend = determineTreasuryTrend(latestBalance, previousBalance);
+    const pendingProposals = pendingTreasuryResult.count ?? 0;
+
+    // -----------------------------------------------------------------------
+    // 6. Active & critical proposals
+    // -----------------------------------------------------------------------
+    const { data: activeProposals } = await supabase
+      .from('proposals')
+      .select('proposal_type')
+      .is('ratified_epoch', null)
+      .is('expired_epoch', null)
+      .is('dropped_epoch', null);
+
+    const activeCount = activeProposals?.length ?? 0;
+    const criticalCount =
+      activeProposals?.filter((p) =>
+        CRITICAL_PROPOSAL_TYPES.some((ct) => p.proposal_type?.includes(ct)),
+      ).length ?? 0;
+
+    // -----------------------------------------------------------------------
+    // 7. Build response
+    // -----------------------------------------------------------------------
+    const { health, headline } = computeHealth(
+      drepId,
+      drepScore,
+      votedThisEpoch,
+      drepScoreMomentum,
+    );
+
+    const delegatedTo = drepPerformance
+      ? {
+          name: drepPerformance.name,
+          id: drepPerformance.id,
+          score: drepPerformance.score,
+          tier: drepPerformance.tier,
+        }
+      : null;
+
+    const response: BriefingResponse = {
+      epoch: currentEpoch,
+
+      status: {
+        health,
+        headline,
+        delegatedTo,
+      },
+
+      headlines: buildHeadlines(recap),
+
+      drepPerformance,
+
+      treasury: {
+        balanceAda: Math.round(balanceAda),
+        trend,
+        withdrawnThisEpoch: recap?.treasury_withdrawn_ada ?? 0,
+        pendingProposals,
+      },
+
+      upcoming: {
+        activeProposals: activeCount,
+        criticalProposals: criticalCount,
+      },
+
+      recap: recap
+        ? {
+            proposalsSubmitted: recap.proposals_submitted ?? 0,
+            proposalsRatified: recap.proposals_ratified ?? 0,
+            drepParticipationPct: recap.drep_participation_pct ?? 0,
+            narrative: recap.ai_narrative ?? null,
+          }
+        : null,
+    };
+
+    return NextResponse.json(response, {
+      headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
+    });
+  },
+  { auth: 'optional' },
+);

--- a/components/civica/home/EpochBriefing.tsx
+++ b/components/civica/home/EpochBriefing.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { posthog } from '@/lib/posthog';
+import {
+  CheckCircle2,
+  AlertTriangle,
+  AlertCircle,
+  Calendar,
+  Vote,
+  Landmark,
+  Activity,
+  ArrowUp,
+  ArrowDown,
+  ArrowRight,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface EpochBriefingProps {
+  drepId: string | null | undefined;
+  wallet: string | null | undefined;
+}
+
+/* ── Data hook ──────────────────────────────────────────────────── */
+
+function useCitizenBriefing(wallet: string | null | undefined) {
+  return useQuery({
+    queryKey: ['citizen-briefing', wallet],
+    queryFn: async () => {
+      const url = wallet
+        ? `/api/briefing/citizen?wallet=${encodeURIComponent(wallet)}`
+        : '/api/briefing/citizen';
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`${res.status}`);
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/* ── Helpers ────────────────────────────────────────────────────── */
+
+function formatAdaCompact(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toFixed(0);
+}
+
+const HEALTH_CONFIG = {
+  green: {
+    bg: 'bg-emerald-500/10 border-emerald-500/20',
+    icon: CheckCircle2,
+    iconColor: 'text-emerald-500',
+  },
+  yellow: {
+    bg: 'bg-amber-500/10 border-amber-500/20',
+    icon: AlertTriangle,
+    iconColor: 'text-amber-500',
+  },
+  red: {
+    bg: 'bg-rose-500/10 border-rose-500/20',
+    icon: AlertCircle,
+    iconColor: 'text-rose-500',
+  },
+} as const;
+
+type HealthLevel = keyof typeof HEALTH_CONFIG;
+
+const HEADLINE_ICONS: Record<string, typeof Vote> = {
+  proposal: Vote,
+  treasury: Landmark,
+  governance: Activity,
+};
+
+/* ── Skeleton (loading state) ───────────────────────────────────── */
+
+function BriefingSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Status banner skeleton */}
+      <div className="rounded-xl border p-4">
+        <Skeleton className="h-5 w-3/4" />
+      </div>
+      {/* Card skeletons */}
+      <div className="rounded-xl border p-5 space-y-3">
+        <Skeleton className="h-4 w-32" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Skeleton className="h-16 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </div>
+      </div>
+      <div className="rounded-xl border p-5 space-y-3">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-12 w-full rounded-lg" />
+      </div>
+      {/* Stats row skeleton */}
+      <div className="grid grid-cols-3 gap-3">
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-14 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+/* ── Main component ─────────────────────────────────────────────── */
+
+export function EpochBriefing({ wallet }: EpochBriefingProps) {
+  const { data, isLoading, isError } = useCitizenBriefing(wallet);
+  const tracked = useRef(false);
+
+  useEffect(() => {
+    if (data && !tracked.current) {
+      tracked.current = true;
+      posthog?.capture('citizen_briefing_viewed', {
+        epoch: data.epoch,
+        health: data.status?.health,
+        has_drep: !!data.drepPerformance,
+      });
+    }
+  }, [data]);
+
+  if (isLoading) return <BriefingSkeleton />;
+
+  if (isError) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        Unable to load your briefing right now.
+      </p>
+    );
+  }
+
+  if (!data) return null;
+
+  const health: HealthLevel = data.status?.health ?? 'green';
+  const config = HEALTH_CONFIG[health];
+  const StatusIcon = config.icon;
+
+  return (
+    <div className="space-y-4">
+      {/* ── Section 1: Status Banner ────────────────────────────────── */}
+      <div className={cn('rounded-xl border p-4 flex items-center gap-3', config.bg)}>
+        <StatusIcon className={cn('h-5 w-5 shrink-0', config.iconColor)} />
+        <p className="flex-1 text-sm font-semibold text-foreground">
+          {data.status?.headline ?? 'Governance is active'}
+        </p>
+        {data.status?.delegatedTo ? (
+          <Link
+            href={`/drep/${data.status.delegatedTo.id}`}
+            className="shrink-0 text-sm font-medium text-primary hover:underline"
+          >
+            {data.status.delegatedTo.name}
+            {data.status.delegatedTo.score != null && (
+              <span className="ml-1.5 tabular-nums text-muted-foreground">
+                {data.status.delegatedTo.score}
+              </span>
+            )}
+          </Link>
+        ) : (
+          <Button asChild size="sm" variant="outline">
+            <Link href="/match">Find My DRep</Link>
+          </Button>
+        )}
+      </div>
+
+      {/* ── Section 2: What Happened ────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            Epoch {data.epoch}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {data.recap?.narrative && (
+            <p className="text-sm italic text-muted-foreground leading-relaxed">
+              {data.recap.narrative}
+            </p>
+          )}
+          {data.headlines && data.headlines.length > 0 && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {data.headlines
+                .slice(0, 4)
+                .map((h: { type: string; title: string; description: string }, i: number) => {
+                  const HeadlineIcon = HEADLINE_ICONS[h.type] ?? Activity;
+                  return (
+                    <div
+                      key={i}
+                      className="flex gap-3 rounded-lg border border-border bg-muted/20 p-3"
+                    >
+                      <HeadlineIcon className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-foreground">{h.title}</p>
+                        <p className="text-xs text-muted-foreground line-clamp-2">
+                          {h.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Section 3: Your DRep This Epoch ─────────────────────────── */}
+      {data.drepPerformance && (
+        <Card>
+          <CardContent className="pt-6 space-y-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1 min-w-0">
+                <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
+                  Your DRep this epoch
+                </p>
+                <Link
+                  href={`/drep/${data.drepPerformance.id}`}
+                  className="text-base font-semibold text-foreground hover:text-primary transition-colors truncate block"
+                >
+                  {data.drepPerformance.name}
+                </Link>
+                {data.drepPerformance.verdict && (
+                  <p className="text-sm text-muted-foreground">{data.drepPerformance.verdict}</p>
+                )}
+              </div>
+              <div className="text-right shrink-0">
+                <p
+                  className={cn(
+                    'font-display text-3xl font-bold tabular-nums',
+                    data.drepPerformance.score >= 70
+                      ? 'text-emerald-500'
+                      : data.drepPerformance.score >= 40
+                        ? 'text-amber-500'
+                        : 'text-rose-500',
+                  )}
+                >
+                  {data.drepPerformance.score}
+                </p>
+                {data.drepPerformance.scoreChange != null &&
+                  data.drepPerformance.scoreChange !== 0 && (
+                    <span
+                      className={cn(
+                        'inline-flex items-center gap-0.5 text-xs font-medium',
+                        data.drepPerformance.scoreChange > 0 ? 'text-emerald-500' : 'text-rose-500',
+                      )}
+                    >
+                      {data.drepPerformance.scoreChange > 0 ? (
+                        <ArrowUp className="h-3 w-3" />
+                      ) : (
+                        <ArrowDown className="h-3 w-3" />
+                      )}
+                      {Math.abs(data.drepPerformance.scoreChange)}
+                    </span>
+                  )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                {
+                  label: 'Votes cast',
+                  value: data.drepPerformance.votesCast ?? 0,
+                },
+                {
+                  label: 'Rationales',
+                  value: data.drepPerformance.rationales ?? 0,
+                },
+                {
+                  label: 'Participation',
+                  value:
+                    data.drepPerformance.participationRate != null
+                      ? `${data.drepPerformance.participationRate}%`
+                      : '--',
+                },
+              ].map((stat) => (
+                <div key={stat.label} className="text-center rounded-lg bg-muted/30 py-2">
+                  <p className="text-base font-semibold tabular-nums text-foreground">
+                    {stat.value}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">{stat.label}</p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Section 4: Treasury Snapshot ─────────────────────────────── */}
+      {data.treasury && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Landmark className="h-4 w-4 text-muted-foreground" />
+              <p className="text-sm font-semibold text-foreground">Treasury</p>
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div className="text-center">
+                <p className="text-base font-semibold tabular-nums text-foreground">
+                  {formatAdaCompact(data.treasury.balance)}
+                </p>
+                <p className="text-[10px] text-muted-foreground">Balance</p>
+              </div>
+              <div className="text-center">
+                <p className="text-base font-semibold tabular-nums text-foreground">
+                  {formatAdaCompact(data.treasury.withdrawnThisEpoch ?? 0)}
+                </p>
+                <p className="text-[10px] text-muted-foreground">Withdrawn</p>
+              </div>
+              <div className="text-center">
+                <p
+                  className={cn(
+                    'text-base font-semibold tabular-nums',
+                    (data.treasury.pendingProposals ?? 0) > 0
+                      ? 'text-amber-500'
+                      : 'text-foreground',
+                  )}
+                >
+                  {data.treasury.pendingProposals ?? 0}
+                </p>
+                <p className="text-[10px] text-muted-foreground">Pending</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Section 5: What's Coming ────────────────────────────────── */}
+      {data.upcoming && data.upcoming.activeProposals > 0 && (
+        <div className="flex items-center justify-between rounded-xl border border-border bg-muted/20 px-4 py-3">
+          <div className="flex items-center gap-2 text-sm text-foreground">
+            <Vote className="h-4 w-4 text-muted-foreground" />
+            <span>
+              <span className="font-semibold">{data.upcoming.activeProposals}</span> proposal
+              {data.upcoming.activeProposals !== 1 ? 's are' : ' is'} open for voting
+            </span>
+            {data.upcoming.critical > 0 && (
+              <Badge className="bg-rose-500/10 text-rose-500 border-rose-500/20">
+                {data.upcoming.critical} critical
+              </Badge>
+            )}
+          </div>
+          <Link
+            href="/discover"
+            className="shrink-0 text-sm font-medium text-primary hover:underline inline-flex items-center gap-1"
+          >
+            View
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -1,9 +1,18 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowRight, Users, ShieldCheck, Activity, Zap, Vote, HelpCircle } from 'lucide-react';
+import {
+  ArrowRight,
+  Users,
+  ShieldCheck,
+  Activity,
+  Zap,
+  Vote,
+  HelpCircle,
+  Coins,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
+import { posthog } from '@/lib/posthog';
 import { ConstellationScene } from '@/components/ConstellationScene';
 
 interface PulseData {
@@ -42,11 +51,11 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
             <span className="tabular-nums">
               <strong className="text-white/90">{pulseData.activeDReps}</strong> DReps
             </span>
-            <span className="text-white/30">·</span>
+            <span className="text-white/30">&middot;</span>
             <span className="tabular-nums">
               <strong className="text-white/90">{pulseData.activeSpOs}</strong> SPOs
             </span>
-            <span className="text-white/30">·</span>
+            <span className="text-white/30">&middot;</span>
             <span className="tabular-nums">
               <strong className="text-white/90">{pulseData.ccMembers}</strong> CC Members
             </span>
@@ -56,14 +65,14 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
         {/* Value prop overlay */}
         <div className="absolute inset-0 flex flex-col items-center justify-center px-4 sm:pt-14">
           <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-white drop-shadow-lg leading-tight text-center">
-            Cardano has a government.
+            Your ADA gives you a voice.
           </h1>
 
           {/* Gap where the constellation core sun shows through */}
           <div className="h-10 sm:h-16" />
 
           <p className="font-display text-xl sm:text-2xl lg:text-3xl font-semibold text-[#fff0d4] drop-shadow-lg text-center">
-            Know who represents you.
+            It takes 60 seconds to use it.
           </p>
 
           {/* Live urgency hook */}
@@ -74,55 +83,88 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
             >
               <strong className="text-white/90">{pulseData.activeProposals} proposals</strong> are
               being decided right now.{' '}
-              <strong className="text-[#fff0d4]">₳{pulseData.totalAdaGoverned}</strong> is at stake.
+              <strong className="text-[#fff0d4]">&#x20B3;{pulseData.totalAdaGoverned}</strong> is at
+              stake.
             </p>
           )}
         </div>
       </section>
 
-      {/* ── Quick Match CTA (direct link — no expand panel) ──────── */}
-      <section className="relative z-10 -mt-10 px-4 flex flex-col items-center gap-5">
-        {/* Glowing primary CTA */}
-        <div className="relative group">
-          <div
+      {/* ── Two-Path Entry ─────────────────────────────────────────── */}
+      <section className="relative z-10 -mt-10 px-4 mx-auto w-full max-w-2xl">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {/* Path 1: Govern — Quick Match */}
+          <Link
+            href="/match"
+            onClick={() => posthog?.capture('citizen_path_clicked', { path: 'govern' })}
             className={cn(
-              'absolute -inset-1 rounded-xl bg-primary/40 blur-md',
-              'animate-pulse group-hover:bg-primary/60 transition-colors',
+              'group relative rounded-xl border border-primary/30 bg-card/80 backdrop-blur-sm p-6',
+              'hover:border-primary/60 hover:bg-card/90 transition-all',
             )}
-            aria-hidden
-          />
-          <Button
-            asChild
-            size="lg"
-            className="relative text-base px-8 py-6 rounded-xl font-semibold shadow-lg"
           >
-            <Link href="/match">
-              <Zap className="mr-2 h-5 w-5" />
-              Find My DRep — 60 Seconds
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-        </div>
-
-        <p className="text-xs text-muted-foreground">
-          No wallet required · 3 questions · Matched to {pulseData.activeDReps}+ DReps
-        </p>
-
-        {/* What is a DRep? micro-explainer */}
-        <div className="max-w-md mx-auto rounded-lg border border-border/50 bg-muted/20 px-4 py-3">
-          <div className="flex items-start gap-2.5">
-            <HelpCircle className="h-4 w-4 text-primary/60 shrink-0 mt-0.5" />
-            <div>
-              <p className="text-xs font-medium text-foreground">What is a DRep?</p>
-              <p className="text-[11px] text-muted-foreground leading-relaxed mt-0.5">
-                A Delegated Representative (DRep) votes on governance proposals on your behalf —
-                protocol changes, treasury spending, and more. You choose who represents your ADA.
+            <div className="absolute -inset-0.5 rounded-xl bg-primary/10 blur-sm opacity-0 group-hover:opacity-100 transition-opacity" />
+            <div className="relative space-y-3">
+              <div className="flex items-center gap-2">
+                <div className="rounded-lg bg-primary/10 p-2">
+                  <Zap className="h-5 w-5 text-primary" />
+                </div>
+                <h2 className="text-lg font-semibold text-foreground">Govern</h2>
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Find a DRep who votes the way you would. 3 questions, 60 seconds, matched to{' '}
+                {pulseData.activeDReps}+ representatives.
               </p>
-              <Link
-                href="/learn"
-                className="text-[11px] text-primary hover:underline mt-1 inline-block"
-              >
-                Learn more about governance →
+              <span className="inline-flex items-center gap-1 text-sm font-medium text-primary group-hover:gap-2 transition-all">
+                Find My DRep
+                <ArrowRight className="h-3.5 w-3.5" />
+              </span>
+            </div>
+          </Link>
+
+          {/* Path 2: Stake — Pool Discovery */}
+          <Link
+            href="/discover?tab=pools"
+            onClick={() => posthog?.capture('citizen_path_clicked', { path: 'stake' })}
+            className={cn(
+              'group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm p-6',
+              'hover:border-primary/40 hover:bg-card/90 transition-all',
+            )}
+          >
+            <div className="relative space-y-3">
+              <div className="flex items-center gap-2">
+                <div className="rounded-lg bg-emerald-500/10 p-2">
+                  <Coins className="h-5 w-5 text-emerald-500" />
+                </div>
+                <h2 className="text-lg font-semibold text-foreground">Stake</h2>
+              </div>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Find a stake pool that represents your values. Compare governance scores, voting
+                records, and community alignment.
+              </p>
+              <span className="inline-flex items-center gap-1 text-sm font-medium text-primary group-hover:gap-2 transition-all">
+                Browse Pools
+                <ArrowRight className="h-3.5 w-3.5" />
+              </span>
+            </div>
+          </Link>
+        </div>
+      </section>
+
+      {/* ── What is governance? ────────────────────────────────────── */}
+      <section className="mx-auto w-full max-w-2xl px-4 mt-8">
+        <div className="rounded-xl border border-border/50 bg-muted/20 px-5 py-4">
+          <div className="flex items-start gap-3">
+            <HelpCircle className="h-4 w-4 text-primary/60 shrink-0 mt-0.5" />
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-foreground">Why does this matter?</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                Cardano has a ratified constitution, a treasury worth billions of ADA, and elected
+                representatives. Protocol changes, treasury spending, and staking rewards are all
+                decided by governance votes. Every ADA holder has a voice &mdash; you just need to
+                use it.
+              </p>
+              <Link href="/learn" className="text-xs text-primary hover:underline inline-block">
+                Learn more about Cardano governance &rarr;
               </Link>
             </div>
           </div>
@@ -130,7 +172,7 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
       </section>
 
       {/* ── Live governance stats ──────────────────────────────────── */}
-      <section className="mx-auto w-full max-w-4xl px-4 mt-10 mb-8">
+      <section className="mx-auto w-full max-w-4xl px-4 mt-8 mb-8">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {[
             {

--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -1,44 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  TrendingUp,
-  TrendingDown,
-  Minus,
-  ArrowRight,
-  ChevronRight,
-  Zap,
-  Vote,
-  BarChart3,
-  Bell,
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { Zap, ArrowRight, Vote, BarChart3, Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
 import { GovTerm } from '@/components/GovTerm';
-import { computeTier } from '@/lib/scoring/tiers';
-import { useDRepReportCard } from '@/hooks/queries';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useWallet } from '@/utils/wallet';
 import { ConstellationScene } from '@/components/ConstellationScene';
-
-const TIER_COLORS: Record<string, string> = {
-  Emerging: 'text-muted-foreground',
-  Bronze: 'text-amber-700 dark:text-amber-600',
-  Silver: 'text-slate-500 dark:text-slate-400',
-  Gold: 'text-yellow-600 dark:text-yellow-500',
-  Diamond: 'text-cyan-600 dark:text-cyan-400',
-  Legendary: 'text-violet-600 dark:text-violet-400',
-};
-
-const TIER_BG: Record<string, string> = {
-  Emerging: 'bg-muted/40',
-  Bronze: 'bg-amber-50 dark:bg-amber-950/30 border-amber-300/40 dark:border-amber-800/30',
-  Silver: 'bg-slate-50 dark:bg-slate-900/40 border-slate-300/40 dark:border-slate-700/30',
-  Gold: 'bg-yellow-50 dark:bg-yellow-950/30 border-yellow-300/50 dark:border-yellow-800/30',
-  Diamond: 'bg-cyan-50 dark:bg-cyan-950/30 border-cyan-300/50 dark:border-cyan-800/30',
-  Legendary: 'bg-violet-50 dark:bg-violet-950/30 border-violet-300/50 dark:border-violet-800/30',
-};
+import { EpochBriefing } from './EpochBriefing';
+import { CivicIdentityCard } from '@/components/civica/shared/CivicIdentityCard';
+import { TreasuryCitizenView } from './TreasuryCitizenView';
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -57,7 +28,7 @@ interface HomeCitizenProps {
   ssrWalletAddress?: string | null;
 }
 
-/* ── Undelegated citizen experience ───────────────────────────────── */
+/* ── Undelegated citizen: wallet connected but no DRep ──────────── */
 
 function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
   const stats = [
@@ -69,7 +40,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
 
   return (
     <div className="relative flex flex-col">
-      {/* ── Constellation hero (~35vh) ─────────────────────────────── */}
+      {/* Constellation hero */}
       <section className="relative h-[35vh] min-h-[280px] sm:-mt-14 overflow-hidden">
         <div className="absolute inset-0">
           <ConstellationScene className="w-full h-full" interactive={false} />
@@ -101,7 +72,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
         </div>
       </section>
 
-      {/* ── Delegation action card ─────────────────────────────────── */}
+      {/* Delegation action card */}
       <section className="mx-auto w-full max-w-2xl px-4 -mt-4 relative z-10">
         <div className="rounded-2xl border border-primary/30 bg-primary/5 backdrop-blur-sm p-6 space-y-4">
           <div className="space-y-1">
@@ -128,7 +99,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
         </div>
       </section>
 
-      {/* ── Governance pulse stats ─────────────────────────────────── */}
+      {/* Governance pulse stats */}
       <section className="mx-auto w-full max-w-2xl px-4 mt-8">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {stats.map((s) => (
@@ -146,7 +117,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
         </div>
       </section>
 
-      {/* ── What you unlock ────────────────────────────────────────── */}
+      {/* What you unlock */}
       <section className="mx-auto w-full max-w-2xl px-4 mt-8 pb-16">
         <div className="rounded-xl border border-border bg-muted/20 p-5 space-y-3">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
@@ -167,7 +138,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
               {
                 icon: Bell,
                 title: 'Governance updates',
-                desc: 'Epoch summaries and alignment drift detection',
+                desc: 'Epoch briefings and smart alerts when it matters',
               },
             ].map(({ icon: Icon, title, desc }) => (
               <div key={title} className="flex gap-3 sm:flex-col sm:gap-1.5">
@@ -185,197 +156,34 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
   );
 }
 
-function MomentumIcon({ momentum }: { momentum: number | null }) {
-  if (momentum === null || momentum === undefined)
-    return <Minus className="h-4 w-4 text-muted-foreground" />;
-  if (momentum > 0.5) return <TrendingUp className="h-4 w-4 text-emerald-400" />;
-  if (momentum < -0.5) return <TrendingDown className="h-4 w-4 text-rose-400" />;
-  return <Minus className="h-4 w-4 text-muted-foreground" />;
-}
+/* ── Delegated citizen: the Epoch Briefing experience ──────────── */
 
 export function HomeCitizen({ pulseData, ssrHolderData, ssrWalletAddress }: HomeCitizenProps) {
   const { delegatedDrep } = useSegment();
   const { address } = useWallet();
 
-  // Prefer SSR delegation data, fall back to segment detection
   const drepId = ssrHolderData?.delegationHealth?.drepId ?? delegatedDrep;
   const wallet = ssrWalletAddress ?? address;
-
-  const { data: reportCardRaw, isLoading } = useDRepReportCard(drepId, wallet);
-  const reportCard = reportCardRaw as any;
-
-  const drepName =
-    ssrHolderData?.delegationHealth?.drepName ??
-    reportCard?.name ??
-    (drepId ? `${drepId.slice(0, 16)}…` : null);
-
-  const score: number = reportCard?.score ?? ssrHolderData?.delegationHealth?.drepScore ?? 0;
-  const tier = reportCard?.tier ?? (score ? computeTier(score) : 'Emerging');
-  const momentum: number | null = reportCard?.momentum ?? null;
-  const openProposals: number =
-    ssrHolderData?.delegationHealth?.openProposalCount ?? reportCard?.openProposalCount ?? 0;
 
   if (!drepId) {
     return <UndelegatedHome pulseData={pulseData} />;
   }
 
   return (
-    <div className="relative flex flex-col">
-      {/* ── Constellation hero (28vh) — branded ambient with personal context ── */}
-      <section className="relative h-[28vh] min-h-[200px] sm:-mt-14 overflow-hidden">
-        <div className="absolute inset-0">
-          <ConstellationScene className="w-full h-full" interactive={false} />
-        </div>
-        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-background to-transparent pointer-events-none" />
-
-        {/* Personal welcome overlay */}
-        <div className="absolute inset-0 flex items-center justify-center px-4 sm:pt-14">
-          <div className="text-center max-w-xl space-y-2">
-            <p className="font-display text-sm sm:text-base font-medium text-[#fff0d4] tracking-wide hero-text-shadow">
-              Your governance is active
-            </p>
-            <h1 className="font-display text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-white drop-shadow-lg leading-tight hero-text-shadow">
-              {isLoading && !drepName ? (
-                <span className="text-white/60">Loading…</span>
-              ) : (
-                <>
-                  Represented by <span className="text-[#fff0d4]">{drepName}</span>
-                </>
-              )}
-            </h1>
-            {openProposals > 0 && (
-              <p
-                className="text-sm text-white/70 hero-text-shadow"
-                style={{ textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)' }}
-              >
-                {openProposals} proposal{openProposals !== 1 ? 's' : ''} awaiting a vote this epoch
-              </p>
-            )}
-          </div>
-        </div>
+    <div className="flex flex-col pb-16">
+      {/* Epoch Briefing — the citizen's primary surface */}
+      <section className="mx-auto w-full max-w-3xl px-4 pt-6">
+        <EpochBriefing drepId={drepId} wallet={wallet} />
       </section>
 
-      {/* ── DRep report card headline ────────────────────────────────── */}
-      <section className="mx-auto w-full max-w-3xl px-4 -mt-6 pb-4 relative z-10">
-        <div
-          className={cn(
-            'rounded-2xl border p-6 space-y-5',
-            TIER_BG[tier] ?? 'bg-card border-border',
-          )}
-        >
-          {/* Header: name + tier badge + trend */}
-          <div className="flex items-start justify-between gap-3">
-            <div className="space-y-0.5 min-w-0">
-              <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-                Your DRep
-              </p>
-              {isLoading && !drepName ? (
-                <Skeleton className="h-7 w-48" />
-              ) : (
-                <h2 className="font-display text-2xl font-bold text-foreground truncate">
-                  {drepName}
-                </h2>
-              )}
-            </div>
+      {/* Treasury — Where Your Money Goes */}
+      <section className="mx-auto w-full max-w-3xl px-4 mt-6">
+        <TreasuryCitizenView />
+      </section>
 
-            <div className="flex items-center gap-2 shrink-0">
-              <span
-                className={cn(
-                  'text-xs font-semibold uppercase tracking-wider px-2.5 py-1 rounded-full border',
-                  TIER_COLORS[tier],
-                  TIER_BG[tier],
-                )}
-              >
-                {tier}
-              </span>
-              <MomentumIcon momentum={momentum} />
-            </div>
-          </div>
-
-          {/* Score + pillars */}
-          <div className="flex items-center gap-6">
-            {isLoading && !score ? (
-              <Skeleton className="h-14 w-20" />
-            ) : (
-              <div className="text-center">
-                <p
-                  className={cn('font-display text-5xl font-bold tabular-nums', TIER_COLORS[tier])}
-                >
-                  {score}
-                </p>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  <GovTerm term="drepScore">score</GovTerm>
-                </p>
-              </div>
-            )}
-
-            {reportCard?.pillars && (
-              <div className="flex-1 grid grid-cols-2 gap-x-4 gap-y-1.5">
-                {[
-                  { key: 'engagementQuality', label: 'Engagement' },
-                  { key: 'effectiveParticipation', label: 'Participation' },
-                  { key: 'reliability', label: 'Reliability' },
-                  { key: 'governanceIdentity', label: 'Identity' },
-                ].map(({ key, label }) => {
-                  const v = Math.round(reportCard.pillars[key] ?? 0);
-                  return (
-                    <div key={key} className="space-y-0.5">
-                      <div className="flex justify-between text-[10px] text-muted-foreground">
-                        <span>{label}</span>
-                        <span className="tabular-nums">{v}</span>
-                      </div>
-                      <div className="h-1 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-primary/60 transition-all duration-500"
-                          style={{ width: `${v}%` }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          {/* This epoch callout */}
-          <div className="rounded-lg bg-muted/30 px-4 py-3 flex items-center justify-between gap-3">
-            <div className="space-y-0.5">
-              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                This <GovTerm term="epoch">epoch</GovTerm>
-              </p>
-              <p className="text-sm text-foreground">
-                {openProposals > 0 ? (
-                  <>
-                    <span className="font-semibold text-amber-400">{openProposals}</span> open
-                    proposals awaiting a vote
-                  </>
-                ) : (
-                  'No open proposals — governance is quiet'
-                )}
-              </p>
-            </div>
-            {reportCard?.votingRecord && (
-              <div className="text-right shrink-0">
-                <p className="text-xs text-muted-foreground">Rationale rate</p>
-                <p className="text-sm font-semibold text-foreground tabular-nums">
-                  {reportCard.votingRecord.rationaleRate}%
-                </p>
-              </div>
-            )}
-          </div>
-
-          {/* Action CTA */}
-          <div className="flex flex-col sm:flex-row gap-2">
-            <Button asChild className="flex-1">
-              <Link href={`/drep/${drepId}`}>
-                Full profile <ChevronRight className="ml-1.5 h-4 w-4" />
-              </Link>
-            </Button>
-            <Button asChild variant="outline" className="flex-1">
-              <Link href="/match">Find a better match</Link>
-            </Button>
-          </div>
-        </div>
+      {/* Civic Identity — grows over time */}
+      <section className="mx-auto w-full max-w-3xl px-4 mt-6">
+        <CivicIdentityCard wallet={wallet} />
       </section>
     </div>
   );

--- a/components/civica/home/TreasuryCitizenView.tsx
+++ b/components/civica/home/TreasuryCitizenView.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  Landmark,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  ArrowRight,
+  Clock,
+  ExternalLink,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useTreasuryCurrent, useTreasuryPending } from '@/hooks/queries';
+
+function formatAdaCitizen(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B ADA`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(0)}M ADA`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K ADA`;
+  return `${Math.round(ada)} ADA`;
+}
+
+function TreasurySkeleton() {
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-4">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-10 w-48" />
+        <div className="grid grid-cols-2 gap-3">
+          <Skeleton className="h-16 w-full rounded-lg" />
+          <Skeleton className="h-16 w-full rounded-lg" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TreasuryCitizenView({ className }: { className?: string }) {
+  const { data: rawCurrent, isLoading: currentLoading } = useTreasuryCurrent();
+  const { data: rawPending, isLoading: pendingLoading } = useTreasuryPending();
+
+  const treasury = rawCurrent as any;
+  const pending = rawPending as any;
+
+  if (currentLoading) return <TreasurySkeleton />;
+  if (!treasury) return null;
+
+  const TrendIcon =
+    treasury.trend === 'growing'
+      ? TrendingUp
+      : treasury.trend === 'shrinking'
+        ? TrendingDown
+        : Minus;
+
+  const trendLabel =
+    treasury.trend === 'growing'
+      ? 'Growing'
+      : treasury.trend === 'shrinking'
+        ? 'Shrinking'
+        : 'Stable';
+
+  const trendColor =
+    treasury.trend === 'growing'
+      ? 'text-emerald-500'
+      : treasury.trend === 'shrinking'
+        ? 'text-rose-500'
+        : 'text-muted-foreground';
+
+  const pendingProposals: any[] = Array.isArray(pending?.proposals)
+    ? pending.proposals.slice(0, 3)
+    : [];
+
+  return (
+    <Card className={className}>
+      <CardContent className="pt-6 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Landmark className="h-4 w-4 text-muted-foreground" />
+            <p className="text-sm font-semibold text-foreground">Where Your Money Goes</p>
+          </div>
+          <Link
+            href="/pulse"
+            className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+          >
+            Full details
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+
+        {/* Balance + Trend */}
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Cardano&apos;s shared treasury</p>
+          <div className="flex items-end gap-3">
+            <p className="font-display text-3xl font-bold tabular-nums text-foreground">
+              {formatAdaCitizen(treasury.balance)}
+            </p>
+            <div className={cn('flex items-center gap-1 pb-0.5', trendColor)}>
+              <TrendIcon className="h-3.5 w-3.5" />
+              <span className="text-xs font-medium">{trendLabel}</span>
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            Funded by protocol reserves and transaction fees. Spent through governance votes.
+          </p>
+        </div>
+
+        {/* Key stats */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg bg-muted/30 p-3 text-center">
+            <p
+              className={cn(
+                'text-xl font-bold tabular-nums',
+                (treasury.runwayMonths ?? 0) > 24 ? 'text-emerald-500' : 'text-amber-500',
+              )}
+            >
+              {treasury.runwayMonths >= 999
+                ? '10+ years'
+                : treasury.runwayMonths != null
+                  ? `${Math.round(treasury.runwayMonths / 12)} years`
+                  : '--'}
+            </p>
+            <p className="text-[10px] text-muted-foreground mt-0.5 flex items-center justify-center gap-1">
+              <Clock className="h-2.5 w-2.5" />
+              Runway at current rate
+            </p>
+          </div>
+          <div className="rounded-lg bg-muted/30 p-3 text-center">
+            <p
+              className={cn(
+                'text-xl font-bold tabular-nums',
+                (treasury.pendingCount ?? 0) > 0 ? 'text-amber-500' : 'text-muted-foreground',
+              )}
+            >
+              {treasury.pendingCount ?? 0}
+            </p>
+            <p className="text-[10px] text-muted-foreground mt-0.5">Proposals requesting funds</p>
+          </div>
+        </div>
+
+        {/* Pending withdrawal previews */}
+        {!pendingLoading && pendingProposals.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">Awaiting decision</p>
+            <div className="rounded-lg border border-border divide-y divide-border overflow-hidden">
+              {pendingProposals.map((item: any, idx: number) => (
+                <Link
+                  key={idx}
+                  href={`/proposal/${item.txHash ?? item.tx_hash}/${item.index ?? 0}`}
+                  className="flex items-center justify-between px-3 py-2.5 hover:bg-muted/30 transition-colors"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium truncate text-foreground">
+                      {item.title ?? item.proposalType ?? 'Treasury withdrawal'}
+                    </p>
+                    {item.withdrawalAda != null && (
+                      <p className="text-xs text-muted-foreground">
+                        {formatAdaCitizen(item.withdrawalAda)}
+                      </p>
+                    )}
+                  </div>
+                  <ExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0 ml-2" />
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/civica/shared/CivicIdentityCard.tsx
+++ b/components/civica/shared/CivicIdentityCard.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Calendar, Flame, Vote, Coins, Share2, User } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface CivicIdentityCardProps {
+  wallet: string | null | undefined;
+  className?: string;
+}
+
+/* ── Data hook ──────────────────────────────────────────────────── */
+
+function useCivicIdentity(wallet: string | null | undefined) {
+  return useQuery({
+    queryKey: ['civic-identity', wallet],
+    queryFn: async () => {
+      const res = await fetch(`/api/governance/footprint?wallet=${encodeURIComponent(wallet!)}`);
+      if (!res.ok) throw new Error(`${res.status}`);
+      return res.json();
+    },
+    enabled: !!wallet,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/* ── Helpers ────────────────────────────────────────────────────── */
+
+function formatAdaGoverned(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toFixed(0);
+}
+
+/* ── Identity fact card ─────────────────────────────────────────── */
+
+function IdentityFact({
+  icon: Icon,
+  label,
+  value,
+  sub,
+}: {
+  icon: typeof Calendar;
+  label: string;
+  value: string | number;
+  sub?: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1 rounded-lg bg-muted/30 p-3 text-center">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <p className="text-lg font-bold tabular-nums text-foreground">{value}</p>
+      <p className="text-xs font-medium text-foreground/80">{label}</p>
+      {sub && <p className="text-[10px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+/* ── Loading skeleton ───────────────────────────────────────────── */
+
+function IdentitySkeleton() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="rounded-lg bg-muted/30 p-3 space-y-2 flex flex-col items-center">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="h-5 w-12" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Main component ─────────────────────────────────────────────── */
+
+export function CivicIdentityCard({ wallet, className }: CivicIdentityCardProps) {
+  const { data, isLoading } = useCivicIdentity(wallet);
+
+  if (!wallet) return null;
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <User className="h-4 w-4 text-muted-foreground" />
+          Your Civic Identity
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <IdentitySkeleton />
+        ) : data ? (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <IdentityFact
+                icon={Calendar}
+                label="Citizen Since"
+                value={data.citizenSinceEpoch != null ? `Epoch ${data.citizenSinceEpoch}` : '--'}
+                sub={
+                  data.epochsActive != null
+                    ? `${data.epochsActive} epoch${data.epochsActive !== 1 ? 's' : ''} ago`
+                    : undefined
+                }
+              />
+              <IdentityFact
+                icon={Flame}
+                label="Delegation Streak"
+                value={data.delegationStreak ?? 0}
+                sub={`epoch${(data.delegationStreak ?? 0) !== 1 ? 's' : ''}`}
+              />
+              <IdentityFact
+                icon={Vote}
+                label="Proposals Influenced"
+                value={data.proposalsInfluenced ?? 0}
+              />
+              <IdentityFact
+                icon={Coins}
+                label="ADA Governed"
+                value={data.adaGoverned != null ? `${formatAdaGoverned(data.adaGoverned)}` : '--'}
+              />
+            </div>
+
+            <div className="flex justify-center">
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground cursor-default">
+                <Share2 className="h-3.5 w-3.5" />
+                Share your civic identity
+              </span>
+            </div>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/strategy/personas/cc-member.md
+++ b/docs/strategy/personas/cc-member.md
@@ -1,0 +1,195 @@
+# Persona: The Constitutional Committee Member
+
+> **Status:** Active -- defines the highest-authority governance persona, primarily an accountability surface.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`, `personas/drep.md`, `personas/spo.md`
+
+---
+
+## Who They Are
+
+Constitutional Committee members are the smallest and most powerful governance body in Cardano. A group of ~7-10 individuals or entities elected to serve as constitutional guardians -- they review governance actions for constitutionality and can ratify or reject proposals independent of DRep and SPO votes.
+
+Their role is unique in Cardano's governance:
+
+- **They don't represent delegators.** Unlike DReps, CC members aren't accountable to a constituency. They're accountable to the constitution.
+- **Their votes carry disproportionate weight.** A CC rejection can block a governance action that DReps and SPOs overwhelmingly support, if it violates the constitution.
+- **They interpret foundational law.** Their judgment calls on constitutionality set precedent for future governance.
+- **They serve fixed terms.** CC members rotate, creating natural accountability cycles.
+
+CC members are citizens first. They hold ADA, they stake, they have personal governance values. Some may also be DReps or SPOs. The multi-wallet identity model handles overlapping roles. But their CC function is distinct: constitutional interpretation, not representation.
+
+### Why This Persona Is Different
+
+With only 7-10 members, the CC is not a growth market. Civica will never have 50 paying CC Pro subscribers. The value of serving this persona flows in the opposite direction: **CC transparency is enormously valuable to every other persona.**
+
+- Citizens want to know: are the constitutional guardians acting in good faith?
+- DReps want to know: will the CC ratify the proposal I'm voting on?
+- SPOs want to know: how does the CC's constitutional interpretation affect protocol parameters?
+- Researchers want to know: how does the CC's voting pattern evolve over time?
+
+The CC persona is primarily an **accountability surface** -- a public transparency layer that serves the entire ecosystem. Secondarily, Civica can offer CC members lightweight governance tooling if they choose to use it.
+
+---
+
+## What They Want
+
+### As citizens (inherited from Citizen persona)
+
+- The epoch briefing, treasury transparency, civic identity, smart alerts
+- Everything a citizen gets -- they're ADA holders too
+
+### As constitutional guardians
+
+- **Clarity on their role:** Tools that help them review proposals against the constitution efficiently
+- **Transparency mechanisms:** Ways to demonstrate that their decisions are principled, not political
+- **Public record:** A clear, accessible record of their votes and reasoning that builds institutional trust
+- **Communication with the community:** Ways to explain constitutional interpretations without becoming politicians
+
+### What the ecosystem wants from them
+
+- **Voting transparency:** How did each CC member vote on every governance action?
+- **Rationale transparency:** Why did they vote that way? What constitutional reasoning applies?
+- **Alignment visibility:** Do CC members vote as a bloc, or do they exercise independent judgment?
+- **Accountability metrics:** Are they participating? Are they providing rationales? Are they responsive?
+- **Community alignment:** How do CC decisions align with citizen sentiment, DRep votes, and SPO votes?
+
+---
+
+## The CC Experience
+
+### Philosophy
+
+The CC member experience on Civica is **80% public accountability surface, 20% lightweight governance tooling.** The primary audience for CC features is not the CC members themselves -- it's everyone else who needs to understand and trust what the CC is doing.
+
+If CC members choose to use Civica for their governance workflow, the same vote-casting and rationale tools available to DReps and SPOs are available to them. But the product doesn't depend on CC member adoption to deliver value. The accountability surface works regardless, built from on-chain data.
+
+### The Public Accountability Surface
+
+#### Committee Overview Page
+
+A dedicated page showing the current state of the Constitutional Committee:
+
+- **Current members:** Who they are, when their term started, when it expires
+- **Participation rates:** Individual and aggregate -- are they doing the job?
+- **Voting record:** Every CC vote on every governance action, with rationales where provided
+- **CC Transparency Index:** A composite score measuring participation, rationale provision, responsiveness, and alignment with community sentiment
+- **Aggregate voting patterns:** Do they vote as a bloc? How often do they disagree? On what types of proposals?
+
+#### Individual CC Member Profiles
+
+Each CC member gets a profile that serves as their public accountability record:
+
+- **Transparency Index score** with component breakdown
+- **Complete voting record** with rationales where available
+- **Voting alignment:** How often they agree with other CC members, with DRep consensus, with SPO consensus, with citizen sentiment
+- **Constitutional reasoning patterns:** What constitutional provisions they cite, how they interpret key clauses
+- **Term information:** When they joined, when their term expires, re-election status
+- **Participation metrics:** Vote rate, rationale rate, responsiveness to governance actions
+
+#### Inter-Body Dynamics
+
+The CC's relationship to the other governance bodies is a key intelligence surface:
+
+- **CC vs. DRep alignment:** On which proposals do they agree? Where do they diverge? When the CC rejects something DReps overwhelmingly supported, what was the constitutional reasoning?
+- **CC vs. SPO alignment:** Same analysis for the SPO governance body
+- **CC vs. Citizen sentiment:** How do CC decisions align with what Civica's citizen engagement layer reveals about community preferences?
+- **Constitutional friction points:** Proposals where the CC's constitutional interpretation diverged from community consensus -- these are the governance moments that matter most and deserve the most visibility
+
+#### Historical Record
+
+Because CC members serve terms and rotate, the historical record is uniquely important:
+
+- **Term comparisons:** How does the current CC's participation compare to previous compositions?
+- **Precedent tracking:** When the CC rejects a proposal on constitutional grounds, that reasoning becomes precedent. Track and surface these.
+- **Transparency trajectory:** Is the CC becoming more or less transparent over time?
+- **Constitutional interpretation evolution:** How has the CC's reading of key constitutional provisions changed across terms and compositions?
+
+### Lightweight Governance Tooling (Optional)
+
+If CC members choose to use Civica, they get the same core governance tools as DReps and SPOs:
+
+- **Vote casting** via MeshJS (CIP-95) -- same integrated flow
+- **Rationale authoring** with CIP-100 compliance -- particularly valuable for CC because constitutional reasoning benefits from structured, well-documented rationales
+- **Proposal workspace** with the full analysis layer -- AI summary, treasury impact, citizen sentiment, inter-body context, plus constitutional alignment analysis tailored to CC concerns
+- **Constitutional reference:** Quick access to the ratified constitution with AI-assisted search for relevant provisions per proposal
+
+The incentive for CC members to use Civica: their rationales appear on their profile automatically, improving their Transparency Index score. If the tool makes constitutional reasoning easier to publish, CC members who use it will appear more transparent and accountable.
+
+### Citizen Engagement with CC
+
+The citizen engagement mechanisms apply to CC specifically:
+
+- **Citizen sentiment on CC decisions:** "72% of citizens agree with the CC's rejection of Proposal X"
+- **Concern flags on CC votes:** When citizens flag a CC vote as concerning, it surfaces as community feedback
+- **Citizen questions to CC:** Aggregated, structured: "85 citizens want to understand why the CC rejected the treasury proposal." CC members can respond once, publicly.
+- **Trust signals:** Citizen endorsements of individual CC members, tracked over their term
+
+---
+
+## The CC Transparency Index
+
+A composite accountability score for CC members, designed to be simple, fair, and transparent:
+
+### Components
+
+- **Participation (35%):** What percentage of governance actions did they vote on? Non-participation is the most basic accountability failure.
+- **Rationale Quality (30%):** Do they explain their votes? Do they cite constitutional provisions? Is the reasoning substantive or boilerplate? AI-assessed with human-readable scoring criteria.
+- **Responsiveness (15%):** How quickly do they vote relative to proposal deadlines? Do they wait until the last moment or engage early?
+- **Independence (10%):** Do they exercise independent judgment, or do they vote identically with the rest of the CC on every proposal? Some agreement is expected; perfect unanimity on every vote suggests groupthink.
+- **Community Engagement (10%):** Do they respond to citizen questions? Do they publish explanations beyond minimal rationales? Are they accessible?
+
+### Design Principles
+
+- The index measures process, not outcomes. A CC member who votes against community sentiment but provides thorough constitutional reasoning scores well. A CC member who votes with the crowd but never explains why scores poorly.
+- All components are derived from on-chain data and Civica's engagement layer. No subjective editorial judgment.
+- The methodology is published and transparent. CC members know exactly how they're being evaluated.
+
+---
+
+## Free Only (No Pro Tier)
+
+There is no CC Pro tier. The population is too small to monetize, and gating CC transparency features would undermine the accountability mission.
+
+Everything CC-related is free:
+
+- The public accountability surface (committee page, individual profiles, inter-body dynamics)
+- CC governance tooling (vote casting, rationale submission, proposal workspace) -- if CC members choose to use it
+- The Transparency Index
+- Historical records and precedent tracking
+- Citizen engagement with CC (sentiment, questions, endorsements)
+
+The value of CC transparency flows to other personas: citizens trust the system, DReps understand CC positions, researchers analyze constitutional dynamics. This is infrastructure, not a product to monetize.
+
+---
+
+## How CC Members Connect to Other Personas
+
+| Persona            | Relationship                                                                                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Citizens**       | CC accountability is a key trust signal. Citizens want to know their constitutional guardians are acting in good faith. CC transparency directly affects citizen confidence in Cardano governance.                       |
+| **DReps**          | DReps need to understand CC positions to govern effectively. A DRep voting Yes on a proposal the CC will reject on constitutional grounds is wasting governance effort. CC voting patterns inform DRep strategy.         |
+| **SPOs**           | SPOs interact with CC on protocol parameters and hard forks. CC ratification is required for these actions. SPOs benefit from understanding CC constitutional interpretation on technical matters.                       |
+| **Treasury Teams** | Treasury proposals require CC ratification. Proposal teams benefit from understanding what the CC considers constitutionally compliant before submitting. CC precedent on treasury spending creates informal guidelines. |
+| **Researchers**    | CC dynamics are a rich research subject: constitutional interpretation patterns, inter-body tension, independence metrics, term-over-term comparison. Small population makes individual-level analysis tractable.        |
+
+---
+
+## Metrics That Matter
+
+| Metric                             | What It Measures                                           | Target                                                           |
+| ---------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
+| **CC page views**                  | Is the accountability surface valuable?                    | Consistent traffic, spikes around controversial decisions        |
+| **CC member profile views**        | Are people checking individual accountability?             | Each member's profile viewed regularly                           |
+| **CC rationale submission rate**   | If CC members use Civica, are they providing rationales?   | Higher rationale rate than through other tools                   |
+| **Citizen questions to CC**        | Is the engagement layer working?                           | Meaningful question volume on significant governance actions     |
+| **Inter-body analysis engagement** | Do DReps/SPOs use CC data for decision-making?             | CC alignment data referenced in DRep/SPO rationales              |
+| **Trust correlation**              | Does CC transparency affect citizen governance confidence? | Citizen engagement metrics correlate with CC transparency levels |
+
+---
+
+## The One-Line Vision
+
+**Civica makes the Constitutional Committee the most transparent governance body in any blockchain -- not by requiring their participation, but by building the accountability surface the ecosystem needs to trust them.**
+
+The CC page isn't for the CC. It's for the 700 DReps, 3,000 SPOs, and millions of ADA holders who need to trust that their constitutional guardians are doing their job. If CC members choose to use Civica's governance tools, they become more transparent. If they don't, the on-chain record still speaks.

--- a/docs/strategy/personas/citizen.md
+++ b/docs/strategy/personas/citizen.md
@@ -1,0 +1,317 @@
+# Persona: The Cardano Citizen
+
+> **Status:** Active -- defines the anchor persona and primary acquisition target for Civica.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`
+
+---
+
+## Who They Are
+
+The Cardano Citizen is anyone who holds ADA. Not governance experts, not DReps, not pool operators -- just people who own a stake in the Cardano network. They range from the ultra-passive investor who only cares about price to the moderately engaged holder who follows ecosystem news. They are 80%+ of Civica's potential userbase and the foundation the entire product is built on.
+
+Most Cardano Citizens today:
+
+- Bought ADA as an investment and check its price occasionally
+- May or may not stake their ADA (many do for rewards, without thinking much about it)
+- Have heard of "governance" but think it's not for them -- too technical, too political, too time-consuming
+- Don't know they have governance rights, or know but don't understand what that means practically
+- Have never delegated to a DRep, or delegated once and forgot about it
+- Get their Cardano news from Twitter, Reddit, or YouTube -- fragmented, noisy, often misleading
+
+### The Identity Shift
+
+The fundamental job of Civica is to transform the Citizen's self-perception from **"I own tokens"** to **"I'm a citizen of a digital nation."**
+
+This is not marketing language. Cardano has a ratified constitution, a treasury worth billions of ADA, elected representatives (DReps), three branches of governance, and a 5-day legislative cycle. It is structurally more democratic than most countries. Every ADA holder has governance rights whether they exercise them or not.
+
+The product's job is to make that citizenship feel _real_ -- tangible, valuable, and effortless to participate in.
+
+---
+
+## What They Want (Whether They Know It or Not)
+
+### What they say they want
+
+- "Number go up"
+- Easy staking with good returns
+- To know if Cardano is "doing well"
+
+### What they actually need
+
+- To understand that governance decisions directly affect their ADA (treasury spending, protocol parameters, staking rewards)
+- Representation in governance that aligns with their values (delegation)
+- Confidence that the people making decisions are doing a good job
+- A way to stay informed without it becoming a second job
+
+### What would delight them
+
+- Feeling like a citizen of something real, not just a token holder
+- A civic identity that grows over time and reflects their participation
+- Being able to understand governance in 30 seconds per epoch
+- Having a voice without needing to become an expert
+- Knowing exactly where treasury money goes and whether it was well spent
+
+---
+
+## The Citizen Experience
+
+### Philosophy
+
+The Citizen experience is **summary intelligence, not analytics.** It answers: "What's happening with my ADA in governance, and should I care right now?" The default answer most epochs should be: "Everything's fine. Here's what happened." Calm is a feature.
+
+The Citizen does not want a simpler version of the DRep dashboard. They want a **fundamentally different product** -- a governance health monitor and civic briefing, not a data platform.
+
+Progressive depth is available for the curious. Every summary has a path to more detail. But the default experience is conclusive, not exploratory.
+
+### Pre-Connection: The Front Door
+
+Before connecting a wallet, Civica should feel like an invitation, not a dashboard. The anonymous experience has one job: convince the visitor that being an active Cardano citizen is easy, valuable, and risk-free.
+
+**What they see:**
+
+- A clear, unintimidating explanation of what Cardano governance is and why it matters to them
+- Two familiar paths in: **Stake** (find a pool that represents your values) and **Govern** (find a representative in 60 seconds)
+- Enough free intelligence to demonstrate value -- DRep browse, SPO browse, proposal summaries, the Constellation, governance health overview
+- A persistent, gentle prompt to connect their wallet for personalized experience
+- Education woven into every surface, not a separate "/learn" destination
+
+**What they don't see:**
+
+- Full navigation (reduced to Explore, Match, Learn, Connect)
+- Analytics, charts, or data-heavy surfaces
+- Jargon without explanation
+
+**The messaging:**
+
+- "Your ADA gives you a voice in Cardano's future. It takes 60 seconds to use it."
+- "Choose someone who shares your values. Your ADA stays in your wallet."
+- "Delegate and forget -- as long as you pick a good representative, you've done your job."
+
+### Post-Connection: The Civic Hub
+
+After connecting a wallet, the Citizen sees their personalized civic experience. This is the product they return to every epoch.
+
+#### The Briefing (Primary Surface)
+
+A personalized, plain-English digest updated every epoch (~5 days). This is the core return driver.
+
+**Content:**
+
+- **Personal status:** Delegation health (green/yellow/red). Staking rewards this epoch. Any alerts that need attention. Usually: "Everything's fine."
+- **What happened:** 2-4 headline cards summarizing governance activity this epoch. Written like news, not data: "The community approved funding for a new developer toolkit (4.2M ADA). Your DRep voted Yes."
+- **Treasury update:** How much was spent, on what, current treasury balance. "Your proportional share of the treasury: X ADA." Make the collective treasury feel personal.
+- **What's coming:** Active proposals, upcoming deadlines, anything the citizen might want to know about.
+- **Your DRep this epoch:** How your representative performed. Votes cast, rationales provided, score change. One-line verdict: "Your DRep is representing you well" or "Your DRep missed 3 votes this epoch -- consider checking their profile."
+
+**What it is NOT:**
+
+- A dashboard with charts and metrics
+- An analytics view with filters and sorting
+- A firehose of every governance action
+
+**Design principle:** If a citizen reads their briefing in 30 seconds and closes the app feeling informed and confident, the product succeeded.
+
+#### Treasury Transparency
+
+A dedicated surface for understanding where the money goes. This bridges the gap between "number go up" and "governance matters" by making treasury spending tangible and personal.
+
+**What citizens see:**
+
+- Treasury balance and trend (growing? shrinking? at what rate?)
+- What got funded: plain-English descriptions of funded projects with delivery status
+- Spending categories: how much goes to development, marketing, research, infrastructure
+- Project accountability: did funded projects deliver? Citizen impact reports.
+- "Your proportional share" framing: personalize the treasury relative to their holdings
+- Who voted for what: connect spending decisions to specific DReps (accountability trail)
+- Historical trends: is spending accelerating? Are projects delivering?
+
+**Why this matters:** The treasury is the most concrete connection between governance and the citizen's economic interest. "People are spending billions of your collective ADA" is an attention-getter. "Here's exactly where it went and whether it worked" is the value.
+
+#### Civic Identity
+
+A persistent, growing profile that represents the citizen's relationship with the Cardano network. Not gamification for its own sake -- meaningful markers of civic participation.
+
+**Components:**
+
+- **Citizen since:** When they first staked or delegated (epoch + approximate date)
+- **Delegation streak:** Consecutive epochs delegated
+- **Representation summary:** "Your DRep has cast X votes on your behalf since you delegated"
+- **Governance alignment:** Their values profile (from Quick Match), visualized simply
+- **Governance footprint:** Total ADA governed across their delegation + staking, proposals touched through their representative, cumulative epoch participation
+- **Milestones:** "100 epochs delegated," "Your DRep voted on 200 proposals on your behalf," "Participated in 5 Citizen Assemblies"
+
+**Why this matters:** Identity creates attachment. A citizen who has been delegated for 100 epochs and can see that history doesn't casually abandon the product. The identity also enables Wrapped -- shareable civic moments that drive acquisition.
+
+#### Civic Engagement (Community Layer)
+
+Structured mechanisms for citizens to participate beyond delegation. Every interaction generates data that feeds the intelligence engine. None require free-text input. None require moderation.
+
+**Engagement mechanisms:**
+
+1. **Proposal Sentiment**
+   - On every active proposal: "Do you support this? Yes / No / Not sure"
+   - Aggregate shown publicly: "72% of Civica citizens support this proposal"
+   - Divergence highlighted: "Citizens support this 80%, but DReps are voting 55% Yes"
+   - Creates accountability signal and citizen voice without formal governance weight
+
+2. **Priority Signals**
+   - Periodic prompt: "What should governance focus on?" (rank from structured list)
+   - Categories: treasury oversight, protocol development, ecosystem growth, decentralization, education, security
+   - Aggregate becomes the "Citizen Mandate" -- visible to DReps and the community
+   - Updated quarterly or when the system detects shifting priorities
+
+3. **Concern Flags**
+   - On any proposal: flag a specific concern from a structured list
+   - Options: "too expensive," "unclear deliverables," "conflicts of interest," "rushed timeline," "affects my staking," "insufficient rationale"
+   - Threshold-based surfacing: when enough citizens flag the same concern, it becomes prominent
+   - Crowdsourced risk assessment without needing expertise
+
+4. **Impact Tags**
+   - On funded projects: "I use this" / "I tried it" / "I didn't know about it"
+   - If they use it: "essential" / "useful" / "okay" / "disappointing"
+   - Optional one-sentence context (the only free-text, and it's optional + short)
+   - Crowdsourced accountability: "89 citizens report using this project, 71% say it's essential"
+
+5. **Citizen Endorsements**
+   - Endorse DReps, SPOs, or funded projects with a single tap
+   - Optional conditional endorsements: "I trust this DRep on treasury proposals"
+   - Social proof alongside algorithmic scores: "342 citizens endorse this DRep"
+   - Domain-specific trust signals feed the matching and scoring engines
+
+6. **Citizen Questions**
+   - Pose structured questions to DReps about specific proposals or votes
+   - Similar questions merge: "47 citizens asked why you voted Yes on Proposal X"
+   - DReps respond once to the aggregate, publicly
+   - Creates accountability loop without becoming messaging/chat
+
+7. **Citizen Assemblies**
+   - Periodic invitations to a random sample of citizens for deeper deliberation
+   - Presented with balanced, AI-generated proposal summaries
+   - Citizens vote and select reasoning from structured options
+   - Published as "Citizen Assembly verdict" alongside official governance results
+   - Digital sortition: random citizen samples produce better collective signals than self-selected participation
+
+**Anti-forum principle:** None of these mechanisms create threads, conversations, or debate spaces. They create _signals_ -- structured, aggregatable, analyzable data that feeds the intelligence engine while giving citizens meaningful agency.
+
+#### Smart Alerts
+
+The default state is quiet. Most epochs, nothing needs the citizen's attention. When something does, the alert earns trust because the platform doesn't cry wolf.
+
+**Alert triggers:**
+
+- "A proposal to change staking reward parameters is being voted on" (affects their income)
+- "Your stake pool announced it's retiring in 3 epochs" (action required)
+- "Your DRep hasn't voted in 2 epochs" (representation degrading)
+- "Your DRep's score dropped significantly" (representation quality change)
+- "A major treasury withdrawal was approved" (large spending event)
+- "Governance participation dropped below 50%" (systemic health concern)
+
+**Alert philosophy:** Every alert must connect to an action. "Your DRep missed votes" links to DRep profile and re-delegation. "Your pool is retiring" links to SPO discovery. No alert is purely informational -- Principle #8 (intelligence demands action) applies especially here.
+
+---
+
+## Discovery Surfaces (Free, Pre- and Post-Connection)
+
+These surfaces remain accessible to everyone (Principle #1: never gate discovery, basic scores, delegation, Quick Match, basic alerts). They serve as both the free value proposition and the ongoing browse experience.
+
+### DRep Browse
+
+**Citizen-appropriate view:**
+
+- Name, score, one-line philosophy, match percentage (if they've done Quick Match)
+- Enough to choose, not enough to overwhelm
+- Sort by match, score, or popularity
+- Quick delegate action on every card
+
+**NOT the citizen view:** alignment radars, temporal trajectories, pillar breakdowns, PCA coordinates. These exist on the full profile for those who drill in.
+
+### SPO Browse
+
+**Citizen-appropriate view:**
+
+- Pool name, ticker, governance score, governance participation rate
+- What makes this different from PoolTool: governance values alignment, not just ROI
+- "This pool operator shares your values on decentralization and votes on 95% of proposals"
+
+### Proposal Browse
+
+**Citizen-appropriate view:**
+
+- Title, one-sentence plain-English summary, status, your DRep's vote
+- Treasury proposals: amount + "X% of treasury"
+- Urgency indicator for proposals closing soon
+- Citizen sentiment (if they or others have voted)
+
+### Quick Match
+
+The primary acquisition funnel. 3 questions, 60 seconds, delegation. Dual-mode: "Find my DRep" / "Find my SPO." The citizen doesn't need to understand governance philosophy -- the quiz translates their values into delegation.
+
+---
+
+## How Citizens Connect to Other Personas
+
+The citizen persona doesn't exist in isolation. Every other persona serves citizens or is accountable to them:
+
+| Persona            | Relationship to Citizens                                                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **DReps**          | Represent citizens. Citizens evaluate, delegate to, endorse, and question them. DRep quality directly determines citizen governance health.                                                             |
+| **SPOs**           | Operate infrastructure citizens stake with. Citizens discover SPOs through governance values, not just financial metrics. SPO governance participation affects the citizen's "full governance picture." |
+| **CC Members**     | Highest-level representatives. Citizens track CC transparency and alignment with citizen sentiment.                                                                                                     |
+| **Treasury Teams** | Spend citizens' collective treasury. Citizens provide impact reports and accountability signals on funded projects.                                                                                     |
+| **Researchers**    | Consume and analyze the data citizens generate through engagement signals. Research findings flow back as intelligence that improves the citizen briefing.                                              |
+
+---
+
+## Metrics That Matter
+
+How to know if the Citizen experience is working:
+
+| Metric                           | What It Measures                               | Target                                                                |
+| -------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------- |
+| **Wallet connections per week**  | Acquisition funnel effectiveness               | Growing week-over-week                                                |
+| **Delegations completed**        | Core conversion (visitor -> citizen)           | >30% of wallet connections lead to delegation                         |
+| **Epoch return rate**            | Do citizens come back?                         | >40% of connected citizens return within 2 epochs                     |
+| **Briefing read rate**           | Is the digest compelling?                      | >60% of returning citizens view their briefing                        |
+| **Sentiment participation rate** | Is civic engagement working?                   | >20% of active citizens vote on at least one proposal per epoch       |
+| **Delegation churn**             | Are citizens sticking with their DRep?         | Low churn = healthy matching; high churn = matching needs improvement |
+| **Time to value**                | How quickly does a new visitor feel "I get it" | <60 seconds to understand value prop; <3 minutes to delegation        |
+
+---
+
+## What This Persona Does NOT Need
+
+Clarity on what to exclude is as important as what to include:
+
+- **Analytics dashboards** -- citizens want conclusions, not charts
+- **Raw data exports** -- that's for researchers
+- **Score methodology deep dives** -- citizens trust the score or they don't; methodology is for transparency docs
+- **DRep management tools** -- that's for DReps
+- **Competitive analysis** -- citizens don't compare DReps analytically; they match and delegate
+- **API access** -- that's for integrators
+- **Admin or moderation capabilities** -- the structured engagement model doesn't need user-facing moderation
+- **Complex filtering or sorting** -- sensible defaults with minimal controls
+
+---
+
+## The Return Loop
+
+What brings a citizen back every epoch:
+
+1. **The Briefing** -- fresh, personalized, 30 seconds. "What happened with my governance?"
+2. **Identity growth** -- their footprint, streak, and milestones accumulate passively
+3. **Civic engagement** -- active proposals to weigh in on, priority signals to set, impact to report
+4. **Smart alerts** -- occasional, high-signal notifications when something actually matters
+5. **Wrapped moments** -- periodic shareable summaries of their civic participation
+
+The cadence is natural: Cardano epochs are ~5 days. Every epoch is a new briefing, potentially new proposals to react to, new treasury activity to review. The product doesn't need to manufacture engagement -- the governance cycle provides it.
+
+---
+
+## The One-Line Vision
+
+**Civica tells Cardano citizens what their ADA is doing in governance, so they don't have to follow it themselves.**
+
+Not analytics. Not research. Not deep intelligence. Just: "Here's what happened. Here's what your representative did. Here's whether you should care. And here's how to make your voice heard if you want to."
+
+The deeper intelligence, DRep/SPO analytics, research tools, and power features serve the other personas and eventually monetize. But the thing that makes Civica a _hub_ for every Cardano citizen is the 30-second epoch check-in that nobody else provides, wrapped in a civic identity that grows over time and a community layer that gives every citizen a voice.

--- a/docs/strategy/personas/drep.md
+++ b/docs/strategy/personas/drep.md
@@ -1,0 +1,302 @@
+# Persona: The DRep (Delegated Representative)
+
+> **Status:** Active -- defines the primary supply-side persona and first monetization target.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`
+
+---
+
+## Who They Are
+
+DReps are Cardano citizens who have volunteered to actively participate in governance on behalf of others. They registered on-chain as Delegated Representatives, accepting the responsibility of reviewing proposals, casting votes, and (ideally) explaining their reasoning to the people who delegated to them.
+
+They range from highly professional governance participants treating it as a career, to community members who registered out of passion, to institutional entities representing organizations. What they all share: they've chosen to be more than passive citizens. They accepted accountability.
+
+**A DRep is a citizen first.** They hold ADA, they stake, they have their own governance values and delegation preferences (many delegate to themselves, some to other DReps). Everything in the Citizen experience applies to them -- the briefing, the civic identity, the treasury transparency, the engagement mechanisms. The DRep layer adds professional governance tooling on top of that foundation.
+
+The analogy is a politician who is also a citizen. They vote in elections, they pay taxes, they use public services. But they also have a professional workspace for doing the work of governance. Civica serves both roles in one product.
+
+### Current Population
+
+~700 registered DReps as of early 2026, though the governance-active subset (regular voters with meaningful delegation) is smaller. This is the initial addressable market for DRep Pro.
+
+---
+
+## What They Want
+
+### As citizens (inherited from Citizen persona)
+
+- The epoch briefing, treasury transparency, civic identity, smart alerts
+- Everything a citizen gets -- they're ADA holders with governance rights too
+
+### As governance professionals
+
+- **Reputation that compounds:** A score, a profile, a track record that reflects their actual governance behavior and grows more valuable over time
+- **Efficiency:** Governance is time-consuming. They need to review proposals, analyze impact, cast votes, write rationales, track delegation, communicate with constituents -- ideally without 5 tabs open
+- **Delegation growth:** More delegators = more governance power = more influence. They want tools to earn and retain delegation.
+- **Accountability tools:** Ways to demonstrate transparency to their delegators and the broader community
+- **Competitive awareness:** Where they stand relative to peers, what's working for other DReps, where they can improve
+
+### What would delight them
+
+- Casting a vote and submitting a CIP-100 rationale in the same flow, in under 2 minutes
+- Opening Civica and seeing exactly what needs their attention, prioritized by urgency and impact
+- Watching their governance score improve as they participate more effectively
+- Getting a notification that says "15 new delegators this epoch -- here's why they chose you"
+- An AI that drafts their rationale from the proposal text + their voting history + their governance philosophy
+
+---
+
+## The DRep Experience
+
+### Philosophy
+
+The DRep experience is a **professional governance workspace** -- Civica is to DReps what VS Code is to developers. They open it, see what needs attention, do the work, track their performance, and communicate with constituents. The intelligence layer (AI analysis, citizen sentiment, treasury context) makes them better at governance without requiring extra effort.
+
+The citizen experience runs underneath. The DRep layer adds to it; it never replaces it.
+
+### The Governance Workspace
+
+#### Inbox / Action Queue (Primary Surface)
+
+When a DRep opens Civica, they see what needs their attention, prioritized:
+
+- **Urgent votes:** Proposals expiring soon that they haven't voted on
+- **New proposals:** Recently submitted governance actions awaiting review
+- **Citizen questions:** Aggregated questions from delegators about specific proposals or past votes
+- **Delegation changes:** Notable shifts in their delegator base
+- **Score alerts:** Changes to their governance score and what drove them
+
+Each item connects directly to action. A proposal in the inbox opens the full proposal workspace. A citizen question links to the response interface. A score alert explains what to do about it.
+
+**Design principle:** The inbox should answer "what should I do right now?" within 5 seconds of opening.
+
+#### Proposal Workspace (Analysis -> Action)
+
+The DRep's primary work surface. Everything they need to make an informed vote and explain it, on one page:
+
+**Analysis layer:**
+
+- AI-generated plain-English summary of the proposal
+- Treasury impact: amount requested, percentage of treasury, spending category
+- Similar past proposals and their outcomes (delivered, partial, failed)
+- Citizen sentiment from Civica's engagement layer: support %, concern flags, priority alignment
+- Citizen questions: "31 citizens want to know your position on this"
+- Inter-body context: how SPOs and CC members are leaning
+- Constitutional alignment: AI analysis of whether the proposal conflicts with the ratified constitution
+- Proposal author track record: delivery history on past funded proposals
+- Other DRep votes (after voting, to avoid anchoring bias -- or configurable)
+
+**Action layer:**
+
+- **Vote casting** directly from Civica. The DRep selects Yes / No / Abstain, the app constructs the governance transaction via MeshJS (CIP-95), the DRep signs with their governance wallet, and the vote is submitted on-chain.
+- **Rationale authoring** integrated with the vote flow:
+  - Rich-text editor for writing the rationale
+  - AI-assisted drafting: generates a first draft from the proposal text, the DRep's voting history, and their stated governance philosophy
+  - Auto-formats to CIP-100 compliant JSON behind the scenes
+  - Hosts the rationale document (Supabase storage or IPFS)
+  - Bundles the metadata anchor with the vote transaction -- one submission: vote + rationale together
+  - The rationale automatically appears on the DRep's profile
+- **Information requests** to proposal authors: structured asks for clarification, aggregated with other DRep requests ("4 DReps requested clarification on milestones"), proposal authors respond publicly
+
+**Why this matters:** Today, voting and rationale submission are separate, tedious processes across multiple tools. Making them a single 2-minute flow inside the analysis workspace fundamentally changes DRep behavior. DReps who use Civica will provide more rationales, score higher, and attract more delegation. The tool makes them better at governance.
+
+#### Reputation Dashboard
+
+The DRep's view of their own governance reputation -- how the ecosystem sees them:
+
+**Score and standing:**
+
+- Current governance score with pillar breakdown (Engagement Quality, Effective Participation, Reliability, Governance Identity)
+- Score trend over time (trajectory, momentum)
+- Rank among active DReps
+- Strengths and weaknesses: "Your participation rate is top 10%, but your rationale rate is below average"
+
+**Delegation health:**
+
+- Total delegators and voting power
+- Delegation trend: growing, stable, or declining
+- Recent delegation events: who arrived, who left (anonymized or by address)
+- Citizen endorsements: how many, in which domains
+
+**Profile as others see it:**
+
+- Preview of their public DRep profile page
+- What citizens see when evaluating them
+- Governance philosophy, featured positions, voting record highlights
+
+#### Delegator Communication Hub
+
+Structured governance communication -- not a blog, not a forum:
+
+**Vote explanations:**
+
+- Every vote + rationale is automatically visible to delegators on the DRep's profile
+- Civica surfaces these as "Your DRep voted Yes on Proposal X" in delegator briefings
+- The rationale IS the communication -- Civica just makes it visible where it matters
+
+**Position statements:**
+
+- Structured declarations: "Here's where I stand on treasury spending / protocol changes / decentralization"
+- Attached to their profile and governance philosophy
+- Feed into the alignment engine: stated positions can be compared to actual voting behavior
+
+**Epoch updates (optional):**
+
+- A short, structured "letter to delegators" each epoch
+- AI-assisted: "Based on your 4 votes this epoch, here's a draft update"
+- Visible on their profile and in delegator briefings
+
+**Citizen question responses:**
+
+- Aggregated questions from the citizen engagement layer
+- "47 citizens asked why you voted Yes on Proposal X"
+- DRep responds once, publicly
+- The response is attached to the relevant proposal and visible on the DRep's profile
+
+**Governance philosophy:**
+
+- A persistent profile section explaining who they are and what they represent
+- Values, priorities, areas of expertise, governance approach
+- Their "campaign page" -- the thing potential delegators read when deciding
+
+#### Campaign and Growth Tools
+
+For DReps seeking to grow their delegation:
+
+- Shareable profile cards and governance summaries
+- "Why delegate to me" highlight reel: best votes, impact, score trajectory
+- Comparison highlights: "I voted on 95% of proposals vs. the average of 62%"
+- Governance Wrapped moments: shareable epoch and annual summaries
+- Embeddable governance card for personal websites, social media, forum signatures
+
+---
+
+## Free vs. Pro
+
+The free tier gives DReps everything they need to govern effectively. Pro gives them the edge to grow their delegation and outperform peers.
+
+### Free (Essential Governance Operations)
+
+Everything a DRep needs to do their job:
+
+- **Vote casting** from within Civica
+- **Rationale authoring + submission** (editor, CIP-100 formatting, hosting, bundled submission)
+- **Proposal workspace** (full analysis: AI summary, treasury impact, citizen sentiment, similar proposals, constitutional alignment)
+- **Basic delegation stats** (total delegators, voting power, recent changes)
+- **Profile management** (governance philosophy, position statements, basic bio)
+- **Citizen question responses** (see and respond to aggregated questions)
+- **Information requests to proposal authors**
+- **The full citizen experience** (briefing, treasury, civic identity, engagement)
+- **Score visibility** (their score, pillar breakdown, basic trend)
+
+### Pro (Competitive Advantage + Growth)
+
+Tools for DReps who want to actively grow their reputation and delegation:
+
+- **AI rationale drafting assistant** -- AI writes the first draft from the proposal + the DRep's history + their governance philosophy. The DRep edits and submits. Dramatically faster than writing from scratch.
+- **Delegation analytics** -- who arrived, who left, trends over time, delegator composition, voting power trajectory, churn analysis
+- **Score simulator** -- "if you provide rationales for the next 5 proposals, your score will reach X." "If you vote on every proposal this epoch, your rank will move from 45th to 32nd."
+- **Competitive intelligence** -- peer comparison, alignment neighborhood analysis, which DReps are gaining delegation and why, where they rank on specific dimensions
+- **Advanced inbox prioritization** -- AI-ranked by impact on score, delegation risk, proposal importance, constitutional significance
+- **Campaign tools** -- enhanced shareable cards, comparison highlights, embeddable widgets, custom branding
+- **Delegator communication suite** -- AI-assisted epoch updates, position statement templates, enhanced delegator analytics
+- **Custom alerts** -- score threshold alerts, delegation movement warnings, competitive shift notifications, proposal-type-specific alerts
+- **Performance coaching** -- AI-generated suggestions: "DReps in your score range who provide rationales on treasury proposals see 15% more delegation growth"
+
+### Why This Split Works
+
+The free tier is generous because DRep usage IS the product:
+
+- Every vote cast through Civica feeds the intelligence engine
+- Every rationale submitted improves the citizen experience
+- Every DRep managing their profile through Civica creates better data
+- The more DReps use free Civica, the more valuable the platform is for everyone
+
+Pro monetizes the competitive layer. DReps who want to _win_ -- attract more delegation, climb rankings, outperform peers -- will pay for the edge. The free tier makes them effective. Pro makes them strategic.
+
+---
+
+## How DReps Connect to Other Personas
+
+| Persona            | Relationship                                                                                                                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Citizens**       | DReps serve citizens. Citizens delegate to them, endorse them, question them, and evaluate them. Every DRep action flows to citizen surfaces. The DRep's primary audience is their delegators.                      |
+| **SPOs**           | DReps and SPOs are parallel governance bodies. Inter-body alignment between DRep votes and SPO votes is a key intelligence surface. Some individuals are both DReps and SPOs (multi-wallet identity handles this).  |
+| **CC Members**     | DReps interact with CC on constitutional matters. CC ratification or rejection of proposals that DReps voted on creates inter-body dynamics. DReps may reference CC positions in their rationales.                  |
+| **Treasury Teams** | DReps vote on treasury proposals. Their track record of approving projects that deliver (or don't) is part of their reputation. They ask proposal authors for clarification through the information request system. |
+| **Researchers**    | DRep voting patterns, alignment shifts, and score trajectories are primary research subjects. Researcher analysis feeds back into the intelligence layer that DReps consume.                                        |
+
+---
+
+## The Rationale Revolution
+
+The single most impactful thing Civica can do for DRep governance quality is make rationale submission effortless. Today:
+
+- CIP-100 rationale submission requires manual JSON creation, self-hosting, and anchor hash submission
+- Most DReps skip it because the friction is too high
+- Citizens have no idea why their DRep voted the way they did
+- Rationale quality is a major scoring factor, but the tooling punishes DReps for trying
+
+If Civica reduces rationale submission to "write (or edit an AI draft) and click submit," the effects cascade:
+
+- More rationales exist on-chain (better for the entire ecosystem)
+- DReps who use Civica score higher (better for them)
+- Citizens can see why their DRep voted a certain way (better citizen experience)
+- The AI gets more training data for governance analysis (better intelligence)
+- Governance transparency improves measurably (better for Cardano's reputation)
+
+This is the feature that could make Civica indispensable for DReps overnight. It solves a real pain point that no other tool addresses, and the benefits compound across every persona.
+
+---
+
+## Technical Requirements
+
+**Vote casting:**
+
+- MeshJS governance transaction construction (CIP-95)
+- Wallet connector supporting governance keys
+- Transaction building, signing, and submission flow
+- Vote confirmation and on-chain verification
+
+**Rationale submission:**
+
+- CIP-100 JSON schema generation from rich-text input
+- Document hosting (Supabase Storage or IPFS pinning)
+- Metadata anchor generation and bundling with vote transaction
+- AI drafting endpoint (existing `/api/rationale/draft`, enhanced with DRep context)
+
+**Proposal workspace:**
+
+- Proposal data enrichment pipeline (AI summary, constitutional analysis, similar proposal matching)
+- Citizen engagement data aggregation (sentiment, flags, questions per proposal)
+- Inter-body vote aggregation
+
+**Communication:**
+
+- Citizen question aggregation and deduplication
+- DRep response system (one response per question cluster, publicly visible)
+- Information request system for proposal authors
+- Position statement and epoch update authoring
+
+---
+
+## Metrics That Matter
+
+| Metric                                 | What It Measures                      | Target                                                   |
+| -------------------------------------- | ------------------------------------- | -------------------------------------------------------- |
+| **DReps using Civica for voting**      | Workspace adoption                    | >30% of active DReps within 6 months                     |
+| **Rationale submission rate**          | Did we solve the friction problem?    | 2x increase in rationale rate for Civica-using DReps     |
+| **Time from proposal to vote**         | Workspace efficiency                  | Measurable reduction vs. multi-tool workflow             |
+| **DRep Pro conversion**                | Monetization                          | 50-100 paying DReps at $15-25/mo                         |
+| **DRep Pro retention**                 | Is Pro actually valuable?             | >80% monthly retention                                   |
+| **Delegation growth for Civica DReps** | Does the platform help DReps succeed? | Civica-using DReps grow delegation faster than non-users |
+| **Citizen question response rate**     | Is the accountability loop working?   | >50% of aggregated questions get DRep responses          |
+
+---
+
+## The One-Line Vision
+
+**Civica is where DReps do governance -- review proposals, cast votes, explain their reasoning, and build their reputation, all in one place.**
+
+The intelligence layer makes them better at governance. The citizen engagement layer keeps them accountable. The reputation system rewards quality participation. And underneath it all, they're citizens too -- receiving the same briefing, building the same civic identity, participating in the same community as the people they represent.

--- a/docs/strategy/personas/integration-partner.md
+++ b/docs/strategy/personas/integration-partner.md
@@ -1,0 +1,250 @@
+# Persona: The Integration Partner
+
+> **Status:** Active -- defines the B2B persona, API monetization target, and ecosystem distribution channel.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`
+
+---
+
+## Who They Are
+
+Integration Partners are the businesses, platforms, and projects that serve Cardano users and need governance intelligence they don't want to build themselves. They embed Civica's data, scores, and experiences into their own products -- extending Civica's reach to users who may never visit the site directly.
+
+### Partner Types
+
+**Wallet Providers** (Eternl, Lace, Vespr, Typhon)
+
+- The highest-value integration target. Wallets are where delegation actually happens.
+- Need: DRep scores, matching API, SPO governance scores, delegation health indicators, embeddable Quick Match widget.
+- What they don't want to build: scoring engines, alignment models, matching algorithms, proposal intelligence.
+- Impact: Every wallet embedding Civica's intelligence is distribution to every wallet user.
+
+**Crypto Exchanges** (Binance, Coinbase, Kraken)
+
+- Custody billions in ADA. Face growing pressure (regulatory and competitive) to participate in governance on behalf of users or enable user participation.
+- Need: governance data for informed delegation decisions, DRep/SPO scoring for user-facing displays, governance health dashboards for compliance reporting.
+- Emerging use case: "Your ADA on Coinbase is delegated to DRep X, who scored 85 on Civica" -- making custodied governance transparent.
+
+**Stake Pool Comparison Tools** (PoolTool, ADApools)
+
+- Deep infrastructure metrics but zero governance data. Civica's SPO governance scores are a completely new dimension for pool comparison.
+- Need: SPO governance scores, alignment data, governance participation rates.
+- Low-friction integration: adding a "Governance Score" column to existing pool listings.
+
+**DeFi Protocols** (SundaeSwap, Minswap, Liqwid)
+
+- Hold ADA in liquidity pools with governance exposure. Some received treasury funding.
+- Need: governance context for protocol operations, treasury tracking for funded protocols, governance data for users.
+- Longer-term: "Your LP position includes ADA governed by DRep X" -- governance transparency for DeFi users.
+
+**Block Explorers** (CardanoScan, Cexplorer)
+
+- Show raw governance transactions but no intelligence. A vote is data; Civica makes it meaning.
+- Need: DRep profiles, scores, and analysis to embed alongside existing governance data views.
+
+**Governance Tools** (GovTool, Summon)
+
+- Handle voting mechanics but lack the intelligence layer.
+- Need: proposal analysis, DRep context, citizen sentiment, constitutional alignment analysis.
+- Partially competitive (Civica builds its own vote-casting flow), but the intelligence layer is complementary.
+
+**Institutional Delegators and Funds**
+
+- Large ADA holders making strategic delegation decisions worth millions.
+- Need: deep analytics, custom reporting, portfolio governance analysis, risk assessment.
+- Higher price point, custom engagement model.
+
+---
+
+## What They Want
+
+### All partners share
+
+- **Reliable data:** Governance intelligence they can depend on without building the engine themselves
+- **Simple integration:** Well-documented APIs, SDKs, and widgets that work out of the box
+- **Stable APIs:** Versioned endpoints with migration paths, not surprise breaking changes
+- **Brand trust:** Association with the canonical source of governance intelligence in Cardano
+
+### By integration depth
+
+- **API consumers:** Clean REST endpoints, good rate limits, comprehensive documentation
+- **Widget embedders:** Pre-built UI components that match their product's look and feel
+- **Deep integrators:** Custom data feeds, co-branded experiences, shared user flows, dedicated support
+
+---
+
+## Why This Persona Is Strategic
+
+### 1. Distribution Without Acquisition Cost
+
+Every wallet embedding Civica's DRep score is marketing to every wallet user. Every pool tool showing governance scores introduces governance reputation to staking delegators. Every exchange displaying governance health makes custodied ADA holders aware of governance. Civica doesn't need to acquire those users -- the partners already have them.
+
+This is potentially the most efficient growth channel in the entire product strategy.
+
+### 2. Data Network Effects
+
+Integrations create feedback loops:
+
+- A wallet using Civica's matching API generates delegation data (which recommendations led to delegations)
+- An exchange providing governance reporting validates data quality at institutional scale
+- Pool tools linking to Civica profiles drive traffic that generates engagement data
+- More integrations produce more data, which improves the intelligence, which makes integrations more valuable
+
+### 3. Revenue at Scale
+
+Individual consumers pay $15-25/mo. Integration partners pay $50-200/mo for API access, with enterprise tiers going much higher. Per-customer revenue is 10-100x the consumer tier, with lower support overhead.
+
+### 4. Ecosystem Lock-In
+
+When a wallet's delegation picker depends on Civica's scoring API, switching costs are high. When a pool tool displays Civica's governance scores, removing them means removing a feature their users value. Each integration deepens Civica's position as infrastructure.
+
+---
+
+## Integration Models
+
+### Tier 1: API Consumers (Data In, Data Out)
+
+Partners pull governance intelligence via REST API. Lowest integration effort, broadest applicability.
+
+**Available data:**
+
+- DRep scores, alignment, voting records, delegation stats
+- SPO governance scores, participation rates, alignment data
+- Proposal metadata, classification, status, vote breakdowns
+- GHI, EDI, inter-body alignment, governance health metrics
+- Treasury data: spending, project outcomes, effectiveness metrics
+- Matching API: submit user governance preferences, get ranked DRep/SPO recommendations
+
+**Pricing tiers:**
+
+| Tier       | Rate Limit      | Price   | Target                                 |
+| ---------- | --------------- | ------- | -------------------------------------- |
+| Free       | 100 req/day     | $0      | Evaluation and hobby projects          |
+| Basic      | 10,000 req/day  | $50/mo  | Small integrations, community tools    |
+| Pro        | 100,000 req/day | $200/mo | Production integrations, exchanges     |
+| Enterprise | Custom          | Custom  | Institutional, high-volume, SLA-backed |
+
+**Requirements:** API key registration. "Powered by Civica" attribution encouraged but not required at this tier.
+
+### Tier 2: Widget Embedders (UI Components)
+
+Partners embed pre-built Civica UI components directly in their products. Moderate integration effort, higher value.
+
+**Available widgets:**
+
+- **Quick Match widget:** The 3-question matching flow, embeddable in any web product. User completes the quiz inside the partner's UI, gets DRep/SPO recommendations, can delegate without leaving the partner's product.
+- **DRep Score card:** Compact score display with governance radar, embeddable alongside DRep listings.
+- **SPO Governance badge:** Governance score and participation indicator for pool comparison surfaces.
+- **Governance Health gauge:** GHI visualization for dashboards and landing pages.
+- **Delegation Health indicator:** Green/yellow/red delegation status for wallet dashboards.
+
+**Customization:** Widgets support theming to match the partner's UI. Colors, typography, and layout adapt to the embedding context.
+
+**Pricing:** Premium tier pricing or revenue share model. Negotiated per partner.
+
+**Requirements:** "Powered by Civica" attribution required. Links back to full profiles on Civica.
+
+### Tier 3: Deep Integrations (Strategic Partnerships)
+
+Custom, co-developed experiences for high-value partners. Highest integration effort, highest value for both parties.
+
+**Examples:**
+
+- Eternl embeds Civica's full delegation flow: quiz, match, compare, delegate -- all inside the wallet
+- Coinbase integrates governance reporting: custodied ADA governance transparency powered by Civica
+- PoolTool co-brands governance metrics: "Governance data by Civica" as a first-class section in pool profiles
+
+**What Civica provides:**
+
+- Custom data feeds optimized for the partner's use case
+- Co-branded UI components
+- Shared user flows (e.g., wallet connect -> Civica quiz -> delegation -> back to wallet)
+- Dedicated integration support and developer relations
+- Custom pricing, potentially including revenue share
+
+**What partners provide:**
+
+- Distribution to their user base
+- Data feedback (anonymized usage data that improves Civica's intelligence)
+- Brand amplification and co-marketing
+- Real-world validation of Civica's data quality at scale
+
+---
+
+## The "Powered by Civica" Brand Strategy
+
+Every integration is a brand touchpoint. The strategy:
+
+- **API consumers:** Attribution encouraged. "Governance data from Civica" link in footnotes or tooltips.
+- **Widget embedders:** Attribution required. "Powered by Civica" with link. The widget itself is a brand impression.
+- **Deep integrations:** Co-branding negotiated per partnership. "Governance intelligence by Civica" or equivalent.
+
+**The flywheel:** More integrations -> more brand recognition -> more direct users -> more data -> better intelligence -> more integration value -> more integrations.
+
+**The end state:** "Civica" becomes synonymous with Cardano governance intelligence the way "Powered by Google" became synonymous with search or "Charts by TradingView" became synonymous with financial data. Not everyone visits Civica directly, but everyone encounters Civica's intelligence through the products they already use.
+
+---
+
+## What Partners Need From Civica
+
+### Technical Requirements
+
+- **Reliability:** SLA guarantees for paid tiers. If a wallet's delegation picker depends on the API, downtime is unacceptable.
+- **Documentation:** OpenAPI spec, SDKs (TypeScript, Python at minimum), integration guides, example implementations, interactive API explorer.
+- **Sandbox:** Test environment with realistic sample data for development and testing.
+- **Versioning:** Semantic versioning with deprecation notices. At least 6 months migration window for breaking changes.
+- **Webhooks:** Event-driven notifications for partners who need real-time updates (new proposals, score changes, delegation events).
+
+### Business Requirements
+
+- **Developer relations:** Dedicated support for integration partners. Not a support ticket queue -- a relationship.
+- **Attribution guidelines:** Clear branding specs that work across partner UIs. Logo assets, placement guidelines, color variations.
+- **Usage analytics:** Partners want to know how their users interact with Civica's data. Aggregate metrics, not individual tracking.
+- **Roadmap visibility:** Partners building on Civica's API need confidence that the data they depend on will continue to exist and improve.
+
+---
+
+## How Integration Partners Connect to Other Personas
+
+| Persona            | How Partners Serve Them                                                                                                                                                                                                                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Citizens**       | Every integration ultimately serves citizens. A wallet embedding Quick Match means more citizens find aligned DReps. A pool tool showing governance scores means governance-informed staking decisions. An exchange displaying governance health means custodied holders see governance. Partners are Civica's distribution channel to citizens. |
+| **DReps**          | Wallet integrations surface DRep scores and profiles to potential delegators inside the tools where delegation happens. This drives delegation to high-scoring DReps.                                                                                                                                                                            |
+| **SPOs**           | Pool comparison tools embedding governance scores create market pressure for SPO governance participation. SPOs who participate are visible; those who don't are invisible on a new competitive dimension.                                                                                                                                       |
+| **Treasury Teams** | Explorer integrations that show Civica's proposal intelligence and project tracking extend treasury transparency beyond Civica's direct user base.                                                                                                                                                                                               |
+| **Researchers**    | Researchers and integration partners share the API surface. Researcher needs drive API depth; partner needs drive API reliability. Both benefit from the same infrastructure investment.                                                                                                                                                         |
+
+---
+
+## Integration Priority (By Likelihood and Impact)
+
+1. **Eternl** -- Most governance-forward wallet. Natural first deep integration. Highest citizen reach for governance features.
+2. **Lace** -- IOG's wallet. Strategic alignment with Cardano's governance vision. Institutional credibility.
+3. **PoolTool** -- Dominant pool comparison tool. SPO governance scores as a new dimension would be immediately valuable and high-visibility.
+4. **Vespr** -- Growing mobile wallet. Mobile-first governance experience via widget embedding.
+5. **CardanoScan** -- Most-used block explorer. Intelligence layer on top of raw governance data.
+6. **ADApools** -- Second pool comparison target after PoolTool.
+7. **Exchanges** -- Longer sales cycle, higher value. Start conversations early, expect integration in 6-12 months.
+8. **DeFi protocols** -- Emerging need. Position for when DeFi governance integration matures.
+
+---
+
+## Metrics That Matter
+
+| Metric                                   | What It Measures           | Target                                                            |
+| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------- |
+| **Active API keys**                      | Developer adoption         | 20+ registered, 5-10 active integrations                          |
+| **API request volume**                   | Usage depth                | Growing monthly request volume                                    |
+| **Paid API subscriptions**               | Monetization               | $1,500-4,000/mo from 5-10 partners                                |
+| **Widget deployments**                   | Embedded distribution      | Quick Match or score cards in 3+ wallets/tools                    |
+| **Delegations via partner integrations** | Distribution effectiveness | Measurable delegation flow from embedded Quick Match              |
+| **"Powered by Civica" impressions**      | Brand reach                | Civica attribution visible to 100K+ monthly users across partners |
+| **Partner retention**                    | Integration stickiness     | >90% annual retention of paying partners                          |
+
+---
+
+## The One-Line Vision
+
+**Civica becomes the governance intelligence engine underneath every Cardano product -- wallets, exchanges, explorers, and pool tools all surface Civica's data because building it themselves would take years and never catch up.**
+
+Not every Cardano user will visit Civica. But every Cardano user will encounter Civica's intelligence through the products they already use. The API and widget ecosystem turns Civica from a destination into infrastructure -- the canonical source of governance truth for the entire ecosystem.

--- a/docs/strategy/personas/researcher.md
+++ b/docs/strategy/personas/researcher.md
@@ -1,0 +1,195 @@
+# Persona: The Governance Researcher
+
+> **Status:** Active -- defines the data consumer persona and research API monetization target.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`
+
+---
+
+## Who They Are
+
+Governance Researchers are the people who study, analyze, and publish findings about Cardano's governance system. They don't participate in governance directly -- they study the system itself. Their work validates, critiques, and advances understanding of how decentralized governance functions.
+
+They span several sub-segments:
+
+- **Academic researchers:** Political scientists, institutional economists, blockchain governance scholars. They publish papers, present at conferences, and contribute to the theoretical foundation of decentralized governance. They need citation-ready data with transparent methodology.
+- **Professional analysts:** Governance consultants, institutional advisory firms, research divisions of crypto funds. They produce reports for clients making delegation or investment decisions. They need reliable, structured data at scale.
+- **Data journalists:** Writers covering Cardano governance for media outlets, newsletters, or community publications. They need accessible data that tells stories and supports narrative.
+- **Independent community researchers:** Cardano community members who dig into governance data out of curiosity or civic interest. They bridge the researcher and citizen personas -- they consume data like researchers but are motivated like citizens.
+
+### What Makes This Persona Different
+
+Researchers are the only persona that doesn't directly interact with the governance system through Civica. They don't vote, delegate, submit proposals, or manage reputation. They observe, analyze, and publish. Their relationship with the platform is extractive in the best sense: they take data out and return credibility and insight.
+
+When an academic paper cites Civica's DRep scoring methodology or a governance report uses Civica's historical alignment data, it legitimizes the entire platform. That credibility flows to every other persona -- citizens trust the scores because researchers validated them, DReps respect the methodology because it withstands academic scrutiny.
+
+---
+
+## What They Want
+
+- **Data access:** Comprehensive, well-structured governance data through APIs and exports. Not consumer-friendly summaries -- raw and semi-processed data they can analyze with their own tools.
+- **Historical depth:** Time-series data spanning many epochs. Snapshots of scores, alignment, GHI, EDI, delegation, treasury flows. The longer the history, the richer the research.
+- **Methodology transparency:** Published scoring models, alignment algorithms, GHI components. They need to understand how derived metrics are calculated to cite them responsibly.
+- **Exportability:** CSV, JSON, bulk downloads. Data in formats their tools can ingest -- R, Python, Stata, Excel.
+- **Versioned datasets:** When methodology changes, the ability to access data under both old and new models. Research reproducibility requires stable datasets.
+- **Cross-sectional queries:** Ability to query across entities, time periods, and dimensions. "All DRep alignment shifts between epochs 480-520" or "treasury proposal outcomes by category and budget tier."
+
+### What would delight them
+
+- A single API call that returns a DRep's complete governance history: scores, alignment, votes, delegation, rationales -- across every epoch since registration
+- Bulk export of the entire alignment dataset with PCA coordinates, ready for statistical analysis
+- Published methodology docs that are rigorous enough to cite in an academic paper
+- Historical EDI metrics for cross-chain governance comparison research
+- A dataset versioning system: "Download the Q1 2026 governance dataset, frozen at methodology v3.2"
+
+---
+
+## The Researcher Experience
+
+### Philosophy
+
+Researchers don't need a consumer product. They need a **data platform with excellent documentation.** The experience is API-first, documentation-heavy, and optimized for programmatic access rather than visual interaction.
+
+The consumer surfaces (DRep profiles, proposal pages, Pulse) serve as visual references for the data they access programmatically. But the primary interface is the API, the docs, and the export tools.
+
+### Data Access Tiers
+
+#### Free Tier (Discovery + Basic Research)
+
+- Public API access: 100 requests/day
+- Current-state endpoints: DRep scores, alignment, basic proposal data, GHI
+- Documentation and methodology papers
+- Enough to evaluate the data quality and decide if deeper access is worth paying for
+
+#### Basic Research ($50/mo)
+
+- 10,000 requests/day
+- Historical endpoints: score snapshots, alignment trajectories, GHI/EDI time series
+- Bulk data exports: CSV/JSON for major datasets
+- Custom date range queries
+- Standard support
+
+#### Pro Research ($200/mo)
+
+- 100,000 requests/day
+- Full historical depth: every snapshot, every epoch, every entity
+- Cross-sectional query API: complex queries across entities and time periods
+- Versioned datasets with methodology documentation
+- Priority support
+- Early access to new data sources and methodology changes
+
+#### Enterprise / Academic (Custom pricing)
+
+- Unlimited access
+- Custom dataset preparation
+- Dedicated support
+- Co-research opportunities
+- Academic pricing available ($50-100/mo for verified academic institutions)
+
+### API Surface
+
+The research API exposes the full depth of Civica's intelligence engine:
+
+**Entity data:**
+
+- `/v2/dreps/:id` -- full DRep profile with current scores, alignment, metadata
+- `/v2/dreps/:id/history` -- score and alignment snapshots across all epochs
+- `/v2/dreps/:id/votes` -- complete voting record with rationales
+- `/v2/dreps/:id/delegation` -- delegation history and trends
+- `/v2/pools/:id` -- SPO governance profile, score, alignment
+- `/v2/pools/:id/history` -- SPO score and alignment snapshots
+- `/v2/pools/:id/votes` -- SPO voting record
+- `/v2/committee/:id` -- CC member profile and transparency index
+- `/v2/committee/:id/votes` -- CC voting record
+
+**Governance system data:**
+
+- `/v2/governance/health` -- GHI with all components and EDI breakdown
+- `/v2/governance/health/history` -- GHI and EDI time series
+- `/v2/governance/decentralization` -- 7 EDI metrics, current and historical
+- `/v2/governance/inter-body` -- tri-body alignment analysis
+- `/v2/governance/trends` -- proposal trends, participation trends, category analysis
+
+**Proposal data:**
+
+- `/v2/proposals` -- all proposals with metadata, classification, status
+- `/v2/proposals/:id/votes` -- complete vote breakdown by body (DRep, SPO, CC)
+- `/v2/proposals/:id/inter-body` -- inter-body alignment on specific proposals
+- `/v2/proposals/:id/similar` -- semantically similar proposals
+- `/v2/proposals/:id/sentiment` -- citizen sentiment data (aggregated, anonymized)
+
+**Treasury data:**
+
+- `/v2/treasury/balance` -- treasury balance history
+- `/v2/treasury/spending` -- spending by category, time period, outcome
+- `/v2/treasury/projects` -- funded projects with delivery scores and citizen impact
+- `/v2/treasury/effectiveness` -- ROI analysis by category and time period
+
+**Matching and alignment:**
+
+- `/v2/alignment/dimensions` -- the 6D alignment framework definition and methodology
+- `/v2/alignment/pca` -- PCA coordinates for all scored entities
+- `/v2/alignment/clusters` -- governance faction detection and cluster analysis
+
+**Bulk exports:**
+
+- `/v2/export/dreps` -- all DRep data, filterable by date range
+- `/v2/export/proposals` -- all proposal data with outcomes
+- `/v2/export/votes` -- complete voting record across all bodies
+- `/v2/export/snapshots` -- all snapshot tables, versioned
+
+### Documentation
+
+Research-grade documentation is essential:
+
+- **Methodology papers:** Published scoring models for DRep Score, SPO Score, GHI, EDI, CC Transparency Index. Rigorous enough to cite in academic work.
+- **Data dictionaries:** Every field in every API response documented with type, source, calculation method, and update frequency.
+- **Changelog:** Every methodology change documented with rationale, date, and impact on historical data.
+- **Dataset versioning guide:** How to access data under specific methodology versions for reproducibility.
+- **OpenAPI spec:** Machine-readable API specification for SDK generation and tooling integration.
+
+### The Feedback Loop
+
+Researchers generate intelligence that flows back to other personas:
+
+- Published analyses of DRep voting patterns become content for citizen briefings
+- Academic validation of scoring methodology builds trust across all personas
+- Treasury effectiveness research informs DRep voting strategy and citizen confidence
+- Cross-chain governance comparisons (using EDI data) attract attention from outside Cardano
+- Identified anomalies or governance risks surface as intelligence for the platform
+
+Civica can amplify this: feature notable research on the Pulse page, cite academic papers in methodology documentation, reference published findings in AI-generated narratives.
+
+---
+
+## How Researchers Connect to Other Personas
+
+| Persona                   | Relationship                                                                                                                                                    |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Citizens**              | Research findings inform the intelligence layer that citizens consume. Academic validation builds citizen trust in scores and recommendations.                  |
+| **DReps**                 | Research on voting patterns, score dynamics, and governance effectiveness gives DReps strategic context. Published methodology keeps DReps honest about gaming. |
+| **SPOs**                  | Research on SPO governance participation rates and impact validates the governance-growth connection.                                                           |
+| **CC Members**            | CC dynamics research (independence metrics, constitutional interpretation patterns) feeds the accountability surface.                                           |
+| **Treasury Teams**        | Treasury effectiveness research helps teams understand what works and informs DRep voting.                                                                      |
+| **Cross-Chain Observers** | Researchers are often the same people producing cross-chain governance comparisons. Their work feeds the Observatory.                                           |
+
+---
+
+## Metrics That Matter
+
+| Metric                          | What It Measures            | Target                                                       |
+| ------------------------------- | --------------------------- | ------------------------------------------------------------ |
+| **API registrations**           | Interest in governance data | Growing developer/researcher signups                         |
+| **Paid research subscriptions** | Monetization                | 5-10 paying subscribers at $50-200/mo                        |
+| **Academic citations**          | Credibility impact          | Civica data cited in governance research papers              |
+| **API usage patterns**          | What data is valuable?      | Identifies which datasets to expand or prioritize            |
+| **Export downloads**            | Bulk data demand            | Steady usage of export endpoints                             |
+| **Research feedback**           | Methodology improvement     | Researcher reports that lead to scoring or data improvements |
+
+---
+
+## The One-Line Vision
+
+**Civica provides the most comprehensive, well-documented governance dataset in blockchain -- the canonical source for anyone studying how decentralized governance works.**
+
+Researchers don't need a pretty interface. They need deep data, transparent methodology, and reliable access. Every paper published using Civica's data validates the platform for every other persona. The data moat that compounds daily is the same moat that makes this dataset irreplaceable for research.

--- a/docs/strategy/personas/spo.md
+++ b/docs/strategy/personas/spo.md
@@ -1,0 +1,321 @@
+# Persona: The SPO (Stake Pool Operator)
+
+> **Status:** Active -- defines the staking-governance bridge persona and second monetization target.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`, `personas/drep.md`
+
+---
+
+## Who They Are
+
+SPOs are the infrastructure operators who keep Cardano alive. They run the nodes that produce blocks, validate transactions, and secure the network. With the Voltaire era, they also became a formal governance body -- SPO votes carry weight in protocol parameter changes and hard fork decisions.
+
+There are ~3,000 registered pools, but the population is stratified:
+
+- **Professional operators:** Multiple pools, significant delegation, treating pool operation as a business. They compete aggressively for delegation and need every competitive edge.
+- **Community operators:** Single pool, moderate delegation, driven by mission. Often also educators, content creators, and community organizers. They're the heart of Cardano's decentralization story.
+- **Hobby/small operators:** Minimal delegation, running at a cost. They believe in decentralization and contribute even when it doesn't pay. Many are at risk of shutting down.
+
+What they all share: **their #1 problem is attracting and retaining delegators.** Everything else is secondary to pool growth.
+
+An SPO is a citizen first. They hold ADA, they have governance values, they may delegate to a DRep for the governance dimensions outside their SPO voting authority. Everything in the Citizen experience applies to them. The SPO layer adds professional tools for governance participation, pool identity, and delegator growth.
+
+### The Business Reality
+
+SPO revenue = margin percentage of pool staking rewards. A pool with 10M ADA delegated at ~3.5% annual rewards and 2% margin earns roughly 7,000 ADA/year. At typical prices, that's a few thousand dollars -- not life-changing for most operators. They do it because they believe in the mission.
+
+Competition for delegation is fierce. Most pools look identical on existing tools -- same uptime, similar ROI, comparable fees. If your pool performs like 500 others, you're invisible.
+
+---
+
+## What They Want
+
+### As citizens (inherited from Citizen persona)
+
+- The epoch briefing, treasury transparency, civic identity, smart alerts
+- Everything a citizen gets -- they're ADA holders with governance rights too
+
+### As infrastructure operators with governance responsibility
+
+- **Delegation growth:** The #1 need. Tools and reputation that help them attract and retain staking delegators.
+- **Differentiation:** A way to stand out from 3,000 other pools beyond financial metrics that all look the same.
+- **A governance reputation:** Proof that they participate, that they care, that choosing their pool means something beyond ROI.
+- **Communication with delegators:** A direct channel to the people staking with them -- currently impossible outside fragmented social media.
+- **Efficient governance participation:** Governance is an additional responsibility on top of infrastructure operation. It needs to be quick and low-friction.
+
+### What would delight them
+
+- Seeing their pool discovered by delegators specifically because of their governance participation
+- A rich profile page they can share everywhere that tells their pool's story -- not just metrics
+- Being able to vote, submit a governance rationale, and post a delegator update in 5 minutes total
+- Data showing that governance participation actually drives delegation growth
+- A communication channel where their staking delegators actually see their updates
+
+---
+
+## The SPO Experience
+
+### Philosophy
+
+Civica helps SPOs build a **complete identity that makes delegators choose them.** Governance participation is the differentiating layer -- the new competitive dimension that no pool comparison tool touches. But the identity extends beyond governance into who they are, what they stand for, and how they communicate with their community.
+
+**Civica is NOT a second PoolTool.** It does not monitor infrastructure, track block production, calculate ROI projections, or manage pool configuration. PoolTool handles operations. Civica handles identity, reputation, governance, communication, and growth.
+
+The citizen experience runs underneath. The SPO layer adds professional governance tooling, pool identity management, and delegator relations.
+
+### The Governance Workspace
+
+#### Governance Inbox
+
+Like DReps, SPOs see what needs their governance attention:
+
+- **Proposals requiring SPO votes:** Not all proposals involve SPOs. The inbox filters to governance actions where SPO votes carry weight (protocol parameters, hard forks), while surfacing other proposals for optional participation.
+- **Urgency indicators:** What's expiring soon, what's new, what they've already voted on.
+- **Citizen context:** How their staking delegators feel about active proposals (from Civica's citizen engagement layer).
+
+**Design principle:** Governance should feel like a 10-minute weekly task, not a second job. The inbox makes that possible by surfacing exactly what matters and nothing else.
+
+#### Vote Casting + Rationale Submission
+
+The same integrated flow as DReps, adapted for SPOs:
+
+- **Vote casting** directly from Civica via MeshJS (CIP-95). SPOs connect their pool governance key, review the proposal workspace, and vote.
+- **Rationale authoring** with AI assistance. Even more valuable for SPOs than DReps because SPO governance rationales are extremely rare today. The friction of CIP-100 compliance is too high when governance is your secondary function.
+- **Governance statement** setup: A guided, one-time flow for SPOs to publish their governance philosophy. "Tell your delegators what you stand for in governance." Very few SPOs have one because the tooling doesn't exist. Civica makes it a 5-minute setup.
+
+**Why this matters for SPOs specifically:** SPO governance participation rates are lower than DRep participation because governance feels like an extra burden on top of infrastructure work. If Civica reduces the entire governance workflow to 10 minutes per epoch, participation rates rise. Every SPO who starts voting through Civica improves Cardano's overall governance health.
+
+#### Proposal Workspace
+
+The same analysis environment as DReps, with SPO-relevant context:
+
+- AI-generated proposal summary
+- Treasury impact analysis
+- SPO-specific relevance: does this proposal affect protocol parameters, staking mechanics, or pool operations?
+- Inter-body context: how are DReps and CC voting on this?
+- Citizen sentiment from Civica's engagement layer
+- Constitutional alignment analysis
+- Vote + rationale submission integrated at the bottom
+
+### Pool Identity (The Rich Profile)
+
+This is where Civica goes beyond governance into the broader SPO identity. The pool profile on Civica should be the richest SPO presence on the internet -- the page SPOs share everywhere as their home page.
+
+#### Who They Are
+
+- Team members, mission statement, why they run a pool
+- The human story behind the infrastructure
+- Location, community involvement, contributions to the ecosystem
+- Links to social channels, websites, other projects they're involved in
+
+#### What They Stand For in Governance
+
+- Governance philosophy and priorities (from the governance statement)
+- Voting record with rationales
+- Governance score with pillar breakdown (Participation, Consistency, Reliability, Governance Identity)
+- 6D alignment visualization -- what values drive their governance decisions
+- Score trajectory over time
+- Inter-body alignment: how their votes compare to DRep consensus and CC positions
+
+#### How They Perform
+
+- Basic pool metrics: delegation size, fee structure, pledge, active status
+- Enough for a delegator to confirm the pool is healthy
+- NOT deep infrastructure analytics (defer to PoolTool for that)
+- Link to PoolTool/ADApools for delegators who want deeper operational metrics
+
+#### What Their Community Says
+
+- Citizen endorsements: "342 citizens endorse this pool"
+- Domain-specific trust: "Endorsed for governance" / "Endorsed for community contribution"
+- Delegation trend: growing, stable, or declining
+
+**The positioning:** PoolTool answers "is this pool technically reliable?" Civica answers "who are these people and do they share my values?"
+
+### Delegator Communication Hub
+
+SPOs currently have no native way to reach their staking delegators. If they need to announce maintenance, share a governance vote, or engage their community, they post on Twitter and hope someone sees it.
+
+Civica solves this because citizens are already checking in every epoch:
+
+#### Pool Updates
+
+- Maintenance announcements: "Planned relay migration this weekend -- no rewards impact expected"
+- Milestone celebrations: "We produced our 10,000th block this epoch"
+- Community news: "We're sponsoring the Cardano Summit side event in Tokyo"
+- General communication: a direct line to the people who chose their pool
+
+#### Governance Communication
+
+- Vote explanations: "Here's why we voted Yes on the protocol parameter change"
+- Governance philosophy updates: "Our priorities for governance this quarter"
+- Rationale highlights: automatically surfaced when the SPO votes and provides a rationale
+
+#### How Citizens See It
+
+- Updates appear in the citizen's epoch briefing: "Your pool operator posted an update"
+- Vote explanations appear alongside "Your SPO voted Yes on Proposal X"
+- Creates a two-way relationship: citizens feel connected to their pool operator, SPOs feel accountable to their delegators
+
+### Delegation Growth Intelligence
+
+This is where Civica directly addresses the SPO's #1 need: growing their pool.
+
+#### The Governance-Growth Connection
+
+- Empirical data: "Pools that participate in governance attract X% more delegation than pools that don't"
+- Personal insight: "Your pool is ranked 145th by delegation but 23rd by governance score -- your governance reputation is an underutilized growth lever"
+- Retention data: "Delegators who found your pool through Civica's governance-based discovery retained at 2x the rate"
+
+#### Competitive Position
+
+- Governance comparison with pools of similar size
+- Financial + governance combined ranking: where they stand on the dimensions that matter
+- What high-performing pools in their size tier do differently
+
+#### Delegator Analytics
+
+- Delegation trends: growing, stable, declining
+- Who's arriving and who's leaving
+- Where departing delegators go (which pools they move to)
+- What those destination pools offer that this pool doesn't
+
+#### Staking Delegator Education
+
+- Ready-made content SPOs can share with their delegators about governance participation
+- "Help your delegators understand governance" -- encouraging DRep delegation through the trusted SPO relationship
+- SPOs become a channel for citizen onboarding: staking delegators who don't yet have DRep delegation get prompted through their SPO
+
+---
+
+## The Flywheel
+
+The self-reinforcing loop that benefits SPOs, citizens, and Cardano governance:
+
+1. SPO participates in governance (votes through Civica)
+2. They score higher on Civica's SPO governance score
+3. They rank better in governance-based pool discovery
+4. Governance-conscious delegators find and stake with them
+5. Their delegation grows
+6. More delegation = more incentive to keep participating in governance
+7. Other SPOs see governance participation driving growth and start participating
+8. Overall SPO governance participation increases
+9. Cardano's governance health improves (stronger inter-body representation)
+10. Citizens get richer SPO governance data in their briefings
+11. More citizens choose pools through governance-based discovery
+12. Return to step 4
+
+Civica doesn't just serve SPOs -- it creates market pressure for governance participation across the entire SPO ecosystem.
+
+---
+
+## Free vs. Pro
+
+### Free (Essential Governance + Basic Identity)
+
+Everything an SPO needs to participate in governance and establish their identity:
+
+- **Vote casting** from within Civica
+- **Rationale submission** (editor, CIP-100 formatting, hosting, bundled submission)
+- **Governance statement** setup (guided flow, one-time)
+- **Proposal workspace** (full analysis for proposals relevant to SPOs)
+- **Pool profile** (basic -- mission, team, governance data, score, voting record)
+- **Basic delegation stats** (total delegation, trend direction)
+- **Delegator communication** (announcements, vote explanations, governance updates)
+- **The full citizen experience** (briefing, treasury, civic identity, engagement)
+- **Governance score visibility** (score, pillar breakdown, basic trend)
+
+### Pro (Growth + Competitive Edge)
+
+Tools for SPOs who want to actively grow their delegation and build their brand:
+
+- **Rich pool profile** -- full marketing page with custom branding, featured content, expanded team bios, media gallery
+- **Delegation analytics** -- detailed growth trends, churn analysis, delegator sources, arrival/departure patterns, retention metrics
+- **Competitive intelligence** -- peer comparison across governance and financial metrics, pool tier analysis, growth benchmarking
+- **Growth coaching** -- AI-generated suggestions: "Pools in your tier that publish governance rationales see 20% more delegation growth"
+- **AI governance statement drafting** -- AI writes the first draft from their voting history and stated values
+- **Advanced communication tools** -- scheduled updates, delegator segmentation, engagement analytics on published content
+- **Campaign tools** -- enhanced shareable cards, embeddable governance widgets, social media assets, custom branding
+- **Custom alerts** -- delegation movements, competitive shifts, governance opportunities, score threshold notifications
+- **Score simulator** -- "If you vote on every proposal this epoch and provide rationales, your governance score will reach X"
+
+### Why This Split Works
+
+The free tier is generous because SPO adoption drives the flywheel:
+
+- Every SPO voting through Civica generates governance data that enriches the intelligence engine
+- Every governance statement published improves citizen pool discovery
+- Every pool profile created makes Civica's SPO discovery more comprehensive
+- The more SPOs participate, the more valuable governance-based pool discovery becomes for citizens
+
+Pro monetizes the growth and competitive layer. SPOs who want to actively grow their delegation -- attract more stakers, outperform peers, build their brand -- will pay for the edge. The free tier makes them governance-active. Pro makes them strategically competitive.
+
+---
+
+## The Staking-Governance Bridge
+
+SPOs occupy a unique position in the Civica ecosystem: they're the bridge between the familiar world of staking and the unfamiliar world of governance.
+
+**For citizens:** SPO discovery is the comfortable entry point. "Find a stake pool" is something ADA holders already understand. Civica's twist -- "find a pool that represents your values in governance" -- reframes staking from a purely financial decision to a civic one. The SPO relationship becomes the gateway to governance engagement.
+
+**For the ecosystem:** SPOs who communicate governance through their delegator channel become an organic onboarding funnel for DRep delegation. A staking delegator who sees their pool operator's governance updates thinks: "I should probably delegate my governance too." The SPO-citizen relationship seeds governance participation across the network.
+
+**For Cardano's governance health:** SPO governance participation strengthens the inter-body balance. When SPOs vote actively, the three-body governance system (DReps + SPOs + CC) functions as designed. Civica's incentive to drive SPO participation through discovery and growth tools directly serves Cardano's constitutional design.
+
+---
+
+## How SPOs Connect to Other Personas
+
+| Persona            | Relationship                                                                                                                                                                                                                                                     |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Citizens**       | Citizens stake with SPOs and discover pools through governance-based alignment. SPO communication reaches citizens through the epoch briefing. SPOs are often the first governance touchpoint for passive stakers.                                               |
+| **DReps**          | SPOs and DReps are parallel governance bodies. Inter-body alignment analysis reveals where they agree and diverge. Some individuals are both SPOs and DReps (multi-wallet identity handles this). Healthy tension between the two bodies strengthens governance. |
+| **CC Members**     | SPOs interact with CC on constitutional and protocol matters. SPO votes on hard fork proposals are particularly significant and visible.                                                                                                                         |
+| **Treasury Teams** | SPOs vote on treasury proposals. Their collective voting patterns on spending shape treasury accountability. Some SPOs may also be treasury proposal teams (building tools for the ecosystem).                                                                   |
+| **Researchers**    | SPO governance participation data is a key research subject: governance participation rates across the operator ecosystem, correlation between governance activity and pool performance, inter-body dynamics.                                                    |
+
+---
+
+## Scope Boundaries
+
+**In scope (Civica's SPO offering):**
+
+- Governance participation (voting, rationales, governance statements)
+- Pool identity and reputation (profile, story, governance values)
+- Delegator communication (updates, governance explanations, announcements)
+- Governance-based pool discovery (the unique competitive dimension)
+- Delegation growth intelligence (analytics, competitive position, coaching)
+- Staking delegator education (governance onboarding through the SPO channel)
+
+**Out of scope (defer to existing tools):**
+
+- Infrastructure monitoring (block production, relay health, missed blocks)
+- Detailed rewards calculations and ROI projections
+- Pool configuration and operational management
+- Node setup and maintenance guides
+- Detailed financial analytics beyond basic delegation metrics
+
+**The line:** Civica helps SPOs with identity, reputation, governance, communication, and growth. Not with operations. SPOs use PoolTool for infrastructure monitoring and Civica for everything people-facing.
+
+---
+
+## Metrics That Matter
+
+| Metric                                     | What It Measures                 | Target                                                                           |
+| ------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------------- |
+| **SPOs voting through Civica**             | Governance workspace adoption    | >15% of governance-active SPOs within 6 months                                   |
+| **SPO governance participation rate**      | Is Civica driving participation? | Measurable increase in overall SPO vote rates                                    |
+| **Governance statements published**        | Identity adoption                | >200 SPOs with published governance statements                                   |
+| **Pool profiles created**                  | Platform as home page            | >500 SPOs with complete Civica profiles                                          |
+| **SPO Pro conversion**                     | Monetization                     | 50-100 paying SPOs at $15-25/mo                                                  |
+| **Delegator-SPO communication engagement** | Is the channel valuable?         | >40% of staking delegators view their SPO's updates                              |
+| **Governance-based discovery conversions** | Is the differentiator working?   | Measurable delegation flow from Civica discovery to pools                        |
+| **Staking delegator -> DRep delegation**   | Is the bridge working?           | SPO delegators who also delegate to a DRep at higher rates than non-Civica users |
+
+---
+
+## The One-Line Vision
+
+**Civica is where SPOs build their governance reputation, communicate with their delegators, and grow their pool through the one competitive dimension nobody else measures.**
+
+PoolTool tells delegators a pool is reliable. Civica tells them the pool operator shares their values. In a market where 500 pools have identical financial metrics, governance reputation becomes the differentiator -- and Civica is the only place it exists.

--- a/docs/strategy/personas/treasury-team.md
+++ b/docs/strategy/personas/treasury-team.md
@@ -1,0 +1,300 @@
+# Persona: The Treasury Team
+
+> **Status:** Active -- defines the treasury accountability persona and the mutual benefit model for funded projects.
+> **Created:** March 2026
+> **Companion to:** `docs/strategy/ultimate-vision.md`, `personas/citizen.md`, `personas/drep.md`
+
+---
+
+## Who They Are
+
+Treasury Teams are the individuals, organizations, and companies who submit governance proposals requesting ADA from the Cardano treasury. They're builders -- developing tools, infrastructure, marketing campaigns, educational content, research, and ecosystem services. They range from solo developers seeking modest funding to established organizations requesting millions of ADA.
+
+The Cardano treasury holds billions of ADA, making it one of the largest decentralized funding mechanisms in existence. Treasury Teams are the people who put that capital to work for the ecosystem.
+
+They are citizens first. They hold ADA, they stake, they participate in governance as holders. Some may also be DReps, SPOs, or community leaders. The Treasury Team persona activates when they seek or have received governance funding.
+
+### The Current Reality
+
+The treasury funding process today is broken on both sides:
+
+**For teams:**
+
+- You write a proposal, submit it on-chain, and hope DReps vote for it
+- You have no structured way to demonstrate past delivery track record
+- You have no channel to gauge community interest before investing weeks in a formal proposal
+- If you deliver, there's no amplification -- many funded projects ship to silence
+- Your next proposal starts from scratch reputation-wise, even if you delivered perfectly last time
+
+**For the community:**
+
+- DReps voting on treasury proposals have minimal data on whether a team has delivered before
+- Citizens have almost no visibility into where billions of their collective ADA goes
+- There's no structured way to verify if funded projects actually ship
+- Bad actors can get funded and disappear without consequence to their reputation
+
+Both sides need Civica. The key insight: **accountability and advantage are the same thing for teams that deliver.**
+
+---
+
+## What They Want
+
+### As citizens (inherited from Citizen persona)
+
+- The epoch briefing, treasury transparency, civic identity, smart alerts
+- Everything a citizen gets -- they're ADA holders too
+
+### As proposal teams
+
+- **Funding:** Their primary goal. They want their proposals approved and funded.
+- **Reputation that carries forward:** A track record that makes each subsequent proposal easier to fund
+- **Community validation:** Confidence that they're building something the ecosystem wants before investing months of effort
+- **Visibility:** A way for citizens and DReps to discover and evaluate their work
+- **Feedback:** Structured input from the community during development, not just after delivery
+- **Amplification:** When they ship, a way for the ecosystem to know about it
+
+### What would delight them
+
+- Testing a proposal concept with citizens and DReps before writing the full proposal -- and getting signal that it's wanted
+- Walking into their fourth proposal with a track record that speaks for itself: "3 of 3 delivered, 88% citizen impact score"
+- Shipping a product and seeing citizens tag it as "essential" on their Civica project page
+- AI-powered proposal guidance: "proposals like yours with quarterly milestones have 80% approval rates"
+- Their funded project becoming discoverable to citizens who would actually use it
+
+---
+
+## The Treasury Team Experience
+
+### Philosophy
+
+Civica doesn't impose accountability on treasury teams. **It rewards accountability by making it a competitive advantage.** Teams that engage transparently build reputation. Reputation gets them funded. Getting funded grows their work. Their work generates citizen impact. Impact builds more reputation.
+
+The teams that deliver WANT accountability because it separates them from teams that don't. Civica makes that separation visible and valuable.
+
+### The Trust Ladder
+
+The relationship between treasury teams and Civica is a voluntary progression. Each step provides tangible benefit:
+
+1. **Anonymous team:** On-chain proposal, no Civica presence. DReps and citizens evaluate blind. Lowest trust signal.
+2. **Registered team:** Claimed their project page on Civica, added team info and description. Basic trust signal established.
+3. **Active team:** Posting progress updates, tracking milestones, engaging with citizen feedback. Growing reputation.
+4. **Verified team:** Identity verified, full accountability tools active, spending transparency published. Maximum trust signal.
+5. **Established team:** Multiple delivered proposals, strong citizen impact scores, proven track record. Their next proposal is nearly pre-approved on reputation alone.
+
+No step is mandatory. Every step is advantageous. Teams climb the ladder because it works, not because they're forced to.
+
+### Pre-Proposal: Validation and Intelligence
+
+Before spending weeks on a formal proposal, teams can use Civica to validate their concept and optimize their approach.
+
+#### Concept Testing
+
+- Submit a structured concept: problem statement, proposed solution, rough budget range, team background
+- Citizens react with interest signals: "I'd use this" / "Not sure" / "Higher priorities exist"
+- DReps can signal likely support (non-binding, directional): "I'd vote for this"
+- Citizen Priority Signals data shows alignment with community demand
+- Result: "87% citizen interest, 14 DReps signaled support" validates the concept. "23% interest, major concern: 'similar project exists'" saves weeks of wasted effort.
+
+#### Proposal Drafting Intelligence
+
+Civica has unique data about what makes proposals succeed:
+
+- Historical voting patterns: what types of proposals do DReps support? At what budget levels? With what milestone structures?
+- Citizen priority alignment: does this concept match what the community says it wants?
+- Similar proposals: what's been funded before in this space? What delivered and what didn't?
+- AI-powered guidance: "Proposals in the developer tooling category with budgets under 5M ADA and quarterly milestones have an 80% approval rate. Similar proposals that included user adoption metrics scored higher on citizen impact."
+
+This turns Civica into a strategic advisor for proposal teams.
+
+### During Funding: The Project Page
+
+Every funded proposal gets a project page on Civica -- the canonical home for the project's lifecycle.
+
+#### Project Identity
+
+- Team members and backgrounds
+- Project description in plain English (not just the on-chain proposal text)
+- Funding amount, category, timeline
+- Links to repositories, documentation, demos
+- "Funded by Cardano Governance" badge -- a trust signal teams can use in their own marketing
+
+#### Milestone Management
+
+- Teams declare milestones when funded (or Civica extracts them from the proposal)
+- As they deliver, they mark milestones complete with evidence: links, demos, documentation, screenshots
+- Public progress display: "Milestone 3 of 5 complete"
+- Citizen verification: community members who expressed interest confirm they can see or use the deliverable
+- This is the team showing their work -- it builds trust proactively
+
+#### Progress Updates
+
+- Structured, not free-form: "What we shipped. What's next. Any blockers."
+- Published on the project page, visible to citizens who tagged interest
+- Notification to interested citizens: "A project you're following posted an update"
+- Regular cadence improves trust signals; long silence degrades them
+- AI-prompted: "You haven't posted an update in 45 days -- your project's trust score is declining"
+
+#### Citizen Feedback Loop
+
+- Citizens who expressed interest ("I'd use this") get notified of progress updates
+- Structured micro-feedback on design decisions: "We're building X. Which of these 3 approaches would you prefer?"
+- Citizens who eventually use the product provide impact tags and ongoing feedback
+- Not a support channel or forum -- structured, lightweight, signal-generating
+- Teams get a user research channel that's impossible to get anywhere else
+
+#### Spending Transparency (Optional, Rewarded)
+
+- Teams can publish structured spending breakdowns: "Here's how we used the 4M ADA"
+- Not mandatory (privacy and competitive concerns exist), but teams that do it get enhanced trust signals
+- Structured categories: development, infrastructure, marketing, operations, reserve
+- Visible on the project page and the team's proposer profile
+
+### Post-Delivery: Impact and Reputation
+
+After a project delivers, the accountability story shifts to impact measurement.
+
+#### Citizen Impact Reports
+
+- Citizens tag the project: "I use this" / "I tried it" / "I didn't know about it"
+- Usage rating: "essential" / "useful" / "okay" / "disappointing"
+- Optional one-sentence context
+- Aggregate becomes the project's impact score: "89 citizens report using this, 71% say essential"
+
+#### Impact Amplification
+
+- When a funded project ships, Civica surfaces it to the citizen community
+- "This project was funded by Cardano governance. Here's the team, here's the product, try it."
+- Project page becomes a living showcase, not a forgotten proposal
+- DReps and SPOs who voted for it can reference the outcome: "I voted Yes, and it delivered"
+- Citizen discovery: funded projects are browsable as "what your treasury built"
+
+#### Delivery Scoring
+
+A composite score measuring overall project execution:
+
+- **Milestone completion rate:** Did they deliver what they promised?
+- **Timeliness:** Did they hit deadlines or slip significantly?
+- **Citizen impact score:** How do actual users rate the deliverable?
+- **Update frequency:** Did they communicate consistently during development?
+- **Spending transparency bonus:** Did they publish how funds were used?
+
+Published on the team's proposer profile. Follows them to future proposals.
+
+#### Return on Governance Investment
+
+The aggregate view that helps the entire ecosystem:
+
+- "This 4M ADA investment resulted in a tool used by 500+ community members, rated essential by 71%"
+- Category-level analysis: "Developer tooling investments have the highest citizen impact scores"
+- Historical trends: is treasury spending becoming more or less effective over time?
+- This data helps future teams learn what works, DReps learn what to fund, and citizens see their treasury creating value
+
+### Cross-Project Intelligence
+
+Civica's proposal analysis creates a collaboration and landscape layer:
+
+- **Similar project discovery:** "3 other teams are working on developer tooling -- here's how your projects compare and complement each other"
+- **Duplication detection:** Before a team submits, they can see what's already funded in their space
+- **Collaboration opportunities:** Teams working on adjacent problems can discover each other
+- **Category health:** How much total funding has gone to each category? What's the delivery rate?
+
+---
+
+## The Proposer Profile
+
+Each team (or individual) who has submitted treasury proposals accumulates a proposer profile on Civica:
+
+- **Proposal history:** Every proposal submitted, with outcomes (approved, rejected, withdrawn)
+- **Delivery track record:** Milestone completion rates, timeliness, citizen impact scores across all projects
+- **Aggregate delivery score:** A single number representing their reliability as a proposer
+- **Citizen trust signals:** Endorsements, impact ratings, feedback sentiment
+- **Spending history:** Total ADA received, total delivered projects, category distribution
+- **Team information:** Who they are, what they've built, their expertise areas
+
+This profile IS their reputation. It compounds over time. A team's fourth proposal comes with three deliveries of evidence. A new team starts with zero -- which is fair, because they haven't proven anything yet.
+
+The proposer profile is public. DReps reference it when voting. Citizens reference it when evaluating treasury spending. It creates natural market pressure for delivery quality.
+
+---
+
+## Monetization: Verified Project
+
+The "Verified Project" designation is a paid trust signal ($10-25/project) that unlocks enhanced tools:
+
+### What Verification Includes
+
+- **Identity verification:** Team members confirmed as real people or entities
+- **Enhanced project page:** Richer media, custom presentation, featured content
+- **Milestone management suite:** Structured tracking, citizen verification flow, progress analytics
+- **Spending transparency tools:** Structured breakdown templates, category tagging
+- **Proposal drafting intelligence:** AI-powered guidance based on historical patterns
+- **Pre-proposal validation:** Concept testing with citizens and DReps
+- **Priority visibility:** Verified projects surface higher in citizen discovery
+- **"Verified" badge:** Visible on the project page and in proposal listings
+
+### Why Teams Pay
+
+The ROI is straightforward: better trust signals = better chance of getting funded = access to treasury ADA. A team requesting 5M ADA will gladly pay $25 for tools that improve their approval odds. The verification cost is negligible relative to the funding they're seeking.
+
+### What Stays Free
+
+- Basic project page (auto-created from on-chain proposal data)
+- Team registration and basic profile
+- Citizen impact tagging and feedback (this must be free to maximize data)
+- Progress update posting
+- Delivery scoring (calculated from available data regardless)
+- Proposer profile (accumulated from on-chain history)
+
+---
+
+## How Treasury Teams Connect to Other Personas
+
+| Persona         | Relationship                                                                                                                                                                                                                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Citizens**    | Treasury teams spend citizens' collective ADA. Citizens provide concept validation, usage feedback, impact ratings, and accountability signals. The citizen's treasury transparency surface is built from treasury team data.                         |
+| **DReps**       | DReps vote on treasury proposals. A team's proposer profile and delivery track record directly inform DRep voting decisions. DReps can ask structured questions about proposals. DReps who vote for successful projects build their own track record. |
+| **SPOs**        | SPOs vote on treasury proposals as a governance body. SPO collective voting patterns on spending shape treasury accountability. Some SPOs may also be treasury proposal teams.                                                                        |
+| **CC Members**  | Treasury proposals require CC ratification for constitutionality. CC precedent on treasury spending creates informal guidelines that future teams should understand.                                                                                  |
+| **Researchers** | Treasury spending data is a rich research subject: effectiveness by category, delivery rates, funding concentration, ROI analysis. Researcher findings feed back into the intelligence that helps all personas evaluate spending.                     |
+
+---
+
+## The Accountability Flywheel
+
+The self-reinforcing loop that improves treasury spending quality over time:
+
+1. Team submits a proposal with concept validation from Civica
+2. DReps evaluate using the team's proposer profile and delivery track record
+3. Proposal is funded
+4. Team posts structured progress updates on their Civica project page
+5. Citizens follow progress and provide feedback during development
+6. Team delivers and citizens tag impact: "I use this, it's essential"
+7. Delivery score and citizen impact score are recorded on the proposer profile
+8. Next proposal carries this track record -- easier to fund if they delivered, harder if they didn't
+9. Teams that deliver attract more DRep confidence, teams that don't lose it
+10. Overall treasury spending effectiveness improves because reputation creates selection pressure
+
+Bad actors are naturally filtered: a team that takes funding and disappears has a zero delivery score that follows them permanently. Good actors are naturally rewarded: a team with strong delivery compounds reputation and gets funded faster.
+
+---
+
+## Metrics That Matter
+
+| Metric                              | What It Measures                              | Target                                                                             |
+| ----------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Teams with Civica project pages** | Platform adoption among proposers             | >50% of funded proposals have claimed pages                                        |
+| **Pre-proposal concept tests**      | Is validation valuable?                       | Growing usage, measurable correlation between validation scores and approval rates |
+| **Progress update frequency**       | Are teams engaging?                           | Average of at least 1 update per quarter for active projects                       |
+| **Citizen impact tag volume**       | Is the feedback loop working?                 | >30% of delivered projects have citizen impact ratings                             |
+| **Verified Project conversions**    | Monetization                                  | Steady growth toward $200-500/mo                                                   |
+| **Delivery score distribution**     | Is accountability improving treasury quality? | Upward trend in average delivery scores over time                                  |
+| **DRep reference rate**             | Do DReps use proposer profiles when voting?   | DReps cite track records in their rationales                                       |
+| **Repeat proposer success rate**    | Does reputation compound?                     | Teams with strong track records see higher approval rates on subsequent proposals  |
+
+---
+
+## The One-Line Vision
+
+**Civica turns treasury accountability from a burden into a competitive advantage -- teams that deliver build reputation that gets them funded again, while the entire ecosystem gains visibility into where its collective ADA goes.**
+
+Accountability isn't surveillance. It's the mechanism that rewards quality, filters bad actors, and gives every Cardano citizen confidence that their treasury is being spent well. The teams that engage benefit the most, because their track record becomes the strongest argument for their next proposal.

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -1,39 +1,201 @@
-# Civica: The Definitive Product Vision
+# Civica: The Definitive Product Vision (V2)
 
 > **Status:** Active north star -- all build decisions, monetization timing, and architecture choices should align with this document.
 > **Created:** March 2026
-> **Last updated:** March 2026 (Multi-wallet identity, progress markers through Step 4)
-> **Supersedes:** `product-wow-plan-v2.md` as the primary product direction document.
+> **Version:** 2.1
+> **Last updated:** 2026-03-07 (V2.1: build sequence rewritten from scratch -- compressed foundation Steps 0-3, persona-driven Steps 4-11 grounded in codebase audit of 269+ components, 145 API routes, 75+ tables, 24 Inngest functions)
+> **Supersedes:** V1 of this document. Persona deep dives live in `docs/strategy/personas/`.
+> **Living document:** Agents should update status markers, progress annotations, and minor refinements as work proceeds. Log changes in `docs/strategy/vision-changelog.md`. Increment minor version (2.1, 2.2...) for progress updates; reserve major version (3.0) for strategic pivots.
+
+---
+
+## The Vision in One Sentence
+
+**Civica is the civic hub for the Cardano nation -- the one place where every ADA holder goes to understand what their stake is doing in governance, and where every governance participant goes to do their work.**
 
 ---
 
 ## The Thesis
 
-Civica is not a dashboard. It is the **governance intelligence layer** for Cardano -- the single system that ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. The product moat is not code -- it is the compounding historical dataset that grows every epoch and becomes impossible to replicate.
+Civica is not a dashboard and not just an intelligence layer. It is the **civic hub** for Cardano -- the place where citizenship in a digital nation becomes real. Underneath, a governance intelligence engine ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. But the engine is not the product. The product is the experience of being a Cardano citizen: informed, represented, engaged, and empowered.
 
-The architectural insight that makes this possible: **every data point feeds every other data point.** A DRep's vote updates their alignment, their score, the GHI, the inter-body alignment, the treasury track record, and the epoch recap -- simultaneously. A delegator's quiz answer improves their match, their footprint, and the system's understanding of citizen preferences. Nothing exists in isolation. The product feels like magic because the dots are genuinely connected underneath.
+The product moat is not code -- it is the compounding historical dataset that grows every epoch and becomes impossible to replicate. And increasingly, it is the community engagement data -- citizen sentiment, priority signals, endorsements, impact reports -- that no competitor collects because no competitor has built the civic hub where citizens participate.
+
+The architectural insight that makes this possible: **every data point feeds every other data point.** A DRep's vote updates their alignment, their score, the GHI, the inter-body alignment, the treasury track record, and the epoch recap -- simultaneously. A citizen's sentiment vote on a proposal improves accountability signals, DRep evaluation, and community intelligence. A delegator's quiz answer improves their match, their footprint, and the system's understanding of citizen preferences. Nothing exists in isolation. The product feels like magic because the dots are genuinely connected underneath.
+
+### The Identity Shift
+
+The fundamental transformation Civica drives: ADA holders go from thinking **"I own tokens"** to feeling **"I'm a citizen of a digital nation."**
+
+Cardano has a ratified constitution, a treasury worth billions of ADA, elected representatives (DReps), three branches of governance, and a 5-day legislative cycle. It is structurally more democratic than most countries. Every ADA holder has governance rights whether they exercise them or not. Civica makes that citizenship tangible, valuable, and effortless.
 
 ---
 
 ## Personas
 
-Civica serves seven distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data engine.
+Civica serves six distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data and intelligence engine. The Citizen is the anchor -- every other persona either serves citizens or is accountable to them.
 
-| Persona                                  | What DRepScore Does For Them                                                                                                                                                                  |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **ADA Holders (Delegators)**             | Find a DRep aligned with their values in 60 seconds, track their delegation health, understand how their governance power is being used. The core free experience.                            |
-| **DReps**                                | Build a governance reputation through transparent scoring, attract delegators, manage their governance inbox, track competitive standing. Monetized via DRep Pro.                             |
-| **SPOs (Stake Pool Operators)**          | Demonstrate governance participation to staking delegators, build an SPO governance score, differentiate their pool through active governance. Monetized via SPO Pro. ~3,000 registered SPOs. |
-| **Constitutional Committee Members**     | Transparent voting record and alignment analysis across all three governance bodies. High-visibility accountability for a small, high-status group (~7-10 members).                           |
-| **Treasury Proposal Teams**              | Showcase delivery track record, manage accountability polls, build proposer reputation for future funding requests. Monetized via Verified Project badges.                                    |
-| **Governance Researchers / Analysts**    | Academic-grade data exports, historical snapshots, EDI metrics, cross-chain comparison datasets. Citation-ready governance data. Monetized via Research API subscriptions.                    |
-| **Crypto Enthusiasts (Outside Cardano)** | See how sophisticated governance can be when done right. Cross-chain observatory, EDI comparison, and the sheer depth of the platform serve as a showcase for Cardano governance.             |
+> **Detailed persona documents** live in `docs/strategy/personas/`. Each document covers: who they are, what they want, their complete product experience, free vs. paid boundaries, connections to other personas, and success metrics. The summaries below provide the essential frame; the persona docs are the authoritative reference for product decisions.
+
+| Persona                  | Role in Ecosystem                                                  | Civica Experience                                                                                                                                                       | Monetization                                                      | Persona Doc                                               |
+| ------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
+| **Citizen** (ADA Holder) | The foundation. 80%+ of users.                                     | Civic hub: epoch briefing, treasury transparency, civic identity, community engagement, smart alerts. Summary intelligence, not analytics.                              | Free core. Premium Delegator (Step 6).                            | [citizen.md](personas/citizen.md)                         |
+| **DRep**                 | Elected governance representatives (~700). Supply side.            | Governance workspace: vote casting, rationale submission, proposal analysis, reputation management, delegator communication. Citizens first, professional layer on top. | Free governance operations. DRep Pro for analytics + growth.      | [drep.md](personas/drep.md)                               |
+| **SPO**                  | Infrastructure operators (~3,000). Staking-governance bridge.      | Identity platform: governance reputation, rich pool profile, delegator communication, governance-based discovery. The competitive dimension nobody else measures.       | Free governance + basic identity. SPO Pro for growth + analytics. | [spo.md](personas/spo.md)                                 |
+| **CC Member**            | Constitutional guardians (~7-10). Highest authority.               | 80% public accountability surface, 20% optional tooling. Transparency Index, voting record, inter-body dynamics. Not a user product -- an ecosystem trust layer.        | Free (no Pro tier).                                               | [cc-member.md](personas/cc-member.md)                     |
+| **Treasury Team**        | Builders who seek governance funding. Accountability subjects.     | Mutual benefit: proposer reputation, pre-proposal validation, milestone tracking, citizen impact reports. Accountability as competitive advantage.                      | Verified Project badge ($10-25/project).                          | [treasury-team.md](personas/treasury-team.md)             |
+| **Researcher**           | Governance scholars, analysts, data journalists.                   | API-first data platform: historical datasets, methodology docs, bulk exports, versioned data. Credibility flows back to all personas.                                   | Research API subscriptions ($50-200/mo).                          | [researcher.md](personas/researcher.md)                   |
+| **Integration Partner**  | Wallets, exchanges, pool tools, DeFi, explorers. B2B distribution. | Governance intelligence engine via API + embeddable widgets. Every integration extends Civica's reach without acquisition cost.                                         | API tiers ($50-200/mo). Widgets + deep integrations custom.       | [integration-partner.md](personas/integration-partner.md) |
+
+### Citizen-Centric Architecture
+
+The Citizen is not one persona among seven -- they are the anchor that gives every other persona meaning:
+
+- **DReps** exist to represent citizens. Their scores, profiles, and accountability are measured by how well they serve citizen interests.
+- **SPOs** operate infrastructure citizens stake with. Their governance reputation helps citizens make informed staking decisions.
+- **CC Members** guard the constitution on citizens' behalf. The transparency surface exists so citizens can trust them.
+- **Treasury Teams** spend citizens' collective ADA. Accountability mechanisms ensure citizens see where the money goes.
+- **Researchers** validate the intelligence that citizens consume. Academic rigor builds citizen trust.
+- **Integration Partners** distribute governance intelligence to citizens through the products they already use.
+
+Every feature decision should pass the citizen test: **"Does this ultimately make a Cardano citizen's life better?"**
 
 ### Segment Fluidity
 
-Most governance participants span multiple personas simultaneously. A DRep is also a delegator (to themselves or others). An SPO may also be a DRep. A CC member has personal delegation and may operate a pool. A treasury proposal team member is also an ADA holder tracking their own governance health.
+Most governance participants span multiple personas simultaneously. A DRep is also a citizen. An SPO may also be a DRep. A CC member has personal delegation and may operate a pool. A treasury team member is also an ADA holder tracking their own governance health.
 
-Civica treats segments as **additive facets of one identity**, not separate user types. The product adapts to the union of all segments detected across a user's linked wallets -- a user who links a DRep wallet and an SPO wallet sees a unified experience that surfaces both roles without mode-switching. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience) below and [ADR 007](../adr/007-multi-wallet-identity.md) for the technical model.
+Civica treats segments as **additive facets of one identity**, not separate user types. The product adapts to the union of all segments detected across a user's linked wallets. A DRep sees the citizen experience PLUS the governance workspace. An SPO sees the citizen experience PLUS pool identity management. Nobody loses the citizen layer; personas add professional capabilities on top.
+
+See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience) and [ADR 007](../adr/007-multi-wallet-identity.md) for the technical model.
+
+---
+
+## The Civic Hub: Three Product Pillars
+
+The civic hub rests on three pillars that together make Civica a destination citizens return to every epoch. Each pillar is described in detail in the [Citizen persona doc](personas/citizen.md). The summaries below establish the concepts that all persona experiences build on.
+
+### Pillar 1: The Briefing (Summary Intelligence)
+
+A personalized, plain-English digest updated every epoch (~5 days). The core return driver.
+
+- **Personal status:** Delegation health (green/yellow/red), staking rewards, alerts. Usually: "Everything's fine."
+- **What happened:** 2-4 headline cards summarizing governance activity. Written like news, not data.
+- **Treasury update:** What was spent, on what, treasury balance. "Your proportional share: X ADA."
+- **Your DRep this epoch:** How your representative performed. One-line verdict.
+- **What's coming:** Active proposals, upcoming deadlines.
+
+**Design rule:** If a citizen reads their briefing in 30 seconds and closes the app feeling informed, the product succeeded.
+
+**What it is NOT:** A dashboard with charts. An analytics view with filters. A firehose of governance actions.
+
+### Pillar 2: Civic Identity
+
+A persistent, growing profile that represents the citizen's relationship with the Cardano network:
+
+- Citizen since (epoch + date). Delegation streak. Representation summary.
+- Governance alignment profile (from Quick Match). Governance footprint.
+- Milestones that accumulate passively: "100 epochs delegated," "Your DRep voted on 200 proposals on your behalf."
+
+Identity creates attachment (citizens who see their history don't casually abandon the product), enables Wrapped (shareable civic moments), and compounds the data flywheel (every citizen's profile enriches matching and intelligence).
+
+### Pillar 3: Community Engagement (Structured Civic Participation)
+
+The layer that gives every citizen a voice without creating a forum. Seven mechanisms, all structured, all analyzable, all feeding the intelligence engine:
+
+1. **Proposal Sentiment:** "Do you support this? Yes / No / Not sure." Aggregate shown publicly. Divergence with DRep votes highlighted.
+2. **Priority Signals:** "What should governance focus on?" Aggregate becomes the Citizen Mandate.
+3. **Concern Flags:** Structured risk flags on proposals (too expensive, unclear deliverables, conflicts of interest). Threshold-based surfacing.
+4. **Impact Tags:** On funded projects: "I use this" / "essential" / "disappointing." Crowdsourced accountability.
+5. **Citizen Endorsements:** Endorse DReps, SPOs, or projects. Optional domain-specific trust signals. Social proof alongside algorithmic scores.
+6. **Citizen Questions:** Structured questions to DReps about specific votes. Aggregated and merged. DReps respond once, publicly.
+7. **Citizen Assemblies:** Periodic invitations to random citizen samples for deeper deliberation on major proposals. Digital sortition.
+
+**Anti-forum principle:** None of these create threads, conversations, or debate spaces. They create _signals_ -- structured, aggregatable data that feeds the intelligence engine while giving citizens meaningful agency. No moderation required because there is nothing to moderate.
+
+**New flywheel input:** Citizen engagement data is a new data source that no competitor collects. It enriches every surface: DRep profiles show citizen trust alongside scores, proposals show community sentiment alongside votes, treasury tracking shows citizen impact alongside spending data.
+
+---
+
+## Treasury Accountability
+
+Treasury transparency is elevated to a first-class product pillar, not just a data layer. The Cardano treasury holds billions of ADA -- citizens' collective wealth -- and the governance process allocates it. Civica makes every aspect of that process visible, understandable, and accountable.
+
+**For citizens:**
+
+- Treasury balance and trend. Spending by category. "Your proportional share."
+- What got funded: plain-English descriptions with delivery status.
+- Project accountability: citizen impact tags, milestone tracking, delivery scores.
+- Who voted for what: connect spending decisions to specific DReps (accountability trail).
+
+**For DReps and SPOs:**
+
+- Treasury impact analysis in the proposal workspace: amount, % of treasury, category, historical comparison.
+- Proposer track record: did this team deliver on past funded proposals?
+- Similar past proposals: what worked, what didn't.
+
+**For Treasury Teams:**
+
+- Proposer reputation that compounds: delivery scores, citizen impact, milestone completion across all projects.
+- Pre-proposal validation: test concepts with citizen interest and DRep support signals before investing in a full proposal.
+- Impact amplification: when funded projects ship, Civica surfaces them to citizens.
+- The trust ladder: anonymous -> registered -> active -> verified -> established. Each step voluntary, each step advantageous.
+
+See [Treasury Team persona doc](personas/treasury-team.md) for the full mutual benefit model.
+
+---
+
+## The Governance Workspace
+
+Civica is not just where governance is observed -- it is **where governance happens.** DReps, SPOs, and CC members can perform their core governance operations directly within Civica, eliminating the fragmented multi-tool workflow that characterizes governance today.
+
+### Vote Casting
+
+DReps, SPOs, and CC members cast votes directly from Civica via MeshJS (CIP-95). The vote is cast from the same page where they reviewed the proposal analysis -- AI summary, treasury impact, citizen sentiment, inter-body context, constitutional alignment. No context switch. The analysis feeds directly into the action.
+
+### Rationale Submission (The Killer Feature)
+
+The single most impactful capability Civica can offer. Today, CIP-100 rationale submission requires manual JSON creation, self-hosting, and anchor hash submission. Most governance participants skip it because the friction is too high.
+
+Civica's flow:
+
+1. Rich-text editor for writing the rationale (or AI-assisted first draft from proposal + voting history + governance philosophy)
+2. Auto-format to CIP-100 compliant JSON behind the scenes
+3. Host the document (Supabase Storage or IPFS)
+4. Bundle the metadata anchor with the vote transaction -- one submission: vote + rationale together
+
+Effects cascade across every persona:
+
+- More rationales on-chain (better for Cardano governance)
+- DReps/SPOs who use Civica score higher (rationale quality is a scoring factor)
+- Citizens see WHY their representative voted a certain way (better citizen experience)
+- AI gets more training data (better governance intelligence)
+- Governance transparency improves measurably (better for Cardano's reputation)
+
+### Proposal Workspace
+
+The analysis environment for governance participants, covering everything needed to make an informed vote:
+
+- AI-generated plain-English proposal summary
+- Treasury impact: amount, % of treasury, spending category
+- Similar past proposals and their outcomes (delivered, partial, failed)
+- Citizen sentiment from the community engagement layer
+- Citizen questions: aggregated asks from the community
+- Inter-body context: how the other governance bodies are leaning
+- Constitutional alignment: AI analysis against the ratified constitution
+- Proposal author track record: delivery history on past funded proposals
+
+### Delegator Communication
+
+Structured governance communication for DReps and SPOs -- not a blog, not a forum:
+
+- Vote explanations automatically visible in citizen briefings
+- Position statements attached to governance profiles
+- Epoch updates (optional, AI-assisted)
+- Citizen question responses (one response per aggregated question cluster, publicly visible)
+- Governance philosophy (persistent profile section -- the "campaign page")
+- SPO pool updates: maintenance announcements, community news, governance priorities
+
+See [DRep persona doc](personas/drep.md) and [SPO persona doc](personas/spo.md) for full workspace specifications.
 
 ---
 
@@ -51,30 +213,30 @@ Cardano governance participants routinely operate multiple wallets: cold storage
 
 The product does not require mode-switching. All governance roles surface in one view, and the UI adapts to whatever segments the user's linked wallets reveal:
 
-- **Home screen adapts:** A DRep+SPO sees both scores, both inboxes, unified action items. A pure citizen sees delegation health and footprint. The same page, different facets.
+- **Home screen adapts:** A DRep+SPO sees both scores, both inboxes, unified action items. A pure citizen sees the briefing and delegation health. The same page, different facets.
 - **Matching adapts:** If you are already a DRep, the product surfaces "find an SPO aligned with your governance values" rather than "find your DRep." If you are both, matching focuses on delegation health.
-- **Wrapped spans all roles:** "As a DRep you voted on 47 proposals; as an SPO your pool participated in 40; as a citizen your delegation health is green." One shareable identity, not three separate cards.
-- **AI Advisor sees everything:** "Your DRep score dropped 3 points, but your SPO alignment with the DRep consensus improved. Your delegation to DRep X is still well-matched." Cross-role insights that no single-wallet system can generate.
-- **Navigation surfaces role-specific deep dives** (DRep management, SPO management, delegation health) from a unified top level. Depth is progressive -- the top layer is unified, the drill-downs are role-specific.
+- **Wrapped spans all roles:** "As a DRep you voted on 47 proposals; as an SPO your pool participated in 40; as a citizen your delegation health stayed green." One shareable identity, not three separate cards.
+- **AI Advisor sees everything:** Cross-role insights that no single-wallet system can generate.
+- **Navigation surfaces role-specific deep dives** from a unified top level. The citizen layer is always present; DRep and SPO workspaces are additive deep dives.
 
 ### Cross-Segment Intelligence
 
-Multi-wallet identity unlocks intelligence that is impossible when each wallet is an island:
+Multi-wallet identity unlocks intelligence impossible when each wallet is an island:
 
 - **Personal inter-body alignment:** "As a DRep, you voted Yes on Proposal X. As an SPO, your pool voted No. Here is why that is interesting."
-- **Aggregated governance footprint:** Total ADA governed across all wallets, total proposals touched across all roles, combined engagement level.
-- **Conflict detection:** "Your DRep delegation and your SPO operation have diverging alignment on treasury proposals -- here is where they split."
-- **Unified governance profile:** The PCA-based governance profile incorporates signal from all roles, producing a richer and more accurate representation of the user's governance values.
+- **Aggregated governance footprint:** Total ADA governed across all wallets, total proposals touched across all roles.
+- **Conflict detection:** "Your DRep delegation and your SPO operation have diverging alignment on treasury proposals."
+- **Unified governance profile:** The PCA-based profile incorporates signal from all roles.
 
 ### Privacy
 
-Wallet linking creates a server-side association between addresses. Privacy-sensitive users can choose to operate with a single wallet and lose nothing -- the core product works identically. Linking is purely additive. Unlinking removes the association completely. There is no on-chain record of linked wallets.
+Wallet linking creates a server-side association between addresses. Privacy-sensitive users can choose to operate with a single wallet and lose nothing. Linking is purely additive. Unlinking removes the association completely. There is no on-chain record of linked wallets.
 
 ---
 
 ## The Data Flywheel
 
-This is the core engine. Every user action generates data that improves every surface in the product:
+This is the core engine. Every user action -- on-chain and off-chain -- generates data that improves every surface in the product:
 
 ```mermaid
 flowchart TB
@@ -88,6 +250,15 @@ flowchart TB
     Treasury["Treasury withdrawals"]
   end
 
+  subgraph civic [Civic Engagement - NEW]
+    Sentiment["Proposal Sentiment"]
+    PrioritySignals["Priority Signals"]
+    ConcernFlags["Concern Flags"]
+    ImpactTags["Impact Tags"]
+    Endorsements["Endorsements"]
+    CitizenQuestions["Citizen Questions"]
+  end
+
   subgraph engine [Intelligence Engine]
     Alignment["6D Alignment + PCA"]
     DRepScore["4-Pillar DRep Score"]
@@ -97,6 +268,7 @@ flowchart TB
     TreasuryIntel["Treasury Intelligence"]
     ProposalAI["Proposal Classification + Similarity"]
     Trends["Proposal Trends"]
+    CitizenIntel["Citizen Intelligence - NEW"]
   end
 
   subgraph personal [Personal Layer]
@@ -106,9 +278,12 @@ flowchart TB
     Footprint["Wallet Governance Footprint"]
     Alerts["Smart Notifications"]
     Wrapped["Governance Wrapped"]
+    CivicIdentity["Civic Identity - NEW"]
   end
 
   subgraph surfaces [User Surfaces]
+    Briefing["Epoch Briefing - NEW"]
+    TreasuryPage["Treasury Transparency - NEW"]
     Constellation["Constellation"]
     DRepDiscover["DRep Discovery"]
     SPODiscover["SPO Discovery"]
@@ -118,6 +293,7 @@ flowchart TB
     Calendar["Governance Calendar"]
     Observatory["Cross-Chain Observatory"]
     Pulse["Governance Pulse"]
+    GovWorkspace["Governance Workspace - NEW"]
   end
 
   DRepVote --> Alignment & DRepScore & InterBody & TreasuryIntel
@@ -128,292 +304,424 @@ flowchart TB
   Proposals --> ProposalAI & TreasuryIntel & Calendar & GHI
   Treasury --> TreasuryIntel & GHI
 
+  Sentiment --> CitizenIntel & ProposalAI
+  PrioritySignals --> CitizenIntel & Trends
+  ConcernFlags --> CitizenIntel & ProposalAI
+  ImpactTags --> TreasuryIntel & CitizenIntel
+  Endorsements --> DRepScore & SPOScore & CitizenIntel
+  CitizenQuestions --> CitizenIntel
+
   Alignment --> DRepMatch & SPOMatch & Constellation & DRepProfiles & SPOProfiles & DRepDiscover & SPODiscover
   DRepScore --> DRepProfiles & DRepDiscover & Alerts & Wrapped
   SPOScore --> SPOProfiles & SPODiscover & Alerts & Wrapped
   GHI --> Pulse & Observatory & Calendar
   InterBody --> DRepProfiles & SPOProfiles & CCPage & Pulse & Calendar
-  TreasuryIntel --> DRepProfiles & SPOProfiles & Pulse & Wrapped
-  ProposalAI --> DRepMatch & SPOMatch & DRepDiscover & Calendar & Trends
-  Trends --> Calendar & Pulse
+  TreasuryIntel --> DRepProfiles & SPOProfiles & Pulse & Wrapped & TreasuryPage & Briefing
+  ProposalAI --> DRepMatch & SPOMatch & DRepDiscover & Calendar & Trends & GovWorkspace
+  Trends --> Calendar & Pulse & Briefing
+  CitizenIntel --> DRepProfiles & SPOProfiles & GovWorkspace & Briefing & TreasuryPage
 
   WalletUnion --> Footprint & DRepMatch & SPOMatch & Wrapped & Alerts
   DRepMatch --> Footprint & DRepDiscover
   SPOMatch --> Footprint & SPODiscover
-  Footprint --> Wrapped & Alerts
+  Footprint --> Wrapped & Alerts & CivicIdentity
+  CivicIdentity --> Wrapped & Briefing
 ```
 
-**Every new data source we add multiplies the value of every existing surface.** This is why adding SPO+CC votes does not just add SPO data -- it enriches every DRep profile, every proposal page, the GHI, the observatory, and the epoch recaps.
+**Every new data source multiplies the value of every existing surface.** The V2 flywheel adds civic engagement as a new input category: citizen sentiment enriches proposal intelligence, priority signals shape trend analysis, impact tags strengthen treasury accountability, endorsements complement algorithmic scores. This is data no competitor collects because no competitor has the civic hub where citizens engage.
 
 ---
 
-## Build Sequence
+## Distribution Strategy
 
-Each step assumes the previous steps are complete. Complexity is rated Low / Medium / High. Detailed implementation plans for each step are linked where they exist.
+Growth comes from three channels, operating in parallel:
 
-### Step 0: Backend Metric Upgrades (HIGH complexity)
+### 1. Direct Acquisition (Citizens Come to Civica)
 
-> **Status: COMPLETE** -- All scoring, alignment, GHI, and observatory systems are live in production.
+- Simplified anonymous experience: two paths in (Stake / Govern), education woven in, gentle wallet connect prompts
+- Quick Match as primary conversion funnel: 3 questions, 60 seconds, delegation
+- Epoch briefing as retention driver: fresh content every ~5 days
+- Civic identity as attachment mechanism: growing footprint creates switching cost
 
-The foundation. Everything downstream depends on the quality of these scores.
+### 2. Viral Distribution (Personas Share Civica)
 
-**What gets built:**
+- DReps share scores, profiles, and Wrapped to attract delegation
+- SPOs share governance reputation to differentiate their pools
+- Citizens share civic identity, Wrapped, and governance footprint
+- Every share is a billboard. DReps and SPOs are the unpaid sales force (Principle #5).
+- Wrapped (Step 4) is the dedicated viral engine
 
-- PCA Alignment System -- AI proposal classification, 6 redesigned dimensions, PCA matching engine, temporal trajectories.
-- DRep Score 10/10 -- 4-pillar redesign (Engagement Quality, Effective Participation, Reliability, Governance Identity), percentile normalization, momentum.
-- GHI 10/10 -- EDI metrics engine, 6 redesigned components, calibration curves, decentralization dashboard.
-- Cross-Chain Observatory 10/10 -- Strip scores/grades, chain-native metrics, EDI comparison, AI insight.
+### 3. B2B Distribution (Partners Embed Civica)
 
-**Why first:** Every downstream feature (matching, footprint, calendar recaps, treasury framing, inter-body analysis) consumes these scores. Getting them right means everything built on top is trustworthy and differentiated. Ship garbage scores, and the whole product is garbage.
+- Wallet providers embed Quick Match, DRep scores, delegation health
+- Pool comparison tools add SPO governance scores as a new column
+- Exchanges display governance data for custodied ADA
+- Block explorers add intelligence layer to raw governance data
+- "Powered by Civica" brand touchpoints across every integration
+- See [Integration Partner persona doc](personas/integration-partner.md) for full strategy
 
-**Data modeling milestone:** After this step, begin snapshotting ALL new scores per epoch -- `alignment_snapshots`, `score_snapshots`, `ghi_snapshots`, `edi_snapshots` are populated daily. This historical data is the moat.
-
----
-
-### Step 1: DNA Quiz + Matching UX (MEDIUM complexity)
-
-> **Status: COMPLETE** -- Quick Match, PCA matching, user governance profiles, confidence scoring, dimension-level agreement all live.
-
-**What gets built:**
-
-- PCA-based matching in quiz and Quick Match
-- Smart proposal selection (type diversity, alignment coverage)
-- Dimension-level agreement ("you agree on decentralization, differ on treasury")
-- User governance profiles (progressive, updates on every vote)
-- Quick Match flow (`/match` -- 3 questions, 60 seconds to delegation)
-- Rich reveal UX with confidence scores, radar overlays, improve-your-match suggestions
-- **Persona-agnostic matching engine** -- design the PCA matching API to accept a `match_type` parameter from day one, enabling both "find my DRep" and "find my SPO" flows with the same infrastructure
-
-**Why second:** Quick Match is the primary acquisition funnel. The homepage strips down to Constellation + "Find your DRep in 60 seconds." This must be world-class before anything else ships to users. It is the single most important UX flow in the product.
-
-**Monetization unlock:** User governance profiles (created here) become the foundation for Premium Delegator features later. The same profiles power SPO matching in Step 2.5.
+**B2B distribution should begin before Step 7.** Early API access and widget prototypes for high-value partners (Eternl, PoolTool) can start as soon as the data is trustworthy (after Steps 0-2.5). The formal API product (Step 7) is the scalable version, but partnerships should not wait.
 
 ---
 
-### Step 2: Phase 1 Metrics Expansion (MEDIUM complexity)
+## Build Sequence (V2)
 
-> **Status: COMPLETE** -- Treasury intelligence, SPO/CC votes, inter-body alignment, wallet footprint, governance calendar, proposal intelligence all live.
+> **Rewritten March 2026** to reflect the V2 persona-centric vision and the current state of the codebase. Steps 0-3 summarize the completed foundation. Steps 4-11 define the forward path with specific references to existing infrastructure that can be reused or extended.
 
-**What gets built:**
+Each step assumes the previous steps are complete. For each forward step, we specify: what gets built, what already exists (reuse/modify), what is net-new, and which personas are served.
 
-- Treasury Intelligence wiring -- API routes for `getDRepTreasuryTrackRecord()`, `getSpendingEffectiveness()`, `findSimilarProposals()`. Treasury % framing in proposal cards.
-- SPO + CC vote fetching, storage, sync. Inter-body alignment library + API.
-- **Full SPO metadata fetching** -- new `fetchPoolList()`, `fetchPoolInfo()`, `fetchPoolMetadata()` functions using Koios `/pool_list`, `/pool_info`, `/pool_metadata` endpoints. New `PoolInfo`, `PoolMetadata` types. New `pools` table storing pool_id, ticker, name, homepage, description, pledge, margin, governance_statement, metadata_hash.
-- **CC member metadata** -- fetch and store CC member info alongside CC votes. Small table, lightweight sync.
-- **SPO metadata sync** -- extend `sync-spo-cc-votes` Inngest function to also sync pool metadata on the same cadence.
-- Wallet Governance Footprint -- ADA balance from Koios, footprint API, citizen report card.
-- Governance Calendar enrichment -- epoch recaps with AI, historical epoch browsing.
-- Proposal Semantic Intelligence -- classification-based similarity, trend detection, integration into recaps.
+### Foundation: Steps 0-3 (COMPLETE)
 
-**Why third:** These are the "connect the dots" data layers. Once SPO/CC votes exist, every proposal page can show "DReps voted 70% Yes, SPOs voted 40% Yes, CC voted 100% Yes." Once treasury framing exists, every proposal shows "this = 0.3% of treasury." Once epoch recaps exist, every epoch has a story. These are individually simple but collectively transform the product from "DRep scores" to "governance intelligence." The SPO metadata fetched here is the foundation for the SPO Governance Layer in Step 2.5.
+The backend intelligence engine and core frontend are production-grade. This foundation includes:
 
-**Data modeling milestone:** Begin snapshotting `inter_body_alignment` per epoch. Begin storing `proposal_similarity_cache` during sync. Begin accumulating `governance_events` per user for footprint. `pools` table populated with metadata for all registered SPOs.
+- **Step 0: Governance Intelligence Engine** -- DRep Score V3 (4-pillar: Engagement Quality 35%, Effective Participation 25%, Reliability 25%, Governance Identity 15%), percentile normalization, momentum tracking. 6D PCA alignment system with AI proposal classification. GHI with 6 calibrated components + 7 EDI metrics. All scores snapshot daily. `lib/scoring/`, `lib/alignment/`, `lib/ghi/`.
+- **Step 1: Matching & Personalization** -- PCA-based Quick Match (`/match`), user governance profiles with progressive confidence, dimension-level agreement, persona-agnostic matching engine (`match_type` parameter). `lib/matching/`.
+- **Step 2: Cross-Body Intelligence** -- Treasury intelligence (spending effectiveness, DRep track records, similar proposals). SPO + CC vote fetching, storage, sync. Inter-body alignment. Governance calendar with AI epoch recaps. Proposal semantic classification. Wallet governance footprint.
+- **Step 2.5: SPO Governance Layer** -- SPO 4-pillar scoring (`lib/scoring/spoScore.ts`), SPO 6D alignment, SPO matching, CC Transparency Index. SPO score and alignment snapshots from day one.
+- **Step 3: Core Frontend** -- 33 page routes, 269+ components, 145 API endpoints, 24 Inngest sync functions, 75+ database tables. Persona-aware homes (HomeCitizen, HomeDRep, HomeSPO), Discover (DRep/SPO/proposal browse), DRep/SPO/CC profiles with two-viewport structure, Pulse observatory, My Gov command centers, admin dashboard, embed routes, Quick Match flow, delegation ceremony, wallet connection.
 
----
+**Existing infrastructure the forward steps build on:**
 
-### Step 2.5: SPO Governance Layer (MEDIUM-HIGH complexity)
-
-> **Status: COMPLETE** -- SPO scoring (4-pillar), SPO alignment, CC fidelity scoring (CIP-136), SPO matching all live.
-
-The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (SPO votes + metadata).
-
-**What gets built:**
-
-- **SPO Score engine** (`lib/scoring/spoScore.ts`) -- adapt DRep Score's 4-pillar model for pool operators:
-  - **Participation (38%):** vote rate, weighted by proposal importance and type
-  - **Consistency (24%):** voting alignment with consensus, type diversity (replaces "Engagement Quality")
-  - **Reliability (23%):** voting responsiveness, epoch-over-epoch continuity
-  - **Governance Identity (15%):** metadata quality, governance statement presence, pledge commitment, active pool status (replaces "Pool Identity")
-  - Percentile normalization across all governance-active SPOs
-  - _Note: canonical pillar names match `lib/scoring/spoScore.ts` `SPO_PILLAR_WEIGHTS`. Use these names in all UI, docs, and API responses._
-- **SPO alignment computation** -- run the same 6D alignment engine on SPO votes, store in `pools` table columns mirroring the `dreps` alignment columns
-- **SPO profiles data layer** -- `getSPOById()`, `getSPOVotes()`, `getSPOAlignment()`, `getSPOTreasuryTrackRecord()` in a new `lib/spoData.ts`
-- **Inter-body alignment per SPO** -- how does this SPO vote relative to the DRep consensus? Relative to the CC?
-- **SPO matching integration** -- extend PCA matching to project SPO votes into PCA space, enabling "find my SPO" alongside "find my DRep"
-- **CC profiles data layer** -- `getCCMembers()`, `getCCVotes()`, `getCCAlignment()` for the Committee page
-- **CC Transparency Index** -- simple scoring: vote participation, rationale provision, alignment with community sentiment
-- **Sync pipeline:** `sync-spo-scores` Inngest function triggered after SPO votes sync, `sync-spo-alignment` for alignment computation
-- **Snapshots from day one:** `spo_score_snapshots` and `spo_alignment_snapshots` tables, populated on the same cadence as DRep snapshots
-
-**Why here (not later):** SPO profiles and scoring must exist before the frontend reimagining (Step 3) so that SPO Discovery, SPO profiles, and the navigation restructure can be designed for all three governance bodies simultaneously. Building the SPO backend after the frontend would mean redesigning surfaces twice.
-
-**Persona unlocked:** ~3,000 SPOs who now have a governance reputation system. "Your pool operator scored 85/100 on governance participation" is a competitive differentiator that SPOs will share with their staking delegators.
+| Domain            | Key Components & APIs                                                                                                                                                                                                                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DRep Profiles     | DRepProfileHero, DRepProfileTabsV2, GovernanceRadar, ScoreHistoryChart, AlignmentTrajectory, SimilarDReps, VoteDetailSheet                                                                                                                                                                               |
+| SPO Profiles      | SpoProfileHero, SpoProfileTabsV1, SPOCommandCenter, SPOClaimHero, CivicaSPOCard                                                                                                                                                                                                                          |
+| Proposals         | ProposalHeroV1, ProposalLifecycleTimeline, ProposalVotersClient, ProposalTopRationales, ProposalDimensionTags, AlignmentCohortBreakdown, ProposalsBrowse                                                                                                                                                 |
+| My Gov            | DRepCommandCenter (24KB), CitizenCommandCenter (25KB), SPOCommandCenter (13.5KB), CivicaProfile, CivicaInbox (16KB)                                                                                                                                                                                      |
+| Pulse             | CivicaPulseOverview (23KB), CivicaObservatory (19.9KB), StateOfGovernance, CivicaEpochReport, CivicaGovernanceCalendar, CivicaTreasury                                                                                                                                                                   |
+| Charts            | GovernanceRadar, DelegationGraph, VotingHistoryChart, TreasuryCharts, ScoreDistribution, VotingPowerTreemap, GovernanceHealthGauge, ProposalStatusFunnel                                                                                                                                                 |
+| Matching          | QuickMatchFlow (23.5KB), MatchCard, GovernanceIdentityCard, ConfidenceBar, RadarOverlay                                                                                                                                                                                                                  |
+| Delegation        | DelegateButton, DelegationCeremony, DelegationIntelligence, DelegatorAnalytics                                                                                                                                                                                                                           |
+| Communication     | StatementComposer, SPOStatementComposer, VoteExplanationEditor, RationaleAssistant, DRepCommunicationFeed, DRepQuestionsInbox                                                                                                                                                                            |
+| Engagement        | SentimentPoll (12.8KB), PollFeedback, TreasuryAccountabilityPoll                                                                                                                                                                                                                                         |
+| Sharing           | WrappedShareCard, ShareActions, ShareModal, OG image generation                                                                                                                                                                                                                                          |
+| Admin             | AdminAuthGate, AdminSidebar, FeatureFlagAdmin, IntegrityDashboard                                                                                                                                                                                                                                        |
+| Infrastructure    | BrandedLoader, LoadingSkeleton, EmptyState, ErrorBanner, FeatureGate, CommandPalette, WalletConnectModal, Providers                                                                                                                                                                                      |
+| Backend APIs      | 8 treasury routes, 39 governance routes, 8 DRep routes, 11 v1 public routes, epoch-recap, briefs, alignment-drift detection, polls                                                                                                                                                                       |
+| Inngest Functions | 24 durable functions: sync (DReps, votes, proposals, scores, alignment, SPO scores, secondary, slow), intelligence (GHI, treasury, benchmarks, drift detection, data moat), notifications (epoch summary, weekly digest, wrapped, state of governance), maintenance (health, integrity, freshness guard) |
 
 ---
 
-### Step 3: Frontend Reimagining (MEDIUM complexity)
+### Step 4: Citizen Experience & Acquisition Funnel (MEDIUM complexity)
 
-> **Status: SUBSTANTIALLY COMPLETE** -- All core surfaces live (homepage, discover, DRep/SPO/CC profiles, My Gov, Pulse, proposals, navigation). Delegation flow is wired into DRep profiles via `InlineDelegationCTA`. Remaining: treasury project pages (`/project/[txHash]`), `/learn` route, delegation CTA on Quick Match results, proposal browse card enrichment (treasury %, tri-body votes, expiration), Discover hero personalization, table view toggle, feature flag audit.
+> **Status: NOT STARTED**
+> **Primary persona:** Citizen (ADA Holder)
+> **Secondary impact:** All personas (improved onboarding benefits everyone)
+
+The on-ramp. Without a clear, unintimidating path from "I hold ADA" to "I'm a Cardano citizen," the product's intelligence goes to waste. The backend data for everything in this step already exists -- this is purely a UX/presentation layer that makes existing intelligence accessible to citizens. Highest impact-to-effort ratio in the entire forward roadmap.
 
 **What gets built:**
 
-- Strip homepage to Constellation + Quick Match CTA + PersonalCard
-- Discover overhaul -- hero with match results, card grid default, table toggle
-- DRep profile two-viewport restructure -- hero/narrative/facts in VP1, record in VP2
-- Proposals with "Your DRep voted" badges and cross-proposal insight hero
-- My Delegation as governance health check (green/yellow/red)
-- DRep Dashboard with single urgent action
-- Pulse page as content destination (GHI, State of Gov, insights, observatory, leaderboard)
-- `/learn` route for governance education content
-- Feature flag audit -- ungating mature features, cleaning up experimental gates
-- **SPO Discovery page** (`/pools`) -- card grid of governance-active SPOs, sortable by SPO Score, filterable by alignment dimension. Same progressive complexity model as DRep Discover.
-- **SPO Profile page** (`/pool/[poolId]`) -- mirrors DRep profile architecture: hero with SPO Score + radar + narrative, voting record below, treasury track record, inter-body alignment with DReps.
-- **SPO Quick Match** -- `/match` page gets a toggle: "Find my DRep" vs "Find my SPO." Same 3-question flow, different result set.
-- **CC Members page** (`/committee`) -- listing of all current Constitutional Committee members with voting records, alignment, and transparency index.
-- **Treasury Project pages** (`/project/[txHash]`) -- funded proposal detail with delivery status, accountability poll results, team track record, similar proposals.
-- **Nav expansion** -- "Governance Bodies" section in navigation: DReps, SPOs, Committee. Unified information architecture for all three bodies.
-- **Production delegation flow** -- `InlineDelegationCTA` on DRep profiles (done), `DelegateButton` on Quick Match result cards, wallet connect → preflight → confirm → ceremony. The complete "90 seconds to delegation" path.
-- **Multi-wallet linking flow** in My Gov -- connect additional wallets, label them, view detected segments per wallet, manage linked wallets. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience).
-- **Unified multi-segment dashboard** -- the home screen adapts to the union of segments across all linked wallets. A DRep+SPO sees both scores and both inboxes. A pure citizen sees delegation health. No mode-switching.
-- **Role-aware navigation** -- DRep management and SPO management surface as deep dives from the unified home, not as separate products.
+1. **Simplified anonymous experience:** Reduced nav surface for unconnected visitors (Explore, Match, Learn, Connect). Two-path entry: Stake (SPO discovery) and Govern (Quick Match). Education woven into every surface, not a separate destination. Messaging: "Your ADA gives you a voice. 60 seconds. Funds stay safe."
 
-**Why here (not earlier):** The backend upgrades, matching UX, and SPO scoring must be solid before we redesign the frontend. The reimagined homepage is JUST the Constellation + Quick Match -- if Quick Match is not world-class, the homepage is empty. If DRep and SPO scores are not trustworthy, the profile restructure means nothing. Build the engine first, then build the car around it.
+2. **Epoch Briefing:** Personalized, plain-English governance digest (every ~5 days at epoch boundary). Sections: personal status, what happened, treasury update, DRep performance, upcoming activity. AI-generated via Claude, citizen-appropriate language. The citizen's primary surface -- replaces the dashboard paradigm.
 
-**Critical design rule:** Every page's Layer 1 (viewport 1) must be emotionally complete on its own. A user who never scrolls must still think "wow." Depth is progressive, not mandatory.
+3. **Treasury Transparency ("Where Your Money Goes"):** Citizen-facing treasury surface. "Your proportional share" framing. Spending by category, project accountability cards, citizen impact highlights, spending trends over time. Every treasury ADA traceable from proposal to vote to delivery.
 
-**Dot connection opportunity:** The reimagined proposal cards now show: treasury % of balance, your DRep's vote, SPO/CC vote summary, AI-generated context, similar proposals, and expiration countdown. Each of these came from a different backend system. Together on one card, they create the "how does this app know all this?" moment.
+4. **Civic Identity:** Citizen-since dating, delegation streaks, representation summaries, governance footprint, milestones (first vote influence, first epoch delegation, 10-epoch streak). Progressive profile that grows with participation.
+
+5. **Smart Alerts:** Low-frequency, high-signal. Default quiet. Every alert connects to an action. Triggers: DRep score drop, alignment drift, new proposal matching interests, delegation anniversary, treasury milestone.
+
+6. **PostHog conversion funnel:** landing → path_selected → quick_match_started → completed → wallet_prompted → connected → delegated. Measure before optimizing.
+
+**What exists (reuse/modify):**
+
+| Asset                                               | Action                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------ |
+| `HomeCitizen.tsx` (16.6KB)                          | **Modify** -- restructure around Epoch Briefing as primary surface |
+| `HomeAnonymous.tsx`                                 | **Modify** -- simplify to two-path entry                           |
+| `CitizenCommandCenter.tsx` (25KB)                   | **Modify** -- integrate briefing, civic identity, alerts           |
+| `CivicaTreasury.tsx`                                | **Modify** -- add citizen "your share" framing                     |
+| `TreasuryCharts.tsx` (14.5KB)                       | **Reuse** -- spending visualizations                               |
+| `/api/treasury/*` (8 routes)                        | **Reuse** -- accountability, effectiveness, history                |
+| `/api/governance/epoch-recap`                       | **Reuse** -- epoch summary data                                    |
+| `/api/briefs/generate`                              | **Reuse** -- AI brief generation                                   |
+| `GovernanceFootprintCard.tsx`                       | **Modify** -- integrate into civic identity                        |
+| `DelegationAnniversaryCard.tsx`                     | **Reuse** -- milestone celebrations                                |
+| `PersonalizedStatsStrip.tsx`                        | **Modify** -- citizen-tuned stats                                  |
+| `SinceLastVisit.tsx`                                | **Reuse** -- returning user context                                |
+| Notification system (`check-notifications` Inngest) | **Modify** -- add citizen alert triggers                           |
+| `detect-alignment-drift` Inngest function           | **Reuse** -- drift detection for alerts                            |
+
+**Net-new:**
+
+| What                                       | Purpose                                                         |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `EpochBriefing.tsx`                        | Core citizen briefing component (AI-generated, epoch-cycle)     |
+| `CivicIdentityCard.tsx`                    | Citizen identity: since-date, streaks, milestones, footprint    |
+| `TreasuryCitizenView.tsx`                  | "Where your money goes" with proportional share calculation     |
+| `SmartAlertManager.tsx`                    | Alert routing: detect triggers → filter by preference → deliver |
+| `citizen_milestones` table                 | Track milestone achievements per user                           |
+| `citizen_briefings` table                  | Cache generated briefings per user per epoch                    |
+| `simplified_onboarding` feature flag       | A/B test simplified vs current anonymous UX                     |
+| `generate-epoch-briefing` Inngest function | Batch-generate citizen briefings at epoch boundary              |
+
+**Persona-appropriate surfaces:** After wallet connection, the citizen sees the briefing (not a dashboard). DReps see their governance inbox. SPOs see their pool identity. Each persona's "home" is designed for them.
 
 ---
 
-### Step 4: Governance Wrapped + Shareable Moments (LOW-MEDIUM complexity)
+### Step 5: Governance Workspace (MEDIUM-HIGH complexity)
 
-> **Status: IN PROGRESS** -- Wrapped generation and OG images live for all entity types (DRep, SPO, Citizen). Remaining: viral distribution UX (one-click social sharing with pre-composed text), animated share previews, multi-role Wrapped, embed enhancements.
+> **Status: NOT STARTED**
+> **Primary persona:** DRep, SPO
+> **Secondary impact:** Citizen (more rationales = better transparency), Researcher (richer data)
+
+The capability that makes Civica indispensable: governance operations happen here, not somewhere else. Citizens are now using the platform (Step 4). DReps and SPOs need a reason to make it their daily tool.
 
 **What gets built:**
 
-- "Governance Wrapped" per-user and per-DRep -- annual or per-epoch summary of governance participation
-- Shareable OG image generation for: wrapped stats, match results, DRep score milestones, governance footprint highlights
-- "Your DRep This Epoch" summary card for delegators
-- DRep year-in-review shareable
-- Embed enhancements: interactive DRep card with live score, GHI gauge with sparkline
-- **SPO Wrapped** -- "Your pool operator voted on 47 proposals this year, scoring 85/100 on governance participation." SPOs share this to attract staking delegators.
-- **"Your Staking Governance" card** -- for staking delegators: not just delegation, but how their pool operator governs. "Your SPO voted on all treasury proposals and aligned with the DRep consensus 70% of the time."
-- **Multi-role Wrapped** -- for users who span segments, Wrapped tells the full story: "As a DRep you voted on 47 proposals. As an SPO your pool participated in 40. As a citizen your delegation health stayed green all year." One shareable identity card, not three separate summaries.
+1. **Vote casting:** MeshJS/CIP-95 governance transaction construction, wallet signing, on-chain submission. Vote from the same page where you analyzed the proposal. Support for DRep votes (VotingProcedure) and SPO votes. Transaction building, fee estimation, confirmation UX, submission tracking, on-chain verification.
 
-**Future extension: Citizen Governance Impact Score.** A personal score for delegators based on: delegation duration, DRep activity level, quiz participation, proposal engagement, and governance footprint depth. This gives citizens a gamified reason to return and a sharable metric that drives virality. Natural fit for Step 6 Premium Delegator features.
+2. **Rationale authoring + CIP-100 submission:** Rich-text editor with AI assist (Claude drafts from: proposal summary + voting history + governance philosophy + alignment dimensions). CIP-100 JSON-LD schema generation. Document hosting on Supabase Storage (with IPFS option). Metadata anchor bundling with vote transaction. Two-minute flow: analyze → draft → review → submit (vote + rationale in one transaction).
 
-**Why here:** At this point every data layer exists for all three governance bodies. Wrapped is the viral growth engine -- users share their governance footprint, DReps share their score history, SPOs share their governance participation, and every share is a billboard for DRepScore. This step transforms all the data work into acquisition.
+3. **Governance statement setup:** Guided flow for DReps and SPOs to publish governance philosophy. CIP-100 compliant. AI-assisted drafting from voting record analysis. Published on-chain as metadata anchor. Displayed on profiles.
 
-**Monetization unlock:** Premium Wrapped (more detail, custom branding for DReps and SPOs) is a natural Pro feature. Wrapped OG images drive organic traffic.
+4. **Proposal workspace enhancements:** Constitutional alignment analysis surfaced alongside proposal, citizen sentiment integration (from Step 6), citizen question surfacing, information request system for proposal authors.
 
-**Data modeling milestone:** No new snapshots needed -- this consumes all existing snapshot tables. The value of having been snapshotting since Step 0 pays off here: rich historical narratives like "your DRep's alignment shifted 15 points toward decentralization over 6 months."
+5. **Delegator communication tools:** Vote explanations (post-vote, AI-assisted), position statements, epoch updates (AI-drafted from actual voting record), citizen question response interface, SPO pool update channel.
+
+**What exists (reuse/modify):**
+
+| Asset                                     | Action                                                            |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `VoteExplanationEditor.tsx`               | **Modify** -- integrate into post-vote rationale flow             |
+| `RationaleAssistant.tsx`                  | **Modify** -- enhanced AI drafting with CIP-100 output            |
+| `DRepCommandCenter.tsx` (24.6KB)          | **Modify** -- add "Pending Votes" action queue with inline voting |
+| `ProposalHeroV1.tsx`                      | **Modify** -- add "Cast Vote" action panel                        |
+| `StatementComposer.tsx`                   | **Modify** -- CIP-100 compliance, governance statement flow       |
+| `SPOStatementComposer.tsx`                | **Modify** -- CIP-100 compliance                                  |
+| `DRepCommunicationFeed.tsx` (12.8KB)      | **Modify** -- structured update templates                         |
+| `DRepQuestionsInbox.tsx` (11KB)           | **Modify** -- response workflow integration                       |
+| `/api/rationale` + `/api/rationale/draft` | **Reuse** -- rationale storage and AI drafting                    |
+| `/api/drep/[drepId]/positions`            | **Reuse** -- position statement storage                           |
+| `/api/drep/[drepId]/philosophy`           | **Reuse** -- governance philosophy                                |
+| `getOpenProposalsForDRep()` in data.ts    | **Reuse** -- pending vote detection                               |
+| `vote_rationales` table                   | **Reuse** -- rationale storage                                    |
+
+**Net-new:**
+
+| What                                | Purpose                                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------------------- |
+| `VoteCaster.tsx`                    | MeshJS/CIP-95 vote transaction builder + wallet signer + confirmation UX               |
+| `RationaleFlow.tsx`                 | Full CIP-100 rationale creation pipeline (editor → AI draft → JSON-LD → host → anchor) |
+| `GovernanceStatementWizard.tsx`     | Step-by-step philosophy/statement setup with AI assist                                 |
+| `lib/cip100.ts`                     | CIP-100 JSON-LD document construction and validation                                   |
+| `lib/metadataAnchor.ts`             | Document hosting (Supabase Storage) + URI generation                                   |
+| MeshJS + `@meshsdk/core` dependency | Wallet interaction for governance transactions                                         |
+| `governance_actions` table          | Track votes cast through Civica (analytics + verification)                             |
+| `rationale_documents` table         | Hosted CIP-100 documents with URIs and on-chain anchors                                |
+
+**Key metric:** If Civica 2x's the ecosystem rationale rate for its users, the value proposition is proven.
 
 ---
 
-### Step 5: DRep Pro + SPO Pro Tiers (MEDIUM complexity)
+### Step 6: Community Engagement Layer (MEDIUM complexity)
+
+> **Status: NOT STARTED**
+> **Primary persona:** Citizen
+> **Secondary impact:** DRep (citizen signal), Treasury Team (validation + impact), Researcher (analyzable data)
+
+The structured signal layer. Civic engagement generates analyzable data, not noise. No forums, no threads, no moderation burden. Each mechanism took inspiration from successful structured civic engagement patterns.
 
 **What gets built:**
 
-- Subscription infrastructure -- ADA-native payments (or Stripe fallback), subscription table, entitlement checks
-- **DRep Pro** features:
-  - Profile analytics (who viewed, delegation trends, audience demographics)
-  - AI rationale drafting assistant (already exists at `/api/rationale/draft`, gate behind Pro)
-  - Smart inbox prioritization (already exists in dashboard, enhance with AI ranking for Pro)
-  - Delegator engagement tools (polls, position statements -- some exist, enhance)
-  - "Verified DRep" badge
-  - Custom alerts (alignment shift, score threshold, competitive context)
-  - Enhanced score simulator
-  - Campaign page / governance philosophy editor
-- **SPO Pro** features (mirrors DRep Pro, adapted for pool operators):
-  - Pool governance analytics (who is viewing, staking delegator governance sentiment)
-  - "Verified SPO" badge with governance participation highlight
-  - Competitive insights vs other SPOs in the same pledge/size tier
-  - AI governance statement drafting
-  - Custom alerts (score changes, governance ranking shifts, delegator movement)
-- **"Verified Project" badge** for treasury proposal teams -- teams pay to verify their identity and get a trust badge on their project page, plus access to accountability management tools
-- Pro-gated API: `/api/v1/dreps/:id/analytics` and `/api/v1/pools/:id/analytics` for own data
+Seven engagement mechanisms, each producing structured data that feeds the intelligence engine:
 
-**Why here (not earlier):** DReps and SPOs need to experience the free product's value before they will pay. By this point: their scores are sophisticated (Steps 0 + 2.5), their profile pages are beautiful (Step 3), delegators are finding them via Quick Match (Step 1), and their governance record is rich with treasury tracking, inter-body alignment, and temporal trajectories (Step 2). The Pro tier enhances what is already obviously valuable.
+1. **Proposal Sentiment:** Simple directional signal on active proposals (Support / Oppose / Unsure). Anonymous until wallet connected. Aggregated on proposal pages. DReps see citizen sentiment as input to voting decisions.
 
-**Open design question:** Pro tier pricing for multi-segment users (e.g., someone who is both a DRep and an SPO) -- bundle discount vs. unified "Gov Pro" tier. See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience).
+2. **Priority Signals:** "What should governance focus on?" Citizens vote on priority areas (infrastructure, education, marketing, DeFi, etc.). Aggregated into community priority dashboard. Treasury teams use to validate concepts before proposing.
 
-**Monetization target:** $2,000-5,000/mo from DRep Pro (50-100 DReps) + SPO Pro (50-100 SPOs) + Verified Projects at $15-25/mo.
+3. **Concern Flags:** Structured flags on proposals: "too expensive," "team unproven," "duplicates existing project," "constitutional concern." Aggregated counts surface systemic concerns without moderation.
+
+4. **Impact Tags:** Post-delivery citizen feedback on funded projects: "I use this" / "I tried it" / "I didn't know about it." Usage rating: essential / useful / okay / disappointing. Feeds treasury accountability.
+
+5. **Citizen Endorsements:** Citizens endorse DReps beyond delegation. "I trust this DRep on treasury matters" or "This DRep's rationales help me understand governance." Lightweight, structured, analyzable.
+
+6. **Citizen Questions:** Directed questions to DReps about specific proposals or positions. Structured format, delivered to DRep inbox, answered asynchronously. Not a chat -- a query/response system.
+
+7. **Citizen Assemblies (lightweight):** Time-bounded structured consultations. "Should governance prioritize X or Y this quarter?" Multiple-choice, 1-week duration, results published. 1-2 per epoch, curated by Civica.
+
+**What exists (reuse/modify):**
+
+| Asset                                    | Action                                                   |
+| ---------------------------------------- | -------------------------------------------------------- |
+| `SentimentPoll.tsx` (12.8KB)             | **Modify** -- adapt for proposal sentiment               |
+| `PollFeedback.tsx`                       | **Modify** -- adapt for priority signals                 |
+| `TreasuryAccountabilityPoll.tsx`         | **Modify** -- adapt for impact tags                      |
+| `/api/polls/vote` + `/api/polls/results` | **Modify** -- generalize for all 7 mechanisms            |
+| `/api/governance/questions` + `/respond` | **Reuse** -- citizen question delivery                   |
+| `DRepQuestionsInbox.tsx`                 | **Reuse** -- question response interface                 |
+| `CivicaInbox.tsx` (16KB)                 | **Modify** -- surface citizen questions prominently      |
+| `poll_responses` table                   | **Modify** -- extend schema for sentiment/priority/flags |
+
+**Net-new:**
+
+| What                                             | Purpose                                              |
+| ------------------------------------------------ | ---------------------------------------------------- |
+| `ProposalSentiment.tsx`                          | Inline sentiment voting on proposal pages            |
+| `PrioritySignals.tsx`                            | Priority area voting dashboard                       |
+| `ConcernFlags.tsx`                               | Structured concern flagging on proposals             |
+| `ImpactTags.tsx`                                 | Post-delivery citizen feedback on funded projects    |
+| `CitizenEndorsements.tsx`                        | DRep endorsement beyond delegation                   |
+| `CitizenAssembly.tsx`                            | Time-bounded consultation component                  |
+| `citizen_sentiment` table                        | Proposal sentiment votes                             |
+| `citizen_priority_signals` table                 | Priority area votes                                  |
+| `citizen_concern_flags` table                    | Proposal concern flags                               |
+| `citizen_impact_tags` table                      | Project impact feedback                              |
+| `citizen_endorsements` table                     | DRep endorsements                                    |
+| `citizen_assembly_responses` table               | Assembly consultation votes                          |
+| `precompute-engagement-signals` Inngest function | Aggregate engagement data for all consuming surfaces |
+
+**Why this order:** Citizens are using the platform (Step 4), DReps are doing governance work (Step 5). Now citizens need channels to express preferences that feed back into the intelligence layer. This creates the data flywheel's newest input stream -- community engagement signals that no competitor collects because no competitor has built the civic hub where citizens participate.
 
 ---
 
-### Step 6: Premium Delegator + AI Governance Advisor (MEDIUM complexity)
+### Step 7: Viral Growth & Shareable Moments (LOW-MEDIUM complexity)
+
+> **Status: PARTIALLY COMPLETE** -- Wrapped generation and OG images live for all entity types.
+> **Primary persona:** All personas (distribution channel)
+
+Every data layer now exists. The workspace generates rich participation records. Community engagement creates citizen-specific content. Wrapped transforms it all into acquisition.
 
 **What gets built:**
 
-- Premium delegator tier ($5-10/mo or stake-weighted free):
-  - AI Governance Advisor: "Based on your values and delegation, here is what changed this epoch and what you should pay attention to" -- personalized AI briefings using the user's governance profile + all system data
-  - Advanced alerts: score drops, alignment shifts, unusual voting patterns, delegation health warnings
-  - Portfolio delegation management: split delegation across multiple DReps (when supported by protocol), track combined alignment
-  - Governance participation tracking + exportable records
-  - Enhanced Wrapped with full historical analysis
-- Free-tier Governance Advisor: simplified version ("3 proposals are open, your DRep voted on 2")
+1. **Governance Wrapped:** Epoch and annual summaries for citizens (governance impact, delegation, engagement), DReps (voting record, score trajectory, delegator growth), SPOs (governance reputation, pool governance comparison).
 
-**Why here:** The user governance profile (Step 1), wallet footprint (Step 2), and epoch recaps (Step 2) create a rich personalization layer. The AI advisor consumes ALL of it: your DRep delegation, your SPO staking, both actors' governance records, treasury impact, proposal trends, inter-body dynamics. This is the "Spotify Wrapped meets Bloomberg Terminal for governance" moment.
+2. **Shareable OG image generation:** Match results, score milestones, governance footprint, civic identity achievements, delegation anniversaries, community engagement stats.
 
-**Monetization target:** $750-2,000/mo from Premium Delegator (staking governance adds incremental value).
+3. **Civic identity shareable moments:** "I've been a Cardano citizen for 100 epochs," "My DRep scored in the top 10%," "I've influenced 3 proposals through my delegation."
 
-**Dot connection highlight:** The AI advisor prompt has access to: the user's alignment profile, their DRep's 4-pillar score breakdown, their SPO's governance score, the DRep's treasury track record, inter-body alignment on recent proposals (including "your DRep voted Yes but your SPO voted No"), governance calendar deadlines, proposal trends, and GHI trajectory. No competitor can generate this insight because no competitor has this data.
+4. **Multi-role Wrapped:** For users who are both DReps and SPOs, or citizens with multiple wallets.
 
-**Multi-wallet amplifier:** For users who span segments, the advisor sees the full picture across all linked wallets and all roles. Cross-role insights become possible: "Your DRep votes and your SPO votes diverged on treasury proposals this epoch -- your DRep approved 80% but your pool only voted on 60%." The advisor can also detect alignment drift between a user's own governance actions (as DRep/SPO) and their delegation choices (as citizen).
+5. **Citizen Governance Impact Score:** Personal gamified score for delegators: delegation duration × DRep activity × quiz participation × engagement depth. Shareable return driver.
+
+**What exists (reuse/modify):**
+
+| Asset                                 | Action                                                     |
+| ------------------------------------- | ---------------------------------------------------------- |
+| `WrappedShareCard.tsx`                | **Modify** -- add civic identity moments, engagement stats |
+| `ShareActions.tsx` + `ShareModal.tsx` | **Reuse** -- sharing infrastructure                        |
+| `/api/my-gov/wrapped/[period]`        | **Reuse** -- wrapped data API                              |
+| `generate-governance-wrapped` Inngest | **Modify** -- enrich with workspace + engagement data      |
+| OG image generation                   | **Reuse** -- existing infrastructure                       |
+| `DelegationCeremony.tsx`              | **Reuse** -- celebration UX                                |
+| `MilestoneCelebration.tsx`            | **Reuse** -- milestone celebrations                        |
+| `CelebrationOverlay.tsx`              | **Reuse** -- animation framework                           |
+
+**Net-new:**
+
+| What                              | Purpose                                       |
+| --------------------------------- | --------------------------------------------- |
+| `GovernanceImpactScore.tsx`       | Citizen impact score calculation + display    |
+| `CivicMilestoneShare.tsx`         | Shareable civic identity moment cards         |
+| Animated share preview generation | Motion-based OG previews for social platforms |
+| `citizen_impact_scores` table     | Stored citizen impact calculations            |
 
 ---
 
-### Step 7: Governance Data API v2 (MEDIUM complexity)
+### Step 8: Monetization (MEDIUM complexity)
+
+> **Status: NOT STARTED**
+> **Primary persona:** DRep, SPO, Citizen (premium), Treasury Team
+
+DReps and SPOs are now using the free workspace daily. Community is engaged. Pro tiers are a natural upsell for competitive advantage on top of indispensable free tools.
 
 **What gets built:**
 
-- Public API expansion beyond existing v1 endpoints:
-  - `/v2/dreps/:id/alignment` -- 6D alignment + PCA coordinates + temporal trajectory
-  - `/v2/dreps/:id/treasury` -- spending profile, approved ADA, accountability ratings
-  - `/v2/pools/:id` -- SPO governance profile, score, alignment, voting record
-  - `/v2/pools/:id/votes` -- SPO voting history
-  - `/v2/pools/:id/alignment` -- SPO 6D alignment + inter-body alignment
-  - `/v2/committee` -- CC members list with voting records
-  - `/v2/committee/:id/votes` -- CC member voting history
-  - `/v2/proposals/:id/inter-body` -- DRep/SPO/CC vote breakdown + alignment score
-  - `/v2/projects/:txHash` -- funded proposal data, accountability, delivery status
-  - `/v2/governance/health` -- GHI with all 6 components + EDI breakdown
-  - `/v2/governance/decentralization` -- 7 EDI metrics, historical
-  - `/v2/governance/trends` -- proposal trends, participation trends
-  - `/v2/matching/quick` -- embeddable Quick Match for wallets (DRep and SPO)
-- Rate limiting tiers: Free (100 req/day), Basic ($50/mo, 10K/day), Pro ($200/mo, 100K/day), Enterprise (custom)
-- **Research tier** -- academic pricing ($50-200/mo): bulk data exports (CSV/JSON), historical snapshots, custom date ranges, cross-sectional queries, versioned datasets with methodology documentation
-- OpenAPI spec, SDK generation, developer docs enhancement
-- Embeddable Quick Match widget for wallet providers
+1. **Subscription infrastructure:** ADA-native payments (or Stripe fallback), subscription table, entitlement checks, billing management.
 
-**Why here:** The data is rich, the scores are trustworthy, and wallet providers need governance UX. Lace showing "DRepScore: 82" in their delegation UI is the dream integration. SPO data adds a second compelling integration use case: stake pool comparison tools. The research tier opens the academic market.
+2. **DRep Pro ($15-25/mo):** Delegation analytics (who delegated, who left, why), AI rationale drafting (enhanced), score simulator (what-if voting), competitive intelligence (vs similar DReps), advanced inbox prioritization, campaign tools, custom alerts, performance coaching.
 
-**Monetization target:** $1,500-4,000/mo from 5-10 integration partners + research subscriptions.
+3. **SPO Pro ($15-25/mo):** Delegation analytics, competitive intelligence, growth coaching, AI governance statement drafting, rich pool profile with custom branding, advanced communication tools, campaign tools.
 
-**Integration targets (in order of likelihood):**
+4. **Premium Delegator ($5-10/mo):** AI Governance Advisor (enhanced briefings beyond the free Epoch Briefing), advanced alerts (score drops, alignment shifts, unusual patterns), portfolio delegation management, governance participation tracking + exportable records, enhanced Wrapped.
 
-1. Eternl -- most governance-forward wallet
-2. Lace -- IOG's wallet, strategic alignment
-3. Vespr -- growing mobile wallet
-4. DeFi platforms with governance exposure
-5. Stake pool comparison tools (PoolTool, ADApools) -- SPO governance data
+5. **Verified Project ($10-25/project):** Identity verification, enhanced project page, milestone management suite, spending transparency tools, proposal drafting intelligence, pre-proposal validation, priority visibility, verified badge.
+
+**What exists (reuse/modify):**
+
+| Asset                    | Action                                      |
+| ------------------------ | ------------------------------------------- |
+| `ScoreSimulator.tsx`     | **Gate** -- move behind DRep Pro            |
+| `DelegatorAnalytics.tsx` | **Gate** -- enhanced version behind Pro     |
+| `CompetitiveContext.tsx` | **Gate** -- detailed competitive behind Pro |
+| Feature flag system      | **Reuse** -- entitlement-based gating       |
+| `RationaleAssistant.tsx` | **Gate** -- AI enhanced drafting behind Pro |
+
+**Net-new:**
+
+| What                                       | Purpose                                                       |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| Subscription system (Stripe or ADA-native) | Payment processing, plan management, entitlements             |
+| `ProGate.tsx`                              | Paywall component with upgrade CTA                            |
+| `SubscriptionManager.tsx`                  | Billing and plan management UI                                |
+| `AIGovernanceAdvisor.tsx`                  | Premium citizen AI briefing (upsell from free Epoch Briefing) |
+| `ProposalDraftingIntelligence.tsx`         | AI-powered proposal guidance for treasury teams               |
+| `subscriptions` table                      | User subscription state                                       |
+| `subscription_events` table                | Payment history and audit trail                               |
+
+**Free/Pro boundary:** Free = everything needed to govern effectively (voting, rationale, proposal workspace, basic stats, basic identity). Pro = competitive advantage, growth analytics, AI-powered efficiency. Never gate essential governance operations.
+
+**Monetization target:** $4,000-10,000/mo combined from all tiers.
 
 ---
 
-### Step 8: Delegation Network Graph + Influence Mapping (HIGH complexity)
+### Step 9: API Platform & B2B Distribution (MEDIUM complexity)
+
+> **Status: V1 API EXISTS** (11 public routes at `/api/v1/`)
+> **Primary persona:** Integration Partner, Researcher
+
+> **Note:** Informal partner relationships and early API access should begin much earlier (post-Step 3). This step formalizes and scales the integration infrastructure.
 
 **What gets built:**
 
-- Delegation flow visualization: who delegates to whom, power concentration, "kingmaker" wallets
-- DRep influence scoring: how much does a DRep's vote swing outcomes (weighted by voting power + proposal margins)
+1. **API v2 expansion:** Full entity, governance system, proposal, treasury, matching, alignment, and bulk export endpoints (see [researcher.md](personas/researcher.md) for complete API surface specification).
+
+2. **Rate limiting tiers:** Free (100/day), Basic ($50/mo, 10K/day), Pro ($200/mo, 100K/day), Enterprise (custom).
+
+3. **Research tier:** Academic pricing ($50-100/mo), bulk exports (CSV/JSON), versioned datasets, methodology documentation.
+
+4. **Embeddable widgets:** Quick Match, DRep Score card, SPO Governance badge, Governance Health gauge, Delegation Health indicator. Themeable, "Powered by Civica" attribution.
+
+5. **Developer experience:** OpenAPI spec, SDK generation (TypeScript, Python), interactive API explorer, sandbox environment, webhook system for real-time partner notifications.
+
+**What exists (reuse/modify):**
+
+| Asset                               | Action                                         |
+| ----------------------------------- | ---------------------------------------------- |
+| `/api/v1/*` (11 routes)             | **Keep** -- maintain backward compatibility    |
+| `DeveloperPage.tsx` (14.5KB)        | **Modify** -- v2 docs and explorer             |
+| `ApiExplorer.tsx` (12KB)            | **Modify** -- v2 endpoints                     |
+| Embed routes (`/embed/*`)           | **Expand** -- add widget endpoints             |
+| `EmbedDRepCard.tsx`, `EmbedGHI.tsx` | **Modify** -- themeable, attribution framework |
+| Upstash Redis rate limiting         | **Reuse** -- scale for API tiers               |
+
+**Integration priority:** Eternl → Lace → PoolTool → Vespr → CardanoScan → ADApools → Exchanges.
+
+**Monetization target:** $1,500-4,000/mo from API subscriptions + widget licensing.
+
+See [Integration Partner persona doc](personas/integration-partner.md) for full integration model.
+
+---
+
+### Step 10: Advanced Intelligence (HIGH complexity)
+
+> **Status: NOT STARTED**
+> **Primary persona:** All (consumer wow), Integration Partner + Researcher (B2B analytics)
+
+Two major features that require the full data picture:
+
+**10a: Delegation Network Graph + Influence Mapping**
+
+- Delegation flow visualization: power concentration, "kingmaker" wallets, governance factions
+- DRep influence scoring: how much does a vote swing outcomes (weighted by voting power + proposal margins)
 - Delegation cluster detection: groups of wallets delegating to similar DReps (governance factions)
 - Historical delegation migration: where do delegators go when they re-delegate?
-- R3F/WebGL visualization using Constellation architecture
-- "Power map" -- system-wide view of governance power distribution
+- R3F/WebGL visualization using existing Constellation architecture
+- "Power map" -- system-wide governance power distribution
+- SPO-delegator relationships alongside DRep delegation flows
 
-**Why here:** This requires all the foundational data (SPO votes, delegation data, voting power snapshots, inter-body alignment) to be robust. It is the "wow, I can see the entire governance ecosystem" moment. Also feeds into EDI metrics (GHI Power Distribution component) for real-time updates.
-
-- **SPO-delegator relationships** included alongside DRep delegation flows -- the full governance power map shows both delegation and staking governance influence.
-
-**Data modeling milestone:** Begin snapshotting delegation relationships per epoch: `delegation_snapshots(wallet_address, drep_id, epoch, voting_power)`. This is net-new data collection that enables delegation migration analysis.
-
-**Monetization angle:** This is both a consumer "wow" feature and a B2B analytics product. Institutional delegators and governance researchers will pay for this data.
-
----
-
-### Step 9: Governance Simulation Engine (HIGH complexity)
-
-**What gets built:**
+**10b: Governance Simulation Engine**
 
 - "What if" analysis: simulate governance outcomes under different delegation distributions
   - "What if the top 10 DReps had 20% less power?"
@@ -421,44 +729,51 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
   - "What if you re-delegated to DRep Y?"
 - Monte Carlo simulation of proposal outcomes based on current voting patterns + alignment distributions
 - Impact modeling for delegation changes: "if you delegate here, the decentralization index improves by X"
-- **Staking governance simulation:** "what if you moved your stake to SPO Y -- how does their governance alignment compare?"
-- DRep score projection: "if you provide rationales for the next 5 proposals, your score will reach X"
-- SPO score projection: same for pool operators
+- DRep/SPO score projection: "if you provide rationales for the next 5 proposals, your score will reach X"
+- Staking governance simulation: "what if you moved your stake to SPO Y -- how does their governance alignment compare?"
 
-**Why here:** Simulation requires the full data picture: accurate scores, alignment, inter-body alignment, voting power, delegation network. It transforms DRepScore from an observatory into an advisory platform. The user is not just told what happened -- they can explore what COULD happen.
+**What exists (reuse/modify):**
 
-**Monetization angle:** Premium/Pro feature. Institutional delegators making $10M+ delegation decisions will absolutely pay for simulation tools.
+| Asset                                 | Action                                    |
+| ------------------------------------- | ----------------------------------------- |
+| `DelegationGraph.tsx` (12.5KB)        | **Extend** -- full network visualization  |
+| `GlobeConstellation.tsx` (24.4KB)     | **Reuse** -- 3D rendering infrastructure  |
+| `GovernanceConstellation.tsx` (24KB)  | **Reuse** -- node visualization framework |
+| `TreasurySimulator.tsx` (15.8KB)      | **Extend** -- governance simulation       |
+| `ScoreSimulator.tsx`                  | **Extend** -- score projection            |
+| `delegation_snapshots` infrastructure | **Extend** -- per-epoch tracking          |
+
+**Data modeling milestone:** `delegation_snapshots(wallet_address, drep_id, epoch, voting_power)` per epoch. Net-new data collection enabling delegation migration analysis.
+
+**Monetization angle:** Both a consumer "wow" feature and a B2B analytics product. Institutional delegators and governance researchers will pay for this data.
 
 ---
 
-### Step 10: Catalyst Score (HIGH complexity, new product line)
+### Step 11: New Product Lines (HIGH complexity, speculative)
 
-**What gets built:**
+> **Status: NOT STARTED**
+> **Primary persona:** New audiences beyond core Cardano governance
 
-- Apply the DRepScore accountability framework to Project Catalyst:
+**11a: Catalyst Score**
+
+- Accountability framework applied to Project Catalyst:
   - Proposal reviewer scoring (accountability for reviewers)
   - Funded project completion tracking (did they deliver?)
   - Fund allocation analytics and ROI tracking
   - Proposer reputation scores
-- Shared infrastructure: same alignment engine, same scoring patterns, same UI components
-- Cross-pollination: DReps who vote on treasury proposals that fund Catalyst can be evaluated on those outcomes too
-- **Proposer reputation** feeds directly from treasury project profiles (Step 3): teams already have a track record on DRepScore before Catalyst Score even launches
+- Shared infrastructure: same scoring/alignment engine, same UI components
+- Cross-pollination: DReps who vote on treasury proposals that fund Catalyst can be evaluated on those outcomes
+- Proposer reputation from treasury project profiles (Step 8) carries forward
 
-**Why here (not earlier):** Catalyst distributes tens of millions in ADA per fund. The accountability need is enormous. But it is a separate product surface with different data sources and different users. Only tackle it after the core governance product is world-class and generating revenue. The infrastructure (scoring engine, AI, UI patterns) transfers directly.
+**Why here (not earlier):** Catalyst distributes tens of millions in ADA per fund. The accountability need is enormous. But it is a separate product surface with different data sources and different users. Only tackle it after the core governance product is world-class and generating revenue. The infrastructure transfers directly.
 
 **Monetization target:** Separate Catalyst funding proposal + its own SaaS tier.
 
-**Data modeling milestone:** New tables for Catalyst proposals, reviewers, milestones, completion tracking. Potentially new API integrations (Catalyst/IdeaScale data).
+**11b: Cross-Ecosystem Governance Identity**
 
----
-
-### Step 11: Cross-Ecosystem Governance Identity (HIGH complexity, speculative)
-
-**What gets built:**
-
-- Portable governance reputation: a "governance passport" that proves your participation
+- Portable governance reputation: a "governance passport" that proves participation
   - Verifiable credentials for governance actions (votes, delegation, participation streaks)
-  - Cross-chain reputation bridging: if you are an active Cardano governance participant, that reputation travels
+  - Cross-chain reputation bridging: active Cardano governance participation travels
   - Integration with DID (Decentralized Identity) standards
 - Privacy-preserving governance verification (Midnight partnership opportunity):
   - ZK proofs that a DRep voted without revealing how
@@ -466,59 +781,63 @@ The SPO persona mirror. Depends on Step 0 (scoring infrastructure) and Step 2 (S
   - Confidential delegation analytics
 - ENS/.ada integration for governance identity
 
-**Why last:** This is genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, Civica's reputation and data moat make it the natural home for governance identity.
+**Why last:** Genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, Civica's reputation and data moat make it the natural home for governance identity.
 
-**Monetization angle:** This is the "Stripe for blockchain governance" play -- other chains and protocols pay to access governance reputation data.
+**Monetization angle:** The "Stripe for blockchain governance" play -- other chains and protocols pay to access governance reputation data.
 
 ---
 
 ## Monetization Roadmap (Aligned to Build Sequence)
 
-| After Step | Revenue Stream                                                                             | Target                |
-| ---------- | ------------------------------------------------------------------------------------------ | --------------------- |
-| 0-2.5      | **Free forever** -- build userbase across all personas, prove value, secure Catalyst grant | $0/mo + $30-75K grant |
-| 4          | **Wrapped virality** -- organic growth, ecosystem sponsor placements                       | $200-500/mo sponsors  |
-| 5          | **DRep Pro** -- 50-100 paying DReps at $15-25/mo                                           | $1,000-2,500/mo       |
-| 5          | **SPO Pro** -- 50-100 paying SPOs at $15-25/mo                                             | $1,000-2,500/mo       |
-| 5          | **Verified Projects** -- treasury proposal teams at $10-25/project                         | $200-500/mo           |
-| 6          | **Premium Delegator** -- power users tracking governance + staking governance              | $750-2,000/mo         |
-| 7          | **API/B2B** -- wallet integrations, exchanges, pool comparison tools                       | $1,500-4,000/mo       |
-| 7          | **Research Subscriptions** -- academic institutions, professional analysts                 | $200-1,000/mo         |
-| 8-9        | **Enterprise** -- institutional delegation advisory, custom reporting                      | $2,000-5,000/mo       |
-| 10         | **Catalyst Score** -- separate product line with own funding                               | $2,000+/mo            |
-| 11         | **Governance-as-a-Service** -- platform play                                               | TBD                   |
+| After Step | Revenue Stream                                                         | Persona Served         | Target                |
+| ---------- | ---------------------------------------------------------------------- | ---------------------- | --------------------- |
+| 0-4        | **Free forever** -- build userbase, prove value, secure Catalyst grant | All                    | $0/mo + $30-75K grant |
+| 7          | **Wrapped virality** -- organic growth, ecosystem sponsor placements   | Citizens, DReps, SPOs  | $200-500/mo sponsors  |
+| 8          | **DRep Pro** -- competitive analytics + growth tools                   | DReps                  | $1,000-2,500/mo       |
+| 8          | **SPO Pro** -- delegation growth + competitive intelligence            | SPOs                   | $1,000-2,500/mo       |
+| 8          | **Verified Projects** -- identity verification + accountability tools  | Treasury Teams         | $200-500/mo           |
+| 8          | **Premium Delegator** -- AI governance advisor + advanced tracking     | Citizens (power users) | $750-2,000/mo         |
+| 9          | **API/B2B** -- wallet integrations, exchanges, pool tools              | Integration Partners   | $1,500-4,000/mo       |
+| 9          | **Research Subscriptions** -- academic + professional data access      | Researchers            | $200-1,000/mo         |
+| 10         | **Enterprise** -- institutional delegation advisory, custom reporting  | Integration Partners   | $2,000-5,000/mo       |
+| 11a        | **Catalyst Score** -- separate product line with own funding           | New persona            | $2,000+/mo            |
+| 11b        | **Governance-as-a-Service** -- platform play                           | Cross-ecosystem        | TBD                   |
 
 **Cumulative target at full maturity: $12,000-25,000+/mo** -- enough to replace full-time income and build a small team.
 
-**Catalyst funding strategy:** Apply to Fund 16 after Steps 0-2 are live. The proposal writes itself: "We built the most sophisticated governance intelligence platform in crypto, here is the data to prove it, fund us to make it accessible to every ADA holder." Target $75-150K ADA.
+**Catalyst funding strategy:** Apply to Fund 16 with Steps 0-3 live. "We built the most sophisticated governance intelligence platform in crypto. Fund us to make it accessible to every ADA holder." Target $75-150K ADA.
 
 ---
 
 ## The "100/100 Wow" Framework
 
-The wow score is not a number we assign -- it is an emergent property of how well these systems connect. Here is how each step contributes:
+The wow score is an emergent property of how well these systems connect. Here is how each capability contributes:
 
-**Scores that matter (not a vibe):** A DRep profile shows a score that reflects their actual governance behavior -- rationale quality assessed by AI, voting patterns weighted by importance, reliability measured by responsiveness, profile completeness scored by quality. The user trusts this score because it _means something specific and defensible_. (Step 0)
+**A citizen who gets it in 30 seconds:** A new visitor sees two paths: Stake or Govern. They choose Govern, answer 3 questions, see a radar chart form in real-time, match with a DRep who shares their values, and delegate. 90 seconds from stranger to citizen. The next epoch, they open Civica and see: "Your DRep voted Yes on a developer toolkit proposal. Everything's healthy." They close the app, informed and confident. That is the entire citizen product, and it is enough. (Foundation + Step 4)
 
-**Matching that feels magic:** A user answers 3 questions about their governance values and sees a radar chart form in real-time, then 3 DReps appear with confidence scores and dimension-level explanations. Each match card has a "Delegate" button. They tap it, their wallet confirms, confetti flies, and they are a governance participant. 90 seconds from first question to confirmed delegation. (Step 1 + Step 3)
+**Scores that matter (not a vibe):** A DRep profile shows a score reflecting actual governance behavior -- rationale quality assessed by AI, voting patterns weighted by importance, reliability measured by responsiveness. The user trusts this score because it means something specific and defensible. (Foundation)
 
-**Proposal cards that connect everything:** A treasury proposal card shows: "4.2M ADA (0.12% of treasury) -- Your DRep voted Yes -- SPOs voted 60% No -- Similar to 3 past proposals (2 delivered, 1 partial) -- Expires in 2 epochs." Every fact from a different system, unified into one glanceable card. (Steps 2+3)
+**A governance workspace that eliminates context switching:** A DRep reads the AI proposal summary, checks citizen sentiment ("72% support, 31 citizens flagged unclear deliverables"), reviews similar past proposals, writes a rationale (starting from an AI draft), and casts their vote. All on one page. Two minutes, start to finish. No other tool does this. (Steps 5+6)
 
-**Proposal browse cards that preview the intelligence:** Even before clicking into a proposal, the browse card on Discover shows: type badge, treasury amount and % (for withdrawals), tri-body vote indicators (DRep/SPO/CC), your DRep's vote, expiration countdown, and status. The user scans 25 proposals and already understands the governance landscape. Clicking in reveals the full story. (Steps 2+3)
+**Treasury spending you can trace from ADA to impact:** A citizen checks the treasury page: "4M ADA funded Project X. Milestone 3 of 5 complete. 89 citizens use it, 71% say essential. DRep Y voted Yes." Every treasury dollar is traceable from proposal to vote to delivery to citizen impact. (Foundation + Steps 4+6+8)
 
-**An epoch that tells a story:** "Epoch 523: 4 proposals ratified, 12M ADA withdrawn, governance decentralization improved by 3%. Your DRep voted on all 4 and provided rationales for 3. Your governance alignment with DRep X grew 5% this epoch." Personal, contextual, narrative. (Steps 2+4)
+**Proposal cards that connect everything:** A treasury proposal card shows: "4.2M ADA (0.12% of treasury) -- Your DRep voted Yes -- SPOs voted 60% No -- Citizens 73% support -- Similar to 3 past proposals (2 delivered, 1 partial) -- Expires in 2 epochs." Every fact from a different system, unified into one glanceable card. (Foundation + Steps 4+6)
 
-**A DRep profile that reads like a person:** Hero viewport: name, HexScore, Governance Radar, personality narrative, 4 key facts. Below: full record with voting history, treasury track record ("approved 50M ADA, 80% rated as delivered"), inter-body alignment ("agrees with SPOs 70%, CC 40%"), alignment trajectory over 12 months. No other governance platform does this. (Steps 0+2+3)
+**An epoch that tells a story:** "Epoch 523: 4 proposals ratified, 12M ADA withdrawn, governance decentralization improved by 3%. Your DRep voted on all 4 and provided rationales for 3." Personal, contextual, narrative. (Foundation + Steps 4+7)
 
-**A system view that inspires confidence:** Pulse page: GHI at 72 (up 3 this epoch), 7 EDI decentralization metrics, proposal trend analysis, inter-body alignment map, cross-chain comparison, AI-generated State of Governance narrative. You understand the ENTIRE governance ecosystem from one page. (Steps 0+2+3)
+**A DRep profile that reads like a person:** Hero: name, HexScore, Governance Radar, personality narrative, key facts, citizen endorsement count. Below: voting record, treasury track record, inter-body alignment, alignment trajectory. Citizen trust alongside algorithmic score. (Foundation + Steps 4+6)
 
-**The full governance picture:** A proposal page shows three governance bodies side by side: "DReps: 72% Yes. SPOs: 45% Yes. CC: 100% Yes." The inter-body alignment score reveals tension. The AI explains why SPOs might be more cautious. No other tool shows governance from all three angles simultaneously. (Steps 2+2.5+3)
+**A system view that inspires confidence:** Pulse: GHI at 72 (up 3), 7 EDI metrics, proposal trends, inter-body alignment map, cross-chain comparison, AI State of Governance narrative. The entire ecosystem, one page. (Foundation)
 
-**SPOs with a governance reputation:** A stake pool profile shows: SPO Score 88, voted on 95% of proposals, alignment radar showing strong decentralization conviction, inter-body alignment with DReps at 70%. Pool delegators see this and choose their SPO based on governance values, not just ROI. An entirely new decision dimension for staking. (Steps 2.5+3)
+**SPOs with a governance reputation:** A stake pool profile shows: SPO Score 88, governance radar, inter-body alignment, pool mission, team, delegator communication channel. Pool delegators choose based on governance values, not just ROI. No pool comparison tool shows this. (Foundation + Step 4)
 
-**One identity, every role:** You connect your second wallet and suddenly your governance profile expands -- your SPO score appears alongside your DRep score, your Wrapped now includes pool governance, and the AI advisor spots that your DRep votes and SPO votes diverge on treasury proposals. You did not set anything up. You just linked a wallet. The product understood what you are and adapted. This is the "how does it know?" moment for power users -- and it is only possible because of the multi-wallet identity model underneath. (Multi-Wallet Identity + Steps 3-6)
+**The full governance picture:** A proposal page shows three bodies side by side: "DReps: 72% Yes. SPOs: 45% Yes. CC: 100% Yes." Plus citizen sentiment: "73% support, 48 flagged 'too expensive'." The AI explains the tension. No other tool shows governance from all angles simultaneously. (Foundation + Step 6)
 
-**An identity you want to share:** Governance Wrapped card: "You delegated 45,000 ADA to DRep X for 8 epochs. Your DRep voted on 47 proposals, provided rationales for 42, and approved 15M ADA in treasury spending -- 90% was rated as delivered. Your SPO voted on 40 proposals and aligned with your DRep 75% of the time." This is a badge of honor. Users share it unprompted. (Step 4)
+**One identity, every role:** You link your second wallet. Your SPO score appears alongside your DRep score. Your Wrapped now includes pool governance. The AI advisor spots your DRep and SPO votes diverge on treasury proposals. You set nothing up. The product understood and adapted. (Multi-Wallet + Steps 4-8)
+
+**An identity you want to share:** Governance Wrapped: "You've been a Cardano citizen for 100 epochs. Your DRep voted on 47 proposals, approved 15M ADA in treasury spending -- 90% rated as delivered. Your SPO voted on 40 proposals." This is a badge of honor. Users share it unprompted. (Step 7)
+
+**Citizens with a voice:** A citizen votes on proposal sentiment, flags a concern about unclear deliverables, endorses their DRep for treasury oversight, and reports that a funded project they use is essential. Each action took 5 seconds. Each generated data that improved the intelligence engine. The citizen feels heard without writing a single forum post. (Step 6)
 
 ---
 
@@ -526,69 +845,100 @@ The wow score is not a number we assign -- it is an emergent property of how wel
 
 This is the silent engine. Every day the product runs, the moat deepens.
 
-| Snapshot                    | Frequency        | Created At   | Compounds Into                                                |
-| --------------------------- | ---------------- | ------------ | ------------------------------------------------------------- |
-| `drep_score_snapshots`      | Per score change | Step 0       | Score history, momentum, Wrapped, alerts                      |
-| `alignment_snapshots`       | Daily per epoch  | Step 0       | Temporal trajectories, shift detection, Wrapped               |
-| `ghi_snapshots`             | Daily            | Step 0       | GHI trends, epoch recaps, State of Gov                        |
-| `edi_snapshots`             | Daily            | Step 0       | Decentralization dashboard, cross-chain comparison            |
-| `treasury_snapshots`        | Daily            | Existing     | Treasury health, runway, epoch recaps                         |
-| `pools`                     | Per sync         | Step 2       | SPO profiles, SPO discovery, pool comparison                  |
-| `inter_body_alignment`      | Per sync         | Step 2       | Proposal pages, DRep/SPO profiles, governance dynamics        |
-| `proposal_similarity_cache` | Per sync         | Step 2       | Related proposals, trend detection                            |
-| `epoch_recaps`              | Per epoch        | Step 2       | Calendar, Wrapped, AI advisor                                 |
-| `governance_events`         | Per event        | Existing     | Footprint, timeline, Wrapped, notifications                   |
-| `spo_score_snapshots`       | Per score change | Step 2.5     | SPO score history, momentum, SPO Wrapped, alerts              |
-| `spo_alignment_snapshots`   | Daily per epoch  | Step 2.5     | SPO temporal trajectories, shift detection, SPO Wrapped       |
-| `user_governance_profiles`  | Per vote/quiz    | Step 1       | Matching (DRep + SPO), AI advisor, Premium features           |
-| `user_wallets`              | Per link event   | Multi-Wallet | Segment detection, cross-role intelligence, unified footprint |
-| `delegation_snapshots`      | Per epoch        | Step 8       | Network graph, migration analysis, influence                  |
+| Snapshot                     | Frequency        | Created At | Compounds Into                                                |
+| ---------------------------- | ---------------- | ---------- | ------------------------------------------------------------- |
+| `drep_score_snapshots`       | Per score change | Foundation | Score history, momentum, Wrapped, alerts                      |
+| `alignment_snapshots`        | Daily per epoch  | Foundation | Temporal trajectories, shift detection, Wrapped               |
+| `ghi_snapshots`              | Daily            | Foundation | GHI trends, epoch recaps, State of Gov                        |
+| `edi_snapshots`              | Daily            | Foundation | Decentralization dashboard, cross-chain comparison            |
+| `treasury_snapshots`         | Daily            | Foundation | Treasury health, runway, epoch recaps                         |
+| `pools`                      | Per sync         | Foundation | SPO profiles, SPO discovery, pool comparison                  |
+| `inter_body_alignment`       | Per sync         | Foundation | Proposal pages, DRep/SPO profiles, governance dynamics        |
+| `proposal_similarity_cache`  | Per sync         | Foundation | Related proposals, trend detection                            |
+| `epoch_recaps`               | Per epoch        | Foundation | Calendar, Wrapped, AI advisor, **Briefing**                   |
+| `governance_events`          | Per event        | Foundation | Footprint, timeline, Wrapped, notifications                   |
+| `spo_score_snapshots`        | Per score change | Foundation | SPO score history, momentum, SPO Wrapped, alerts              |
+| `spo_alignment_snapshots`    | Daily per epoch  | Foundation | SPO temporal trajectories, shift detection, SPO Wrapped       |
+| `user_governance_profiles`   | Per vote/quiz    | Foundation | Matching (DRep + SPO), AI advisor, Premium features           |
+| `user_wallets`               | Per link event   | Foundation | Segment detection, cross-role intelligence, unified footprint |
+| `citizen_milestones`         | Per milestone    | Step 4     | Civic identity, shareable moments, Wrapped                    |
+| `citizen_briefings`          | Per epoch        | Step 4     | Epoch Briefing, returning user context                        |
+| `governance_actions`         | Per vote cast    | Step 5     | Workspace analytics, rationale tracking, Wrapped              |
+| `rationale_documents`        | Per submission   | Step 5     | CIP-100 rationale hosting, methodology validation             |
+| `citizen_sentiment`          | Per vote         | Step 6     | Proposal intelligence, DRep accountability, briefing          |
+| `citizen_priority_signals`   | Per signal       | Step 6     | Citizen Mandate, trend analysis, proposal relevance           |
+| `citizen_endorsements`       | Per endorsement  | Step 6     | DRep/SPO trust scores, discovery ranking, matching            |
+| `citizen_impact_tags`        | Per tag          | Step 6     | Treasury accountability, project scoring, proposer reputation |
+| `citizen_concern_flags`      | Per flag         | Step 6     | Proposal intelligence, systemic concern detection             |
+| `citizen_assembly_responses` | Per assembly     | Step 6     | Community consensus, governance direction                     |
+| `proposer_profiles`          | Per project      | Step 8     | Treasury team reputation, DRep voting context                 |
+| `citizen_impact_scores`      | Per epoch        | Step 7     | Gamified engagement, shareable moments, retention             |
+| `delegation_snapshots`       | Per epoch        | Step 10    | Network graph, migration analysis, influence                  |
 
-**The compounding insight:** A DRep who has been scored for 50 epochs has a richer profile than one scored for 5. An SPO who has been governance-tracked since day one has a story no latecomer can match. A delegator with 20 quiz answers has a better match than one with 3. An epoch recap for epoch 550 (built on 50 prior recaps) tells a richer story than epoch 500. Time is our advantage. Every day a competitor does NOT collect this data is a day they can never get back.
+**The compounding insight:** A DRep who has been scored for 50 epochs has a richer profile than one scored for 5. A treasury team with three delivered projects has a track record no newcomer can match. A citizen assembly with 20 verdicts creates a precedent library. Time is our advantage. Every day a competitor does NOT collect this data is a day they can never get back.
 
 ---
 
 ## New Integration Opportunities (Beyond Koios)
 
-| Integration                            | What It Unlocks                                      | When                 |
-| -------------------------------------- | ---------------------------------------------------- | -------------------- |
-| **Koios `/vote_list` SPO+CC**          | Tri-body alignment, full governance picture          | Step 2               |
-| **Koios `/pool_list`**                 | Full SPO registry, pool discovery                    | Step 2               |
-| **Koios `/pool_info`**                 | Pool metadata, pledge, margin, governance statements | Step 2               |
-| **Koios `/pool_metadata`**             | Extended pool metadata, off-chain references         | Step 2               |
-| **Koios `/pool_delegators`**           | SPO delegator count, staking governance footprint    | Step 2.5             |
-| **Koios `/pool_voting_power_history`** | SPO governance power over time                       | Step 2.5             |
-| **Koios `account_info` full**          | ADA balance, rewards, wallet footprint               | Step 2               |
-| **Tally API (enhanced)**               | Ethereum delegate power for EDI comparison           | Step 0 (Observatory) |
-| **SubSquare API (enhanced)**           | Polkadot validator power for EDI comparison          | Step 0 (Observatory) |
-| **CIP-100 metadata**                   | On-chain rationale retrieval, hash verification      | Step 0 (DRep Score)  |
-| **Catalyst/IdeaScale**                 | Funded project tracking, reviewer scoring            | Step 10              |
-| **Midnight SDK**                       | ZK governance proofs, privacy features               | Step 11              |
-| **Cardano DB Sync (optional)**         | Deep historical chain data, delegation history       | Step 8               |
+| Integration                            | What It Unlocks                                              | When                |
+| -------------------------------------- | ------------------------------------------------------------ | ------------------- |
+| **Koios `/vote_list` SPO+CC**          | Tri-body alignment, full governance picture                  | Foundation (done)   |
+| **Koios `/pool_list`**                 | Full SPO registry, pool discovery                            | Foundation (done)   |
+| **Koios `/pool_info`**                 | Pool metadata, pledge, margin, governance statements         | Foundation (done)   |
+| **Koios `/pool_metadata`**             | Extended pool metadata, off-chain references                 | Foundation (done)   |
+| **Koios `/pool_delegators`**           | SPO delegator count, staking governance footprint            | Foundation (done)   |
+| **Koios `/pool_voting_power_history`** | SPO governance power over time                               | Foundation (done)   |
+| **Koios `account_info` full**          | ADA balance, rewards, wallet footprint                       | Foundation (done)   |
+| **MeshJS CIP-95**                      | Vote casting, governance transactions                        | Step 5              |
+| **CIP-100 metadata**                   | Rationale retrieval, hash verification, rationale submission | Foundation + Step 5 |
+| **Tally API (enhanced)**               | Ethereum delegate power for EDI comparison                   | Foundation (done)   |
+| **SubSquare API (enhanced)**           | Polkadot validator power for EDI comparison                  | Foundation (done)   |
+| **Catalyst/IdeaScale**                 | Funded project tracking, reviewer scoring                    | Step 11a            |
+| **Midnight SDK**                       | ZK governance proofs, privacy features                       | Step 11b            |
+| **Cardano DB Sync (optional)**         | Deep historical chain data, delegation history               | Step 10             |
 
 ---
 
 ## Competitive Position
 
-No governance product in crypto does what DRepScore will do after this vision is executed. No competitor serves all three governance bodies (DReps, SPOs, CC), scores them, matches users to them, tracks their treasury impact, and wraps it in AI-powered intelligence. The closest comparators:
+No governance product in crypto does what Civica does -- and no competitor CAN, because no competitor has the civic hub where citizens engage and the compounding dataset that makes the intelligence possible.
 
-- **Tally (Ethereum):** Proposal voting interface. No scoring, no matching, no intelligence, no cross-chain. Single governance body only.
-- **SubSquare (Polkadot):** Referendum tracking. Basic analytics. No reputation system. No multi-body analysis.
-- **Snapshot:** Off-chain voting tool. No accountability, no intelligence layer. No on-chain governance data.
-- **DRep.tools:** Basic Cardano DRep listing. No scoring, no matching, no AI, no analytics. DReps only, no SPOs or CC.
-- **PoolTool / ADApools:** Stake pool metrics (uptime, rewards, fees). Zero governance data. The SPO governance layer is a completely untapped opportunity that no pool comparison tool has touched.
+The closest comparators:
 
-Civica's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the notification engine feeds the growth engine. Seven personas served by one interconnected data flywheel. No competitor can replicate this by copying one feature.
+- **Tally (Ethereum):** Proposal voting interface. No scoring, no matching, no intelligence, no community engagement, no cross-chain. Single governance body only.
+- **SubSquare (Polkadot):** Referendum tracking. Basic analytics. No reputation system. No multi-body analysis. No civic engagement layer.
+- **Snapshot:** Off-chain voting tool. No accountability, no intelligence layer. No on-chain governance data. No citizen experience.
+- **DRep.tools:** Basic Cardano DRep listing. No scoring, no matching, no AI, no analytics. DReps only.
+- **PoolTool / ADApools:** Stake pool metrics (uptime, rewards, fees). Zero governance data. The SPO governance layer is a completely untapped opportunity.
+- **GovTool:** Cardano's official governance tool. Handles voting mechanics but has no intelligence layer, no scoring, no matching, no citizen experience, no community engagement. Complementary infrastructure, not a competitor.
+
+Civica's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the community engagement engine feeds the notification engine feeds the growth engine. Six personas served by one interconnected data flywheel, powered by community engagement data no competitor collects. No one can replicate this by copying one feature.
+
+**The civic hub moat:** Even if a competitor replicated every algorithm, they would still lack: (a) the compounding historical dataset, (b) the citizen engagement data, (c) the proposer reputation records, (d) the integration partner ecosystem, and (e) the governance workspace adoption. The moat is not code -- it is the system operating over time.
 
 ---
 
 ## Principles (Non-Negotiable)
 
-1. **Free core, paid power tools.** Never gate: discovery, basic scores, delegation, Quick Match, basic alerts. These are the growth engine and the mission.
-2. **Data is the product.** Open methodology builds trust. Proprietary historical data builds revenue. Never stop collecting.
-3. **Progressive complexity.** Layer 1 must be emotionally complete. No user should NEED to scroll to feel the product is valuable.
-4. **Ship fast, iterate faster.** AI-assisted development means we can move at speeds that make traditional teams look glacial. Every step above is achievable, not aspirational.
-5. **DReps and SPOs are the sales force.** Every DRep who shares their score and every SPO who shares their governance participation is marketing. Make sharing effortless and rewarding.
-6. **Vertical depth over horizontal breadth.** Be THE indispensable governance layer for Cardano. Depth wins.
-7. **Build in public.** Share the roadmap, the methodology, the decisions. Governance participants value transparency.
-8. **Intelligence demands action.** Every insight the product surfaces must connect to something the user can do. A score without a delegation button is just a number. A health warning without a "fix this" CTA is just anxiety. The product's job is not to inform -- it is to empower.
+1. **Citizens first.** Every feature, every surface, every data point ultimately serves the Cardano citizen. Other personas either serve citizens or are accountable to them. When in doubt, ask: "Does this make a citizen's life better?"
+
+2. **Free core, paid power tools.** Never gate: discovery, basic scores, delegation, Quick Match, basic alerts, essential governance operations (voting, rationale submission). These are the growth engine and the mission. Monetize competitive advantage, growth analytics, and AI-powered efficiency -- not core governance.
+
+3. **Data is the product.** Open methodology builds trust. Proprietary historical data builds revenue. Citizen engagement data builds the moat no competitor can cross. Never stop collecting.
+
+4. **Persona-appropriate depth.** Citizens get summary intelligence. DReps get a workspace. SPOs get an identity platform. CC members get a transparency surface. Each persona's primary experience must be emotionally complete for their needs. Different personas need different products, not different depths of the same product.
+
+5. **Intelligence demands action.** Every insight must connect to something the user can do. A score without a delegation button is just a number. A health warning without a "fix this" CTA is just anxiety. A proposal without a vote button is a missed opportunity. Civica is where governance HAPPENS, not just where it is observed.
+
+6. **Accountability is advantage.** Transparency is not imposed -- it is rewarded. DReps who provide rationales score higher. SPOs who participate in governance get discovered. Treasury teams who deliver build reputation. The system creates natural incentives for good governance behavior.
+
+7. **Structured signal over open discourse.** Civic engagement generates analyzable data, not noise. Every citizen interaction feeds the intelligence engine. No forums, no threads, no moderation burden. Structure prevents abuse while preserving meaningful agency.
+
+8. **DReps, SPOs, and Integration Partners are the sales force.** Every DRep who shares their score, every SPO who shares their governance reputation, every wallet that embeds Quick Match is marketing. Make sharing effortless, embedding simple, and attribution clear.
+
+9. **Ship fast, iterate faster.** AI-assisted development means we move at speeds that make traditional teams look glacial. Every step above is achievable, not aspirational.
+
+10. **Vertical depth over horizontal breadth.** Be THE indispensable civic hub for Cardano governance. Depth wins. Do not expand to other chains until Cardano is completely served.
+
+11. **Build in public.** Share the roadmap, the methodology, the decisions. Governance participants value transparency. A governance intelligence platform that is not itself transparent has no credibility.

--- a/docs/strategy/vision-changelog.md
+++ b/docs/strategy/vision-changelog.md
@@ -1,0 +1,30 @@
+# Vision Document Changelog
+
+Track incremental updates to `ultimate-vision.md` and persona docs. Agents should log changes here when updating vision documents.
+
+## Format
+
+```
+### vX.Y -- YYYY-MM-DD
+- **Section:** What changed and why
+```
+
+---
+
+### v2.1 -- 2026-03-07
+
+- **Build sequence:** Complete rewrite grounded in codebase audit. Compressed completed Steps 0-3 into "Foundation" summary with existing infrastructure inventory (269+ components, 145 API routes, 75+ tables, 24 Inngest functions). Renumbered forward steps: Step 4 (Citizen Experience), Step 5 (Governance Workspace), Step 6 (Community Engagement), Step 7 (Viral Growth), Step 8 (Monetization), Step 9 (API Platform), Step 10 (Advanced Intelligence), Step 11 (New Product Lines). Each forward step now specifies: what exists to reuse/modify, what is net-new, primary/secondary personas served.
+- **Monetization Roadmap:** Updated step references to match new numbering. Consolidated DRep Pro + SPO Pro + Premium Delegator + Verified Projects under Step 8.
+- **Wow Framework:** Updated all step references from old numbering (Steps 0-3.75) to new (Foundation + Steps 4-10).
+- **Data Compounding Schedule:** Updated step references. Added new snapshots for Steps 4-7 (citizen_milestones, citizen_briefings, governance_actions, rationale_documents, citizen_concern_flags, citizen_assembly_responses, citizen_impact_scores).
+- **Integration Opportunities:** Marked all Koios integrations as "Foundation (done)". Updated MeshJS CIP-95 to Step 5, Catalyst to Step 11a, Midnight to Step 11b.
+
+### v2.0 -- 2026-03-07
+
+- **Full document:** V2 rewrite. Persona-centric reframe, civic hub thesis, governance workspace, community engagement layer, treasury accountability. Added Steps 3.5 and 3.75 to build sequence. Updated principles from 8 to 11. Expanded data flywheel with civic engagement inputs. Added distribution strategy section.
+- **Personas:** Created 6 persona documents in `docs/strategy/personas/`: citizen, drep, spo, cc-member, treasury-team, researcher, integration-partner. Dropped Cross-Chain Observer persona, added Integration Partner.
+- **Build sequence:** Restored full detail for Steps 8-11 (rationale, monetization angles, data modeling milestones).
+
+### v1.0 -- 2026-03 (original)
+
+- **Full document:** Original vision document. Governance intelligence layer framing, 7 personas, build sequence Steps 0-11, monetization roadmap, wow framework, data compounding schedule, principles.


### PR DESCRIPTION
## Summary

Step 4 of the V2.1 build sequence: rebuild the citizen experience around the **Epoch Briefing** paradigm — summary intelligence, not analytics.

- **Citizen Briefing API** (`/api/briefing/citizen`): aggregates epoch status, DRep performance, treasury snapshot, headlines, and upcoming proposals into one structured response
- **EpochBriefing component**: 5-section personalized governance digest (status banner, what happened, DRep performance, treasury, upcoming) — replaces the old report card dashboard
- **CivicIdentityCard**: progressive civic identity showing citizen-since date, delegation streak, proposals influenced, and ADA governed
- **TreasuryCitizenView**: "Where Your Money Goes" citizen-facing treasury with plain-English framing, runway estimate, and pending proposal previews
- **HomeAnonymous**: simplified two-path entry (Govern + Stake) replacing single CTA, with governance education woven into the landing page
- **HomeCitizen**: delegated citizens see Briefing → Treasury → Identity; undelegated see constellation hero + Quick Match
- **PostHog events**: `citizen_briefing_viewed`, `citizen_path_clicked` for conversion funnel tracking
- **Vision doc v2.1**: persona-driven build sequence rewrite, 7 persona docs, changelog

### Architecture decisions
- Briefing API uses `withRouteHandler` with `auth: 'optional'` — works for both anonymous and authenticated
- DRep resolution chain: `user_wallets.drep_id` → `users.claimed_drep_id` → `delegation_history` → query param
- Health status logic: green (score ≥ 70 + active), yellow (moderate), red (low/inactive)
- All new components use existing TanStack Query hooks — no new API endpoints needed for treasury or identity

## Test plan

- [ ] Verify `/api/briefing/citizen` returns structured response (unauthenticated)
- [ ] Verify `/api/briefing/citizen?drepId=<valid_id>` returns DRep performance data
- [ ] Check delegated citizen home shows EpochBriefing, Treasury, and CivicIdentity sections
- [ ] Check undelegated citizen home shows constellation + Quick Match CTA
- [ ] Check anonymous home shows two-path entry (Govern + Stake)
- [ ] Verify "Govern" path links to `/match`, "Stake" path links to `/discover?tab=pools`
- [ ] Check PostHog events fire in browser devtools (citizen_briefing_viewed, citizen_path_clicked)
- [ ] Verify treasury citizen view shows balance, runway, and pending proposals
- [ ] Build passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)