### PR TITLE
feat: citizen sentiment feedback + AI inter-body dynamics (WP-7+8)

### DIFF
--- a/app/api/drep/[drepId]/engagement/route.ts
+++ b/app/api/drep/[drepId]/engagement/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+interface SentimentAgg {
+  support: number;
+  oppose: number;
+  unsure: number;
+  total: number;
+}
+
+/**
+ * GET /api/drep/[drepId]/engagement
+ *
+ * Returns citizen engagement signals for a DRep:
+ * - How many citizens expressed sentiment on proposals this DRep voted on
+ * - Whether the DRep tends to vote with or against citizen sentiment
+ * - Per-proposal breakdown of alignment
+ */
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const drepId = request.nextUrl.pathname.split('/api/drep/')[1]?.split('/')[0];
+  if (!drepId) {
+    return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+  }
+  const decodedId = decodeURIComponent(drepId);
+  const supabase = createClient();
+
+  // 1. Get this DRep's votes
+  const { data: votes } = await supabase
+    .from('drep_votes')
+    .select('proposal_tx_hash, proposal_index, vote')
+    .eq('drep_id', decodedId);
+
+  if (!votes || votes.length === 0) {
+    return NextResponse.json({
+      proposalsWithSentiment: 0,
+      totalCitizenVotes: 0,
+      sentimentAlignment: null,
+      alignedCount: 0,
+      divergedCount: 0,
+      noSentimentCount: 0,
+    });
+  }
+
+  // 2. Fetch sentiment aggregations for proposals this DRep voted on
+  const proposalKeys = votes.map((v) => `${v.proposal_tx_hash}:${v.proposal_index}`);
+  const { data: sentimentRows } = await supabase
+    .from('engagement_signal_aggregations')
+    .select('entity_id, data')
+    .eq('entity_type', 'proposal')
+    .eq('signal_type', 'sentiment')
+    .in('entity_id', proposalKeys);
+
+  if (!sentimentRows || sentimentRows.length === 0) {
+    return NextResponse.json({
+      proposalsWithSentiment: 0,
+      totalCitizenVotes: 0,
+      sentimentAlignment: null,
+      alignedCount: 0,
+      divergedCount: 0,
+      noSentimentCount: votes.length,
+    });
+  }
+
+  // Build lookup: proposalKey -> sentiment data
+  const sentimentMap = new Map<string, SentimentAgg>();
+  for (const row of sentimentRows) {
+    const data = row.data as SentimentAgg;
+    if (data && data.total > 0) {
+      sentimentMap.set(row.entity_id, data);
+    }
+  }
+
+  // 3. Compare DRep vote with citizen majority for each proposal
+  let aligned = 0;
+  let diverged = 0;
+  let totalCitizenVotes = 0;
+
+  for (const v of votes) {
+    const key = `${v.proposal_tx_hash}:${v.proposal_index}`;
+    const sentiment = sentimentMap.get(key);
+    if (!sentiment || sentiment.total === 0) continue;
+
+    totalCitizenVotes += sentiment.total;
+
+    // Map DRep vote to sentiment direction
+    // Yes -> support, No -> oppose, Abstain -> unsure
+    const drepDirection = v.vote === 'Yes' ? 'support' : v.vote === 'No' ? 'oppose' : 'unsure';
+
+    // Citizen majority
+    const citizenMajority =
+      sentiment.support >= sentiment.oppose && sentiment.support >= sentiment.unsure
+        ? 'support'
+        : sentiment.oppose >= sentiment.unsure
+          ? 'oppose'
+          : 'unsure';
+
+    if (drepDirection === citizenMajority) {
+      aligned++;
+    } else {
+      diverged++;
+    }
+  }
+
+  const proposalsWithSentiment = sentimentMap.size;
+  const compared = aligned + diverged;
+  const sentimentAlignment = compared > 0 ? Math.round((aligned / compared) * 100) : null;
+
+  return NextResponse.json(
+    {
+      proposalsWithSentiment,
+      totalCitizenVotes,
+      sentimentAlignment,
+      alignedCount: aligned,
+      divergedCount: diverged,
+      noSentimentCount: votes.length - compared,
+    },
+    {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    },
+  );
+});

--- a/app/api/governance/inter-body-narrative/route.ts
+++ b/app/api/governance/inter-body-narrative/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { computeInterBodyAlignment } from '@/lib/interBodyAlignment';
+import { generateText } from '@/lib/ai';
+import { cached } from '@/lib/redis';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+const NARRATIVE_TTL = 86_400; // 24 hours
+
+/**
+ * GET /api/governance/inter-body-narrative?txHash=X&index=Y
+ *
+ * Returns an AI-generated narrative explaining inter-body governance dynamics
+ * for a specific proposal. Only generates when alignment < 85%.
+ */
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const txHash = request.nextUrl.searchParams.get('txHash');
+  const indexStr = request.nextUrl.searchParams.get('index');
+
+  if (!txHash || !indexStr) {
+    return NextResponse.json({ error: 'txHash and index required' }, { status: 400 });
+  }
+
+  const index = parseInt(indexStr, 10);
+  if (isNaN(index)) {
+    return NextResponse.json({ error: 'index must be a number' }, { status: 400 });
+  }
+
+  const cacheKey = `interbody-narrative:${txHash}:${index}`;
+
+  const narrative = await cached<string | null>(cacheKey, NARRATIVE_TTL, async () => {
+    const alignment = await computeInterBodyAlignment(txHash, index);
+
+    // Only generate narrative when there's meaningful divergence
+    if (alignment.bodiesVoting < 2 || alignment.alignmentScore >= 85) {
+      return null;
+    }
+
+    // Get proposal title/type for context
+    const supabase = createClient();
+    const { data: proposal } = await supabase
+      .from('proposals')
+      .select('title, proposal_type')
+      .eq('tx_hash', txHash)
+      .eq('proposal_index', index)
+      .single();
+
+    // Get citizen sentiment if available
+    const { data: sentimentRow } = await supabase
+      .from('engagement_signal_aggregations')
+      .select('data')
+      .eq('entity_type', 'proposal')
+      .eq('entity_id', `${txHash}:${index}`)
+      .eq('signal_type', 'sentiment')
+      .maybeSingle();
+
+    const sentiment = sentimentRow?.data as {
+      support: number;
+      oppose: number;
+      unsure: number;
+      total: number;
+    } | null;
+
+    const { drep, spo, cc } = alignment;
+    const proposalTitle = proposal?.title || 'this proposal';
+    const proposalType = proposal?.proposal_type || 'governance action';
+
+    const prompt = buildNarrativePrompt({
+      proposalTitle,
+      proposalType,
+      alignmentScore: alignment.alignmentScore,
+      drep,
+      spo,
+      cc,
+      sentiment,
+    });
+
+    return generateText(prompt, {
+      model: 'FAST',
+      maxTokens: 300,
+      temperature: 0.3,
+      system:
+        'You are a governance analyst for Cardano. Write concise, insightful analysis of governance dynamics. Be specific about what the voting patterns suggest. Never use markdown. Write 2-3 sentences max.',
+    });
+  });
+
+  if (!narrative) {
+    return NextResponse.json(
+      { narrative: null },
+      { headers: { 'Cache-Control': 'public, s-maxage=3600' } },
+    );
+  }
+
+  return NextResponse.json(
+    { narrative },
+    { headers: { 'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800' } },
+  );
+});
+
+function buildNarrativePrompt({
+  proposalTitle,
+  proposalType,
+  alignmentScore,
+  drep,
+  spo,
+  cc,
+  sentiment,
+}: {
+  proposalTitle: string;
+  proposalType: string;
+  alignmentScore: number;
+  drep: { yes: number; no: number; abstain: number; total: number; yesPct: number };
+  spo: { yes: number; no: number; abstain: number; total: number; yesPct: number };
+  cc: { yes: number; no: number; abstain: number; total: number; yesPct: number };
+  sentiment: { support: number; oppose: number; unsure: number; total: number } | null;
+}): string {
+  const parts: string[] = [
+    `Proposal: "${proposalTitle}" (${proposalType})`,
+    `Inter-body alignment: ${alignmentScore}%`,
+    '',
+    'Voting breakdown:',
+  ];
+
+  if (drep.total > 0) {
+    parts.push(
+      `- DReps: ${drep.yes} Yes, ${drep.no} No, ${drep.abstain} Abstain (${drep.total} total, ${drep.yesPct}% Yes)`,
+    );
+  }
+  if (spo.total > 0) {
+    parts.push(
+      `- SPOs: ${spo.yes} Yes, ${spo.no} No, ${spo.abstain} Abstain (${spo.total} total, ${spo.yesPct}% Yes)`,
+    );
+  }
+  if (cc.total > 0) {
+    parts.push(
+      `- CC: ${cc.yes} Yes, ${cc.no} No, ${cc.abstain} Abstain (${cc.total} total, ${cc.yesPct}% Yes)`,
+    );
+  }
+
+  if (sentiment && sentiment.total > 0) {
+    const supportPct = Math.round((sentiment.support / sentiment.total) * 100);
+    parts.push(
+      '',
+      `Citizen sentiment: ${sentiment.support} support, ${sentiment.oppose} oppose, ${sentiment.unsure} unsure (${sentiment.total} citizens, ${supportPct}% support)`,
+    );
+  }
+
+  parts.push(
+    '',
+    'Explain the governance dynamics: why these bodies might vote differently, what the pattern suggests about this proposal, and any tension between representative votes and citizen sentiment. Be specific and analytical.',
+  );
+
+  return parts.join('\n');
+}

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -55,6 +55,7 @@ const SimilarDReps = nextDynamic(
 import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
+import { DRepCitizenSignals } from '@/components/DRepCitizenSignals';
 const AlignmentTrajectory = nextDynamic(
   () => import('@/components/AlignmentTrajectory').then((m) => m.AlignmentTrajectory),
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
@@ -611,6 +612,9 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         delegatorCount={drep.delegatorCount}
         scoreMomentum={drep.scoreMomentum}
       />
+
+      {/* 3c. Citizen Sentiment Signal */}
+      <DRepCitizenSignals drepId={drep.drepId} />
 
       {/* 4. Key Facts Strip */}
       <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 py-4 border-y border-border">

--- a/components/DRepCitizenSignals.tsx
+++ b/components/DRepCitizenSignals.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Users, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+interface EngagementData {
+  proposalsWithSentiment: number;
+  totalCitizenVotes: number;
+  sentimentAlignment: number | null;
+  alignedCount: number;
+  divergedCount: number;
+  noSentimentCount: number;
+}
+
+export function DRepCitizenSignals({ drepId }: { drepId: string }) {
+  const { data, isLoading } = useQuery<EngagementData>({
+    queryKey: ['drep-engagement', drepId],
+    queryFn: () =>
+      fetch(`/api/drep/${encodeURIComponent(drepId)}/engagement`).then((r) => r.json()),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isLoading || !data || data.proposalsWithSentiment === 0) return null;
+
+  const alignment = data.sentimentAlignment;
+  const compared = data.alignedCount + data.divergedCount;
+
+  const AlignIcon =
+    alignment != null && alignment >= 70
+      ? TrendingUp
+      : alignment != null && alignment < 50
+        ? TrendingDown
+        : Minus;
+
+  const alignColor =
+    alignment != null && alignment >= 70
+      ? 'text-emerald-500'
+      : alignment != null && alignment < 50
+        ? 'text-rose-500'
+        : 'text-amber-500';
+
+  const alignLabel =
+    alignment != null && alignment >= 70
+      ? 'votes with citizen sentiment'
+      : alignment != null && alignment < 50
+        ? 'often diverges from citizen sentiment'
+        : 'mixed alignment with citizen sentiment';
+
+  return (
+    <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
+      <div className="flex items-center gap-2">
+        <Users className="h-4 w-4 text-primary" />
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Citizen Sentiment Signal
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          {alignment != null && (
+            <div className="flex items-center gap-1.5">
+              <AlignIcon className={`h-4 w-4 ${alignColor}`} />
+              <span className="text-sm font-medium">
+                <span className={`font-bold tabular-nums ${alignColor}`}>{alignment}%</span>{' '}
+                {alignLabel}
+              </span>
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground">
+            {data.totalCitizenVotes.toLocaleString()} citizen
+            {data.totalCitizenVotes !== 1 ? 's' : ''} expressed views across {compared} proposal
+            {compared !== 1 ? 's' : ''}
+          </p>
+        </div>
+
+        {alignment != null && compared > 0 && (
+          <div className="flex items-center gap-1">
+            <div className="w-16 h-1.5 rounded-full bg-border overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${
+                  alignment >= 70
+                    ? 'bg-emerald-500'
+                    : alignment >= 50
+                      ? 'bg-amber-500'
+                      : 'bg-rose-500'
+                }`}
+                style={{ width: `${alignment}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/TriBodyVotePanel.tsx
+++ b/components/TriBodyVotePanel.tsx
@@ -158,7 +158,33 @@ export function TriBodyVotePanel({ triBody, txHash, proposalIndex }: TriBodyVote
             {alignmentCallout}
           </div>
         )}
+
+        <InterBodyNarrative txHash={txHash} proposalIndex={proposalIndex} />
       </CardContent>
     </Card>
+  );
+}
+
+function InterBodyNarrative({ txHash, proposalIndex }: { txHash: string; proposalIndex: number }) {
+  const [narrative, setNarrative] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/governance/inter-body-narrative?txHash=${txHash}&index=${proposalIndex}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.narrative) setNarrative(data.narrative);
+      })
+      .catch(() => {});
+  }, [txHash, proposalIndex]);
+
+  if (!narrative) return null;
+
+  return (
+    <div className="rounded-md border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-muted-foreground">
+      <span className="font-medium text-primary text-xs uppercase tracking-wider block mb-1">
+        Governance Dynamics
+      </span>
+      {narrative}
+    </div>
   );
 }

--- a/docs/strategy/work-packages.md
+++ b/docs/strategy/work-packages.md
@@ -1,0 +1,267 @@
+# Vision Parity Work Packages (Steps 1-5)
+
+> **Created:** 2026-03-07
+> **Purpose:** Close all gaps between current production state and 100/100 vision parity for Steps 1-5 of `ultimate-vision.md`
+> **Tracking:** Each WP is a focused unit of work. Ship individually or batch into PRs.
+
+---
+
+## Status Overview
+
+| WP    | Name                                      | Step | Status      | PR   |
+| ----- | ----------------------------------------- | ---- | ----------- | ---- |
+| WP-1  | Briefing-first citizen home               | 4    | SHIPPED     | #159 |
+| WP-2  | Simplified anonymous onboarding           | 4    | SHIPPED     | #159 |
+| WP-3  | Citizen notification steps                | 4    | SHIPPED     | #159 |
+| WP-4  | Citizen milestone detection               | 4    | SHIPPED     | #159 |
+| WP-5  | Proportional treasury share in briefing   | 4    | SHIPPED     | #159 |
+| WP-6  | DRep delegator sentiment view             | 5+6  | SHIPPED     | #160 |
+| WP-7  | Engagement signals -> score feedback loop | 6->1 | IN PROGRESS |      |
+| WP-8  | Inter-body dynamics narrative             | 2+5  | IN PROGRESS |      |
+| WP-9  | SPO Command Center parity                 | 2.5  | PENDING     |      |
+| WP-10 | SPO vote casting                          | 5    | PENDING     |      |
+| WP-11 | Progressive match confidence              | 1    | PENDING     |      |
+| WP-12 | Proposal outcome tracking                 | 2+4  | PENDING     |      |
+| WP-13 | CC Member Transparency Index              | 2.5  | PENDING     |      |
+| WP-14 | Mobile briefing optimization              | 4    | PENDING     |      |
+| WP-15 | Vote + rationale flow timing              | 5    | PENDING     |      |
+
+---
+
+## WP-1: Briefing-First Citizen Home (SHIPPED)
+
+**Vision gap:** HomeCitizen showed a dashboard. Vision says citizens see the Epoch Briefing as primary surface.
+
+**Changes:**
+
+- Restructured `HomeCitizen.tsx` around `EpochBriefing` as the hero element
+- Briefing replaces dashboard paradigm for connected citizens
+- Treasury citizen view positioned below briefing
+
+**Files:** `components/civica/home/HomeCitizen.tsx`
+
+---
+
+## WP-2: Simplified Anonymous Onboarding (SHIPPED)
+
+**Vision gap:** Anonymous visitors saw a complex nav. Vision says two-path entry (Stake/Govern) with education woven in.
+
+**Changes:**
+
+- Simplified `HomeAnonymous.tsx` to two-path entry
+- Education integrated into paths, not separate destination
+- Messaging: "Your ADA gives you a voice"
+
+**Files:** `components/civica/home/HomeAnonymous.tsx`
+
+---
+
+## WP-3: Citizen Notification Steps (SHIPPED)
+
+**Vision gap:** `check-notifications` Inngest function only handled DRep/SPO alerts. No citizen-specific alert triggers.
+
+**Changes:**
+
+- Added 3 citizen-specific steps (12-14) to `check-notifications.ts`
+- Step 12: Gather citizen delegators from `user_wallets`
+- Step 13: Check citizen DRep alerts (score drops >3pts, inactivity 3+ epochs, missed votes)
+- Step 14: Check citizen milestones and send `citizen-level-up` notifications
+
+**Files:** `inngest/functions/check-notifications.ts`
+
+---
+
+## WP-4: Citizen Milestone Detection (SHIPPED)
+
+**Vision gap:** `citizen_milestones` table existed but no detection logic to award milestones.
+
+**Changes:**
+
+- Created `lib/citizenMilestones.ts` with 13 milestone definitions across 4 categories
+  - Delegation: first delegation, 10/50/100 epoch streaks, delegation loyalty
+  - Influence: 1K/10K/100K ADA governed
+  - Engagement: first sentiment vote, 10 polls completed
+  - Identity: first briefing read, governance profile created
+- `checkAndAwardCitizenMilestones(userId, drepId)` function
+- Called from `generate-citizen-briefings` Inngest and `check-notifications` Step 14
+- Milestones stored via upsert on `user_id,milestone_key`
+
+**Files:** `lib/citizenMilestones.ts`, `inngest/functions/generate-citizen-briefings.ts`
+
+---
+
+## WP-5: Proportional Treasury Share in Briefing (SHIPPED)
+
+**Vision gap:** Treasury section of briefing showed balance but not "your proportional share."
+
+**Changes:**
+
+- Extended `/api/briefing/citizen` to fetch DRep delegated stake from `drep_power_snapshots`
+- Added `circulating_supply_lovelace` from `governance_stats`
+- Computes `proportionalShareAda = treasury * (drepStake / circulatingSupply)`
+- `EpochBriefing.tsx` displays "Your DRep's X ADA delegation represents Y ADA of the treasury"
+
+**Files:** `app/api/briefing/citizen/route.ts`, `components/civica/home/EpochBriefing.tsx`
+
+---
+
+## WP-6: DRep Delegator Sentiment View (SHIPPED)
+
+**Vision gap:** DReps saw community-wide sentiment but not how their own delegators felt about proposals.
+
+**Changes:**
+
+- Wired `ownDRepId` from `useWallet()` through to `useSentimentResults` hook
+- Added "Your Delegators" highlighted section in `ResultsView` with per-sentiment bars
+- Shows stake-weighted support percentage
+- "All Citizens" label separates delegator vs community results
+
+**Files:** `components/engagement/ProposalSentiment.tsx`
+
+---
+
+## WP-7: Engagement Signals -> Score Feedback Loop
+
+**Vision gap:** Community engagement data (sentiment, endorsements, concern flags) is collected but doesn't feed back into the intelligence engine. The data flywheel diagram shows: Endorsements -> DRepScore & SPOScore, Sentiment -> CitizenIntel -> DRepProfiles.
+
+**Goal:** Close the loop so citizen engagement data influences DRep/SPO intelligence surfaces.
+
+**Scope:**
+
+- Aggregate citizen engagement signals per DRep (endorsement count, sentiment alignment with delegators, concern flag activity)
+- Surface engagement summary on DRep profile pages (citizen trust signal alongside algorithmic score)
+- Add endorsement/sentiment data to proposal workspace context
+- Wire precomputed engagement signals into profile API responses
+
+**Key files to modify:**
+
+- `inngest/functions/precompute-engagement-signals.ts` (extend aggregation)
+- DRep profile API routes (include engagement data)
+- DRep profile components (display citizen trust)
+- `lib/data.ts` (engagement data reads)
+
+---
+
+## WP-8: Inter-Body Dynamics Narrative
+
+**Vision gap:** Proposal pages show raw DRep/SPO/CC vote counts but no AI-generated narrative explaining governance body tensions. Vision says "The AI explains the tension."
+
+**Goal:** Add AI-generated inter-body dynamics narrative to proposal pages.
+
+**Scope:**
+
+- Generate AI narrative when significant voting divergence exists between governance bodies
+- Display on proposal detail pages alongside existing vote breakdown
+- Narrative explains: why bodies might disagree, what the tension means, historical context
+- Cache narrative to avoid regeneration
+
+**Key files to modify:**
+
+- Proposal detail page and/or API route
+- New component for dynamics narrative display
+- AI generation logic (Claude API call, similar to epoch recap pattern)
+
+---
+
+## WP-9: SPO Command Center Parity
+
+**Vision gap:** SPO Command Center is 13.5KB vs DRep Command Center at 24.6KB. SPOs need governance inbox, pending votes, statement management, and delegator communication comparable to DReps.
+
+**Scope:**
+
+- SPO pending governance actions queue (like DRep's)
+- SPO governance statement management
+- SPO delegator communication channel
+- SPO governance performance summary
+
+**Key files:** `components/spo/SPOCommandCenter.tsx`, SPO API routes
+
+---
+
+## WP-10: SPO Vote Casting
+
+**Vision gap:** Vote casting (PR #143) was built for DReps. SPOs need the same capability via MeshJS/CIP-95.
+
+**Scope:**
+
+- Adapt `VoteCaster` for SPO governance transactions
+- SPO-specific vote transaction construction (different cert type)
+- Integration into SPO Command Center pending votes queue
+- SPO rationale submission flow
+
+**Key files:** `components/governance/VoteCaster.tsx`, SPO command center, CIP-95 transaction building
+
+---
+
+## WP-11: Progressive Match Confidence
+
+**Vision gap:** Quick Match shows results after 3 questions but confidence should improve as more data accumulates (voting history, quiz answers, engagement patterns).
+
+**Scope:**
+
+- Confidence indicator that grows with user data sources
+- Sources: quiz answers, voting observations, engagement patterns, delegation history
+- Visual confidence bar on match results
+- "Improve your match" CTAs pointing to additional quiz questions
+
+**Key files:** `lib/matching/`, `components/matching/`, match API routes
+
+---
+
+## WP-12: Proposal Outcome Tracking
+
+**Vision gap:** Proposals show lifecycle but not delivery outcomes. Vision says trace treasury spending "from proposal to vote to delivery to citizen impact."
+
+**Scope:**
+
+- Track proposal status transitions (ratified -> enacted -> delivered/failed)
+- Display delivery status on proposal cards and pages
+- Connect to citizen impact tags for funded projects
+- Proposal outcome summary in DRep voting record
+
+**Key files:** Proposal components, proposal API routes, treasury tracking
+
+---
+
+## WP-13: CC Member Transparency Index
+
+**Vision gap:** CC Transparency Index exists in scoring (`lib/scoring/`) but may not be fully surfaced on CC member profiles.
+
+**Scope:**
+
+- Ensure CC transparency metrics display on CC profile pages
+- Voting record completeness, rationale provision rate, response time
+- Inter-body alignment from CC perspective
+- Historical transparency trend
+
+**Key files:** CC profile components, CC scoring, CC API routes
+
+---
+
+## WP-14: Mobile Briefing Optimization
+
+**Vision gap:** Epoch Briefing is the primary citizen surface but may not be optimized for mobile viewports where most citizens will read it.
+
+**Scope:**
+
+- Responsive layout audit of EpochBriefing component
+- Touch-friendly interactions (swipe between sections, tap to expand)
+- Performance optimization (lazy loading, reduced bundle for mobile)
+- PWA-friendly briefing delivery
+
+**Key files:** `components/civica/home/EpochBriefing.tsx`, related layout components
+
+---
+
+## WP-15: Vote + Rationale Flow Timing
+
+**Vision gap:** Vote casting and rationale submission are separate flows. Vision says "one submission: vote + rationale together."
+
+**Scope:**
+
+- Streamline vote + rationale into single flow (analyze -> draft -> vote+rationale)
+- Bundle metadata anchor with vote transaction
+- Post-vote rationale fallback for quick votes
+- Timing UX: fee estimation, confirmation, submission tracking
+
+**Key files:** `components/governance/VoteCaster.tsx`, `components/governance/RationaleFlow.tsx`, CIP-100/metadata anchor logic


### PR DESCRIPTION
## Summary

- **WP-7**: Citizen Sentiment Signal on DRep profiles -- new API route (`/api/drep/[drepId]/engagement`) computes sentiment alignment (how often DRep votes with citizen majority). Displayed as a compact card on DRep profile pages.
- **WP-8**: AI-generated governance dynamics narrative on proposal pages -- when governance bodies diverge (<85% alignment), Claude generates a 2-3 sentence analysis. Cached in Redis (24h). Displayed below the tri-body vote panel.
- Adds `docs/strategy/work-packages.md` with full WP-1 through WP-15 reference.

## Test plan

- [ ] DRep profile page loads without errors
- [ ] Citizen Sentiment Signal card appears on DRep profiles with engagement data
- [ ] Proposal page tri-body panel shows AI narrative when alignment < 85%
- [ ] Narrative is cached (second load is instant)
- [ ] No new type errors or test failures

## Files changed

| File | Change |
|------|--------|
| `app/api/drep/[drepId]/engagement/route.ts` | NEW: DRep citizen engagement API |
| `app/api/governance/inter-body-narrative/route.ts` | NEW: AI narrative generation + Redis cache |
| `components/DRepCitizenSignals.tsx` | NEW: Citizen sentiment signal display |
| `components/TriBodyVotePanel.tsx` | ADD: InterBodyNarrative sub-component |
| `app/drep/[drepId]/page.tsx` | ADD: DRepCitizenSignals in VP1 |
| `docs/strategy/work-packages.md` | NEW: Full WP reference document |

🤖 Generated with [Claude Code](https://claude.com/claude-code)