### PR TITLE
fix: add authentication to unprotected admin routes

### DIFF
--- a/app/admin/AdminOverviewClient.tsx
+++ b/app/admin/AdminOverviewClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Activity, Database, TrendingUp, AlertTriangle, CheckCircle2, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -22,7 +23,10 @@ interface OverviewData {
 }
 
 async function fetchOverview(): Promise<OverviewData> {
-  const res = await fetch('/api/admin/overview');
+  const token = getStoredSession();
+  const headers: HeadersInit = {};
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch('/api/admin/overview', { headers });
   if (!res.ok) throw new Error('Failed to fetch overview');
   return res.json();
 }

--- a/app/admin/governance/GovernanceClient.tsx
+++ b/app/admin/governance/GovernanceClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Users, Vote, TrendingUp, Shield, BarChart3 } from 'lucide-react';
@@ -246,7 +247,10 @@ export function GovernanceClient() {
   const { data, isLoading } = useQuery<GovernanceData>({
     queryKey: ['admin', 'governance'],
     queryFn: async () => {
-      const res = await fetch('/api/admin/governance');
+      const token = getStoredSession();
+      const headers: HeadersInit = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch('/api/admin/governance', { headers });
       if (!res.ok) throw new Error('Failed to fetch governance data');
       return res.json();
     },

--- a/app/admin/pipeline/PipelineClient.tsx
+++ b/app/admin/pipeline/PipelineClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -250,9 +251,12 @@ export function PipelineClient() {
   const { data, isLoading } = useQuery<PipelineData>({
     queryKey: ['admin', 'pipeline', hours, syncTypeFilter],
     queryFn: async () => {
+      const token = getStoredSession();
+      const headers: HeadersInit = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
       const params = new URLSearchParams({ hours });
       if (syncTypeFilter !== 'all') params.set('syncType', syncTypeFilter);
-      const res = await fetch(`/api/admin/pipeline?${params}`);
+      const res = await fetch(`/api/admin/pipeline?${params}`, { headers });
       if (!res.ok) throw new Error('Failed to fetch pipeline data');
       return res.json();
     },

--- a/app/api/admin/governance/route.ts
+++ b/app/api/admin/governance/route.ts
@@ -1,9 +1,17 @@
 export const dynamic = 'force-dynamic';
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth instanceof NextResponse) return auth;
+  if (!isAdminWallet(auth.wallet)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const supabase = getSupabaseAdmin();
 
   const [epochStats, ghiSnapshots, decentralization, tierDistribution, proposalTypes] =

--- a/app/api/admin/integrity/route.ts
+++ b/app/api/admin/integrity/route.ts
@@ -1,49 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase';
-import { bech32 } from 'bech32';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
 
 export const dynamic = 'force-dynamic';
 
-function deriveStakeFromPaymentAddress(paymentAddress: string): string | null {
-  try {
-    const decoded = bech32.decode(paymentAddress, 256);
-    if (decoded.prefix !== 'addr' && decoded.prefix !== 'addr_test') return null;
-    const data = bech32.fromWords(decoded.words);
-    if (data.length !== 57) return null;
-    const headerByte = data[0];
-    if ((headerByte & 0xf0) >> 4 > 3) return null;
-    const networkId = headerByte & 0x0f;
-    const stakeKeyHash = data.slice(29);
-    const stakeBytes = new Uint8Array(1 + stakeKeyHash.length);
-    stakeBytes[0] = 0xe0 | networkId;
-    stakeBytes.set(stakeKeyHash, 1);
-    return bech32.encode(networkId === 1 ? 'stake' : 'stake_test', bech32.toWords(stakeBytes), 256);
-  } catch {
-    return null;
-  }
-}
-
-async function isAuthorized(request: NextRequest): Promise<boolean> {
-  const authHeader = request.headers.get('authorization');
-  if (authHeader && authHeader === `Bearer ${process.env.CRON_SECRET}`) return true;
-
-  const { searchParams } = new URL(request.url);
-  const address = searchParams.get('address');
-  if (!address) return false;
-  const adminWallets = (process.env.ADMIN_WALLETS || '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean);
-  const lower = address.toLowerCase();
-  if (adminWallets.includes(lower)) return true;
-  const stakeAddr = deriveStakeFromPaymentAddress(lower);
-  return !!(stakeAddr && adminWallets.includes(stakeAddr.toLowerCase()));
-}
-
 export const GET = withRouteHandler(async (request) => {
-  if (!(await isAuthorized(request))) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  // Allow cron jobs via CRON_SECRET bearer token
+  const authHeader = request.headers.get('authorization');
+  const isCron = authHeader === `Bearer ${process.env.CRON_SECRET}`;
+
+  if (!isCron) {
+    // Require authenticated admin session
+    const auth = await requireAuth(request);
+    if (auth instanceof NextResponse) return auth;
+    if (!isAdminWallet(auth.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
   }
 
   const supabase = createClient();

--- a/app/api/admin/overview/route.ts
+++ b/app/api/admin/overview/route.ts
@@ -1,9 +1,17 @@
 export const dynamic = 'force-dynamic';
 
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth instanceof NextResponse) return auth;
+  if (!isAdminWallet(auth.wallet)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const supabase = getSupabaseAdmin();
 
   const [syncResult, drepsResult, proposalsResult, votesResult, failuresResult] = await Promise.all(

--- a/app/api/admin/pipeline/route.ts
+++ b/app/api/admin/pipeline/route.ts
@@ -2,8 +2,16 @@ export const dynamic = 'force-dynamic';
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
 
 export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth instanceof NextResponse) return auth;
+  if (!isAdminWallet(auth.wallet)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const searchParams = request.nextUrl.searchParams;
   const hours = parseInt(searchParams.get('hours') || '24', 10);
   const syncType = searchParams.get('syncType') || null;

--- a/components/admin/IntegrityDashboard.tsx
+++ b/components/admin/IntegrityDashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
+import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -379,7 +380,7 @@ function SyncRow({ entry }: { entry: IntegrityData['sync_history'][0] }) {
 
 // ── Main Component ───────────────────────────────────────────────────────────
 
-export function IntegrityDashboard({ adminAddress }: { adminAddress: string }) {
+export function IntegrityDashboard({ adminAddress: _adminAddress }: { adminAddress: string }) {
   const [data, setData] = useState<IntegrityData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -388,7 +389,10 @@ export function IntegrityDashboard({ adminAddress }: { adminAddress: string }) {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/integrity?address=${encodeURIComponent(adminAddress)}`);
+      const token = getStoredSession();
+      const headers: HeadersInit = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch('/api/admin/integrity', { headers });
       if (!res.ok) throw new Error(`${res.status}`);
       setData(await res.json());
     } catch (err) {
@@ -396,7 +400,7 @@ export function IntegrityDashboard({ adminAddress }: { adminAddress: string }) {
     } finally {
       setLoading(false);
     }
-  }, [adminAddress]);
+  }, []);
 
   useEffect(() => {
     fetchData();

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -407,7 +407,15 @@ export function useFeatureFlags() {
 export function useAdminIntegrity(address: string | null | undefined) {
   return useQuery({
     queryKey: ['admin-integrity', address],
-    queryFn: () => fetchJson(`/api/admin/integrity?address=${encodeURIComponent(address!)}`),
+    queryFn: async () => {
+      const { getStoredSession } = await import('@/lib/supabaseAuth');
+      const token = getStoredSession();
+      const headers: HeadersInit = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch('/api/admin/integrity', { headers });
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return res.json();
+    },
     enabled: !!address,
   });
 }


### PR DESCRIPTION
## Summary
- Protect 3 completely unauthenticated admin routes (`overview`, `governance`, `pipeline`) with `requireAuth()` + `isAdminWallet()`
- Fix `integrity` route: replace query-param wallet address (no ownership proof) with Bearer session token validation
- Update 5 client-side callers to send `Authorization: Bearer <token>` headers
- Remove duplicated `deriveStakeFromPaymentAddress` function from integrity route (already in `lib/adminAuth.ts`)

## Impact
- **What changed**: All admin routes now require authenticated session + admin wallet verification
- **User-facing**: No — admin-only routes, existing admin users authenticate via wallet
- **Risk**: Low — follows exact pattern used by other authenticated admin routes
- **Scope**: 4 API routes + 5 client callers (9 files total)

## Audit Reference
Closes P0 launch blockers from 2026-03-08 comprehensive audit (Security SEC2):
- 3 unauthenticated admin routes exposing system internals
- Admin integrity route trusting bare wallet address without ownership proof

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] Anonymous GET to `/api/admin/overview` → 401
- [ ] Authenticated non-admin → 403
- [ ] Authenticated admin → 200
- [ ] Admin dashboard pages still functional for admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>