### PR TITLE
fix: use pool_info for SPO relay geocoding

### DIFF
--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -665,8 +665,8 @@ export const syncSpoScores = inngest.createFunction(
         const poolIds = batch.map((p: { pool_id: string }) => p.pool_id);
 
         try {
-          // Fetch relay info from Koios
-          const relayRes = await fetch(`${KOIOS_BASE}/pool_relays`, {
+          // Fetch relay info from Koios via pool_info (pool_relays is GET-only, no POST RPC)
+          const relayRes = await fetch(`${KOIOS_BASE}/pool_info`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ _pool_bech32_ids: poolIds }),
@@ -674,7 +674,9 @@ export const syncSpoScores = inngest.createFunction(
           });
 
           if (!relayRes.ok) {
-            logger.warn('[sync-spo-scores] Koios pool_relays failed', { status: relayRes.status });
+            logger.warn('[sync-spo-scores] Koios pool_info (relays) failed', {
+              status: relayRes.status,
+            });
             continue;
           }
 


### PR DESCRIPTION
## Summary
- `pool_relays` is a GET-only view in Koios API — POST returns 404
- Switch geocoding step to use `pool_info` which supports POST RPC and includes the same `relays` array
- This was causing the geocode-relay-ips step to silently fail on every sync run

## Test plan
- [ ] Merge and deploy
- [ ] Trigger `drepscore/sync.spo-scores` event via Inngest
- [ ] Verify `pools` table has `relay_lat`/`relay_lon` populated after sync
- [ ] Check globe visualization shows SPOs at real geographic positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)