### PR TITLE
feat: Step 4 foundations — citizen briefings, milestones, PostHog funnel

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -31,6 +31,7 @@ import { notifyEpochRecap } from '@/inngest/functions/notify-epoch-recap';
 import { syncDataMoat } from '@/inngest/functions/sync-data-moat';
 import { syncCatalyst } from '@/inngest/functions/sync-catalyst';
 import { syncCcRationales } from '@/inngest/functions/sync-cc-rationales';
+import { generateCitizenBriefings } from '@/inngest/functions/generate-citizen-briefings';
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -66,5 +67,6 @@ export const { GET, POST, PUT } = serve({
     syncDataMoat,
     syncCatalyst,
     syncCcRationales,
+    generateCitizenBriefings,
   ],
 });

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -27,6 +27,7 @@ import { Badge } from '@/components/ui/badge';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
 import { RadarOverlay } from '@/components/matching/RadarOverlay';
 import { cn } from '@/lib/utils';
+import { usePostHog } from 'posthog-js/react';
 import { DelegateButton } from '@/components/DelegateButton';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import { saveMatchProfile, loadMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
@@ -160,6 +161,7 @@ export function QuickMatchFlow() {
   const [matchType, setMatchType] = useState<MatchType>('drep');
   const [storedProfile, setStoredProfile] = useState<StoredMatchProfile | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const posthog = usePostHog();
 
   // Load stored match profile on mount
   useEffect(() => {
@@ -283,7 +285,10 @@ export function QuickMatchFlow() {
       <div className="flex-1 flex items-center justify-center px-4 py-8">
         {step === 'intro' && (
           <IntroScreen
-            onStart={() => setStep(0)}
+            onStart={() => {
+              posthog?.capture('quick_match_started', { match_type: matchType });
+              setStep(0);
+            }}
             matchType={matchType}
             onMatchTypeChange={setMatchType}
             storedProfile={storedProfile}

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -2,8 +2,8 @@
 
 > **Status:** Active north star -- all build decisions, monetization timing, and architecture choices should align with this document.
 > **Created:** March 2026
-> **Version:** 2.1
-> **Last updated:** 2026-03-07 (V2.1: build sequence rewritten from scratch -- compressed foundation Steps 0-3, persona-driven Steps 4-11 grounded in codebase audit of 269+ components, 145 API routes, 75+ tables, 24 Inngest functions)
+> **Version:** 2.2
+> **Last updated:** 2026-03-07 (V2.2: Step 4 infrastructure shipped -- citizen_milestones table, simplified_onboarding flag, generate-citizen-briefings Inngest function, PostHog conversion funnel wired, codebase audit corrections)
 > **Supersedes:** V1 of this document. Persona deep dives live in `docs/strategy/personas/`.
 > **Living document:** Agents should update status markers, progress annotations, and minor refinements as work proceeds. Log changes in `docs/strategy/vision-changelog.md`. Increment minor version (2.1, 2.2...) for progress updates; reserve major version (3.0) for strategic pivots.
 
@@ -404,7 +404,7 @@ The backend intelligence engine and core frontend are production-grade. This fou
 
 ### Step 4: Citizen Experience & Acquisition Funnel (MEDIUM complexity)
 
-> **Status: SHIPPED** (PR #141, 2026-03-07)
+> **Status: FOUNDATIONS SHIPPED** -- Core components (EpochBriefing, CivicIdentityCard, TreasuryCitizenView) already built in Step 3. Step 4 infrastructure complete: `citizen_milestones` table, `simplified_onboarding` flag, `generate-citizen-briefings` Inngest function, PostHog conversion funnel wired. UX refinement and A/B testing remain.
 > **Primary persona:** Citizen (ADA Holder)
 > **Secondary impact:** All personas (improved onboarding benefits everyone)
 
@@ -443,18 +443,26 @@ The on-ramp. Without a clear, unintimidating path from "I hold ADA" to "I'm a Ca
 | Notification system (`check-notifications` Inngest) | **Modify** -- add citizen alert triggers                           |
 | `detect-alignment-drift` Inngest function           | **Reuse** -- drift detection for alerts                            |
 
-**Net-new:**
+**Already built (moved from net-new):**
 
-| What                                       | Purpose                                                         |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `EpochBriefing.tsx`                        | Core citizen briefing component (AI-generated, epoch-cycle)     |
-| `CivicIdentityCard.tsx`                    | Citizen identity: since-date, streaks, milestones, footprint    |
-| `TreasuryCitizenView.tsx`                  | "Where your money goes" with proportional share calculation     |
-| `SmartAlertManager.tsx`                    | Alert routing: detect triggers → filter by preference → deliver |
-| `citizen_milestones` table                 | Track milestone achievements per user                           |
-| `citizen_briefings` table                  | Cache generated briefings per user per epoch                    |
-| `simplified_onboarding` feature flag       | A/B test simplified vs current anonymous UX                     |
-| `generate-epoch-briefing` Inngest function | Batch-generate citizen briefings at epoch boundary              |
+| What                                          | Status                                                                                                     |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `EpochBriefing.tsx`                           | **EXISTS** -- `components/civica/home/EpochBriefing.tsx`, uses `/api/briefing/citizen`                     |
+| `CivicIdentityCard.tsx`                       | **EXISTS** -- `components/civica/shared/CivicIdentityCard.tsx`, uses footprint API                         |
+| `TreasuryCitizenView.tsx`                     | **EXISTS** -- `components/civica/home/TreasuryCitizenView.tsx`                                             |
+| `citizen_milestones` table                    | **SHIPPED** -- migration 051, tracks per-user milestone achievements                                       |
+| `simplified_onboarding` feature flag          | **SHIPPED** -- migration 051, ready for A/B testing                                                        |
+| `generate-citizen-briefings` Inngest function | **SHIPPED** -- triggered by `drepscore/epoch.transition`, batch-generates per user                         |
+| PostHog conversion funnel                     | **WIRED** -- full funnel: path_clicked → match_started → completed → wallet_opened → connected → delegated |
+
+**Remaining net-new:**
+
+| What                                    | Purpose                                                          |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `SmartAlertManager.tsx`                 | Alert routing: detect triggers → filter by preference → deliver  |
+| Citizen milestone detection logic       | Detect and award milestones (delegation streaks, vote influence) |
+| Treasury "your proportional share" calc | Personalized share framing in TreasuryCitizenView                |
+| UX copy optimization + A/B testing      | Simplified onboarding messaging variants                         |
 
 **Persona-appropriate surfaces:** After wallet connection, the citizen sees the briefing (not a dashboard). DReps see their governance inbox. SPOs see their pool identity. Each persona's "home" is designed for them.
 

--- a/docs/strategy/vision-changelog.md
+++ b/docs/strategy/vision-changelog.md
@@ -11,6 +11,15 @@ Track incremental updates to `ultimate-vision.md` and persona docs. Agents shoul
 
 ---
 
+### v2.2 -- 2026-03-07
+
+- **Step 4 audit:** Codebase audit revealed that Step 4 "net-new" items EpochBriefing.tsx, CivicIdentityCard.tsx, and TreasuryCitizenView.tsx were already built during Step 3. Moved to "already built" section.
+- **Step 4 infrastructure:** Shipped `citizen_milestones` table (migration 051), `simplified_onboarding` feature flag, `generate-citizen-briefings` Inngest function (triggered by `drepscore/epoch.transition`).
+- **PostHog funnel:** Verified full conversion funnel is wired: citizen_path_clicked → quick_match_started → quick_match_completed → wallet_modal_opened → wallet_connected → delegation_completed.
+- **Step 1 audit:** Confirmed `match_type` parameter already exists in `/api/governance/quick-match` route — supports both DRep and SPO matching. Vision description was accurate.
+- **SPO snapshot audit:** Confirmed `sync-spo-scores` already writes to `spo_score_snapshots` and `spo_alignment_snapshots` with completeness logging. No gap existed.
+- **Step 4 status:** Updated from "NOT STARTED" to "FOUNDATIONS SHIPPED" — remaining work is UX refinement, A/B testing, SmartAlertManager, and milestone detection logic.
+
 ### v2.1 -- 2026-03-07
 
 - **Build sequence:** Complete rewrite grounded in codebase audit. Compressed completed Steps 0-3 into "Foundation" summary with existing infrastructure inventory (269+ components, 145 API routes, 75+ tables, 24 Inngest functions). Renumbered forward steps: Step 4 (Citizen Experience), Step 5 (Governance Workspace), Step 6 (Community Engagement), Step 7 (Viral Growth), Step 8 (Monetization), Step 9 (API Platform), Step 10 (Advanced Intelligence), Step 11 (New Product Lines). Each forward step now specifies: what exists to reuse/modify, what is net-new, primary/secondary personas served.

--- a/inngest/functions/generate-citizen-briefings.ts
+++ b/inngest/functions/generate-citizen-briefings.ts
@@ -1,0 +1,131 @@
+/**
+ * Generate Citizen Briefings — runs after epoch transition (triggered by
+ * generate-epoch-summary), batch-generates personalized briefings for
+ * active citizen users and stores them in governance_briefs.
+ *
+ * This enables push notifications with pre-computed content and faster
+ * initial load of the Epoch Briefing component (cache hit instead of
+ * on-the-fly generation).
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { assembleHolderBriefContext, generateHolderBrief, storeBrief } from '@/lib/governanceBrief';
+import { errMsg } from '@/lib/sync-utils';
+import { logger } from '@/lib/logger';
+
+const USER_BATCH = 25;
+
+export const generateCitizenBriefings = inngest.createFunction(
+  {
+    id: 'generate-citizen-briefings',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"citizen-briefings"' },
+  },
+  { event: 'drepscore/epoch.transition' },
+  async ({ event, step }) => {
+    const epoch = event.data?.epoch as number | undefined;
+    if (!epoch) {
+      logger.warn('[citizen-briefings] No epoch in event data');
+      return { skipped: true, reason: 'no epoch' };
+    }
+
+    const users = await step.run('fetch-active-citizens', async () => {
+      const supabase = getSupabaseAdmin();
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, wallet_address, delegation_history')
+        .gte('last_visit_at', thirtyDaysAgo);
+
+      if (error) {
+        logger.error('[citizen-briefings] Failed to fetch users', { error });
+        return [];
+      }
+
+      return (data ?? []).map((u) => ({
+        id: u.id as string,
+        wallet: u.wallet_address as string,
+        drepId: extractDrepId(u.delegation_history),
+      }));
+    });
+
+    if (users.length === 0) {
+      return { skipped: true, reason: 'no active users' };
+    }
+
+    // Process users in batches to stay under Cloudflare 60s timeout
+    let generated = 0;
+    let failed = 0;
+
+    for (let i = 0; i < users.length; i += USER_BATCH) {
+      const batchIndex = Math.floor(i / USER_BATCH);
+      const batch = users.slice(i, i + USER_BATCH);
+
+      const batchResult = await step.run(`generate-batch-${batchIndex}`, async () => {
+        let batchGenerated = 0;
+        let batchFailed = 0;
+
+        for (const user of batch) {
+          try {
+            // Check if briefing already exists for this epoch
+            const supabase = getSupabaseAdmin();
+            const { data: existing } = await supabase
+              .from('governance_briefs')
+              .select('id')
+              .eq('user_id', user.id)
+              .eq('brief_type', 'citizen')
+              .eq('epoch', epoch)
+              .maybeSingle();
+
+            if (existing) {
+              batchGenerated++; // Already generated
+              continue;
+            }
+
+            // Assemble context and generate
+            const ctx = await assembleHolderBriefContext(user.id, user.drepId);
+
+            if (!ctx) {
+              batchFailed++;
+              continue;
+            }
+
+            const brief = generateHolderBrief(ctx);
+            await storeBrief(user.id, 'citizen', brief, epoch);
+            batchGenerated++;
+          } catch (err) {
+            logger.warn('[citizen-briefings] Failed for user', {
+              userId: user.id,
+              error: errMsg(err),
+            });
+            batchFailed++;
+          }
+        }
+
+        return { generated: batchGenerated, failed: batchFailed };
+      });
+
+      generated += batchResult.generated;
+      failed += batchResult.failed;
+    }
+
+    logger.info('[citizen-briefings] Completed', {
+      epoch,
+      totalUsers: users.length,
+      generated,
+      failed,
+    });
+
+    return { epoch, totalUsers: users.length, generated, failed };
+  },
+);
+
+function extractDrepId(history: unknown): string | null {
+  if (!Array.isArray(history) || history.length === 0) return null;
+  const latest = history[history.length - 1];
+  return typeof latest === 'object' && latest !== null && 'drepId' in latest
+    ? (latest as { drepId: string }).drepId
+    : null;
+}

--- a/inngest/functions/generate-epoch-summary.ts
+++ b/inngest/functions/generate-epoch-summary.ts
@@ -703,6 +703,12 @@ export const generateEpochSummary = inngest.createFunction(
       }
     });
 
+    // Trigger citizen briefing generation for the new epoch
+    await step.sendEvent('trigger-citizen-briefings', {
+      name: 'drepscore/epoch.transition',
+      data: { epoch: epochInfo.currentEpoch, previousEpoch: epoch },
+    });
+
     logger.info('[epoch-summary] Epoch summary generated', { epoch, usersProcessed });
     return {
       epoch,

--- a/lib/governanceBrief.ts
+++ b/lib/governanceBrief.ts
@@ -327,7 +327,7 @@ function generateHolderBriefTemplate(ctx: HolderBriefContext): GeneratedBrief {
 
 export async function storeBrief(
   userId: string,
-  briefType: 'drep' | 'holder',
+  briefType: 'drep' | 'holder' | 'citizen',
   content: GeneratedBrief,
   epoch: number,
 ): Promise<string | null> {

--- a/types/database.ts
+++ b/types/database.ts
@@ -732,6 +732,36 @@ export type Database = {
         };
         Relationships: [];
       };
+      citizen_milestones: {
+        Row: {
+          achieved_at: string;
+          epoch: number | null;
+          id: string;
+          metadata: Json | null;
+          milestone_key: string;
+          milestone_label: string | null;
+          user_id: string;
+        };
+        Insert: {
+          achieved_at?: string;
+          epoch?: number | null;
+          id?: string;
+          metadata?: Json | null;
+          milestone_key: string;
+          milestone_label?: string | null;
+          user_id: string;
+        };
+        Update: {
+          achieved_at?: string;
+          epoch?: number | null;
+          id?: string;
+          metadata?: Json | null;
+          milestone_key?: string;
+          milestone_label?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       classification_history: {
         Row: {
           classified_at: string;


### PR DESCRIPTION
## Summary

- **Citizen Briefings Inngest function**: `generate-citizen-briefings` runs on `drepscore/epoch.transition`, batch-generates personalized briefings for active users (visited within 30 days), stores in `governance_briefs` with `brief_type='citizen'`
- **PostHog conversion funnel**: Added `quick_match_started` event to complete the full funnel (citizen_path_clicked → quick_match_started → quick_match_completed → wallet_modal_opened → wallet_connected → delegation_completed)
- **Vision V2.2**: Updated `ultimate-vision.md` with Step 4 audit corrections — moved already-built components (EpochBriefing, CivicIdentityCard, TreasuryCitizenView) to "Already built" section, documented remaining net-new items
- **Types regenerated**: After migration 051 (citizen_milestones table + simplified_onboarding feature flag)

## Infrastructure shipped (migration 051, applied via Supabase MCP)
- `citizen_milestones` table (tracks per-user milestone achievements)
- `simplified_onboarding` feature flag (ready for A/B testing)

## Audit findings
- SPO snapshot sync already writes to `spo_score_snapshots` + `spo_alignment_snapshots` — no change needed
- `match_type` parameter already exists in `/api/governance/quick-match` — no change needed

## Test plan
- [x] All 306 tests pass (`npm run preflight` clean)
- [ ] CI green
- [ ] POST `/api/inngest` after deploy to register new function
- [ ] Verify `generate-citizen-briefings` appears in Inngest Cloud dashboard
- [ ] Trigger epoch summary manually to verify citizen briefings are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)