### PR TITLE
fix: add nonce consumption and rate limiting to auth endpoints

### DIFF
--- a/__tests__/api/auth.test.ts
+++ b/__tests__/api/auth.test.ts
@@ -52,7 +52,8 @@ import { checkSignature } from '@meshsdk/core';
 
 describe('GET /api/auth/nonce', () => {
   it('returns a nonce with signature and expiry', async () => {
-    const res = await getNonce();
+    const req = createRequest('/api/auth/nonce');
+    const res = await getNonce(req);
     const body = (await parseJson(res)) as any;
 
     expect(res.status).toBe(200);

--- a/app/api/auth/nonce/route.ts
+++ b/app/api/auth/nonce/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from 'next/server';
 import { createNonce } from '@/lib/nonce';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
-export async function GET() {
-  const nonceData = await createNonce();
-  return NextResponse.json(nonceData);
-}
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(
+  async () => {
+    const nonceData = await createNonce();
+    return NextResponse.json(nonceData);
+  },
+  { auth: 'none', rateLimit: { max: 10, window: 60 } },
+);

--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -5,21 +5,15 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { verifyNonce } from '@/lib/nonce';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
-import { ZodError } from 'zod';
 import { WalletAuthSchema } from '@/lib/api/schemas/auth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
-export async function POST(request: NextRequest) {
-  try {
-    let body;
-    try {
-      body = WalletAuthSchema.parse(await request.json());
-    } catch (e) {
-      if (e instanceof ZodError)
-        return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
-      throw e;
-    }
+export const POST = withRouteHandler(
+  async (request: NextRequest) => {
+    const body = WalletAuthSchema.parse(await request.json());
     const { address, nonce, nonceSignature, signature, key } = body;
 
     const nonceValid = await verifyNonce(nonce, nonceSignature);
@@ -137,8 +131,6 @@ export async function POST(request: NextRequest) {
     captureServerEvent('wallet_authenticated_server', { wallet_address: address }, address);
 
     return response;
-  } catch (error) {
-    logger.error('Auth error', { context: 'auth/wallet', error: error });
-    return NextResponse.json({ error: 'Authentication failed' }, { status: 500 });
-  }
-}
+  },
+  { auth: 'none', rateLimit: { max: 5, window: 60 } },
+);

--- a/lib/nonce.ts
+++ b/lib/nonce.ts
@@ -1,6 +1,7 @@
 import * as jose from 'jose';
 
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const NONCE_TTL_SECONDS = 5 * 60; // 5 minutes in seconds (for Redis EX)
 
 function getSecretKey(): Uint8Array {
   const secret = process.env.SESSION_SECRET;
@@ -15,6 +16,7 @@ export async function createNonce(): Promise<{
 }> {
   const timestamp = Date.now();
   const sessionId = crypto.randomUUID().slice(0, 8);
+  const jti = crypto.randomUUID();
   const timeStr = new Date(timestamp).toLocaleString('en-US', {
     dateStyle: 'medium',
     timeStyle: 'short',
@@ -25,16 +27,41 @@ export async function createNonce(): Promise<{
 
   const signature = await new jose.SignJWT({ nonce, timestamp })
     .setProtectedHeader({ alg: 'HS256' })
+    .setJti(jti)
     .setExpirationTime(Math.floor((timestamp + NONCE_TTL_MS) / 1000))
     .sign(getSecretKey());
 
   return { nonce, signature, expiresAt: timestamp + NONCE_TTL_MS };
 }
 
+/**
+ * Mark a nonce JTI as consumed in Redis so it cannot be replayed.
+ * Returns true if the nonce was freshly consumed, false if already used.
+ * Falls back to allowing the request if Redis is unavailable (fail-open to avoid locking out users).
+ */
+async function consumeNonce(jti: string): Promise<boolean> {
+  try {
+    const { getRedis } = await import('@/lib/redis');
+    const redis = getRedis();
+    const key = `nonce:consumed:${jti}`;
+    // SET NX returns truthy only if the key did not already exist
+    const wasSet = await redis.set(key, '1', { ex: NONCE_TTL_SECONDS, nx: true });
+    return wasSet !== null;
+  } catch {
+    // Redis unavailable — fail open so users can still authenticate
+    return true;
+  }
+}
+
 export async function verifyNonce(nonce: string, signature: string): Promise<boolean> {
   try {
     const { payload } = await jose.jwtVerify(signature, getSecretKey());
-    return payload.nonce === nonce;
+    if (payload.nonce !== nonce) return false;
+
+    // Reject replay: each nonce JTI can only be consumed once
+    const jti = payload.jti;
+    if (!jti) return false;
+    return consumeNonce(jti);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- Add nonce consumption via Redis SET NX with 5-min TTL — replayed nonce JWTs are now rejected
- Rate limit auth endpoints: `/api/auth/nonce` (10 req/min), `/api/auth/wallet` (5 req/min)
- Add `force-dynamic` to both auth routes

## Impact
- **What changed**: Auth endpoints are now protected against nonce replay attacks and brute-force flooding
- **User-facing**: No — legitimate users won't notice (rate limits are generous)
- **Risk**: Low — fail-open if Redis unavailable, existing auth flow unchanged
- **Scope**: `lib/nonce.ts`, `app/api/auth/nonce/route.ts`, `app/api/auth/wallet/route.ts`, 1 test fix

## Audit Reference
Closes P0 gaps #1, #2, #3 from 2026-03-08 comprehensive audit (Security SEC1, SEC3)

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] Verify nonce replay returns 401
- [ ] Verify rate limiting returns 429 after threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>