### PR TITLE
feat: SPO Command Center parity + SPO vote casting (WP-9, WP-10)

### DIFF
--- a/app/api/dashboard/spo-urgent/route.ts
+++ b/app/api/dashboard/spo-urgent/route.ts
@@ -1,0 +1,142 @@
+/**
+ * SPO Urgent Dashboard API
+ * Returns pending proposals, urgent (expiring) proposals, unexplained votes,
+ * and governance statement status for the SPO Command Center.
+ */
+
+import { NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { getProposalDisplayTitle } from '@/utils/display';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(async (request) => {
+  const poolId = request.nextUrl.searchParams.get('poolId');
+  if (!poolId) {
+    return NextResponse.json({ error: 'Missing poolId' }, { status: 400 });
+  }
+
+  const supabase = createClient();
+  const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+
+  // Fetch open proposals and SPO's votes in parallel
+  const [openResult, votesResult, poolResult] = await Promise.all([
+    supabase
+      .from('proposals')
+      .select('tx_hash, proposal_index, title, proposal_type, expiration_epoch')
+      .is('ratified_epoch', null)
+      .is('enacted_epoch', null)
+      .is('dropped_epoch', null)
+      .is('expired_epoch', null)
+      .order('block_time', { ascending: false }),
+    supabase.from('spo_votes').select('proposal_tx_hash, proposal_index').eq('pool_id', poolId),
+    supabase.from('pools').select('governance_statement').eq('pool_id', poolId).single(),
+  ]);
+
+  const openProposals = openResult.data ?? [];
+  const spoVotes = votesResult.data ?? [];
+  const pool = poolResult.data;
+
+  const votedKeys = new Set(spoVotes.map((v) => `${v.proposal_tx_hash}-${v.proposal_index}`));
+
+  // Pending proposals (unvoted)
+  const pending = openProposals.filter((p) => !votedKeys.has(`${p.tx_hash}-${p.proposal_index}`));
+
+  // Urgent proposals (expiring within 2 epochs)
+  const urgent = pending
+    .filter((p) => {
+      const expiryEpoch = p.expiration_epoch ?? 0;
+      return expiryEpoch > 0 && expiryEpoch - currentEpoch <= 2;
+    })
+    .map((p) => {
+      const expiryEpoch = p.expiration_epoch ?? 0;
+      return {
+        txHash: p.tx_hash,
+        index: p.proposal_index,
+        title: getProposalDisplayTitle(p.title, p.tx_hash, p.proposal_index),
+        proposalType: p.proposal_type || 'Proposal',
+        epochsRemaining: Math.max(0, expiryEpoch - currentEpoch),
+      };
+    })
+    .sort((a, b) => a.epochsRemaining - b.epochsRemaining);
+
+  // Top pending proposals list (up to 5, sorted by expiry)
+  const pendingList = pending
+    .map((p) => {
+      const expiryEpoch = p.expiration_epoch ?? 0;
+      return {
+        txHash: p.tx_hash,
+        index: p.proposal_index,
+        title: getProposalDisplayTitle(p.title, p.tx_hash, p.proposal_index),
+        proposalType: p.proposal_type || 'Proposal',
+        epochsRemaining: expiryEpoch > 0 ? Math.max(0, expiryEpoch - currentEpoch) : null,
+      };
+    })
+    .sort((a, b) => (a.epochsRemaining ?? 999) - (b.epochsRemaining ?? 999))
+    .slice(0, 5);
+
+  // Unexplained votes (recent SPO votes without rationale)
+  let unexplainedVotes: { txHash: string; index: number; title: string }[] = [];
+  try {
+    const { data: recentVotes } = await supabase
+      .from('spo_votes')
+      .select('proposal_tx_hash, proposal_index')
+      .eq('pool_id', poolId)
+      .order('block_time', { ascending: false })
+      .limit(10);
+
+    if (recentVotes && recentVotes.length > 0) {
+      const { data: rationales } = await supabase
+        .from('vote_rationales')
+        .select('proposal_tx_hash, proposal_index')
+        .eq('voter_id', poolId)
+        .eq('voter_type', 'spo');
+
+      const rationaleSet = new Set(
+        (rationales ?? []).map((r) => `${r.proposal_tx_hash}-${r.proposal_index}`),
+      );
+
+      const unexplained = recentVotes.filter(
+        (v) => !rationaleSet.has(`${v.proposal_tx_hash}-${v.proposal_index}`),
+      );
+
+      if (unexplained.length > 0) {
+        const txHashes = [...new Set(unexplained.map((v) => v.proposal_tx_hash))];
+        const { data: proposals } = await supabase
+          .from('proposals')
+          .select('tx_hash, proposal_index, title')
+          .in('tx_hash', txHashes);
+
+        const titleMap = new Map(
+          (proposals ?? []).map((p) => [`${p.tx_hash}-${p.proposal_index}`, p.title]),
+        );
+
+        unexplainedVotes = unexplained.map((v) => ({
+          txHash: v.proposal_tx_hash,
+          index: v.proposal_index,
+          title: titleMap.get(`${v.proposal_tx_hash}-${v.proposal_index}`) || 'Untitled Proposal',
+        }));
+      }
+    }
+  } catch (err) {
+    logger.error('SPO unexplained votes check failed', {
+      context: 'dashboard/spo-urgent',
+      error: err,
+    });
+  }
+
+  const hasGovernanceStatement = !!(
+    pool?.governance_statement && pool.governance_statement.trim().length > 0
+  );
+
+  return NextResponse.json({
+    proposals: urgent,
+    unexplainedVotes,
+    pendingProposals: pendingList,
+    pendingCount: pending.length,
+    hasGovernanceStatement,
+  });
+});

--- a/app/api/rationale/draft/route.ts
+++ b/app/api/rationale/draft/route.ts
@@ -1,13 +1,13 @@
 /**
  * AI Rationale Draft API
- * Generates a structured rationale draft using Anthropic, personalized to the DRep's
- * stated objectives and the proposal's content.
+ * Generates a structured rationale draft using Anthropic, personalized to the
+ * DRep's or SPO's stated objectives and the proposal's content.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getDRepById } from '@/lib/data';
 import { captureServerEvent } from '@/lib/posthog-server';
-import { logger } from '@/lib/logger';
+import { createClient } from '@/lib/supabase';
 import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 import { RationaleDraftSchema } from '@/lib/api/schemas/governance';
 
@@ -16,7 +16,7 @@ export const maxDuration = 30;
 
 export const POST = withRouteHandler(
   async (request: NextRequest, { requestId }: RouteContext) => {
-    const { drepId, proposalTitle, proposalAbstract, proposalType, aiSummary } =
+    const { drepId, voterRole, proposalTitle, proposalAbstract, proposalType, aiSummary } =
       RationaleDraftSchema.parse(await request.json());
 
     const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -24,23 +24,44 @@ export const POST = withRouteHandler(
       return NextResponse.json({ error: 'AI features not configured' }, { status: 503 });
     }
 
-    const drep = await getDRepById(drepId);
-    if (!drep) {
-      return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
+    let voterContext = '';
+    let voterLabel = 'DRep (Delegated Representative)';
+
+    if (voterRole === 'spo') {
+      // Look up SPO pool info for context
+      voterLabel = 'SPO (Stake Pool Operator)';
+      const supabase = createClient();
+      const { data: pool } = await supabase
+        .from('pools')
+        .select('pool_name, ticker, governance_statement')
+        .eq('pool_id', drepId)
+        .single();
+
+      if (pool) {
+        const parts = [
+          pool.pool_name && `Pool: ${pool.pool_name} (${pool.ticker || 'N/A'})`,
+          pool.governance_statement &&
+            `Governance Statement: ${pool.governance_statement.slice(0, 500)}`,
+        ].filter(Boolean);
+        voterContext = parts.join('\n');
+      }
+    } else {
+      // DRep context
+      const drep = await getDRepById(drepId);
+      if (drep) {
+        const metadata = drep.metadata || {};
+        const objectives = (metadata.objectives as string) || '';
+        const motivations = (metadata.motivations as string) || '';
+        const qualifications = (metadata.qualifications as string) || '';
+        voterContext = [
+          objectives && `Objectives: ${objectives}`,
+          motivations && `Motivations: ${motivations}`,
+          qualifications && `Qualifications: ${qualifications}`,
+        ]
+          .filter(Boolean)
+          .join('\n');
+      }
     }
-
-    const metadata = drep.metadata || {};
-    const objectives = (metadata.objectives as string) || '';
-    const motivations = (metadata.motivations as string) || '';
-    const qualifications = (metadata.qualifications as string) || '';
-
-    const drepContext = [
-      objectives && `Objectives: ${objectives}`,
-      motivations && `Motivations: ${motivations}`,
-      qualifications && `Qualifications: ${qualifications}`,
-    ]
-      .filter(Boolean)
-      .join('\n');
 
     const proposalContext = [
       `Title: ${proposalTitle}`,
@@ -60,19 +81,19 @@ export const POST = withRouteHandler(
       messages: [
         {
           role: 'user',
-          content: `You are helping a Cardano DRep (Delegated Representative) write a CIP-100 compatible voting rationale for a governance proposal.
+          content: `You are helping a Cardano ${voterLabel} write a CIP-100 compatible voting rationale for a governance proposal.
 
 PROPOSAL:
 ${proposalContext}
 
-${drepContext ? `DREP'S STATED VALUES AND OBJECTIVES:\n${drepContext}\n` : ''}
-Write a professional, structured voting rationale draft. The DRep will review and edit this before submitting. Include:
+${voterContext ? `VOTER'S STATED VALUES AND CONTEXT:\n${voterContext}\n` : ''}
+Write a professional, structured voting rationale draft. The voter will review and edit this before submitting. Include:
 
 1. **Context**: Brief summary of what this proposal does (1-2 sentences)
 2. **Analysis**: Key considerations, trade-offs, and implications (2-3 bullet points)
-3. **Position**: A template position statement the DRep can customize (leave the actual vote choice as [SUPPORT/OPPOSE/ABSTAIN] for them to fill in)
+3. **Position**: A template position statement the voter can customize (leave the actual vote choice as [SUPPORT/OPPOSE/ABSTAIN] for them to fill in)
 
-Keep it concise (under 300 words), factual, and neutral in tone. Do not make assumptions about the DRep's vote choice. Reference the DRep's stated objectives where relevant to help them frame their position.
+Keep it concise (under 300 words), factual, and neutral in tone. Do not make assumptions about the voter's choice. Reference the voter's stated objectives where relevant to help them frame their position.
 
 Output only the rationale text, no preamble.`,
         },
@@ -81,7 +102,7 @@ Output only the rationale text, no preamble.`,
 
     const draft = message.content[0].type === 'text' ? message.content[0].text : '';
 
-    captureServerEvent('rationale_ai_drafted', { drep_id: drepId }, drepId);
+    captureServerEvent('rationale_ai_drafted', { voter_id: drepId, voter_role: voterRole }, drepId);
 
     return NextResponse.json({ draft });
   },

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -164,7 +164,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         <ParamChangesCard paramChanges={proposal.paramChanges} />
       )}
 
-      {/* Vote Casting (DReps only, open proposals only) */}
+      {/* Vote Casting (DReps and SPOs, open proposals only) */}
       <VoteCastingPanel
         txHash={txHash}
         proposalIndex={proposalIndex}

--- a/components/civica/mygov/ActionFeed.tsx
+++ b/components/civica/mygov/ActionFeed.tsx
@@ -2,7 +2,17 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Vote, AlertCircle, TrendingDown, Clock, Star, Sparkles, ChevronRight } from 'lucide-react';
+import {
+  Vote,
+  AlertCircle,
+  TrendingDown,
+  Clock,
+  Star,
+  Sparkles,
+  ChevronRight,
+  FileText,
+  ScrollText,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { Action, ActionType } from '@/lib/actionFeed';
 
@@ -13,6 +23,8 @@ const TYPE_ICON: Record<ActionType, React.FC<{ className?: string }>> = {
   proposal_expiring: Clock,
   tier_approaching: Star,
   wrapped_ready: Sparkles,
+  statement_missing: ScrollText,
+  rationale_missing: FileText,
 };
 
 const TYPE_COLOR: Record<ActionType, string> = {
@@ -22,6 +34,8 @@ const TYPE_COLOR: Record<ActionType, string> = {
   proposal_expiring: 'text-amber-400 border-amber-900/40 bg-amber-950/10',
   tier_approaching: 'text-violet-400 border-violet-900/40 bg-violet-950/10',
   wrapped_ready: 'text-amber-300 border-violet-900/40 bg-violet-950/10',
+  statement_missing: 'text-cyan-400 border-cyan-900/40 bg-cyan-950/10',
+  rationale_missing: 'text-amber-400 border-amber-900/40 bg-amber-950/10',
 };
 
 const TYPE_ICON_COLOR: Record<ActionType, string> = {
@@ -31,6 +45,8 @@ const TYPE_ICON_COLOR: Record<ActionType, string> = {
   proposal_expiring: 'text-amber-400',
   tier_approaching: 'text-violet-400',
   wrapped_ready: 'text-amber-300',
+  statement_missing: 'text-cyan-400',
+  rationale_missing: 'text-amber-400',
 };
 
 function ActionCard({ action, featured = false }: { action: Action; featured?: boolean }) {

--- a/components/civica/mygov/SPOCommandCenter.tsx
+++ b/components/civica/mygov/SPOCommandCenter.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
+import { motion } from 'framer-motion';
 import {
   Vote,
   Users,
@@ -12,8 +14,15 @@ import {
   XCircle,
   Clock,
   Shield,
-  BarChart3,
+  Target,
+  AlertTriangle,
+  FileText,
+  Share2,
+  Zap,
+  Fingerprint,
+  ScrollText,
 } from 'lucide-react';
+import { ShareModal } from '@/components/civica/shared/ShareModal';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -22,6 +31,7 @@ import {
   useSPOPoolCompetitive,
   useGovernancePulse,
   useSPODelegatorTrends,
+  useSPOUrgent,
 } from '@/hooks/queries';
 import {
   tierKey,
@@ -34,6 +44,30 @@ import { computeTier } from '@/lib/scoring/tiers';
 import { generateActions } from '@/lib/actionFeed';
 import { ActionFeed } from './ActionFeed';
 import { SPOClaimHero } from './SPOClaimHero';
+
+const PILLAR_META = [
+  { key: 'participationRate', label: 'Participation', icon: Vote, weight: '35%' },
+  { key: 'deliberationQuality', label: 'Deliberation', icon: Zap, weight: '25%' },
+  { key: 'reliabilityRate', label: 'Reliability', icon: Shield, weight: '25%' },
+  { key: 'governanceIdentity', label: 'Identity', icon: Fingerprint, weight: '15%' },
+] as const;
+
+const ALIGNMENT_META = [
+  { key: 'treasuryConservative', label: 'Treasury Conservative', color: 'bg-red-500' },
+  { key: 'treasuryGrowth', label: 'Treasury Growth', color: 'bg-emerald-500' },
+  { key: 'decentralization', label: 'Decentralization', color: 'bg-purple-500' },
+  { key: 'security', label: 'Security', color: 'bg-blue-500' },
+  { key: 'innovation', label: 'Innovation', color: 'bg-cyan-500' },
+  { key: 'transparency', label: 'Transparency', color: 'bg-amber-500' },
+] as const;
+
+const TIER_THRESHOLDS: Record<string, number> = {
+  Bronze: 20,
+  Silver: 40,
+  Gold: 60,
+  Diamond: 80,
+  Legendary: 95,
+};
 
 function ScoreGauge({ score, tier }: { score: number; tier: string }) {
   const tKey = tierKey(tier);
@@ -51,9 +85,11 @@ function ScoreGauge({ score, tier }: { score: number; tier: string }) {
         {score.toFixed(1)}
       </p>
       <div className="w-full h-2 bg-border rounded-full overflow-hidden">
-        <div
-          className="h-full rounded-full transition-all bg-current"
-          style={{ width: `${Math.min(100, score)}%` }}
+        <motion.div
+          className="h-full rounded-full bg-current"
+          initial={{ width: 0 }}
+          animate={{ width: `${Math.min(100, score)}%` }}
+          transition={{ type: 'spring', stiffness: 60, damping: 20, delay: 0.3 }}
         />
       </div>
       <span
@@ -69,34 +105,122 @@ function ScoreGauge({ score, tier }: { score: number; tier: string }) {
   );
 }
 
+function ScoreSparkline({
+  history,
+}: {
+  history: { epoch_no: number; governance_score: number }[];
+}) {
+  if (history.length < 2) return null;
+  const sorted = [...history].sort((a, b) => a.epoch_no - b.epoch_no);
+  const scores = sorted.map((h) => h.governance_score);
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const range = max - min || 1;
+  const width = 120;
+  const height = 32;
+  const points = scores
+    .map((s, i) => {
+      const x = (i / (scores.length - 1)) * width;
+      const y = height - ((s - min) / range) * (height - 4) - 2;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="w-[120px] h-8" preserveAspectRatio="none">
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="text-primary/60"
+      />
+    </svg>
+  );
+}
+
+function getTierProgress(score: number, currentTier: string) {
+  const entries = Object.entries(TIER_THRESHOLDS);
+  const nextEntry = entries.find(([, t]) => score < t);
+  if (!nextEntry) return null;
+  const [nextTier, nextThreshold] = nextEntry;
+  const currentIdx = entries.findIndex(([name]) => name === currentTier);
+  const currentThreshold = currentIdx > 0 ? entries[currentIdx - 1][1] : 0;
+  const tierRange = nextThreshold - currentThreshold;
+  const progressInTier = score - currentThreshold;
+  return {
+    currentTier,
+    nextTier,
+    pointsToNext: +(nextThreshold - score).toFixed(1),
+    percentWithinTier: tierRange > 0 ? Math.round((progressInTier / tierRange) * 100) : 0,
+  };
+}
+
 export function SPOCommandCenter({ poolId }: { poolId: string }) {
+  const [shareOpen, setShareOpen] = useState(false);
   const { data: rawSummary, isLoading: summaryLoading } = useSPOSummary(poolId);
   const { data: rawVotes, isLoading: votesLoading } = useSPOVotesHistory(poolId);
   const { data: rawCompetitive } = useSPOPoolCompetitive(poolId);
-  const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
+  const { data: rawPulse } = useGovernancePulse();
   const { data: rawDelegatorTrends } = useSPODelegatorTrends(poolId);
+  const { data: rawUrgent } = useSPOUrgent(poolId);
 
   const summary = rawSummary as any;
   const pulse = rawPulse as any;
   const competitive = rawCompetitive as any;
   const delegatorTrends = rawDelegatorTrends as any;
+  const urgent = rawUrgent as any;
   const votes: any[] = (rawVotes as any)?.votes ?? rawVotes ?? [];
   const allVotes = Array.isArray(votes) ? votes : [];
 
   const spoScore: number = summary?.spoScore ?? summary?.score ?? 0;
-  const spoTier: string = computeTier(spoScore) ?? 'Emerging';
+  const spoTier: string = summary?.tier ?? computeTier(spoScore) ?? 'Emerging';
   const isClaimed: boolean = summary?.isClaimed ?? summary?.claimed ?? false;
   const poolName: string = summary?.name ?? summary?.ticker ?? poolId;
   const delegatorCount: number = summary?.delegatorCount ?? delegatorTrends?.current ?? 0;
   const scoreDelta: number | undefined = summary?.scoreDelta ?? summary?.weeklyDelta;
   const participationRate: number = summary?.participationRate ?? 0;
   const rationaleRate: number = summary?.rationaleRate ?? 0;
+  const deliberationQuality: number = summary?.deliberationQuality ?? 0;
+  const reliabilityRate: number = summary?.reliabilityRate ?? 0;
+  const governanceIdentity: number = summary?.governanceIdentity ?? 0;
   const voteCount: number = summary?.voteCount ?? allVotes.length;
+  const alignment = summary?.alignment;
+  const totalVotes: number = (rawVotes as any)?.totalVotes ?? allVotes.length;
 
   const activeProposals: number = pulse?.activeProposals ?? 0;
   const criticalProposals: number = pulse?.criticalProposals ?? 0;
 
   const recentVotes = allVotes.slice(0, 5);
+
+  // Urgent data
+  const urgentProposals: any[] = urgent?.proposals ?? [];
+  const unexplainedVotes: any[] = urgent?.unexplainedVotes ?? [];
+  const pendingProposals: any[] = urgent?.pendingProposals ?? [];
+  const pendingCount: number = urgent?.pendingCount ?? 0;
+  const hasGovernanceStatement: boolean = urgent?.hasGovernanceStatement ?? true;
+
+  // Competitive data
+  const rank: number | null = competitive?.rank ?? null;
+  const totalPools: number = competitive?.totalPools ?? 0;
+  const neighbors: any[] = competitive?.neighbors ?? [];
+  const scoreHistory: { epoch_no: number; governance_score: number }[] =
+    competitive?.scoreHistory ?? [];
+
+  // Pillar values for display
+  const pillars = {
+    participationRate,
+    deliberationQuality,
+    reliabilityRate,
+    governanceIdentity,
+  };
+
+  const hasAlignment =
+    alignment && ALIGNMENT_META.some((a) => alignment[a.key] != null && alignment[a.key] !== 50);
+
+  const tierProgress = getTierProgress(spoScore, spoTier);
 
   if (!summaryLoading && !isClaimed) {
     return <SPOClaimHero poolId={poolId} poolName={poolName} summary={summary} />;
@@ -106,11 +230,15 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
     segment: 'spo',
     activeProposals,
     criticalProposals,
-    pendingVotesCount: activeProposals,
+    pendingVotesCount: pendingCount || activeProposals,
     spoScore,
     spoScoreDelta: scoreDelta,
     spoVoteCount: voteCount,
     spoIsClaimed: isClaimed,
+    spoTier,
+    spoPoolId: poolId,
+    spoHasGovernanceStatement: hasGovernanceStatement,
+    spoUnexplainedVotesCount: unexplainedVotes.length,
   });
 
   const DeltaIcon =
@@ -128,8 +256,10 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
         ? 'text-emerald-400'
         : 'text-rose-400';
 
-  const rank = competitive?.rank;
-  const nearbyPools: any[] = competitive?.nearby ?? [];
+  // Split neighbors into above/below for leaderboard display
+  const selfIdx = neighbors.findIndex((n: any) => n.isTarget);
+  const nearbyAbove = selfIdx > 0 ? neighbors.slice(0, selfIdx) : [];
+  const nearbyBelow = selfIdx >= 0 ? neighbors.slice(selfIdx + 1) : [];
 
   return (
     <div className="space-y-6">
@@ -144,18 +274,16 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
       ) : (
         <div className="relative">
           <ScoreGauge score={spoScore} tier={spoTier} />
-          {scoreDelta != null && (
-            <div
-              className={cn(
-                'absolute top-5 right-5 flex items-center gap-1 text-sm font-medium',
-                deltaColor,
-              )}
-            >
-              <DeltaIcon className="h-4 w-4" />
-              {scoreDelta > 0 ? '+' : ''}
-              {scoreDelta.toFixed(1)} this week
-            </div>
-          )}
+          <div className="absolute top-5 right-5 flex flex-col items-end gap-2">
+            {scoreDelta != null && (
+              <div className={cn('flex items-center gap-1 text-sm font-medium', deltaColor)}>
+                <DeltaIcon className="h-4 w-4" />
+                {scoreDelta > 0 ? '+' : ''}
+                {scoreDelta.toFixed(1)} this week
+              </div>
+            )}
+            <ScoreSparkline history={scoreHistory} />
+          </div>
           {rank != null && (
             <div className="absolute bottom-5 right-5">
               <span className="text-xs text-muted-foreground font-medium px-2 py-0.5 rounded-full border border-border bg-card">
@@ -166,18 +294,42 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
         </div>
       )}
 
+      {/* Tier progress */}
+      {!summaryLoading && tierProgress && tierProgress.pointsToNext > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Target className="h-4 w-4 text-primary" />
+            <div>
+              <p className="text-sm font-medium">
+                {tierProgress.pointsToNext} points to{' '}
+                <span className="text-primary font-bold">{tierProgress.nextTier}</span>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {tierProgress.percentWithinTier}% through {tierProgress.currentTier}
+              </p>
+            </div>
+          </div>
+          <div className="w-20 h-1.5 bg-border rounded-full overflow-hidden">
+            <div
+              className="h-full rounded-full bg-primary"
+              style={{ width: `${tierProgress.percentWithinTier}%` }}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Stats row */}
       <div className="grid grid-cols-3 gap-2">
         {[
           {
             label: 'Delegators',
-            value: delegatorCount > 0 ? delegatorCount.toLocaleString() : '—',
+            value: delegatorCount > 0 ? delegatorCount.toLocaleString() : '\u2014',
             icon: Users,
             color: 'text-primary',
           },
           {
             label: 'Participation',
-            value: participationRate > 0 ? `${participationRate.toFixed(0)}%` : '—',
+            value: participationRate > 0 ? `${participationRate.toFixed(0)}%` : '\u2014',
             icon: CheckCircle2,
             color:
               participationRate >= 70
@@ -190,7 +342,7 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
           },
           {
             label: 'Rationale',
-            value: rationaleRate > 0 ? `${rationaleRate.toFixed(0)}%` : '—',
+            value: rationaleRate > 0 ? `${rationaleRate.toFixed(0)}%` : '\u2014',
             icon: Vote,
             color:
               rationaleRate >= 60
@@ -217,6 +369,73 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
         ))}
       </div>
 
+      {/* Pillar breakdown */}
+      {!summaryLoading && voteCount > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Score Breakdown
+          </p>
+          <div className="space-y-2.5">
+            {PILLAR_META.map(({ key, label, icon: Icon, weight }) => {
+              const val = pillars[key] ?? 0;
+              return (
+                <div key={key} className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="text-sm font-medium">{label}</span>
+                      <span className="text-[10px] text-muted-foreground">{weight}</span>
+                    </div>
+                    <span className="text-sm font-bold tabular-nums">{val.toFixed(0)}</span>
+                  </div>
+                  <div className="h-1.5 bg-border rounded-full overflow-hidden">
+                    <motion.div
+                      className={cn(
+                        'h-full rounded-full',
+                        val >= 70 ? 'bg-emerald-500' : val >= 40 ? 'bg-amber-500' : 'bg-rose-500',
+                      )}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${Math.min(100, val)}%` }}
+                      transition={{ type: 'spring', stiffness: 60, damping: 20, delay: 0.2 }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 6D Alignment */}
+      {!summaryLoading && hasAlignment && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Governance Alignment
+          </p>
+          <div className="space-y-2">
+            {ALIGNMENT_META.map(({ key, label, color }) => {
+              const val = alignment[key] ?? 50;
+              return (
+                <div key={key} className="flex items-center gap-3">
+                  <span className="text-xs text-muted-foreground w-32 shrink-0 truncate">
+                    {label}
+                  </span>
+                  <div className="flex-1 h-1.5 bg-border rounded-full overflow-hidden">
+                    <div
+                      className={cn('h-full rounded-full', color)}
+                      style={{ width: `${Math.min(100, val)}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-bold tabular-nums w-8 text-right">
+                    {Math.round(val)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Inter-body context */}
       {summary?.interBodyAlignment != null && (
         <div className="rounded-xl border border-border bg-card p-4 space-y-1">
@@ -226,7 +445,7 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
           <p className="text-sm">
             You agreed with DRep consensus on{' '}
             <span className="font-bold text-foreground">
-              {summary.interBodyAlignment.drepConsensus ?? '—'}%
+              {summary.interBodyAlignment.drepConsensus ?? '\u2014'}%
             </span>{' '}
             of proposals
             {summary.interBodyAlignment.ccConsensus != null && (
@@ -243,35 +462,199 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
         </div>
       )}
 
-      {/* Alignment radar placeholder */}
-      {voteCount === 0 && (
+      {/* Alignment/identity placeholder for new SPOs */}
+      {voteCount === 0 && !summaryLoading && (
         <div className="rounded-xl border border-border bg-card p-5 text-center space-y-2">
           <Shield className="h-6 w-6 text-muted-foreground mx-auto" />
           <p className="text-sm font-medium text-foreground">Build your governance identity</p>
           <p className="text-xs text-muted-foreground">
-            Vote on more proposals to generate your alignment radar and inter-body context.
+            Vote on proposals to generate your score breakdown, alignment radar, and inter-body
+            context.
           </p>
         </div>
       )}
 
-      {/* Pending votes widget */}
-      {!pulseLoading && activeProposals > 0 && (
-        <Link href="/discover" className="block group">
-          <div className="rounded-xl border border-amber-900/30 bg-amber-950/10 p-4 flex items-center justify-between hover:brightness-110 transition-all">
+      {/* Urgent votes */}
+      {urgentProposals.length > 0 && (
+        <div className="rounded-xl border border-amber-900/30 bg-amber-950/10 p-4 space-y-2">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-400" />
+            <p className="text-sm font-medium text-amber-200">Expiring Soon</p>
+          </div>
+          {urgentProposals.slice(0, 3).map((p: any) => (
+            <Link
+              key={`${p.txHash}-${p.index}`}
+              href={`/proposal/${p.txHash}/${p.index}`}
+              className="flex items-center justify-between text-sm py-1.5 hover:text-primary transition-colors"
+            >
+              <span className="truncate flex-1">{p.title}</span>
+              <span className="text-xs text-amber-400 shrink-0 ml-2">
+                {p.epochsRemaining === 0 ? 'Last epoch!' : `${p.epochsRemaining}ep left`}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Unexplained votes nudge */}
+      {unexplainedVotes.length > 0 && (
+        <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <FileText className="h-4 w-4 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">
+                {unexplainedVotes.length} vote{unexplainedVotes.length > 1 ? 's' : ''} without
+                rationale
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Adding rationales boosts your Deliberation score
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Governance statement CTA */}
+      {!summaryLoading && !hasGovernanceStatement && voteCount > 0 && (
+        <Link href={`/pool/${poolId}`} className="block group">
+          <div className="rounded-xl border border-cyan-900/30 bg-cyan-950/10 p-4 flex items-center justify-between hover:brightness-110 transition-all">
             <div className="flex items-center gap-3">
-              <Clock className="h-4 w-4 text-amber-400" />
+              <ScrollText className="h-4 w-4 text-cyan-400" />
               <div>
-                <p className="text-sm font-medium text-amber-200">
-                  {activeProposals} proposal{activeProposals > 1 ? 's' : ''} open for voting
+                <p className="text-sm font-medium text-cyan-200">
+                  Publish your governance statement
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  Cast your pool&apos;s vote to build governance reputation
+                  Tell delegators what your pool stands for. Boosts your Identity score.
                 </p>
               </div>
             </div>
-            <ChevronRight className="h-4 w-4 text-amber-400 group-hover:translate-x-0.5 transition-transform" />
+            <ChevronRight className="h-4 w-4 text-cyan-400 group-hover:translate-x-0.5 transition-transform" />
           </div>
         </Link>
+      )}
+
+      {/* Pending votes queue */}
+      {pendingProposals.length > 0 && urgentProposals.length === 0 && (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <div className="px-4 py-3 flex items-center justify-between border-b border-border">
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-primary" />
+              <p className="text-sm font-medium">
+                {pendingCount} proposal{pendingCount !== 1 ? 's' : ''} awaiting your vote
+              </p>
+            </div>
+            {pendingCount > 5 && (
+              <Link
+                href="/discover"
+                className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
+              >
+                View all
+                <ChevronRight className="h-3 w-3" />
+              </Link>
+            )}
+          </div>
+          <div className="divide-y divide-border">
+            {pendingProposals.map((p: any) => (
+              <Link
+                key={`${p.txHash}-${p.index}`}
+                href={`/proposal/${p.txHash}/${p.index}`}
+                className="px-4 py-2.5 flex items-center gap-3 hover:bg-muted/20 transition-colors group"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm truncate group-hover:text-primary transition-colors">
+                    {p.title}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {p.proposalType}
+                    {p.epochsRemaining != null && (
+                      <span
+                        className={cn('ml-1.5', p.epochsRemaining <= 2 ? 'text-amber-400' : '')}
+                      >
+                        &middot;{' '}
+                        {p.epochsRemaining === 0
+                          ? 'Last epoch!'
+                          : `${p.epochsRemaining} epoch${p.epochsRemaining !== 1 ? 's' : ''} left`}
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <span className="text-xs text-primary font-medium shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  Vote
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 group-hover:text-primary transition-colors" />
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Competitive context / Leaderboard */}
+      {rank != null && (
+        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Leaderboard Position
+            </p>
+            <span className="text-xs text-muted-foreground">
+              {totalPools} governance-active SPOs
+            </span>
+          </div>
+          <div className="flex items-center gap-4">
+            <p className="font-display text-3xl font-bold tabular-nums text-primary">#{rank}</p>
+          </div>
+          {(nearbyAbove.length > 0 || nearbyBelow.length > 0) && (
+            <div className="divide-y divide-border/50 rounded-lg border overflow-hidden">
+              {nearbyAbove.map((pool: any) => (
+                <Link
+                  key={pool.poolId}
+                  href={`/pool/${pool.poolId}`}
+                  className="px-3 py-2 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs font-bold text-muted-foreground tabular-nums w-6">
+                      #{pool.rank}
+                    </span>
+                    <span className="text-sm truncate">
+                      {pool.ticker ?? pool.poolName ?? pool.poolId}
+                    </span>
+                  </div>
+                  <span className="text-sm font-bold tabular-nums shrink-0">
+                    {pool.score?.toFixed(1)}
+                  </span>
+                </Link>
+              ))}
+              <div className="px-3 py-2 flex items-center justify-between bg-primary/5">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-bold text-primary tabular-nums w-6">#{rank}</span>
+                  <span className="text-sm font-bold text-primary">You</span>
+                </div>
+                <span className="text-sm font-bold tabular-nums text-primary">
+                  {spoScore.toFixed(1)}
+                </span>
+              </div>
+              {nearbyBelow.map((pool: any) => (
+                <Link
+                  key={pool.poolId}
+                  href={`/pool/${pool.poolId}`}
+                  className="px-3 py-2 flex items-center justify-between hover:bg-muted/20 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-xs font-bold text-muted-foreground tabular-nums w-6">
+                      #{pool.rank}
+                    </span>
+                    <span className="text-sm truncate">
+                      {pool.ticker ?? pool.poolName ?? pool.poolId}
+                    </span>
+                  </div>
+                  <span className="text-sm font-bold tabular-nums shrink-0">
+                    {pool.score?.toFixed(1)}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {/* Recent votes */}
@@ -301,63 +684,77 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
                     ? 'text-rose-400'
                     : 'text-muted-foreground';
               return (
-                <div key={idx} className="px-4 py-3 flex items-center gap-3">
+                <Link
+                  key={idx}
+                  href={
+                    vote.proposalTxHash
+                      ? `/proposal/${vote.proposalTxHash}/${vote.proposalIndex}`
+                      : '#'
+                  }
+                  className="px-4 py-3 flex items-center gap-3 hover:bg-muted/20 transition-colors"
+                >
                   <VoteIcon className={cn('h-3.5 w-3.5 shrink-0', voteColor)} />
-                  <p className="text-sm truncate flex-1">
-                    {vote.proposalTitle ?? vote.title ?? 'Proposal'}
-                  </p>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm truncate">
+                      {vote.proposalTitle ?? vote.title ?? 'Proposal'}
+                    </p>
+                    {vote.proposalType && (
+                      <p className="text-[10px] text-muted-foreground">{vote.proposalType}</p>
+                    )}
+                  </div>
                   <div className="flex items-center gap-2 shrink-0">
                     {hasRationale && (
-                      <span className="text-[10px] text-emerald-400/70">✓ rationale</span>
+                      <span className="text-[10px] text-emerald-400/70">rationale</span>
                     )}
                     <span className={cn('text-xs font-bold', voteColor)}>{voteDir}</span>
                   </div>
-                </div>
+                </Link>
               );
             })}
           </div>
-        </div>
-      )}
-
-      {/* Competitive context */}
-      {nearbyPools.length > 0 && (
-        <div className="space-y-2">
-          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-            Nearby SPOs
-          </p>
-          <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
-            {nearbyPools.slice(0, 3).map((pool: any, idx: number) => (
-              <Link
-                key={pool.poolId ?? idx}
-                href={`/pool/${pool.poolId}`}
-                className="px-4 py-3 flex items-center justify-between hover:bg-muted/20 transition-colors"
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-xs font-bold text-muted-foreground tabular-nums w-6">
-                    #{pool.rank}
-                  </span>
-                  <span className="text-sm truncate">
-                    {pool.name ?? pool.ticker ?? pool.poolId}
-                  </span>
-                </div>
-                <span className="text-sm font-bold tabular-nums shrink-0">
-                  {pool.score?.toFixed(1) ?? '—'}
-                </span>
-              </Link>
-            ))}
-          </div>
+          {totalVotes > 0 && (
+            <p className="text-xs text-muted-foreground text-center">{totalVotes} total votes</p>
+          )}
         </div>
       )}
 
       {/* Action feed */}
-      {actions.length > 0 && (
+      {actions.length > 0 ? (
         <div className="space-y-2">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-            Recommended Actions
+            {actions.length === 1 ? 'Action Required' : 'Recommended Actions'}
           </p>
-          <ActionFeed actions={actions} />
+          <ActionFeed actions={actions} emphasizeFirst />
+        </div>
+      ) : (
+        <div className="rounded-xl border border-emerald-900/30 bg-emerald-950/10 px-5 py-4 text-center space-y-1">
+          <p className="text-sm font-medium text-emerald-300">All caught up</p>
+          <p className="text-xs text-muted-foreground">
+            No proposals need your vote right now. Use this time to write a governance statement or
+            review your rationale quality.
+          </p>
         </div>
       )}
+
+      {/* Share profile CTA */}
+      <div className="pt-4 border-t border-border">
+        <button
+          onClick={() => setShareOpen(true)}
+          className="w-full flex items-center gap-2 rounded-lg border border-border p-3 text-sm text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+        >
+          <Share2 className="h-4 w-4" />
+          Share your pool profile
+        </button>
+      </div>
+
+      <ShareModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        ogImageUrl={`/api/og/wrapped/spo/${encodeURIComponent(poolId)}`}
+        shareText={`My pool's governance score on @CivicaGov \u2014 check it out!`}
+        shareUrl={`${typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io'}/pool/${encodeURIComponent(poolId)}`}
+        title="Share your pool profile"
+      />
     </div>
   );
 }

--- a/components/civica/proposals/VoteCastingPanel.tsx
+++ b/components/civica/proposals/VoteCastingPanel.tsx
@@ -15,9 +15,10 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useWallet } from '@/utils/wallet';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { useVote, type VotePhase } from '@/hooks/useVote';
 import { useFeatureFlag } from '@/components/FeatureGate';
-import type { VoteChoice } from '@/lib/voting';
+import type { VoteChoice, VoterRole } from '@/lib/voting';
 
 interface VoteCastingPanelProps {
   txHash: string;
@@ -138,7 +139,8 @@ export function VoteCastingPanel({
   aiSummary,
 }: VoteCastingPanelProps) {
   const { connected, ownDRepId } = useWallet();
-  const { phase, startVote, confirmVote, reset, isProcessing, canVote } = useVote();
+  const { segment, poolId } = useSegment();
+  const { phase, startVote, confirmVote, reset, isProcessing } = useVote();
   const [selectedVote, setSelectedVote] = useState<VoteChoice | null>(null);
   const [rationaleText, setRationaleText] = useState('');
   const [showRationale, setShowRationale] = useState(true);
@@ -146,11 +148,16 @@ export function VoteCastingPanel({
   const [isPublishing, setIsPublishing] = useState(false);
   const voteCastingEnabled = useFeatureFlag('governance_vote_casting');
 
+  // Determine voter role and credential from segment
+  const voterRole: VoterRole = segment === 'spo' ? 'spo' : 'drep';
+  const voterId = segment === 'spo' ? poolId : ownDRepId;
+  const canVote = connected && !!voterId;
+
   // Don't show for closed proposals
   if (!isOpen) return null;
 
-  // Don't show if not a DRep
-  if (!connected || !ownDRepId) return null;
+  // Don't show if not a DRep or SPO
+  if (!connected || !voterId) return null;
 
   // Gated behind feature flag
   if (voteCastingEnabled === null || !voteCastingEnabled) return null;
@@ -159,25 +166,31 @@ export function VoteCastingPanel({
   const isDone = phase.status === 'success';
   const hasError = phase.status === 'error';
 
+  const roleLabel = voterRole === 'spo' ? 'SPO' : 'DRep';
+  const scoringHint =
+    voterRole === 'spo'
+      ? 'SPOs who explain votes score higher on Deliberation Quality (25% weight)'
+      : 'DReps who explain votes score higher on Engagement (25% weight)';
+
   const handleVoteSelect = (vote: VoteChoice) => {
     if (isProcessing || isDone) return;
     setSelectedVote(vote);
 
     if (hasError) reset();
 
-    // Start preflight immediately
-    startVote({ txHash, txIndex: proposalIndex, title }, 'drep');
+    startVote({ txHash, txIndex: proposalIndex, title }, voterRole, voterId);
   };
 
   const handleAiDraft = async () => {
-    if (!ownDRepId) return;
+    if (!voterId) return;
     setIsDrafting(true);
     try {
       const res = await fetch('/api/rationale/draft', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          drepId: ownDRepId,
+          drepId: voterId,
+          voterRole,
           proposalTitle: title,
           proposalAbstract: proposalAbstract || undefined,
           proposalType: proposalType || undefined,
@@ -194,7 +207,7 @@ export function VoteCastingPanel({
   };
 
   const handleConfirm = async () => {
-    if (!selectedVote || !ownDRepId) return;
+    if (!selectedVote || !voterId) return;
 
     let anchorUrl: string | undefined;
     let anchorHash: string | undefined;
@@ -207,7 +220,7 @@ export function VoteCastingPanel({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            drepId: ownDRepId,
+            drepId: voterId,
             proposalTxHash: txHash,
             proposalIndex,
             rationaleText: rationaleText.trim(),
@@ -237,7 +250,7 @@ export function VoteCastingPanel({
     <Card className="border-primary/20">
       <CardContent className="pt-6 space-y-4">
         <div className="flex items-center justify-between">
-          <p className="text-sm font-semibold text-foreground">Cast Your Vote</p>
+          <p className="text-sm font-semibold text-foreground">Cast Your {roleLabel} Vote</p>
           {(isDone || hasError) && (
             <Button variant="ghost" size="sm" onClick={handleReset} className="text-xs">
               {isDone ? 'Vote again' : 'Try again'}
@@ -331,9 +344,7 @@ export function VoteCastingPanel({
                   maxLength={10000}
                 />
                 <div className="flex items-center justify-between">
-                  <p className="text-[10px] text-muted-foreground">
-                    DReps who explain votes score higher on Engagement (25% weight)
-                  </p>
+                  <p className="text-[10px] text-muted-foreground">{scoringHint}</p>
                   <p className="text-xs text-muted-foreground tabular-nums">
                     {rationaleText.length.toLocaleString()} / 10,000
                   </p>

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -478,3 +478,11 @@ export function useSPOPoolCompetitive(poolId: string | null | undefined) {
     staleTime: 60_000,
   });
 }
+
+export function useSPOUrgent(poolId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['spo-urgent', poolId],
+    queryFn: () => fetchJson(`/api/dashboard/spo-urgent?poolId=${encodeURIComponent(poolId!)}`),
+    enabled: !!poolId,
+  });
+}

--- a/hooks/useVote.ts
+++ b/hooks/useVote.ts
@@ -26,16 +26,17 @@ export type VotePhase =
   | { status: 'error'; code: string; message: string; hint: string };
 
 export function useVote() {
-  const { wallet, walletName, connected, ownDRepId } = useWallet();
+  const { wallet, walletName, connected } = useWallet();
   const [phase, setPhase] = useState<VotePhase>({ status: 'idle' });
   const preflightRef = useRef<VotePreflight | null>(null);
   const targetRef = useRef<VoteTarget | null>(null);
 
   /**
    * Step 1: Run preflight checks and move to confirmation state.
+   * @param credentialId - DRep bech32 ID or SPO bech32 pool ID
    */
   const startVote = useCallback(
-    async (target: VoteTarget, role: VoterRole = 'drep') => {
+    async (target: VoteTarget, role: VoterRole = 'drep', credentialId?: string | null) => {
       if (!wallet || !connected) {
         setPhase({
           status: 'error',
@@ -46,8 +47,6 @@ export function useVote() {
         return;
       }
 
-      // Resolve credential based on role
-      const credentialId = role === 'drep' ? ownDRepId : null;
       if (!credentialId) {
         setPhase({
           status: 'error',
@@ -94,7 +93,7 @@ export function useVote() {
         }
       }
     },
-    [wallet, walletName, connected, ownDRepId],
+    [wallet, walletName, connected],
   );
 
   /**
@@ -198,6 +197,5 @@ export function useVote() {
     confirmVote,
     reset,
     isProcessing,
-    canVote: connected && !!wallet && !!ownDRepId,
   };
 }

--- a/lib/actionFeed.ts
+++ b/lib/actionFeed.ts
@@ -4,7 +4,9 @@ export type ActionType =
   | 'score_dropped'
   | 'proposal_expiring'
   | 'tier_approaching'
-  | 'wrapped_ready';
+  | 'wrapped_ready'
+  | 'statement_missing'
+  | 'rationale_missing';
 
 export interface Action {
   id: string;
@@ -32,6 +34,10 @@ export interface ActionFeedInput {
   spoScoreDelta?: number;
   spoVoteCount?: number;
   spoIsClaimed?: boolean;
+  spoTier?: string;
+  spoPoolId?: string;
+  spoHasGovernanceStatement?: boolean;
+  spoUnexplainedVotesCount?: number;
   /** When set, injects a wrapped_ready action linking to /my-gov/wrapped/[period] */
   wrappedReadyPeriod?: string;
 }
@@ -246,6 +252,49 @@ export function generateActions(input: ActionFeedInput): Action[] {
         priority: 2,
         cta: 'View Now',
       });
+    }
+
+    if (input.spoHasGovernanceStatement === false && input.spoIsClaimed !== false) {
+      actions.push({
+        id: 'spo_no_statement',
+        type: 'statement_missing',
+        title: 'Publish your governance statement',
+        description:
+          'Tell delegators what your pool stands for in governance. Boosts your Identity score.',
+        href: input.spoPoolId ? `/pool/${input.spoPoolId}` : '/my-gov',
+        priority: 2,
+        cta: 'Write Statement',
+      });
+    }
+
+    if (input.spoUnexplainedVotesCount && input.spoUnexplainedVotesCount > 0) {
+      actions.push({
+        id: 'spo_unexplained_votes',
+        type: 'rationale_missing',
+        title: `${input.spoUnexplainedVotesCount} vote${input.spoUnexplainedVotesCount > 1 ? 's' : ''} without rationale`,
+        description: 'Adding rationales improves your Deliberation Quality score.',
+        href: input.spoPoolId ? `/pool/${input.spoPoolId}` : '/my-gov',
+        priority: 2,
+        cta: 'Add Rationale',
+      });
+    }
+
+    if (input.spoScore !== undefined) {
+      const nextTier = Object.entries(TIER_THRESHOLDS).find(([, t]) => input.spoScore! < t);
+      if (nextTier) {
+        const gap = nextTier[1] - input.spoScore;
+        if (gap <= 5) {
+          actions.push({
+            id: 'spo_tier_approaching',
+            type: 'tier_approaching',
+            title: `${gap.toFixed(1)} pts from ${nextTier[0]} tier`,
+            description: 'Keep voting and providing rationales to reach the next tier.',
+            href: '/my-gov',
+            priority: 3,
+            cta: 'See Breakdown',
+          });
+        }
+      }
     }
   }
 

--- a/lib/api/schemas/governance.ts
+++ b/lib/api/schemas/governance.ts
@@ -8,6 +8,7 @@ export const ProposalExplainSchema = z.object({
 
 export const RationaleDraftSchema = z.object({
   drepId: DrepIdSchema,
+  voterRole: z.enum(['drep', 'spo']).optional().default('drep'),
   proposalTitle: z.string().min(1, 'proposalTitle is required').max(500),
   proposalAbstract: z.string().max(5000).optional(),
   proposalType: z.string().max(200).optional(),

--- a/lib/voting.ts
+++ b/lib/voting.ts
@@ -7,6 +7,7 @@
  */
 
 import { MeshTxBuilder, KoiosProvider, BrowserWallet } from '@meshsdk/core';
+import { poolBech32ToKeyHash } from '@/utils/drepId';
 
 const KOIOS_BASE = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
 
@@ -223,10 +224,15 @@ export async function castVote(
     }
 
     // Build voter object based on role
+    // SPO credentials: convert bech32 pool ID (pool1...) to hex key hash
+    const poolKeyHash =
+      role === 'spo' && credentialId.startsWith('pool')
+        ? poolBech32ToKeyHash(credentialId)
+        : credentialId;
     const voter =
       role === 'drep'
         ? { type: 'DRep' as const, drepId: credentialId }
-        : { type: 'StakingPool' as const, keyHash: credentialId };
+        : { type: 'StakingPool' as const, keyHash: poolKeyHash };
 
     // Build voting procedure
     const votingProcedure: {

--- a/utils/drepId.ts
+++ b/utils/drepId.ts
@@ -46,6 +46,18 @@ export function deriveDRepIdFromStakeAddress(stakeAddress: string): string | nul
 }
 
 /**
+ * Decode a bech32 pool ID (pool1...) to its raw hex key hash.
+ * MeshJS StakingPool voter requires the hex credential, not bech32.
+ */
+export function poolBech32ToKeyHash(poolId: string): string {
+  const decoded = bech32.decode(poolId, 256);
+  const data = bech32.fromWords(decoded.words);
+  return Array.from(data)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
  * Check if a DRep ID exists in the database via the API.
  * Light client-side check; avoids importing Supabase client in the browser.
  */


### PR DESCRIPTION
## Summary

- **WP-9: SPO Command Center Parity** — Full rewrite of `SPOCommandCenter.tsx` from 13.5KB basic dashboard to DRep Command Center feature parity:
  - Score sparkline from competitive scoreHistory
  - Tier progress indicator with points-to-next-tier
  - 4-pillar breakdown (Participation 35%, Deliberation 25%, Reliability 25%, Identity 15%) with animated bars
  - 6D alignment visualization (Treasury, Decentralization, Security, Innovation, Transparency)
  - Urgent proposals section (expiring within 2 epochs)
  - Unexplained votes nudge
  - Governance statement CTA
  - Pending votes queue with proposal type, epochs remaining, "Vote" action
  - Leaderboard with nearby competitors
  - Share profile button
  - New `/api/dashboard/spo-urgent` API route
  - New `useSPOUrgent` hook
  - Extended `ActionFeed` with `statement_missing` and `rationale_missing` action types

- **WP-10: SPO Vote Casting** — Enable governance vote casting for SPOs via CIP-95/CIP-1694:
  - `VoteCastingPanel` now supports both DRep and SPO roles (detects from segment context)
  - `useVote` hook accepts credential ID externally for role-agnostic voting
  - `poolBech32ToKeyHash()` utility converts bech32 pool IDs to hex key hashes for MeshJS
  - `lib/voting.ts` auto-converts bech32 pool IDs when building SPO voter objects
  - AI rationale drafting uses pool governance statement context for SPOs
  - Vote casting integrated into SPO Command Center pending queue flow

## Files changed (12)

| File | Change |
|------|--------|
| `app/api/dashboard/spo-urgent/route.ts` | New API route |
| `hooks/queries.ts` | Added `useSPOUrgent` hook |
| `lib/actionFeed.ts` | Added SPO-specific action types |
| `components/civica/mygov/ActionFeed.tsx` | New icon/color mappings |
| `components/civica/mygov/SPOCommandCenter.tsx` | Full rewrite |
| `components/civica/proposals/VoteCastingPanel.tsx` | DRep + SPO support |
| `hooks/useVote.ts` | Accept external credential |
| `lib/voting.ts` | Bech32 pool ID conversion |
| `utils/drepId.ts` | `poolBech32ToKeyHash()` utility |
| `lib/api/schemas/governance.ts` | Added `voterRole` field |
| `app/api/rationale/draft/route.ts` | SPO-aware AI drafting |
| `app/proposal/[txHash]/[index]/page.tsx` | Comment update |

## Test plan

- [x] `npm run preflight` passes (format, lint, type-check, 306 tests)
- [ ] SPO Command Center renders all new sections with mock data
- [ ] Vote casting panel shows for SPO segment on proposal pages
- [ ] AI rationale draft works with SPO pool context
- [ ] DRep vote casting still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)