### PR TITLE
feat: add deregistered DRep detection and citizen alert in epoch briefing

### DIFF
--- a/app/api/briefing/citizen/route.ts
+++ b/app/api/briefing/citizen/route.ts
@@ -58,6 +58,7 @@ interface BriefingResponse {
     health: HealthStatus;
     headline: string;
     delegatedTo: { name: string; id: string; score: number; tier: string } | null;
+    drepDeregistered?: boolean;
   };
 
   headlines: Headline[];
@@ -122,11 +123,18 @@ function computeHealth(
   score: number | null,
   votedThisEpoch: boolean,
   scoreMomentum: number | null,
+  drepDeregistered: boolean,
 ): { health: HealthStatus; headline: string } {
   if (!drepId) {
     return {
       health: 'yellow',
       headline: 'Your ADA is unrepresented \u2014 delegate to have a voice',
+    };
+  }
+  if (drepDeregistered) {
+    return {
+      health: 'red',
+      headline: 'Your DRep has deregistered \u2014 your delegation is no longer active',
     };
   }
   const s = score ?? 0;
@@ -399,6 +407,26 @@ export const GET = withRouteHandler(
     }
 
     // -----------------------------------------------------------------------
+    // 4a. DRep deregistration check
+    // -----------------------------------------------------------------------
+    let drepDeregistered = false;
+
+    if (drepId) {
+      const { data: latestLifecycle } = await supabase
+        .from('drep_lifecycle_events')
+        .select('action')
+        .eq('drep_id', drepId)
+        .order('epoch_no', { ascending: false })
+        .order('id', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (latestLifecycle?.action === 'deregistration') {
+        drepDeregistered = true;
+      }
+    }
+
+    // -----------------------------------------------------------------------
     // 4b. DRep delegated stake (for proportional treasury share)
     // -----------------------------------------------------------------------
     let drepDelegatedAda: number | null = null;
@@ -568,6 +596,7 @@ export const GET = withRouteHandler(
       drepScore,
       votedThisEpoch,
       drepScoreMomentum,
+      drepDeregistered,
     );
 
     const delegatedTo = drepPerformance
@@ -586,6 +615,7 @@ export const GET = withRouteHandler(
         health,
         headline,
         delegatedTo,
+        drepDeregistered: drepDeregistered || undefined,
       },
 
       headlines: buildHeadlines(recap),

--- a/components/civica/home/EpochBriefing.tsx
+++ b/components/civica/home/EpochBriefing.tsx
@@ -10,6 +10,7 @@ import {
   CheckCircle2,
   AlertTriangle,
   AlertCircle,
+  ShieldAlert,
   Vote,
   ArrowUp,
   ArrowDown,
@@ -268,6 +269,7 @@ interface EpochBriefingData {
     health?: string;
     headline?: string;
     delegatedTo?: { id: string; name: string } | null;
+    drepDeregistered?: boolean;
   };
   recap?: { narrative?: string };
   headlines?: { type: string; title: string; description: string }[];
@@ -329,6 +331,7 @@ function EpochBriefingContent({
         epoch: data.epoch,
         health: data.status?.health,
         has_drep: !!data.drepPerformance,
+        drep_deregistered: !!data.status?.drepDeregistered,
       });
     }
   }, [data]);
@@ -401,6 +404,33 @@ function EpochBriefingContent({
       )}
     </div>
   );
+
+  const deregisteredAlert = data.status?.drepDeregistered ? (
+    <div
+      className="py-4 border-b border-rose-500/30"
+      role="alert"
+      aria-label="DRep deregistered alert"
+    >
+      <div className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-4">
+        <div className="flex items-start gap-3">
+          <ShieldAlert className="h-5 w-5 text-rose-500 shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <p className="text-sm font-semibold text-rose-500">Your DRep has deregistered</p>
+            <p className="text-sm text-muted-foreground">
+              {data.status.delegatedTo?.name
+                ? `${data.status.delegatedTo.name} is`
+                : 'Your representative is'}{' '}
+              no longer an active DRep. Your delegation is void and your ADA is unrepresented in
+              governance votes.
+            </p>
+            <Button asChild size="sm" className="mt-1">
+              <Link href="/match">Find a new DRep</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : null;
 
   const narrativeSection = data.recap?.narrative ? (
     <div className="py-5 border-b border-border">
@@ -759,6 +789,7 @@ function EpochBriefingContent({
       <article className="space-y-0">
         {briefingHeader}
         {statusBanner}
+        {deregisteredAlert}
 
         <div className="py-3">
           <SectionTabs sections={sections} activeIndex={activeSection} onSelect={navigateSection} />
@@ -798,6 +829,7 @@ function EpochBriefingContent({
     >
       <motion.div variants={briefingItem}>{briefingHeader}</motion.div>
       <motion.div variants={briefingItem}>{statusBanner}</motion.div>
+      {deregisteredAlert && <motion.div variants={briefingItem}>{deregisteredAlert}</motion.div>}
       <motion.div variants={briefingItem}>{narrativeSection}</motion.div>
       <motion.div variants={briefingItem}>{headlinesSection}</motion.div>
       <motion.div variants={briefingItem}>{drepSection}</motion.div>


### PR DESCRIPTION
## Summary
- Detect when a citizen's delegated DRep has deregistered via `drep_lifecycle_events` table
- Surface a prominent red-level alert banner in the Epoch Briefing with personalized messaging
- Include "Find a new DRep" CTA linking to Quick Match (`/match`)
- Alert appears in both mobile swipeable and desktop stacked layouts
- Deregistration is now the highest-priority health check (produces `health: 'red'`)
- Added PostHog tracking (`drep_deregistered` property on `citizen_briefing_viewed`)

## Impact
- **What changed**: Citizens whose DRep deregisters now see an urgent alert instead of silent representation void
- **User-facing**: Yes — red banner with actionable CTA when DRep is deregistered
- **Risk**: Low — additive change, no existing behavior modified
- **Scope**: `app/api/briefing/citizen/route.ts`, `components/civica/home/EpochBriefing.tsx`

## Audit Reference
Closes P1 gap #17 from 2026-03-08 comprehensive audit (Journeys J-C3, J-C7)

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] Citizen delegated to deregistered DRep sees red alert in briefing
- [ ] CTA navigates to `/match`
- [ ] PostHog event includes `drep_deregistered: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>