### PR TITLE
fix: add onFailure handlers to all sync functions and validate SPO/CC votes

### DIFF
--- a/inngest/functions/snapshot-ghi.ts
+++ b/inngest/functions/snapshot-ghi.ts
@@ -9,7 +9,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { computeGHI } from '@/lib/ghi';
-import { SyncLogger, errMsg } from '@/lib/sync-utils';
+import { SyncLogger, errMsg, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 export const snapshotGhi = inngest.createFunction(
@@ -17,6 +17,20 @@ export const snapshotGhi = inngest.createFunction(
     id: 'snapshot-ghi',
     name: 'Snapshot GHI',
     retries: 3,
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[ghi] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'ghi')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '30 4 * * *' }, { event: 'drepscore/sync.ghi' }],
   async ({ step }) => {

--- a/inngest/functions/sync-catalyst.ts
+++ b/inngest/functions/sync-catalyst.ts
@@ -7,8 +7,9 @@
  */
 
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
-import { alertCritical, emitPostHog, errMsg } from '@/lib/sync-utils';
+import { alertCritical, emitPostHog, errMsg, capMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
 import { syncCatalystFunds, syncCatalystProposals } from '@/lib/sync/catalyst';
 
@@ -17,6 +18,20 @@ export const syncCatalyst = inngest.createFunction(
     id: 'sync-catalyst',
     retries: 2,
     concurrency: { limit: 1, scope: 'env', key: '"catalyst"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[catalyst] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'catalyst')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '30 4 * * *' }, { event: 'drepscore/sync.catalyst' }],
   async ({ step }) => {

--- a/inngest/functions/sync-cc-rationales.ts
+++ b/inngest/functions/sync-cc-rationales.ts
@@ -19,13 +19,27 @@ import {
 import { computeFullTransparencyIndex } from '@/lib/scoring/ccTransparency';
 import type { CCMemberVoteData } from '@/lib/scoring/ccTransparency';
 import { logger } from '@/lib/logger';
-import { errMsg } from '@/lib/sync-utils';
+import { errMsg, capMsg } from '@/lib/sync-utils';
 
 export const syncCcRationales = inngest.createFunction(
   {
     id: 'sync-cc-rationales',
     retries: 2,
     concurrency: { limit: 1, scope: 'env', key: '"cc-rationales"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[cc-rationales] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'cc_votes')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '15 */6 * * *' }, { event: 'drepscore/sync.cc-rationales' }],
   async ({ step }) => {

--- a/inngest/functions/sync-data-moat.ts
+++ b/inngest/functions/sync-data-moat.ts
@@ -11,8 +11,9 @@
  */
 
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
-import { alertCritical, emitPostHog, errMsg } from '@/lib/sync-utils';
+import { alertCritical, emitPostHog, errMsg, capMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
 import {
   prepareDelegatorSnapshot,
@@ -31,6 +32,20 @@ export const syncDataMoat = inngest.createFunction(
     id: 'sync-data-moat',
     retries: 2,
     concurrency: { limit: 1, scope: 'env', key: '"data-moat"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[data-moat] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'data_moat')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '15 3 * * *' }, { event: 'drepscore/sync.data-moat' }],
   async ({ step }) => {

--- a/inngest/functions/sync-drep-scores.ts
+++ b/inngest/functions/sync-drep-scores.ts
@@ -21,7 +21,7 @@ import {
   type ProposalVotingSummary,
   type DRepProfileData,
 } from '@/lib/scoring';
-import { batchUpsert, SyncLogger, errMsg, emitPostHog } from '@/lib/sync-utils';
+import { batchUpsert, SyncLogger, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 export const syncDrepScores = inngest.createFunction(
@@ -29,6 +29,20 @@ export const syncDrepScores = inngest.createFunction(
     id: 'sync-drep-scores',
     retries: 3,
     concurrency: { limit: 1, scope: 'env', key: '"scoring-compute"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[scoring] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'scoring')
+        .is('finished_at', null);
+    },
   },
   [{ event: 'drepscore/sync.scores' }, { cron: '0 2 * * *' }],
   async ({ step }) => {

--- a/inngest/functions/sync-dreps.ts
+++ b/inngest/functions/sync-dreps.ts
@@ -1,13 +1,29 @@
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { executeDrepsSync } from '@/lib/sync/dreps';
-import { pingHeartbeat } from '@/lib/sync-utils';
+import { pingHeartbeat, errMsg, capMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
+import { logger } from '@/lib/logger';
 
 export const syncDreps = inngest.createFunction(
   {
     id: 'sync-dreps',
     retries: 2,
     concurrency: { limit: 2, scope: 'env', key: '"koios-batch"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[dreps] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'dreps')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '0 */6 * * *' }, { event: 'drepscore/sync.dreps' }],
   async ({ step }) => {

--- a/inngest/functions/sync-governance-benchmarks.ts
+++ b/inngest/functions/sync-governance-benchmarks.ts
@@ -10,7 +10,7 @@ import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 
 import { generateText } from '@/lib/ai';
-import { SyncLogger, errMsg } from '@/lib/sync-utils';
+import { SyncLogger, errMsg, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 import {
   fetchEthereumBenchmark,
@@ -24,6 +24,20 @@ export const syncGovernanceBenchmarks = inngest.createFunction(
     id: 'sync-governance-benchmarks',
     name: 'Sync Governance Benchmarks',
     retries: 3,
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[benchmarks] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'benchmarks')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '0 6 * * 0' }, { event: 'drepscore/sync.benchmarks' }],
   async ({ step }) => {

--- a/inngest/functions/sync-proposals.ts
+++ b/inngest/functions/sync-proposals.ts
@@ -1,7 +1,9 @@
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { executeProposalsSync } from '@/lib/sync/proposals';
-import { pingHeartbeat } from '@/lib/sync-utils';
+import { pingHeartbeat, errMsg, capMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
+import { logger } from '@/lib/logger';
 
 export const syncProposals = inngest.createFunction(
   {
@@ -11,6 +13,20 @@ export const syncProposals = inngest.createFunction(
       limit: 2,
       scope: 'env',
       key: '"koios-frequent"',
+    },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[proposals] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'proposals')
+        .is('finished_at', null);
     },
   },
   [{ cron: '*/30 * * * *' }, { event: 'drepscore/sync.proposals' }],

--- a/inngest/functions/sync-secondary.ts
+++ b/inngest/functions/sync-secondary.ts
@@ -1,12 +1,28 @@
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { executeSecondarySync } from '@/lib/sync/secondary';
-import { pingHeartbeat } from '@/lib/sync-utils';
+import { pingHeartbeat, errMsg, capMsg } from '@/lib/sync-utils';
+import { logger } from '@/lib/logger';
 
 export const syncSecondary = inngest.createFunction(
   {
     id: 'sync-secondary',
     retries: 2,
     concurrency: { limit: 2, scope: 'env', key: '"koios-batch"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[secondary] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'secondary')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '30 */6 * * *' }, { event: 'drepscore/sync.secondary' }],
   async ({ step }) => {

--- a/inngest/functions/sync-slow.ts
+++ b/inngest/functions/sync-slow.ts
@@ -1,12 +1,28 @@
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { executeSlowSync } from '@/lib/sync/slow';
-import { pingHeartbeat } from '@/lib/sync-utils';
+import { pingHeartbeat, errMsg, capMsg } from '@/lib/sync-utils';
+import { logger } from '@/lib/logger';
 
 export const syncSlow = inngest.createFunction(
   {
     id: 'sync-slow',
     retries: 1,
     concurrency: { limit: 1, scope: 'env', key: '"slow-sync"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[slow] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'slow')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '0 4 * * *' }, { event: 'drepscore/sync.slow' }],
   async ({ step }) => {

--- a/inngest/functions/sync-spo-cc-votes.ts
+++ b/inngest/functions/sync-spo-cc-votes.ts
@@ -6,7 +6,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { fetchAllSPOVotesBulk, fetchAllCCVotesBulk } from '@/utils/koios';
-import { SyncLogger, batchUpsert, errMsg, emitPostHog } from '@/lib/sync-utils';
+import { SyncLogger, batchUpsert, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 import { computeAndCacheAlignment } from '@/lib/interBodyAlignment';
 
@@ -15,6 +15,32 @@ export const syncSpoAndCcVotes = inngest.createFunction(
     id: 'sync-spo-cc-votes',
     retries: 2,
     concurrency: { limit: 1, scope: 'env', key: '"spo-cc-votes"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[spo-cc-votes] Function failed permanently', { error });
+      // Clean up ghost entries for both sync types this function manages
+      await Promise.all([
+        sb
+          .from('sync_log')
+          .update({
+            finished_at: new Date().toISOString(),
+            success: false,
+            error_message: capMsg(`onFailure: ${msg}`),
+          })
+          .eq('sync_type', 'spo_votes')
+          .is('finished_at', null),
+        sb
+          .from('sync_log')
+          .update({
+            finished_at: new Date().toISOString(),
+            success: false,
+            error_message: capMsg(`onFailure: ${msg}`),
+          })
+          .eq('sync_type', 'cc_votes')
+          .is('finished_at', null),
+      ]);
+    },
   },
   [{ cron: '45 */6 * * *' }, { event: 'drepscore/sync.spo-cc-votes' }],
   async ({ step }) => {

--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -1,7 +1,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { SyncLogger, batchUpsert, errMsg, emitPostHog } from '@/lib/sync-utils';
+import { SyncLogger, batchUpsert, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import {
   computeSpoScores,
   computeProposalMarginMultipliers,
@@ -104,6 +104,20 @@ export const syncSpoScores = inngest.createFunction(
     id: 'sync-spo-scores',
     retries: 3,
     concurrency: { limit: 1, scope: 'env', key: '"spo-scores"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[spo-scores] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'spo_scores')
+        .is('finished_at', null);
+    },
   },
   [{ event: 'drepscore/sync.spo-scores' }, { cron: '0 3 * * *' }],
   async ({ step }) => {

--- a/inngest/functions/sync-treasury-snapshot.ts
+++ b/inngest/functions/sync-treasury-snapshot.ts
@@ -7,7 +7,7 @@ import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { fetchTreasuryBalance } from '@/utils/koios';
 import { calculateTreasuryHealthScore } from '@/lib/treasury';
-import { SyncLogger, emitPostHog, errMsg, pingHeartbeat } from '@/lib/sync-utils';
+import { SyncLogger, emitPostHog, errMsg, capMsg, pingHeartbeat } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 export const syncTreasurySnapshot = inngest.createFunction(
@@ -15,11 +15,45 @@ export const syncTreasurySnapshot = inngest.createFunction(
     id: 'sync-treasury-snapshot',
     retries: 3,
     concurrency: { limit: 1, scope: 'env', key: '"treasury-sync"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[treasury] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'treasury')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '30 22 * * *' }, { event: 'drepscore/sync.treasury' }],
   async ({ step }) => {
     let snapshotEpoch = 0;
     let errorMessage: string | null = null;
+
+    // Idempotency guard: skip if another treasury sync is already in progress
+    const alreadyRunning = await step.run('check-idempotency', async () => {
+      const sb = getSupabaseAdmin();
+      const cutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 min window
+      const { data } = await sb
+        .from('sync_log')
+        .select('id')
+        .eq('sync_type', 'treasury')
+        .eq('success', false)
+        .is('finished_at', null)
+        .gte('started_at', cutoff)
+        .limit(1);
+      return (data?.length ?? 0) > 0;
+    });
+
+    if (alreadyRunning) {
+      logger.info('[treasury] Skipping — another treasury sync is already in progress');
+      return { skipped: true, reason: 'concurrent run detected' };
+    }
 
     const logId = await step.run('init-sync-log', async () => {
       const sb = getSupabaseAdmin();

--- a/inngest/functions/sync-votes.ts
+++ b/inngest/functions/sync-votes.ts
@@ -1,13 +1,29 @@
 import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { executeVotesSync } from '@/lib/sync/votes';
-import { pingHeartbeat } from '@/lib/sync-utils';
+import { pingHeartbeat, errMsg, capMsg } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
+import { logger } from '@/lib/logger';
 
 export const syncVotes = inngest.createFunction(
   {
     id: 'sync-votes',
     retries: 2,
     concurrency: { limit: 2, scope: 'env', key: '"koios-batch"' },
+    onFailure: async ({ error }) => {
+      const sb = getSupabaseAdmin();
+      const msg = errMsg(error);
+      logger.error('[votes] Function failed permanently', { error });
+      await sb
+        .from('sync_log')
+        .update({
+          finished_at: new Date().toISOString(),
+          success: false,
+          error_message: capMsg(`onFailure: ${msg}`),
+        })
+        .eq('sync_type', 'votes')
+        .is('finished_at', null);
+    },
   },
   [{ cron: '15 */6 * * *' }, { event: 'drepscore/sync.votes' }],
   async ({ step }) => {

--- a/utils/koios-schemas.ts
+++ b/utils/koios-schemas.ts
@@ -84,6 +84,32 @@ export const KoiosTreasurySchema = z
   })
   .passthrough();
 
+export const KoiosSPOVoteSchema = z
+  .object({
+    vote_tx_hash: z.string(),
+    voter_id: z.string(),
+    proposal_tx_hash: z.string(),
+    proposal_index: z.number(),
+    epoch_no: z.number(),
+    block_time: z.number(),
+    vote: z.enum(['Yes', 'No', 'Abstain']),
+  })
+  .passthrough();
+
+export const KoiosCCVoteSchema = z
+  .object({
+    vote_tx_hash: z.string(),
+    voter_id: z.string(),
+    proposal_tx_hash: z.string(),
+    proposal_index: z.number(),
+    epoch_no: z.number(),
+    block_time: z.number(),
+    vote: z.enum(['Yes', 'No', 'Abstain']),
+    meta_url: z.string().nullable(),
+    meta_hash: z.string().nullable(),
+  })
+  .passthrough();
+
 export const KoiosDelegatorSchema = z
   .object({
     stake_address: z.string(),

--- a/utils/koios.ts
+++ b/utils/koios.ts
@@ -17,6 +17,7 @@ import {
   KoiosAccountInfo,
 } from '@/types/koios';
 import { logger } from '@/lib/logger';
+import { KoiosSPOVoteSchema, KoiosCCVoteSchema, validateArray } from '@/utils/koios-schemas';
 import * as Sentry from '@sentry/nextjs';
 
 const KOIOS_BASE_URL = process.env.NEXT_PUBLIC_KOIOS_BASE_URL || 'https://api.koios.rest/api/v1';
@@ -889,25 +890,23 @@ export async function fetchAllSPOVotesBulk(): Promise<SPOVote[]> {
   const allVotes: SPOVote[] = [];
   let offset = 0;
   let page = 0;
+  let totalInvalid = 0;
 
   while (true) {
     const url = `/vote_list?voter_role=eq.SPO&limit=${VOTE_LIST_PAGE_SIZE}&offset=${offset}`;
-    const data = await koiosFetch<
-      Array<{
-        vote_tx_hash: string;
-        voter_id: string;
-        proposal_tx_hash: string;
-        proposal_index: number;
-        epoch_no: number;
-        block_time: number;
-        vote: 'Yes' | 'No' | 'Abstain';
-      }>
-    >(url, { cache: 'no-store' });
+    const data = await koiosFetch<unknown[]>(url, { cache: 'no-store' });
 
     const pageData = data || [];
     page++;
 
-    for (const row of pageData) {
+    const { valid: validatedRows, invalidCount } = validateArray(
+      pageData,
+      KoiosSPOVoteSchema,
+      'SPO votes',
+    );
+    totalInvalid += invalidCount;
+
+    for (const row of validatedRows) {
       allVotes.push({
         pool_id: row.voter_id,
         proposal_tx_hash: row.proposal_tx_hash,
@@ -920,11 +919,15 @@ export async function fetchAllSPOVotesBulk(): Promise<SPOVote[]> {
     }
 
     console.log(
-      `[Koios] SPO vote_list page ${page}: ${pageData.length} votes (total: ${allVotes.length})`,
+      `[Koios] SPO vote_list page ${page}: ${pageData.length} votes (valid: ${validatedRows.length}, total: ${allVotes.length})`,
     );
 
     if (pageData.length < VOTE_LIST_PAGE_SIZE) break;
     offset += VOTE_LIST_PAGE_SIZE;
+  }
+
+  if (totalInvalid > 0) {
+    logger.warn(`[Koios] SPO votes: ${totalInvalid} total records failed validation`);
   }
 
   return allVotes;
@@ -938,27 +941,23 @@ export async function fetchAllCCVotesBulk(): Promise<CCVote[]> {
   const allVotes: CCVote[] = [];
   let offset = 0;
   let page = 0;
+  let totalInvalid = 0;
 
   while (true) {
     const url = `/vote_list?voter_role=eq.ConstitutionalCommittee&limit=${VOTE_LIST_PAGE_SIZE}&offset=${offset}`;
-    const data = await koiosFetch<
-      Array<{
-        vote_tx_hash: string;
-        voter_id: string;
-        proposal_tx_hash: string;
-        proposal_index: number;
-        epoch_no: number;
-        block_time: number;
-        vote: 'Yes' | 'No' | 'Abstain';
-        meta_url: string | null;
-        meta_hash: string | null;
-      }>
-    >(url, { cache: 'no-store' });
+    const data = await koiosFetch<unknown[]>(url, { cache: 'no-store' });
 
     const pageData = data || [];
     page++;
 
-    for (const row of pageData) {
+    const { valid: validatedRows, invalidCount } = validateArray(
+      pageData,
+      KoiosCCVoteSchema,
+      'CC votes',
+    );
+    totalInvalid += invalidCount;
+
+    for (const row of validatedRows) {
       allVotes.push({
         cc_hot_id: row.voter_id,
         proposal_tx_hash: row.proposal_tx_hash,
@@ -973,11 +972,15 @@ export async function fetchAllCCVotesBulk(): Promise<CCVote[]> {
     }
 
     console.log(
-      `[Koios] CC vote_list page ${page}: ${pageData.length} votes (total: ${allVotes.length})`,
+      `[Koios] CC vote_list page ${page}: ${pageData.length} votes (valid: ${validatedRows.length}, total: ${allVotes.length})`,
     );
 
     if (pageData.length < VOTE_LIST_PAGE_SIZE) break;
     offset += VOTE_LIST_PAGE_SIZE;
+  }
+
+  if (totalInvalid > 0) {
+    logger.warn(`[Koios] CC votes: ${totalInvalid} total records failed validation`);
   }
 
   return allVotes;


### PR DESCRIPTION
## Summary
- Add `onFailure` handlers to all 13 sync functions that lacked them (copy pattern from `sync-alignment.ts`)
  - Each handler marks orphaned `sync_log` entries as failed and logs errors
- Fix treasury sync concurrency stampede: add idempotency guard step that checks for in-progress runs within 10-min window
- Add Zod validation schemas for SPO and CC vote data from Koios (`KoiosSPOVoteSchema`, `KoiosCCVoteSchema`)
- Apply `validateArray()` to `fetchAllSPOVotesBulk` and `fetchAllCCVotesBulk`

16 files changed, 311 insertions, 42 deletions

## Impact
- **What changed**: Ghost sync_log entries are now cleaned up immediately on failure (not waiting 30-min sweep), treasury sync won't stampede, SPO/CC votes are schema-validated
- **User-facing**: No — backend pipeline resilience improvements
- **Risk**: Low — additive error handling, no sync logic changes
- **Scope**: 14 Inngest sync functions, `utils/koios.ts`, `utils/koios-schemas.ts`

## Audit Reference
Closes P1 gaps #10, #15, #16 from 2026-03-08 comprehensive audit (Sync S1/S2/S3, Data D3)

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] Kill a sync mid-run → onFailure fires, sync_log entry cleaned
- [ ] Treasury sync runs only 1 instance per cron trigger
- [ ] SPO/CC vote sync validates data through Zod schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>