### PR TITLE
feat: Step 5c — Governance statement CIP-100 anchoring + on-chain publish

### DIFF
--- a/app/api/drep/[drepId]/philosophy/route.ts
+++ b/app/api/drep/[drepId]/philosophy/route.ts
@@ -5,6 +5,8 @@ import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
 import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 import { DrepPhilosophySchema } from '@/lib/api/schemas/drep';
+import { buildAndHashRationale } from '@/lib/rationale';
+import { BASE_URL } from '@/lib/constants';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,11 +18,18 @@ export async function GET(
   const supabase = getSupabaseAdmin();
   const { data } = await supabase
     .from('governance_philosophy')
-    .select('philosophy_text, updated_at')
+    .select('philosophy_text, updated_at, anchor_hash')
     .eq('drep_id', drepId)
     .single();
 
-  return NextResponse.json(data || { philosophy_text: null });
+  const anchorUrl = data?.anchor_hash ? `${BASE_URL}/api/rationale/${data.anchor_hash}` : null;
+
+  return NextResponse.json({
+    philosophy_text: data?.philosophy_text ?? null,
+    updated_at: data?.updated_at ?? null,
+    anchor_url: anchorUrl,
+    anchor_hash: data?.anchor_hash ?? null,
+  });
 }
 
 export const POST = withRouteHandler(
@@ -45,9 +54,34 @@ export const POST = withRouteHandler(
       return NextResponse.json({ error: 'Not authorized' }, { status: 403 });
     }
 
+    // Build CIP-100 document and store it
+    const { document, contentHash } = buildAndHashRationale(philosophyText, drepId);
+    const anchorUrl = `${BASE_URL}/api/rationale/${contentHash}`;
+
+    // Store CIP-100 document (idempotent by content hash)
+    await supabase.from('rationale_documents').upsert(
+      {
+        content_hash: contentHash,
+        drep_id: drepId,
+        proposal_tx_hash: 'governance_statement',
+        proposal_index: 0,
+        document,
+        rationale_text: philosophyText,
+      },
+      { onConflict: 'content_hash' },
+    );
+
+    // Save philosophy with anchor reference
     const { data, error } = await supabase
       .from('governance_philosophy')
-      .upsert({ drep_id: drepId, philosophy_text: philosophyText }, { onConflict: 'drep_id' })
+      .upsert(
+        {
+          drep_id: drepId,
+          philosophy_text: philosophyText,
+          anchor_hash: contentHash,
+        },
+        { onConflict: 'drep_id' },
+      )
       .select()
       .single();
 
@@ -56,9 +90,13 @@ export const POST = withRouteHandler(
       return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
     }
 
-    captureServerEvent('philosophy_updated', { drep_id: drepId }, drepId);
+    captureServerEvent('philosophy_updated', { drep_id: drepId, anchor_hash: contentHash }, drepId);
 
-    return NextResponse.json(data);
+    return NextResponse.json({
+      ...data,
+      anchor_url: anchorUrl,
+      anchor_hash: contentHash,
+    });
   },
   { auth: 'none', rateLimit: { max: 20, window: 60 } },
 );

--- a/components/GovernancePhilosophyEditor.tsx
+++ b/components/GovernancePhilosophyEditor.tsx
@@ -1,12 +1,32 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { posthog } from '@/lib/posthog';
 import { getStoredSession } from '@/lib/supabaseAuth';
+import { useWallet } from '@/utils/wallet';
+import { useDRepUpdate } from '@/hooks/useDRepUpdate';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { BookOpen, Save, Loader2, PenLine } from 'lucide-react';
+import {
+  BookOpen,
+  Save,
+  Loader2,
+  PenLine,
+  Globe,
+  CheckCircle2,
+  ExternalLink,
+  AlertCircle,
+  Copy,
+  Check,
+} from 'lucide-react';
+
+interface PhilosophyData {
+  philosophy_text: string | null;
+  updated_at: string | null;
+  anchor_url: string | null;
+  anchor_hash: string | null;
+}
 
 interface GovernancePhilosophyEditorProps {
   drepId: string;
@@ -17,7 +37,11 @@ export function GovernancePhilosophyEditor({
   drepId,
   readOnly = false,
 }: GovernancePhilosophyEditorProps) {
-  const { data: philData, isLoading: loading } = useQuery({
+  const queryClient = useQueryClient();
+  const { connected, ownDRepId } = useWallet();
+  const { phase, publishOnChain, reset, isProcessing, canPublish } = useDRepUpdate();
+
+  const { data: philData, isLoading: loading } = useQuery<PhilosophyData>({
     queryKey: ['drep-philosophy', drepId],
     queryFn: () =>
       fetch(`/api/drep/${encodeURIComponent(drepId)}/philosophy`).then((r) =>
@@ -25,18 +49,26 @@ export function GovernancePhilosophyEditor({
       ),
     enabled: !!drepId,
   });
-  const initialText = (philData as any)?.philosophy_text || '';
+
   const [text, setText] = useState('');
   const [savedText, setSavedText] = useState('');
   const [saving, setSaving] = useState(false);
   const [editing, setEditing] = useState(false);
   const [initialized, setInitialized] = useState(false);
+  const [anchorUrl, setAnchorUrl] = useState<string | null>(null);
+  const [anchorHash, setAnchorHash] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   if (!initialized && philData !== undefined) {
+    const initialText = philData?.philosophy_text || '';
     setText(initialText);
     setSavedText(initialText);
+    setAnchorUrl(philData?.anchor_url ?? null);
+    setAnchorHash(philData?.anchor_hash ?? null);
     setInitialized(true);
   }
+
+  const isOwner = connected && ownDRepId === drepId;
 
   const handleSave = useCallback(async () => {
     const token = getStoredSession();
@@ -49,15 +81,32 @@ export function GovernancePhilosophyEditor({
         body: JSON.stringify({ sessionToken: token, philosophyText: text.trim() }),
       });
       if (res.ok) {
+        const result = await res.json();
         setSavedText(text.trim());
+        setAnchorUrl(result.anchor_url ?? null);
+        setAnchorHash(result.anchor_hash ?? null);
         setEditing(false);
+        reset();
+        queryClient.invalidateQueries({ queryKey: ['drep-philosophy', drepId] });
         posthog.capture('philosophy_saved', { drep_id: drepId, length: text.trim().length });
       }
     } catch {
     } finally {
       setSaving(false);
     }
-  }, [text, drepId]);
+  }, [text, drepId, reset, queryClient]);
+
+  const handlePublish = useCallback(async () => {
+    if (!anchorUrl || !anchorHash) return;
+    await publishOnChain(anchorUrl, anchorHash);
+  }, [anchorUrl, anchorHash, publishOnChain]);
+
+  const handleCopyHash = useCallback(() => {
+    if (!anchorHash) return;
+    navigator.clipboard.writeText(anchorHash).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [anchorHash]);
 
   if (loading) {
     return (
@@ -85,8 +134,14 @@ export function GovernancePhilosophyEditor({
             Governance Philosophy
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
           <p className="text-sm text-muted-foreground whitespace-pre-wrap">{savedText}</p>
+          {anchorHash && (
+            <p className="text-xs text-muted-foreground flex items-center gap-1">
+              <CheckCircle2 className="h-3 w-3 text-green-500" />
+              CIP-100 anchored
+            </p>
+          )}
         </CardContent>
       </Card>
     );
@@ -112,7 +167,7 @@ export function GovernancePhilosophyEditor({
           )}
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-3">
         {!savedText && !editing ? (
           <div className="text-center py-3 space-y-2">
             <p className="text-xs text-muted-foreground">Tell delegators what you stand for.</p>
@@ -132,35 +187,120 @@ export function GovernancePhilosophyEditor({
               placeholder="Describe your governance values, priorities, and approach..."
               value={text}
               onChange={(e) => setText(e.target.value)}
+              maxLength={10000}
             />
-            <div className="flex justify-end gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  setText(savedText);
-                  setEditing(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                className="gap-1.5"
-                onClick={handleSave}
-                disabled={saving || !text.trim()}
-              >
-                {saving ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Save className="h-3 w-3" />
-                )}{' '}
-                Save
-              </Button>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">{text.length}/10,000</span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setText(savedText);
+                    setEditing(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={handleSave}
+                  disabled={saving || !text.trim()}
+                >
+                  {saving ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Save className="h-3 w-3" />
+                  )}{' '}
+                  Save
+                </Button>
+              </div>
             </div>
           </div>
         ) : (
           <p className="text-sm text-muted-foreground whitespace-pre-wrap">{savedText}</p>
+        )}
+
+        {/* Anchor info + Publish On-Chain (only for owner with saved text) */}
+        {isOwner && savedText && !editing && anchorHash && (
+          <div className="border-t pt-3 space-y-2">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <CheckCircle2 className="h-3 w-3 text-green-500 shrink-0" />
+              <span>CIP-100 document ready</span>
+              <button
+                onClick={handleCopyHash}
+                className="ml-auto flex items-center gap-1 hover:text-foreground transition-colors"
+                title="Copy content hash"
+              >
+                {copied ? (
+                  <Check className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+                <span className="font-mono">{anchorHash.slice(0, 12)}...</span>
+              </button>
+            </div>
+
+            {/* Publish on-chain button */}
+            {phase.status === 'idle' && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full gap-1.5 text-xs"
+                onClick={handlePublish}
+                disabled={!canPublish || isProcessing}
+              >
+                <Globe className="h-3 w-3" />
+                Publish On-Chain
+              </Button>
+            )}
+
+            {/* Processing states */}
+            {isProcessing && (
+              <Button size="sm" variant="outline" className="w-full gap-1.5 text-xs" disabled>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {phase.status === 'building'
+                  ? 'Building transaction...'
+                  : phase.status === 'signing'
+                    ? 'Waiting for wallet signature...'
+                    : 'Submitting to network...'}
+              </Button>
+            )}
+
+            {/* Success */}
+            {phase.status === 'success' && (
+              <div className="rounded-md bg-green-500/10 border border-green-500/20 p-2 space-y-1">
+                <p className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Published on-chain!
+                </p>
+                <a
+                  href={`https://cexplorer.io/tx/${phase.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  View transaction
+                </a>
+              </div>
+            )}
+
+            {/* Error */}
+            {phase.status === 'error' && (
+              <div className="rounded-md bg-destructive/10 border border-destructive/20 p-2 space-y-1">
+                <p className="text-xs text-destructive flex items-center gap-1">
+                  <AlertCircle className="h-3 w-3" />
+                  {phase.message}
+                </p>
+                <p className="text-xs text-muted-foreground">{phase.hint}</p>
+                <Button size="sm" variant="ghost" className="h-6 px-2 text-xs" onClick={reset}>
+                  Try again
+                </Button>
+              </div>
+            )}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -404,7 +404,7 @@ The backend intelligence engine and core frontend are production-grade. This fou
 
 ### Step 4: Citizen Experience & Acquisition Funnel (MEDIUM complexity)
 
-> **Status: NOT STARTED**
+> **Status: SHIPPED** (PR #141, 2026-03-07)
 > **Primary persona:** Citizen (ADA Holder)
 > **Secondary impact:** All personas (improved onboarding benefits everyone)
 
@@ -462,7 +462,7 @@ The on-ramp. Without a clear, unintimidating path from "I hold ADA" to "I'm a Ca
 
 ### Step 5: Governance Workspace (MEDIUM-HIGH complexity)
 
-> **Status: NOT STARTED**
+> **Status: IN PROGRESS** -- 5a Vote Casting (PR #143), 5b Rationale Submission (PR #145), 5c Governance Statement shipped. 5d/5e pending.
 > **Primary persona:** DRep, SPO
 > **Secondary impact:** Citizen (more rationales = better transparency), Researcher (richer data)
 

--- a/hooks/useDRepUpdate.ts
+++ b/hooks/useDRepUpdate.ts
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useWallet } from '@/utils/wallet';
+import { checkGovernanceSupport } from '@/lib/delegation';
+import { updateDRepMetadata, DRepUpdateError, type DRepUpdateResult } from '@/lib/drepUpdate';
+
+export type DRepUpdatePhase =
+  | { status: 'idle' }
+  | { status: 'building' }
+  | { status: 'signing' }
+  | { status: 'submitting' }
+  | { status: 'success'; txHash: string }
+  | { status: 'error'; code: string; message: string; hint: string };
+
+export function useDRepUpdate() {
+  const { wallet, walletName, connected, ownDRepId } = useWallet();
+  const [phase, setPhase] = useState<DRepUpdatePhase>({ status: 'idle' });
+
+  const publishOnChain = useCallback(
+    async (anchorUrl: string, anchorHash: string): Promise<DRepUpdateResult | null> => {
+      if (!wallet || !connected) {
+        setPhase({
+          status: 'error',
+          code: 'no_wallet',
+          message: 'Wallet not connected',
+          hint: 'Connect your wallet to publish on-chain.',
+        });
+        return null;
+      }
+
+      if (!ownDRepId) {
+        setPhase({
+          status: 'error',
+          code: 'no_drep_credential',
+          message: 'Not registered as a DRep',
+          hint: 'You must be a registered DRep to update your metadata anchor.',
+        });
+        return null;
+      }
+
+      if (walletName) {
+        const govCheck = checkGovernanceSupport(walletName);
+        if (!govCheck.supported) {
+          setPhase({
+            status: 'error',
+            code: 'wallet_unsupported',
+            message: 'Wallet does not support governance transactions.',
+            hint: govCheck.hint || 'Try Eternl or Lace.',
+          });
+          return null;
+        }
+      }
+
+      try {
+        const result = await updateDRepMetadata(wallet, ownDRepId, anchorUrl, anchorHash, {
+          onPhase: (p) => setPhase({ status: p }),
+        });
+
+        setPhase({ status: 'success', txHash: result.txHash });
+
+        import('@/lib/posthog')
+          .then(({ posthog }) => {
+            posthog.capture('drep_metadata_updated', {
+              drep_id: ownDRepId,
+              anchor_url: anchorUrl,
+              tx_hash: result.txHash,
+            });
+          })
+          .catch(() => {});
+
+        return result;
+      } catch (err) {
+        if (err instanceof DRepUpdateError) {
+          setPhase({ status: 'error', code: err.code, message: err.message, hint: err.hint });
+        } else {
+          setPhase({
+            status: 'error',
+            code: 'unknown',
+            message: String(err),
+            hint: 'Something went wrong. Please try again.',
+          });
+        }
+        return null;
+      }
+    },
+    [wallet, walletName, connected, ownDRepId],
+  );
+
+  const reset = useCallback(() => {
+    setPhase({ status: 'idle' });
+  }, []);
+
+  const isProcessing =
+    phase.status === 'building' || phase.status === 'signing' || phase.status === 'submitting';
+
+  return {
+    phase,
+    publishOnChain,
+    reset,
+    isProcessing,
+    canPublish: connected && !!wallet && !!ownDRepId,
+  };
+}

--- a/lib/drepUpdate.ts
+++ b/lib/drepUpdate.ts
@@ -1,0 +1,139 @@
+/**
+ * DRep metadata update transaction builder.
+ * Constructs a CIP-1694 DRep update certificate with a CIP-100 metadata anchor,
+ * using MeshJS for transaction building, signing, and submission.
+ *
+ * Follows the same pattern as lib/voting.ts.
+ */
+
+import { MeshTxBuilder, KoiosProvider, BrowserWallet } from '@meshsdk/core';
+
+const provider = new KoiosProvider('api');
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+export type DRepUpdateErrorCode =
+  | 'no_wallet'
+  | 'no_drep_credential'
+  | 'user_rejected'
+  | 'insufficient_funds'
+  | 'tx_build_failed'
+  | 'tx_submit_failed'
+  | 'wallet_unsupported'
+  | 'unknown';
+
+export class DRepUpdateError extends Error {
+  code: DRepUpdateErrorCode;
+  hint: string;
+
+  constructor(code: DRepUpdateErrorCode, message: string, hint: string) {
+    super(message);
+    this.name = 'DRepUpdateError';
+    this.code = code;
+    this.hint = hint;
+  }
+}
+
+function classifyError(err: unknown): DRepUpdateError {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+
+  if (
+    lower.includes('user') &&
+    (lower.includes('reject') || lower.includes('cancel') || lower.includes('declined'))
+  ) {
+    return new DRepUpdateError('user_rejected', msg, 'No worries — you can publish anytime.');
+  }
+  if (lower.includes('insufficient') || lower.includes('not enough') || lower.includes('utxo')) {
+    return new DRepUpdateError(
+      'insufficient_funds',
+      msg,
+      'You need ADA to cover the transaction fee (~0.2 ADA).',
+    );
+  }
+  if (
+    lower.includes('not supported') ||
+    lower.includes('not implemented') ||
+    lower.includes('api.get')
+  ) {
+    return new DRepUpdateError(
+      'wallet_unsupported',
+      msg,
+      'Your wallet may not support governance transactions. Try Eternl or Lace.',
+    );
+  }
+  return new DRepUpdateError('unknown', msg, 'Something went wrong. Please try again.');
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DRepUpdateResult {
+  txHash: string;
+  anchorUrl: string;
+  anchorHash: string;
+}
+
+export type DRepUpdatePhaseCallback = (phase: 'building' | 'signing' | 'submitting') => void;
+
+// ---------------------------------------------------------------------------
+// Transaction builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build, sign, and submit a DRep metadata update transaction.
+ * This updates the DRep's on-chain metadata anchor to point to
+ * a CIP-100 governance statement document.
+ */
+export async function updateDRepMetadata(
+  wallet: BrowserWallet,
+  drepId: string,
+  anchorUrl: string,
+  anchorHash: string,
+  options?: {
+    onPhase?: DRepUpdatePhaseCallback;
+  },
+): Promise<DRepUpdateResult> {
+  try {
+    options?.onPhase?.('building');
+
+    const utxos = await wallet.getUtxos();
+    const changeAddress = await wallet.getChangeAddress();
+
+    if (!utxos || utxos.length === 0) {
+      throw new DRepUpdateError(
+        'insufficient_funds',
+        'No UTXOs found in wallet.',
+        'Your wallet needs ADA to pay for the transaction fee.',
+      );
+    }
+
+    const anchor = {
+      anchorUrl,
+      anchorDataHash: anchorHash,
+    };
+
+    const txBuilder = new MeshTxBuilder({ fetcher: provider });
+
+    txBuilder
+      .drepUpdateCertificate(drepId, anchor)
+      .changeAddress(changeAddress)
+      .selectUtxosFrom(utxos);
+
+    const unsignedTx = await txBuilder.complete();
+
+    options?.onPhase?.('signing');
+    const signedTx = await wallet.signTx(unsignedTx);
+
+    options?.onPhase?.('submitting');
+    const txHash = await wallet.submitTx(signedTx);
+
+    return { txHash, anchorUrl, anchorHash };
+  } catch (err) {
+    if (err instanceof DRepUpdateError) throw err;
+    throw classifyError(err);
+  }
+}

--- a/supabase/migrations/050_governance_philosophy_anchor.sql
+++ b/supabase/migrations/050_governance_philosophy_anchor.sql
@@ -1,0 +1,6 @@
+-- Add anchor_hash column to governance_philosophy table.
+-- Links a DRep's governance statement to its CIP-100 document
+-- stored in rationale_documents.
+
+ALTER TABLE governance_philosophy
+  ADD COLUMN IF NOT EXISTS anchor_hash TEXT;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1698,16 +1698,19 @@ export type Database = {
       };
       governance_philosophy: {
         Row: {
+          anchor_hash: string | null;
           drep_id: string;
           philosophy_text: string;
           updated_at: string | null;
         };
         Insert: {
+          anchor_hash?: string | null;
           drep_id: string;
           philosophy_text: string;
           updated_at?: string | null;
         };
         Update: {
+          anchor_hash?: string | null;
           drep_id?: string;
           philosophy_text?: string;
           updated_at?: string | null;


### PR DESCRIPTION
## Summary
- **DRep metadata update transaction builder** (`lib/drepUpdate.ts`) using MeshJS `drepUpdateCertificate` with CIP-100 anchor
- **React hook** (`hooks/useDRepUpdate.ts`) for the full DRep metadata update lifecycle (build → sign → submit)
- **Philosophy API** now generates CIP-100 JSON-LD document on save, stores in `rationale_documents`, returns anchor URL + hash
- **GovernancePhilosophyEditor** enhanced with "Publish On-Chain" button, transaction status UI, anchor hash display with copy
- **Migration 050**: adds `anchor_hash` column to `governance_philosophy`
- **Vision doc**: Step 4 marked SHIPPED, Step 5 marked IN PROGRESS

## Flow
1. DRep writes/edits governance philosophy → Save
2. API builds CIP-100 envelope, hashes with Blake2b-256, stores document
3. UI shows "CIP-100 document ready" with content hash
4. DRep clicks "Publish On-Chain" → MeshJS builds `drepUpdateCertificate` tx → wallet signs → submits
5. On-chain DRep metadata now points to `drepscore.io/api/rationale/{hash}`

## Test plan
- [ ] Verify preflight passes (format, lint, types, tests)
- [ ] Verify CI passes (build)
- [ ] Test philosophy save returns `anchor_url` and `anchor_hash`
- [ ] Test CIP-100 document stored in `rationale_documents` and servable via GET `/api/rationale/{hash}`
- [ ] Test "Publish On-Chain" button appears for DRep owners with saved philosophy
- [ ] Test transaction flow with governance-capable wallet (Eternl/Lace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)