### PR TITLE
feat: atmospheric globe with slower rotation

### DIFF
--- a/components/GlobeConstellation.tsx
+++ b/components/GlobeConstellation.tsx
@@ -286,11 +286,22 @@ void main() {
 }
 `;
 
-function GlobeAtmosphere({ radius, color, intensity }: { radius: number; color: string; intensity: number }) {
-  const uniforms = useMemo(() => ({
-    uColor: { value: new THREE.Color(color) },
-    uIntensity: { value: intensity },
-  }), [color, intensity]);
+function GlobeAtmosphere({
+  radius,
+  color,
+  intensity,
+}: {
+  radius: number;
+  color: string;
+  intensity: number;
+}) {
+  const uniforms = useMemo(
+    () => ({
+      uColor: { value: new THREE.Color(color) },
+      uIntensity: { value: intensity },
+    }),
+    [color, intensity],
+  );
 
   return (
     <mesh>


### PR DESCRIPTION
## Summary
- Replace heavy lat/lon wireframe grid with fresnel atmospheric rim glow
- Slow rotation 3x (0.04 → 0.012 rad/s) for majestic, cinematic feel
- Fix counter-rotating starfield (now static background)
- Better camera angle: slightly above looking down vs. looking up from below
- Reduce wireframe to 3 latitude rings + 6 meridians at 4% opacity

## Test plan
- [ ] Verify globe renders with blue atmospheric glow rim
- [ ] Confirm single rotation direction (no counter-spinning elements)
- [ ] Check rotation speed feels slow and dignified
- [ ] Verify camera angle shows globe from slightly above

🤖 Generated with [Claude Code](https://claude.com/claude-code)