### PR TITLE
feat: error recovery + resilience (QP-4)

### DIFF
--- a/app/discover/error.tsx
+++ b/app/discover/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertCircle, RotateCcw, Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function DiscoverError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <AlertCircle className="h-8 w-8 text-muted-foreground" />
+      <h2 className="text-xl font-semibold">Couldn&apos;t load proposals</h2>
+      <p className="text-muted-foreground max-w-md text-sm">
+        We had trouble loading governance proposals. This is usually temporary.
+      </p>
+      <div className="flex gap-3 mt-2">
+        <Button onClick={reset} variant="default">
+          <RotateCcw className="mr-1.5 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-1.5 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/engage/error.tsx
+++ b/app/engage/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertCircle, RotateCcw, Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function EngageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <AlertCircle className="h-8 w-8 text-muted-foreground" />
+      <h2 className="text-xl font-semibold">Couldn&apos;t load community engagement</h2>
+      <p className="text-muted-foreground max-w-md text-sm">
+        We had trouble loading engagement data. This is usually temporary.
+      </p>
+      <div className="flex gap-3 mt-2">
+        <Button onClick={reset} variant="default">
+          <RotateCcw className="mr-1.5 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-1.5 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/my-gov/error.tsx
+++ b/app/my-gov/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertCircle, RotateCcw, Home } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export default function MyGovError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <AlertCircle className="h-8 w-8 text-muted-foreground" />
+      <h2 className="text-xl font-semibold">Couldn&apos;t load your governance dashboard</h2>
+      <p className="text-muted-foreground max-w-md text-sm">
+        We had trouble loading your governance data. Your delegation and votes are safe on-chain.
+      </p>
+      <div className="flex gap-3 mt-2">
+        <Button onClick={reset} variant="default">
+          <RotateCcw className="mr-1.5 h-4 w-4" />
+          Try again
+        </Button>
+        <Button asChild variant="outline">
+          <Link href="/">
+            <Home className="mr-1.5 h-4 w-4" />
+            Go home
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/NetworkBanner.tsx
+++ b/components/NetworkBanner.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { WifiOff } from 'lucide-react';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+
+export function NetworkBanner() {
+  const { isOnline } = useNetworkStatus();
+
+  if (isOnline) return null;
+
+  return (
+    <div className="fixed top-0 inset-x-0 z-50 bg-amber-600 text-white text-center text-sm py-1.5 px-4">
+      <WifiOff className="inline h-3.5 w-3.5 mr-1.5 -mt-0.5" />
+      You&apos;re offline. Showing cached data.
+    </div>
+  );
+}

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { WalletProvider } from '@/utils/wallet';
 import { initPostHog } from '@/lib/posthog';
 import { getQueryClient } from '@/lib/queryClient';
+import { NetworkBanner } from '@/components/NetworkBanner';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
@@ -15,7 +16,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <WalletProvider>{children}</WalletProvider>
+      <WalletProvider>
+        <NetworkBanner />
+        {children}
+      </WalletProvider>
     </QueryClientProvider>
   );
 }

--- a/components/civica/home/EpochBriefing.tsx
+++ b/components/civica/home/EpochBriefing.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { AsyncContent } from '@/components/ui/AsyncContent';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTreasuryCurrent, useTreasuryPending } from '@/hooks/queries';
@@ -213,10 +214,41 @@ function BriefingSkeleton() {
 /* ── Main component ─────────────────────────────────────────────── */
 
 export function EpochBriefing({ wallet }: EpochBriefingProps) {
-  const { data, isLoading, isError } = useCitizenBriefing(wallet);
+  const briefingQuery = useCitizenBriefing(wallet);
   const { data: identity } = useCivicIdentity(wallet);
   const { data: rawTreasury } = useTreasuryCurrent();
   const { data: rawPending } = useTreasuryPending();
+  return (
+    <AsyncContent
+      query={briefingQuery}
+      skeleton={<BriefingSkeleton />}
+      errorMessage="Couldn't load your briefing"
+    >
+      {(data) => (
+        <EpochBriefingContent
+          data={data}
+          identity={identity}
+          rawTreasury={rawTreasury}
+          rawPending={rawPending}
+        />
+      )}
+    </AsyncContent>
+  );
+}
+
+/* ── Content component (extracted for AsyncContent) ──────────── */
+
+function EpochBriefingContent({
+  data,
+  identity,
+  rawTreasury,
+  rawPending,
+}: {
+  data: any;
+  identity: any;
+  rawTreasury: any;
+  rawPending: any;
+}) {
   const tracked = useRef(false);
   const isMobile = useIsMobile();
   const [activeSection, setActiveSection] = useState(0);
@@ -250,18 +282,6 @@ export function EpochBriefing({ wallet }: EpochBriefingProps) {
       });
     }
   }, [data]);
-
-  if (isLoading) return <BriefingSkeleton />;
-
-  if (isError) {
-    return (
-      <p className="text-sm text-muted-foreground text-center py-8">
-        Unable to load your briefing right now.
-      </p>
-    );
-  }
-
-  if (!data) return null;
 
   const health: HealthLevel = data.status?.health ?? 'green';
   const config = HEALTH_CONFIG[health];

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -17,12 +17,14 @@ import {
   Target,
   AlertTriangle,
   FileText,
+  RotateCcw,
   Shield,
   Zap,
   Eye,
   Fingerprint,
   HelpCircle,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -132,7 +134,12 @@ function ScoreSparkline({ history }: { history: { snapshot_date: string; score: 
 
 export function DRepCommandCenter({ drepId }: { drepId: string }) {
   const [shareOpen, setShareOpen] = useState(false);
-  const { data: rawCard, isLoading: summaryLoading } = useDRepReportCard(drepId);
+  const {
+    data: rawCard,
+    isLoading: summaryLoading,
+    isError: summaryError,
+    refetch: refetchSummary,
+  } = useDRepReportCard(drepId);
   const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
   const { data: rawVotes, isLoading: votesLoading } = useDRepVotes(drepId);
   const { data: rawCompetitive } = useDashboardCompetitive(drepId);
@@ -177,6 +184,23 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
   const nearbyBelow: any[] = competitive?.nearbyBelow ?? [];
   const top10FocusArea = competitive?.top10FocusArea ?? null;
   const distanceToTop10: number = competitive?.distanceToTop10 ?? 0;
+
+  // Show error state if primary query failed
+  if (summaryError && !summaryLoading) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12 text-center">
+        <AlertTriangle className="h-6 w-6 text-muted-foreground" />
+        <p className="text-sm font-medium">Couldn&apos;t load your dashboard</p>
+        <p className="text-xs text-muted-foreground">
+          Your delegation and votes are safe on-chain.
+        </p>
+        <Button variant="outline" size="sm" onClick={() => refetchSummary()}>
+          <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+          Try again
+        </Button>
+      </div>
+    );
+  }
 
   const actions = generateActions({
     segment: 'drep',

--- a/components/civica/mygov/SPOCommandCenter.tsx
+++ b/components/civica/mygov/SPOCommandCenter.tsx
@@ -17,11 +17,13 @@ import {
   Target,
   AlertTriangle,
   FileText,
+  RotateCcw,
   Share2,
   Zap,
   Fingerprint,
   ScrollText,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -160,7 +162,12 @@ function getTierProgress(score: number, currentTier: string) {
 
 export function SPOCommandCenter({ poolId }: { poolId: string }) {
   const [shareOpen, setShareOpen] = useState(false);
-  const { data: rawSummary, isLoading: summaryLoading } = useSPOSummary(poolId);
+  const {
+    data: rawSummary,
+    isLoading: summaryLoading,
+    isError: summaryError,
+    refetch: refetchSummary,
+  } = useSPOSummary(poolId);
   const { data: rawVotes, isLoading: votesLoading } = useSPOVotesHistory(poolId);
   const { data: rawCompetitive } = useSPOPoolCompetitive(poolId);
   const { data: rawPulse } = useGovernancePulse();
@@ -221,6 +228,21 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
     alignment && ALIGNMENT_META.some((a) => alignment[a.key] != null && alignment[a.key] !== 50);
 
   const tierProgress = getTierProgress(spoScore, spoTier);
+
+  // Show error state if primary query failed
+  if (summaryError && !summaryLoading) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12 text-center">
+        <AlertTriangle className="h-6 w-6 text-muted-foreground" />
+        <p className="text-sm font-medium">Couldn&apos;t load your dashboard</p>
+        <p className="text-xs text-muted-foreground">Your pool and votes are safe on-chain.</p>
+        <Button variant="outline" size="sm" onClick={() => refetchSummary()}>
+          <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+          Try again
+        </Button>
+      </div>
+    );
+  }
 
   if (!summaryLoading && !isClaimed) {
     return <SPOClaimHero poolId={poolId} poolName={poolName} summary={summary} />;

--- a/components/engagement/ProposalSentiment.tsx
+++ b/components/engagement/ProposalSentiment.tsx
@@ -15,6 +15,7 @@ import {
   HelpCircle,
   Info,
   RefreshCw,
+  RotateCcw,
   Wallet,
 } from 'lucide-react';
 import { resolveRewardAddress } from '@meshsdk/core';
@@ -35,6 +36,7 @@ export function ProposalSentiment({ txHash, proposalIndex, isOpen }: ProposalSen
   const {
     data: results,
     isLoading,
+    isError: fetchError,
     refetch,
   } = useSentimentResults(txHash, proposalIndex, ownDRepId);
 
@@ -120,6 +122,20 @@ export function ProposalSentiment({ txHash, proposalIndex, isOpen }: ProposalSen
             <Skeleton className="h-11 flex-1" />
             <Skeleton className="h-11 flex-1" />
           </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <Card className="ring-1 ring-primary/10">
+        <CardContent className="py-6 text-center space-y-3">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load sentiment data</p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+            Try again
+          </Button>
         </CardContent>
       </Card>
     );

--- a/components/ui/AsyncContent.tsx
+++ b/components/ui/AsyncContent.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { AlertCircle, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface AsyncContentProps<T> {
+  query: UseQueryResult<T>;
+  skeleton: ReactNode;
+  errorMessage?: string;
+  children: (data: T) => ReactNode;
+}
+
+export function AsyncContent<T>({
+  query,
+  skeleton,
+  errorMessage = "Couldn't load this content",
+  children,
+}: AsyncContentProps<T>) {
+  const { data, isLoading, isError, refetch, dataUpdatedAt } = query;
+
+  if (isLoading) return <>{skeleton}</>;
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-8 text-center">
+        <AlertCircle className="h-5 w-5 text-muted-foreground" />
+        <p className="text-sm font-medium text-foreground">{errorMessage}</p>
+        {dataUpdatedAt > 0 && (
+          <p className="text-xs text-muted-foreground">
+            Last updated {new Date(dataUpdatedAt).toLocaleTimeString()}
+          </p>
+        )}
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return <>{children(data)}</>;
+}

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertCircle, RotateCcw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  children: ReactNode;
+  fallbackMessage?: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // Report to Sentry if available
+    import('@sentry/nextjs')
+      .then((Sentry) => {
+        Sentry.captureException(error, {
+          contexts: { react: { componentStack: errorInfo.componentStack ?? undefined } },
+        });
+      })
+      .catch(() => {});
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center gap-3 py-12 text-center">
+          <AlertCircle className="h-6 w-6 text-muted-foreground" />
+          <p className="text-sm font-medium text-foreground">
+            {this.props.fallbackMessage ?? 'Something went wrong'}
+          </p>
+          <p className="text-xs text-muted-foreground max-w-sm">
+            This section encountered an error. You can try again or refresh the page.
+          </p>
+          <Button variant="outline" size="sm" onClick={this.handleRetry}>
+            <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+            Try again
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/hooks/useNetworkStatus.ts
+++ b/hooks/useNetworkStatus.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+export function useNetworkStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+  const queryClient = useQueryClient();
+
+  const checkHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/health', { cache: 'no-store' });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  useEffect(() => {
+    setIsOnline(navigator.onLine);
+
+    const handleOnline = async () => {
+      const healthy = await checkHealth();
+      if (healthy) {
+        setIsOnline(true);
+        queryClient.invalidateQueries();
+      }
+    };
+
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [checkHealth, queryClient]);
+
+  return { isOnline };
+}

--- a/lib/queryClient.ts
+++ b/lib/queryClient.ts
@@ -7,8 +7,11 @@ function makeQueryClient() {
     defaultOptions: {
       queries: {
         staleTime: 5 * 60 * 1000,
+        gcTime: 30 * 60 * 1000, // Keep cache 30min so stale data survives outages
         refetchOnWindowFocus: false,
-        retry: 1,
+        retry: 2,
+        retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
+        refetchOnReconnect: 'always',
       },
     },
   });


### PR DESCRIPTION
## Summary
- **TanStack Query hardening**: retry 2x with exponential backoff, 30min gcTime for stale data persistence during outages, auto-refetch on reconnect
- **AsyncContent wrapper**: thin component (<50 lines) providing loading skeleton → content → error with retry for all TanStack Query consumers
- **ErrorBoundary + route error boundaries**: Sentry-reporting error boundary component + context-appropriate `error.tsx` for `/discover`, `/my-gov`, `/engage`
- **Network status**: offline detection banner with auto-query-invalidation on reconnect via `/api/health` verification
- **Component resilience**: EpochBriefing, DRepCommandCenter, SPOCommandCenter, and ProposalSentiment all now have proper error states with retry buttons (previously showed blank/gray text on failure)

## Test plan
- [x] `npm run preflight` passes (306/306 tests, 0 lint errors, formatting clean)
- [ ] Simulate offline in DevTools → verify amber banner appears, cached data stays visible
- [ ] Simulate API error (DevTools block `/api/briefing/citizen`) → verify EpochBriefing shows retry button
- [ ] Verify `/discover`, `/my-gov`, `/engage` error boundaries render on server error
- [ ] Verify DRep/SPO command centers show retry on dashboard load failure
- [ ] Verify ProposalSentiment shows retry on fetch failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)