### PR TITLE
fix: normalize CC node sizing on globe

### DIFF
--- a/lib/constellation/globe-layout.ts
+++ b/lib/constellation/globe-layout.ts
@@ -36,7 +36,7 @@ const SPO_ARC_RADIUS = GLOBE_RADIUS + 0.3; // slightly above surface
 const MIN_VISIBLE_SCALE = 0.06;
 const MAX_VISIBLE_SCALE = 0.25;
 const SPO_SCALE_FACTOR = 0.6;
-const CC_SCALE_FACTOR = 1.5; // larger — few but important
+const CC_SCALE_FACTOR = 1.0; // same base size — perspective handles visual weight
 const SPO_LIMIT = 400;
 
 interface LayoutInput {


### PR DESCRIPTION
## Summary
- Reduces `CC_SCALE_FACTOR` from 1.5 to 1.0 in globe layout engine
- CC nodes previously appeared wildly different sizes due to perspective-based sizing (`gl_PointSize = aSize * 600.0 / -mvPosition.z`) amplifying the 1.5x scale factor
- Their orbital position at radius 9.5 (vs globe surface at 8.0) already gives them visual distinction

## Test plan
- [ ] Verify CC members appear as consistent sizes on the globe
- [ ] Verify CC nodes are still visually distinct (gold color, orbital altitude)
- [ ] Check that pulse particles still travel between CC nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)