### PR TITLE
feat: Step 5b — Vote rationale submission (CIP-100)

### DIFF
--- a/app/api/rationale/[hash]/route.ts
+++ b/app/api/rationale/[hash]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Rationale Document Retrieval API
+ * GET: Serves a CIP-100 JSON-LD document by its Blake2b-256 content hash.
+ * This URL is used as the on-chain vote anchor.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ hash: string }> },
+) {
+  const { hash } = await params;
+
+  if (!hash || hash.length < 16) {
+    return NextResponse.json({ error: 'Invalid hash' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('rationale_documents')
+    .select('document')
+    .eq('content_hash', hash)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Rationale not found' }, { status: 404 });
+  }
+
+  return NextResponse.json(data.document, {
+    headers: {
+      'Content-Type': 'application/json+ld',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+}

--- a/app/api/rationale/route.ts
+++ b/app/api/rationale/route.ts
@@ -1,22 +1,71 @@
 /**
- * Rationale Fetch API Route (DEPRECATED)
- *
- * Rationale text is now fetched and cached during the sync cron job.
- * This endpoint is kept as a no-op to avoid 404s from any stale client calls.
+ * Rationale Submission API
+ * POST: Accepts rationale text, builds CIP-100 JSON-LD, stores in Supabase,
+ *       returns the anchor URL and Blake2b-256 hash for on-chain vote anchoring.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { buildAndHashRationale } from '@/lib/rationale';
+import { BASE_URL } from '@/lib/constants';
+import { logger } from '@/lib/logger';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { RationaleSubmitSchema } from '@/lib/api/schemas/governance';
 
 export const dynamic = 'force-dynamic';
 
-export const POST = withRouteHandler(async (request, { requestId }) => {
-  return NextResponse.json(
-    {
-      results: [],
-      message:
-        'Rationale fetching has moved to the sync pipeline. Data is available from Supabase.',
-    },
-    { status: 200 },
-  );
-});
+export const POST = withRouteHandler(
+  async (request: NextRequest, { requestId }: RouteContext) => {
+    const body = RationaleSubmitSchema.parse(await request.json());
+
+    const { document, contentHash } = buildAndHashRationale(body.rationaleText, body.drepId);
+
+    const anchorUrl = `${BASE_URL}/api/rationale/${contentHash}`;
+
+    // Upsert: if same content hash exists, just return the URL
+    const supabase = getSupabaseAdmin();
+    const { error } = await supabase.from('rationale_documents').upsert(
+      {
+        content_hash: contentHash,
+        drep_id: body.drepId,
+        proposal_tx_hash: body.proposalTxHash,
+        proposal_index: body.proposalIndex,
+        document,
+        rationale_text: body.rationaleText,
+      },
+      { onConflict: 'content_hash' },
+    );
+
+    if (error) {
+      logger.error('[Rationale] Failed to store document', { error, requestId });
+      return NextResponse.json({ error: 'Failed to store rationale' }, { status: 500 });
+    }
+
+    logger.info('[Rationale] Document stored', {
+      contentHash,
+      drepId: body.drepId,
+      proposalTxHash: body.proposalTxHash,
+      requestId,
+    });
+
+    captureServerEvent(
+      'rationale_submitted',
+      {
+        drep_id: body.drepId,
+        proposal_tx_hash: body.proposalTxHash,
+        proposal_index: body.proposalIndex,
+        content_hash: contentHash,
+        rationale_length: body.rationaleText.length,
+      },
+      body.drepId,
+    );
+
+    return NextResponse.json({
+      anchorUrl,
+      anchorHash: contentHash,
+      contentHash,
+    });
+  },
+  { auth: 'none', rateLimit: { max: 20, window: 60 } },
+);

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -161,6 +161,9 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         proposalIndex={proposalIndex}
         title={title}
         isOpen={isOpen}
+        proposalAbstract={proposal.abstract}
+        proposalType={proposal.proposalType}
+        aiSummary={proposal.aiSummary}
       />
 
       {/* VP2 stack */}

--- a/components/civica/proposals/VoteCastingPanel.tsx
+++ b/components/civica/proposals/VoteCastingPanel.tsx
@@ -8,6 +8,8 @@ import {
   Loader2,
   AlertTriangle,
   ExternalLink,
+  Sparkles,
+  FileText,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -22,6 +24,10 @@ interface VoteCastingPanelProps {
   proposalIndex: number;
   title: string;
   isOpen: boolean;
+  /** Optional context for AI rationale drafting */
+  proposalAbstract?: string | null;
+  proposalType?: string | null;
+  aiSummary?: string | null;
 }
 
 const VOTE_OPTIONS: {
@@ -122,10 +128,22 @@ function PhaseIndicator({ phase }: { phase: VotePhase }) {
   return null;
 }
 
-export function VoteCastingPanel({ txHash, proposalIndex, title, isOpen }: VoteCastingPanelProps) {
+export function VoteCastingPanel({
+  txHash,
+  proposalIndex,
+  title,
+  isOpen,
+  proposalAbstract,
+  proposalType,
+  aiSummary,
+}: VoteCastingPanelProps) {
   const { connected, ownDRepId } = useWallet();
   const { phase, startVote, confirmVote, reset, isProcessing, canVote } = useVote();
   const [selectedVote, setSelectedVote] = useState<VoteChoice | null>(null);
+  const [rationaleText, setRationaleText] = useState('');
+  const [showRationale, setShowRationale] = useState(false);
+  const [isDrafting, setIsDrafting] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
   const voteCastingEnabled = useFeatureFlag('governance_vote_casting');
 
   // Don't show for closed proposals
@@ -151,13 +169,67 @@ export function VoteCastingPanel({ txHash, proposalIndex, title, isOpen }: VoteC
     startVote({ txHash, txIndex: proposalIndex, title }, 'drep');
   };
 
-  const handleConfirm = () => {
-    if (!selectedVote) return;
-    confirmVote(selectedVote);
+  const handleAiDraft = async () => {
+    if (!ownDRepId) return;
+    setIsDrafting(true);
+    try {
+      const res = await fetch('/api/rationale/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          drepId: ownDRepId,
+          proposalTitle: title,
+          proposalAbstract: proposalAbstract || undefined,
+          proposalType: proposalType || undefined,
+          aiSummary: aiSummary || undefined,
+        }),
+      });
+      if (res.ok) {
+        const { draft } = await res.json();
+        if (draft) setRationaleText(draft);
+      }
+    } finally {
+      setIsDrafting(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedVote || !ownDRepId) return;
+
+    let anchorUrl: string | undefined;
+    let anchorHash: string | undefined;
+
+    // Publish rationale if provided
+    if (rationaleText.trim()) {
+      setIsPublishing(true);
+      try {
+        const res = await fetch('/api/rationale', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            drepId: ownDRepId,
+            proposalTxHash: txHash,
+            proposalIndex,
+            rationaleText: rationaleText.trim(),
+          }),
+        });
+        if (res.ok) {
+          const data = await res.json();
+          anchorUrl = data.anchorUrl;
+          anchorHash = data.anchorHash;
+        }
+      } finally {
+        setIsPublishing(false);
+      }
+    }
+
+    confirmVote(selectedVote, anchorUrl, anchorHash);
   };
 
   const handleReset = () => {
     setSelectedVote(null);
+    setRationaleText('');
+    setShowRationale(false);
     reset();
   };
 
@@ -182,13 +254,13 @@ export function VoteCastingPanel({ txHash, proposalIndex, title, isOpen }: VoteC
                 <button
                   key={value}
                   onClick={() => handleVoteSelect(value)}
-                  disabled={isProcessing}
+                  disabled={isProcessing || isPublishing}
                   className={cn(
                     'flex flex-col items-center gap-1.5 rounded-lg border p-3 transition-all',
                     isSelected
                       ? `${bgColor} ring-2 ring-offset-1 ring-offset-background`
                       : 'border-border hover:bg-muted/30',
-                    isProcessing && 'opacity-50 cursor-not-allowed',
+                    (isProcessing || isPublishing) && 'opacity-50 cursor-not-allowed',
                     isSelected && value === 'Yes' && 'ring-emerald-500/50',
                     isSelected && value === 'No' && 'ring-rose-500/50',
                     isSelected && value === 'Abstain' && 'ring-muted-foreground/50',
@@ -218,12 +290,63 @@ export function VoteCastingPanel({ txHash, proposalIndex, title, isOpen }: VoteC
                 You already voted on this proposal. This will replace your previous vote.
               </div>
             )}
+
+            {/* Rationale section */}
+            {!showRationale ? (
+              <button
+                onClick={() => setShowRationale(true)}
+                className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Add rationale (optional, published on-chain)
+              </button>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    Vote Rationale (CIP-100)
+                  </label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs gap-1"
+                    onClick={handleAiDraft}
+                    disabled={isDrafting}
+                  >
+                    {isDrafting ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Sparkles className="h-3 w-3" />
+                    )}
+                    {isDrafting ? 'Drafting...' : 'AI Draft'}
+                  </Button>
+                </div>
+                <textarea
+                  value={rationaleText}
+                  onChange={(e) => setRationaleText(e.target.value)}
+                  placeholder="Explain your vote. This will be published as a CIP-100 document anchored to your on-chain vote."
+                  className="w-full min-h-[120px] p-3 text-sm border rounded-lg bg-background resize-y focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  maxLength={10000}
+                />
+                <p className="text-xs text-muted-foreground text-right">
+                  {rationaleText.length.toLocaleString()} / 10,000
+                </p>
+              </div>
+            )}
+
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">Estimated fee</span>
               <span className="font-medium">{phase.preflight.estimatedFee}</span>
             </div>
-            <Button onClick={handleConfirm} className="w-full" disabled={!canVote}>
-              Confirm &amp; Sign
+            <Button onClick={handleConfirm} className="w-full" disabled={!canVote || isPublishing}>
+              {isPublishing ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  Publishing rationale...
+                </>
+              ) : (
+                <>Confirm &amp; Sign</>
+              )}
             </Button>
           </div>
         )}

--- a/lib/api/schemas/governance.ts
+++ b/lib/api/schemas/governance.ts
@@ -14,6 +14,13 @@ export const RationaleDraftSchema = z.object({
   aiSummary: z.string().max(5000).optional(),
 });
 
+export const RationaleSubmitSchema = z.object({
+  drepId: DrepIdSchema,
+  proposalTxHash: TxHashSchema,
+  proposalIndex: ProposalIndexSchema,
+  rationaleText: z.string().min(1, 'Rationale text is required').max(10000),
+});
+
 export const PollVoteSchema = z.object({
   proposalTxHash: TxHashSchema,
   proposalIndex: ProposalIndexSchema,

--- a/lib/rationale.ts
+++ b/lib/rationale.ts
@@ -1,0 +1,110 @@
+/**
+ * CIP-100 rationale document builder and Blake2b hashing.
+ * Produces JSON-LD documents compliant with CIP-100 for governance vote anchors.
+ */
+
+import { blake2bHex } from 'blakejs';
+
+// ---------------------------------------------------------------------------
+// CIP-100 JSON-LD envelope
+// ---------------------------------------------------------------------------
+
+const CIP100_CONTEXT = {
+  '@language': 'en-us',
+  CIP100: 'https://github.com/cardano-foundation/CIPs/blob/master/CIP-0100/README.md#',
+  hashAlgorithm: 'CIP100:hashAlgorithm',
+  body: {
+    '@id': 'CIP100:body',
+    '@context': {
+      references: {
+        '@id': 'CIP100:references',
+        '@container': '@set',
+        '@context': {
+          GovernanceMetadataReference: 'CIP100:GovernanceMetadataReference',
+          Other: 'CIP100:Other',
+          label: 'CIP100:reference-label',
+          uri: 'CIP100:reference-uri',
+          referenceHash: {
+            '@id': 'CIP100:referenceHash',
+            '@context': {
+              hashDigest: 'CIP100:hashDigest',
+              hashAlgorithm: 'CIP100:hashAlgorithm',
+            },
+          },
+        },
+      },
+      comment: 'CIP100:comment',
+    },
+  },
+  authors: {
+    '@id': 'CIP100:authors',
+    '@container': '@set',
+    '@context': {
+      name: 'http://xmlns.com/foaf/0.1/name',
+      witness: {
+        '@id': 'CIP100:witness',
+        '@context': {
+          witnessAlgorithm: 'CIP100:witnessAlgorithm',
+          publicKey: 'CIP100:publicKey',
+          signature: 'CIP100:signature',
+        },
+      },
+    },
+  },
+};
+
+export interface Cip100Document {
+  '@context': typeof CIP100_CONTEXT;
+  hashAlgorithm: string;
+  body: {
+    comment: string;
+    references?: Array<{
+      '@type': string;
+      label: string;
+      uri: string;
+    }>;
+  };
+  authors?: Array<{
+    name?: string;
+  }>;
+}
+
+/**
+ * Build a CIP-100 compliant JSON-LD rationale document.
+ */
+export function buildCip100Document(rationaleText: string, drepId?: string): Cip100Document {
+  const doc: Cip100Document = {
+    '@context': CIP100_CONTEXT,
+    hashAlgorithm: 'blake2b-256',
+    body: {
+      comment: rationaleText,
+    },
+  };
+
+  if (drepId) {
+    doc.authors = [{ name: drepId }];
+  }
+
+  return doc;
+}
+
+/**
+ * Compute the Blake2b-256 hash of a CIP-100 document.
+ * The hash is computed over the canonical JSON serialization.
+ */
+export function hashRationale(document: Cip100Document): string {
+  const canonical = JSON.stringify(document);
+  return blake2bHex(canonical, undefined, 32);
+}
+
+/**
+ * Build a CIP-100 document and compute its hash in one call.
+ */
+export function buildAndHashRationale(
+  rationaleText: string,
+  drepId?: string,
+): { document: Cip100Document; contentHash: string } {
+  const document = buildCip100Document(rationaleText, drepId);
+  const contentHash = hashRationale(document);
+  return { document, contentHash };
+}

--- a/supabase/migrations/049_rationale_documents.sql
+++ b/supabase/migrations/049_rationale_documents.sql
@@ -1,0 +1,16 @@
+-- Stores CIP-100 JSON-LD rationale documents submitted by DReps via Civica.
+-- Served at /api/rationale/[hash] as the on-chain vote anchor URL.
+
+CREATE TABLE IF NOT EXISTS rationale_documents (
+  content_hash TEXT PRIMARY KEY,
+  drep_id TEXT NOT NULL,
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INTEGER NOT NULL,
+  document JSONB NOT NULL,
+  rationale_text TEXT NOT NULL,
+  vote_tx_hash TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rationale_documents_drep ON rationale_documents(drep_id);
+CREATE INDEX IF NOT EXISTS idx_rationale_documents_proposal ON rationale_documents(proposal_tx_hash, proposal_index);


### PR DESCRIPTION
## Summary

- **lib/rationale.ts**: CIP-100 JSON-LD document builder + Blake2b-256 hashing (uses existing `blakejs` package)
- **POST /api/rationale**: Accepts rationale text, wraps in CIP-100 envelope, stores in Supabase, returns anchor URL + hash
- **GET /api/rationale/[hash]**: Serves CIP-100 JSON-LD documents by content hash (immutable, cache-forever)
- **VoteCastingPanel**: Optional rationale textarea in confirmation step with AI Draft button (uses existing `/api/rationale/draft` endpoint)
- **Migration 049**: `rationale_documents` table for CIP-100 document storage
- **PostHog**: `rationale_submitted` event tracked server-side

### Flow
1. DRep selects vote → preflight runs
2. In confirmation step, DRep can optionally write rationale (or use AI Draft)
3. On confirm: rationale is published to `/api/rationale`, gets anchor URL + Blake2b hash
4. Vote transaction includes anchor (URL + hash) per CIP-1694 spec
5. Rationale is permanently retrievable at `/api/rationale/{hash}`

## Test plan

- [ ] Preflight passes (format, lint, type-check, 306 tests)
- [ ] CI passes (all checks green)
- [ ] Apply migration 049 via Supabase MCP after merge
- [ ] VoteCastingPanel still gated behind `governance_vote_casting` feature flag
- [ ] Rationale textarea is optional — voting without rationale still works
- [ ] AI Draft button calls existing `/api/rationale/draft` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)