### PR TITLE
fix: CC nodes — soft glow + committee ring

### DIFF
--- a/components/GlobeConstellation.tsx
+++ b/components/GlobeConstellation.tsx
@@ -431,7 +431,7 @@ void main() {
 }
 `;
 
-// Ring + core shader for CC orbital nodes (satellite halo effect)
+// Soft wide-glow shader for CC orbital nodes (warm diffused presence)
 const CC_FRAG = /* glsl */ `
 varying vec3 vColor;
 varying float vAlpha;
@@ -439,13 +439,10 @@ varying float vAlpha;
 void main() {
   float dist = length(gl_PointCoord - vec2(0.5));
   if (dist > 0.5) discard;
-  // Bright core
-  float core = 1.0 - smoothstep(0.0, 0.12, dist);
-  // Ring halo around the core
-  float ring = smoothstep(0.2, 0.25, dist) * (1.0 - smoothstep(0.35, 0.5, dist));
-  float alpha = max(ring * 0.7, core);
-  vec3 col = vColor * (1.0 + core * 2.5);
-  gl_FragColor = vec4(col, alpha * vAlpha);
+  float glow = 1.0 - smoothstep(0.0, 0.5, dist);
+  float core = 1.0 - smoothstep(0.0, 0.2, dist);
+  vec3 col = vColor * (1.0 + core * 1.5);
+  gl_FragColor = vec4(col, glow * vAlpha);
 }
 `;
 

--- a/lib/constellation/globe-layout.ts
+++ b/lib/constellation/globe-layout.ts
@@ -239,20 +239,28 @@ function computeGlobeEdges(
     }
   }
 
-  // Layer 4: Orbital tethers — CC members to their nearest surface DReps
+  // Layer 4: CC committee ring — connect CC members to each other above the surface
+  for (let i = 0; i < ccNodes.length; i++) {
+    const next = ccNodes[(i + 1) % ccNodes.length];
+    // Great-circle arc between adjacent CC members at orbital altitude
+    const arcPoints = greatCircleArc(ccNodes[i].position, next.position, CC_RADIUS, 8);
+    for (let k = 0; k < arcPoints.length - 1; k++) {
+      edges.push({ from: arcPoints[k], to: arcPoints[k + 1], edgeType: 'orbital' });
+    }
+  }
+
+  // Layer 5: Orbital tethers — each CC member to nearest surface node
   const surfaceNodes = [...drepNodes, ...spoNodes];
   for (const cc of ccNodes) {
     if (surfaceNodes.length === 0) break;
-    // Connect each CC to 2-3 nearest surface nodes
     const nearest = surfaceNodes
       .map((n) => ({ node: n, dist: dist3D(cc.position, n.position) }))
-      .sort((a, b) => a.dist - b.dist)
-      .slice(0, 3);
+      .sort((a, b) => a.dist - b.dist)[0];
 
-    for (const { node } of nearest) {
+    if (nearest) {
       edges.push({
         from: cc.position,
-        to: node.position,
+        to: nearest.node.position,
         edgeType: 'orbital',
       });
     }


### PR DESCRIPTION
## Summary
- Replace ring-halo CC shader with simple soft wide-glow (less gimmicky)
- CC members now connected to each other via golden great-circle arcs forming a committee ring above the globe
- Each CC tethers to nearest surface node (reduced from 3 to 1 for cleaner look)

## Test plan
- [ ] CC nodes appear as warm gold dots (no ring effect)
- [ ] Golden arcs connect CC members to each other above the surface
- [ ] Single tether line from each CC down to nearest surface node

🤖 Generated with [Claude Code](https://claude.com/claude-code)