### PR TITLE
feat: wire DRep communication hub with statements, questions, and epoch updates

### DIFF
--- a/app/api/drep/[drepId]/statements/route.ts
+++ b/app/api/drep/[drepId]/statements/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { validateSessionToken } from '@/lib/supabaseAuth';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { logger } from '@/lib/logger';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { z } from 'zod';
+import { SessionTokenSchema } from '@/lib/api/schemas/common';
+
+export const dynamic = 'force-dynamic';
+
+const GeneralStatementSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  statementText: z.string().min(1, 'statementText is required').max(5000),
+});
+
+/**
+ * GET /api/drep/[drepId]/statements
+ * Returns general (non-proposal-specific) position statements for a DRep.
+ * These are stored in position_statements with proposal_tx_hash = 'general'.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ drepId: string }> },
+) {
+  const { drepId } = await params;
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('position_statements')
+    .select('id, drep_id, statement_text, created_at')
+    .eq('drep_id', drepId)
+    .eq('proposal_tx_hash', 'general')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  return NextResponse.json(data || []);
+}
+
+/**
+ * POST /api/drep/[drepId]/statements
+ * Creates a general governance statement (not tied to a specific proposal).
+ * Only the DRep owner (claimed DRep) can post statements.
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest) => {
+    const drepId = decodeURIComponent(request.nextUrl.pathname.split('/')[3]);
+    const body = await request.json();
+    const { sessionToken, statementText } = GeneralStatementSchema.parse(body);
+
+    const parsed = await validateSessionToken(sessionToken);
+    if (!parsed) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { data: user } = await supabase
+      .from('users')
+      .select('claimed_drep_id')
+      .eq('wallet_address', parsed.walletAddress)
+      .single();
+
+    if (!user || user.claimed_drep_id !== drepId) {
+      return NextResponse.json({ error: 'Not authorized for this DRep' }, { status: 403 });
+    }
+
+    // Use 'general' as sentinel tx_hash and a unique index per statement
+    // to avoid upsert conflicts with proposal-specific statements
+    const uniqueIndex = Date.now() % 2147483647; // fits in int4
+
+    const { data, error } = await supabase
+      .from('position_statements')
+      .insert({
+        drep_id: drepId,
+        proposal_tx_hash: 'general',
+        proposal_index: uniqueIndex,
+        statement_text: statementText.trim(),
+      })
+      .select()
+      .single();
+
+    if (error) {
+      logger.error('Error creating general statement', {
+        context: 'drep-statements',
+        error: error?.message,
+      });
+      return NextResponse.json({ error: 'Failed to save statement' }, { status: 500 });
+    }
+
+    captureServerEvent('drep_statement_created', { drep_id: drepId }, drepId);
+
+    return NextResponse.json(data, { status: 201 });
+  },
+  { auth: 'none', rateLimit: { max: 10, window: 60 } },
+);

--- a/app/api/governance/drep-feed/route.ts
+++ b/app/api/governance/drep-feed/route.ts
@@ -11,37 +11,53 @@ export const GET = withRouteHandler(async (request) => {
   }
 
   const supabase = createClient();
-  const [explanationsRes, positionsRes, philosophyRes, drepRes, epochUpdatesRes] =
-    await Promise.all([
-      supabase
-        .from('vote_explanations')
-        .select('drep_id, proposal_tx_hash, proposal_index, explanation_text, created_at')
-        .eq('drep_id', drepId)
-        .order('created_at', { ascending: false })
-        .limit(10),
+  const [
+    explanationsRes,
+    positionsRes,
+    generalStatementsRes,
+    philosophyRes,
+    drepRes,
+    epochUpdatesRes,
+  ] = await Promise.all([
+    supabase
+      .from('vote_explanations')
+      .select('drep_id, proposal_tx_hash, proposal_index, explanation_text, created_at')
+      .eq('drep_id', drepId)
+      .order('created_at', { ascending: false })
+      .limit(10),
 
-      supabase
-        .from('position_statements')
-        .select('drep_id, proposal_tx_hash, proposal_index, statement_text, created_at')
-        .eq('drep_id', drepId)
-        .order('created_at', { ascending: false })
-        .limit(5),
+    supabase
+      .from('position_statements')
+      .select('drep_id, proposal_tx_hash, proposal_index, statement_text, created_at')
+      .eq('drep_id', drepId)
+      .neq('proposal_tx_hash', 'general')
+      .order('created_at', { ascending: false })
+      .limit(5),
 
-      supabase
-        .from('governance_philosophy')
-        .select('philosophy_text, updated_at')
-        .eq('drep_id', drepId)
-        .maybeSingle(),
+    // General (non-proposal-specific) statements
+    supabase
+      .from('position_statements')
+      .select('drep_id, statement_text, created_at')
+      .eq('drep_id', drepId)
+      .eq('proposal_tx_hash', 'general')
+      .order('created_at', { ascending: false })
+      .limit(10),
 
-      supabase.from('dreps').select('info').eq('id', drepId).single(),
+    supabase
+      .from('governance_philosophy')
+      .select('philosophy_text, updated_at')
+      .eq('drep_id', drepId)
+      .maybeSingle(),
 
-      supabase
-        .from('drep_epoch_updates')
-        .select('epoch, update_text, vote_count, rationale_count, generated_at')
-        .eq('drep_id', drepId)
-        .order('epoch', { ascending: false })
-        .limit(5),
-    ]);
+    supabase.from('dreps').select('info').eq('id', drepId).single(),
+
+    supabase
+      .from('drep_epoch_updates')
+      .select('epoch, update_text, vote_count, rationale_count, generated_at')
+      .eq('drep_id', drepId)
+      .order('epoch', { ascending: false })
+      .limit(5),
+  ]);
 
   const explanations = explanationsRes.data || [];
   const positions = positionsRes.data || [];
@@ -84,6 +100,8 @@ export const GET = withRouteHandler(async (request) => {
 
   const drepName = ((drepRes.data?.info as Record<string, unknown>)?.name as string | null) ?? null;
 
+  const generalStatements = generalStatementsRes.data || [];
+
   return NextResponse.json({
     explanations: explanations.map((e) => {
       const key = `${e.proposal_tx_hash}:${e.proposal_index}`;
@@ -106,6 +124,10 @@ export const GET = withRouteHandler(async (request) => {
         createdAt: p.created_at,
       };
     }),
+    generalStatements: generalStatements.map((s) => ({
+      statementText: s.statement_text,
+      createdAt: s.created_at,
+    })),
     philosophy: philosophyRes.data?.philosophy_text || null,
     drepName,
     epochUpdates: (epochUpdatesRes.data || []).map((u) => ({

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -76,6 +76,10 @@ import { computeTierProgress } from '@/lib/scoring/tiers';
 import { getFeatureFlag } from '@/lib/featureFlags';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { DRepProfileTabsV2 } from '@/components/civica/profiles/DRepProfileTabsV2';
+const DRepStatementsTab = nextDynamic(
+  () => import('@/components/civica/profiles/DRepStatementsTab').then((m) => m.DRepStatementsTab),
+  { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
+);
 import { getDRepTraitTags } from '@/lib/alignment';
 import type { EnrichedDRep } from '@/lib/koios';
 import { generateDRepNarrative } from '@/lib/narratives';
@@ -450,7 +454,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     getSocialLinkChecks(drep.drepId),
     isDRepClaimed(drep.drepId),
     getSpoAlignment(drep.votes),
-    getFeatureFlag('drep_communication', false),
+    getFeatureFlag('drep_communication', true),
   ]);
 
   const brokenLinks = new Set(linkChecks.filter((c) => c.status === 'broken').map((c) => c.uri));
@@ -515,14 +519,10 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     governanceIdentity: drep.governanceIdentity,
   });
 
-  // Phase B: Statements tab placeholder (scaffold for when drep_communication flag is on)
+  // Phase B: Statements tab — shows vote explanations, positions, epoch updates, and Q&A
+  // For DRep owners, also shows a "Write Statement" button
   const statementsContent = drepCommunicationEnabled ? (
-    <div className="rounded-xl border border-border bg-card p-8 text-center space-y-2">
-      <p className="text-sm font-medium text-foreground">Statements coming soon</p>
-      <p className="text-xs text-muted-foreground">
-        Position statements and governance philosophy from this DRep will appear here.
-      </p>
-    </div>
+    <DRepStatementsTab drepId={drep.drepId} />
   ) : undefined;
 
   const profileContent = (

--- a/components/DRepCommunicationFeed.tsx
+++ b/components/DRepCommunicationFeed.tsx
@@ -30,6 +30,11 @@ interface Position {
   createdAt: string;
 }
 
+interface GeneralStatement {
+  statementText: string;
+  createdAt: string;
+}
+
 interface EpochUpdate {
   epoch: number;
   updateText: string;
@@ -41,6 +46,7 @@ interface EpochUpdate {
 interface FeedData {
   explanations: Explanation[];
   positions: Position[];
+  generalStatements: GeneralStatement[];
   philosophy: string | null;
   drepName: string | null;
   epochUpdates: EpochUpdate[];
@@ -58,6 +64,7 @@ interface QAItem {
 type FeedItem =
   | { type: 'explanation'; date: string; content: Explanation }
   | { type: 'position'; date: string; content: Position }
+  | { type: 'general_statement'; date: string; content: GeneralStatement }
   | { type: 'epoch_update'; date: string; content: EpochUpdate };
 
 type TabKey = 'feed' | 'qa';
@@ -128,6 +135,7 @@ export function DRepCommunicationFeed({ drepId }: DRepCommunicationFeedProps) {
     data &&
     (data.explanations.length > 0 ||
       data.positions.length > 0 ||
+      (data.generalStatements || []).length > 0 ||
       (data.epochUpdates || []).length > 0);
   const drepName = data?.drepName || `${drepId.slice(0, 16)}...`;
 
@@ -138,6 +146,9 @@ export function DRepCommunicationFeed({ drepId }: DRepCommunicationFeedProps) {
     }
     for (const p of data.positions) {
       feedItems.push({ type: 'position', date: p.createdAt, content: p });
+    }
+    for (const s of data.generalStatements || []) {
+      feedItems.push({ type: 'general_statement', date: s.createdAt, content: s });
     }
     for (const u of data.epochUpdates || []) {
       feedItems.push({ type: 'epoch_update', date: u.generatedAt, content: u });
@@ -254,6 +265,28 @@ export function DRepCommunicationFeed({ drepId }: DRepCommunicationFeedProps) {
                         <p className="text-sm text-muted-foreground mt-1">{u.updateText}</p>
                         <p className="text-[10px] text-muted-foreground mt-1">
                           {new Date(u.generatedAt).toLocaleDateString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                          })}
+                        </p>
+                      </div>
+                    );
+                  }
+
+                  if (item.type === 'general_statement') {
+                    const s = item.content as GeneralStatement;
+                    return (
+                      <div key={`gs-${i}`} className="border-l-2 border-emerald-400/30 pl-3 py-1">
+                        <p className="text-sm">
+                          <span className="font-medium">{drepName}</span> shared a governance
+                          statement
+                        </p>
+                        <p className="text-sm text-muted-foreground mt-1 line-clamp-3">
+                          &ldquo;{s.statementText}&rdquo;
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                          {new Date(s.createdAt).toLocaleDateString('en-US', {
                             month: 'short',
                             day: 'numeric',
                             year: 'numeric',

--- a/components/civica/mygov/CivicaInbox.tsx
+++ b/components/civica/mygov/CivicaInbox.tsx
@@ -14,18 +14,24 @@ import {
   ChevronRight,
   BarChart2,
   Activity,
+  MessageSquare,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { useDRepReportCard, useGovernancePulse, useDashboardInbox } from '@/hooks/queries';
+import {
+  useDRepReportCard,
+  useGovernancePulse,
+  useDashboardInbox,
+  useDashboardUrgent,
+} from '@/hooks/queries';
 import { generateActions } from '@/lib/actionFeed';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type NotificationCategory = 'proposal' | 'score' | 'alignment' | 'system';
+type NotificationCategory = 'proposal' | 'score' | 'alignment' | 'communication' | 'system';
 type FilterTab = 'all' | NotificationCategory;
 
 interface NotificationItem {
@@ -73,6 +79,7 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
   { key: 'proposal', label: 'Proposals' },
   { key: 'score', label: 'Score' },
   { key: 'alignment', label: 'Alignment' },
+  { key: 'communication', label: 'Communication' },
   { key: 'system', label: 'System' },
 ];
 
@@ -269,6 +276,7 @@ export function CivicaInbox() {
   const { data: rawInbox, isLoading: inboxLoading } = useDashboardInbox(
     segment === 'drep' ? drepId : null,
   );
+  const { data: rawUrgent } = useDashboardUrgent(segment === 'drep' ? drepId : null);
 
   const card = rawCard as
     | {
@@ -335,8 +343,28 @@ export function CivicaInbox() {
   });
 
   const systemNotes = buildSystemNotifications(pulse);
+  const urgent = rawUrgent as { unansweredQuestions?: number } | undefined;
+  const communicationNotes: NotificationItem[] = [];
+  if (segment === 'drep' && (urgent?.unansweredQuestions ?? 0) > 0) {
+    const count = urgent!.unansweredQuestions!;
+    communicationNotes.push({
+      id: `comm_unanswered_${count}`,
+      category: 'communication',
+      icon: MessageSquare,
+      iconColor: 'text-primary',
+      borderColor: 'border-primary/20',
+      bgColor: 'bg-primary/5',
+      title: `${count} unanswered question${count > 1 ? 's' : ''} from delegators`,
+      description: 'Responding to questions builds trust and improves engagement.',
+      href: '/my-gov',
+      cta: 'Respond',
+      priority: 2,
+    });
+  }
+
   const allNotifications: NotificationItem[] = [
     ...actions.map(actionToNotification),
+    ...communicationNotes,
     ...systemNotes,
   ];
 

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -22,7 +22,6 @@ import {
   Zap,
   Eye,
   Fingerprint,
-  HelpCircle,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
@@ -45,6 +44,7 @@ import {
 import { computeTier } from '@/lib/scoring/tiers';
 import { generateActions } from '@/lib/actionFeed';
 import { ActionFeed } from './ActionFeed';
+import { DRepQuestionsInbox } from '@/components/DRepQuestionsInbox';
 import type {
   DRepReportCardData,
   PulseData,
@@ -186,7 +186,6 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
   const unexplainedVotes = urgent?.unexplainedVotes ?? [];
   const pendingProposals = urgent?.pendingProposals ?? [];
   const pendingCount: number = urgent?.pendingCount ?? 0;
-  const unansweredQuestions: number = urgent?.unansweredQuestions ?? 0;
 
   const rank: number | null = competitive?.rank ?? null;
   const totalActive: number = competitive?.totalActive ?? 0;
@@ -513,26 +512,8 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
         </div>
       )}
 
-      {/* Unanswered questions */}
-      {unansweredQuestions > 0 && (
-        <Link href={`/drep/${drepId}?tab=community`} className="block group">
-          <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between hover:border-primary/30 transition-colors">
-            <div className="flex items-center gap-3">
-              <HelpCircle className="h-4 w-4 text-primary" />
-              <div>
-                <p className="text-sm font-medium">
-                  {unansweredQuestions} unanswered question
-                  {unansweredQuestions > 1 ? 's' : ''}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  Citizens are waiting for your response
-                </p>
-              </div>
-            </div>
-            <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
-          </div>
-        </Link>
-      )}
+      {/* Delegator questions inbox */}
+      <DRepQuestionsInbox drepId={drepId} />
 
       {/* Competitive context */}
       {rank != null && (

--- a/components/civica/profiles/DRepStatementsTab.tsx
+++ b/components/civica/profiles/DRepStatementsTab.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { PenLine } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useWallet } from '@/utils/wallet';
+import { DRepCommunicationFeed } from '@/components/DRepCommunicationFeed';
+import { StatementComposer } from '@/components/civica/shared/StatementComposer';
+
+interface DRepStatementsTabProps {
+  drepId: string;
+}
+
+/**
+ * Statements tab content for the DRep profile.
+ * Shows the DRepCommunicationFeed (vote explanations, positions, epoch updates, Q&A)
+ * and, for the DRep owner, a "Write Statement" button that opens the StatementComposer.
+ */
+export function DRepStatementsTab({ drepId }: DRepStatementsTabProps) {
+  const { isAuthenticated, ownDRepId } = useWallet();
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const isOwner = isAuthenticated && ownDRepId === drepId;
+
+  const handleStatementSuccess = useCallback(() => {
+    // Bump the key to force the feed to re-fetch
+    setRefreshKey((k) => k + 1);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      {isOwner && (
+        <div className="flex items-center justify-between rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
+          <div>
+            <p className="text-sm font-medium">Share your governance perspective</p>
+            <p className="text-xs text-muted-foreground">
+              Let your delegators know what you&apos;re thinking
+            </p>
+          </div>
+          <Button size="sm" className="gap-1.5" onClick={() => setComposerOpen(true)}>
+            <PenLine className="h-3.5 w-3.5" />
+            Write Statement
+          </Button>
+        </div>
+      )}
+
+      <DRepCommunicationFeed key={refreshKey} drepId={drepId} />
+
+      {isOwner && (
+        <StatementComposer
+          open={composerOpen}
+          onClose={() => setComposerOpen(false)}
+          drepId={drepId}
+          onSuccess={handleStatementSuccess}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/civica/shared/StatementComposer.tsx
+++ b/components/civica/shared/StatementComposer.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { getStoredSession } from '@/lib/supabaseAuth';
 
 interface StatementComposerProps {
   open: boolean;
@@ -20,26 +21,37 @@ interface StatementComposerProps {
 export function StatementComposer({ open, onClose, drepId, onSuccess }: StatementComposerProps) {
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const MAX_CHARS = 1000;
 
   const handleSubmit = async () => {
     if (!text.trim() || loading) return;
+
+    const sessionToken = getStoredSession();
+    if (!sessionToken) {
+      setError('Please connect your wallet first');
+      return;
+    }
+
     setLoading(true);
+    setError(null);
     try {
-      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/positions`, {
+      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/statements`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ statement_text: text.trim() }),
+        body: JSON.stringify({ sessionToken, statementText: text.trim() }),
       });
       if (res.ok) {
         setText('');
         onSuccess?.();
         onClose();
       } else {
-        console.error('Failed to submit statement');
+        const data = await res.json();
+        setError(data.error || 'Failed to submit statement');
       }
     } catch (err) {
       console.error('Error submitting statement', err);
+      setError('Network error, please try again');
     } finally {
       setLoading(false);
     }
@@ -49,22 +61,26 @@ export function StatementComposer({ open, onClose, drepId, onSuccess }: Statemen
     <Dialog
       open={open}
       onOpenChange={(o) => {
-        if (!o) onClose();
+        if (!o) {
+          setError(null);
+          onClose();
+        }
       }}
     >
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Share your position</DialogTitle>
+          <DialogTitle>Share a governance statement</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Let your delegators know how you&apos;re thinking about active governance proposals.
+            Let your delegators know how you&apos;re thinking about governance. Your statements will
+            appear on the Statements tab of your profile.
           </p>
           <div className="relative">
             <Textarea
               value={text}
               onChange={(e) => setText(e.target.value.slice(0, MAX_CHARS))}
-              placeholder="Share your perspective on current governance activity…"
+              placeholder="Share your perspective on current governance activity..."
               className="min-h-[120px] resize-none"
             />
             <span
@@ -75,13 +91,14 @@ export function StatementComposer({ open, onClose, drepId, onSuccess }: Statemen
               {text.length}/{MAX_CHARS}
             </span>
           </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
         <DialogFooter>
           <Button variant="ghost" onClick={onClose} disabled={loading}>
             Cancel
           </Button>
           <Button onClick={handleSubmit} disabled={loading || !text.trim()}>
-            {loading ? 'Sharing…' : 'Share statement'}
+            {loading ? 'Sharing...' : 'Share statement'}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- Enable `drep_communication` feature flag and replace "coming soon" stub with working `DRepStatementsTab`
- Create `/api/drep/[drepId]/statements` API route (GET/POST) for general DRep statements
- Fix `StatementComposer`: proper auth, field name mismatch, error handling
- Wire `DRepCommunicationFeed` to display general statements alongside epoch updates and positions
- Add `DRepQuestionsInbox` to `DRepCommandCenter` for direct question responses
- Add `communication` notification category to `CivicaInbox` surfacing unanswered delegator questions

8 files changed, 306 insertions, 71 deletions

## Impact
- **What changed**: DReps can now publish statements, respond to delegator questions, and see communication activity in their inbox. Citizens see DRep statements on profile pages.
- **User-facing**: Yes — completes the DRep accountability loop (delegate → vote → explain → assess)
- **Risk**: Medium — new API route + feature flag change, but uses existing DB tables and patterns
- **Scope**: 1 new API route, 1 new component, 6 modified files

## Audit Reference
Closes P0 gap #7 from 2026-03-08 comprehensive audit — flagged by 3 separate audits (UX U2, Journeys J-D4, Bedrock Step 5)

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] DRep profile shows working statements tab with compose button for claimed DReps
- [ ] Statement submission creates record and appears in feed
- [ ] DRep Command Center shows citizen questions inbox
- [ ] CivicaInbox shows communication notification category

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>