### PR TITLE
feat: Step 5.5 — governance workspace cohesion

### DIFF
--- a/app/api/dashboard/urgent/route.ts
+++ b/app/api/dashboard/urgent/route.ts
@@ -4,6 +4,7 @@ import { getOpenProposalsForDRep } from '@/lib/data';
 import { blockTimeToEpoch } from '@/lib/koios';
 import { getProposalDisplayTitle } from '@/utils/display';
 import { createClient } from '@/lib/supabase';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -84,5 +85,44 @@ export const GET = withRouteHandler(async (request, { requestId }) => {
     logger.error('Unexplained votes check failed', { context: 'dashboard/urgent', error: err });
   }
 
-  return NextResponse.json({ proposals: urgent, unexplainedVotes });
+  // Top pending proposals (unvoted, prioritized by expiry)
+  const currentEpochNow = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+  const pendingList = pendingProposals
+    .map((p: any) => {
+      const expiryEpoch = p.expirationEpoch ?? 0;
+      return {
+        txHash: p.txHash,
+        index: p.proposalIndex,
+        title: getProposalDisplayTitle(p.title, p.txHash, p.proposalIndex),
+        proposalType: p.proposalType || 'Proposal',
+        epochsRemaining: expiryEpoch > 0 ? Math.max(0, expiryEpoch - currentEpochNow) : null,
+      };
+    })
+    .sort((a: any, b: any) => (a.epochsRemaining ?? 999) - (b.epochsRemaining ?? 999))
+    .slice(0, 5);
+
+  // Unanswered questions count
+  let unansweredQuestions = 0;
+  try {
+    const admin = getSupabaseAdmin();
+    const { count } = await admin
+      .from('drep_questions')
+      .select('id', { count: 'exact', head: true })
+      .eq('drep_id', drepId)
+      .eq('status', 'open');
+    unansweredQuestions = count ?? 0;
+  } catch (err) {
+    logger.error('Unanswered questions count failed', {
+      context: 'dashboard/urgent',
+      error: err,
+    });
+  }
+
+  return NextResponse.json({
+    proposals: urgent,
+    unexplainedVotes,
+    pendingProposals: pendingList,
+    pendingCount: pendingProposals.length,
+    unansweredQuestions,
+  });
 });

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -21,6 +21,7 @@ import {
   Zap,
   Eye,
   Fingerprint,
+  HelpCircle,
 } from 'lucide-react';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
 import { cn } from '@/lib/utils';
@@ -166,6 +167,9 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
 
   const urgentProposals: any[] = urgent?.proposals ?? [];
   const unexplainedVotes: any[] = urgent?.unexplainedVotes ?? [];
+  const pendingProposals: any[] = urgent?.pendingProposals ?? [];
+  const pendingCount: number = urgent?.pendingCount ?? 0;
+  const unansweredQuestions: number = urgent?.unansweredQuestions ?? 0;
 
   const rank: number | null = competitive?.rank ?? null;
   const totalActive: number = competitive?.totalActive ?? 0;
@@ -420,22 +424,78 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
         </div>
       )}
 
-      {/* Pending votes widget */}
-      {!pulseLoading && activeProposals > 0 && urgentProposals.length === 0 && (
-        <Link href="/discover" className="block group">
-          <div className="rounded-xl border border-amber-900/30 bg-amber-950/10 p-4 flex items-center justify-between hover:brightness-110 transition-all">
+      {/* Pending votes queue */}
+      {pendingProposals.length > 0 && urgentProposals.length === 0 && (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <div className="px-4 py-3 flex items-center justify-between border-b border-border">
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-primary" />
+              <p className="text-sm font-medium">
+                {pendingCount} proposal{pendingCount !== 1 ? 's' : ''} awaiting your vote
+              </p>
+            </div>
+            {pendingCount > 5 && (
+              <Link
+                href="/discover"
+                className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
+              >
+                View all
+                <ChevronRight className="h-3 w-3" />
+              </Link>
+            )}
+          </div>
+          <div className="divide-y divide-border">
+            {pendingProposals.map((p: any) => (
+              <Link
+                key={`${p.txHash}-${p.index}`}
+                href={`/proposal/${p.txHash}/${p.index}`}
+                className="px-4 py-2.5 flex items-center gap-3 hover:bg-muted/20 transition-colors group"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm truncate group-hover:text-primary transition-colors">
+                    {p.title}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {p.proposalType}
+                    {p.epochsRemaining != null && (
+                      <span
+                        className={cn('ml-1.5', p.epochsRemaining <= 2 ? 'text-amber-400' : '')}
+                      >
+                        ·{' '}
+                        {p.epochsRemaining === 0
+                          ? 'Last epoch!'
+                          : `${p.epochsRemaining} epoch${p.epochsRemaining !== 1 ? 's' : ''} left`}
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <span className="text-xs text-primary font-medium shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  Vote
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 group-hover:text-primary transition-colors" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Unanswered questions */}
+      {unansweredQuestions > 0 && (
+        <Link href={`/drep/${drepId}?tab=community`} className="block group">
+          <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between hover:border-primary/30 transition-colors">
             <div className="flex items-center gap-3">
-              <Clock className="h-4 w-4 text-amber-400" />
+              <HelpCircle className="h-4 w-4 text-primary" />
               <div>
-                <p className="text-sm font-medium text-amber-200">
-                  {activeProposals} proposal{activeProposals > 1 ? 's' : ''} awaiting your vote
+                <p className="text-sm font-medium">
+                  {unansweredQuestions} unanswered question
+                  {unansweredQuestions > 1 ? 's' : ''}
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {votesThisWeek} votes cast network-wide this week
+                  Citizens are waiting for your response
                 </p>
               </div>
             </div>
-            <ChevronRight className="h-4 w-4 text-amber-400 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
           </div>
         </Link>
       )}

--- a/components/civica/proposals/VoteCastingPanel.tsx
+++ b/components/civica/proposals/VoteCastingPanel.tsx
@@ -141,7 +141,7 @@ export function VoteCastingPanel({
   const { phase, startVote, confirmVote, reset, isProcessing, canVote } = useVote();
   const [selectedVote, setSelectedVote] = useState<VoteChoice | null>(null);
   const [rationaleText, setRationaleText] = useState('');
-  const [showRationale, setShowRationale] = useState(false);
+  const [showRationale, setShowRationale] = useState(true);
   const [isDrafting, setIsDrafting] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const voteCastingEnabled = useFeatureFlag('governance_vote_casting');
@@ -292,34 +292,36 @@ export function VoteCastingPanel({
             )}
 
             {/* Rationale section */}
-            {!showRationale ? (
-              <button
-                onClick={() => setShowRationale(true)}
-                className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <FileText className="h-3.5 w-3.5" />
-                Add rationale (optional, published on-chain)
-              </button>
-            ) : (
+            {showRationale ? (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <label className="text-xs font-medium text-muted-foreground">
                     Vote Rationale (CIP-100)
                   </label>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 text-xs gap-1"
-                    onClick={handleAiDraft}
-                    disabled={isDrafting}
-                  >
-                    {isDrafting ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <Sparkles className="h-3 w-3" />
-                    )}
-                    {isDrafting ? 'Drafting...' : 'AI Draft'}
-                  </Button>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 text-xs gap-1"
+                      onClick={handleAiDraft}
+                      disabled={isDrafting}
+                    >
+                      {isDrafting ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Sparkles className="h-3 w-3" />
+                      )}
+                      {isDrafting ? 'Drafting...' : 'AI Draft'}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 text-xs text-muted-foreground"
+                      onClick={() => setShowRationale(false)}
+                    >
+                      Hide
+                    </Button>
+                  </div>
                 </div>
                 <textarea
                   value={rationaleText}
@@ -328,10 +330,23 @@ export function VoteCastingPanel({
                   className="w-full min-h-[120px] p-3 text-sm border rounded-lg bg-background resize-y focus:outline-none focus:ring-2 focus:ring-primary/30"
                   maxLength={10000}
                 />
-                <p className="text-xs text-muted-foreground text-right">
-                  {rationaleText.length.toLocaleString()} / 10,000
-                </p>
+                <div className="flex items-center justify-between">
+                  <p className="text-[10px] text-muted-foreground">
+                    DReps who explain votes score higher on Engagement (25% weight)
+                  </p>
+                  <p className="text-xs text-muted-foreground tabular-nums">
+                    {rationaleText.length.toLocaleString()} / 10,000
+                  </p>
+                </div>
               </div>
+            ) : (
+              <button
+                onClick={() => setShowRationale(true)}
+                className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Add rationale (optional)
+              </button>
             )}
 
             <div className="flex items-center justify-between text-sm">


### PR DESCRIPTION
## Summary
- **Inline pending votes queue** on DRep dashboard — replaces generic link with prioritized proposal list showing titles, types, expiry countdown, and direct vote links
- **Unanswered questions badge** — surfaces citizen Q&A count on dashboard with link to community tab
- **Rationale prominence** — textarea shown by default with scoring hint; still collapsible

## Motivation
Step 5 features (vote casting, rationale, statements, constitutional analysis, epoch updates) were all shipped but scattered across 5+ URLs. These three surgical changes unify the DRep daily workflow so they never need to leave the dashboard to know what needs attention.

## Test plan
- [ ] Preflight passes (format + lint + types + tests)
- [ ] `/my-gov` dashboard shows pending votes as inline list with proposal links
- [ ] Dashboard shows unanswered questions count with link to DRep profile Q&A tab
- [ ] Proposal page vote casting panel shows rationale textarea expanded by default
- [ ] Rationale can be collapsed via "Hide" button
- [ ] Scoring hint text visible below rationale textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)