### PR TITLE
fix: enforce fail-closed security pattern and activate CSP

### DIFF
--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -28,11 +28,15 @@ async function sendMessage(chatId: number, text: string, parseMode = 'HTML') {
  * Set webhook via: https://api.telegram.org/bot{TOKEN}/setWebhook?url={SITE_URL}/api/telegram/webhook&secret_token={SECRET}
  */
 export async function POST(request: NextRequest) {
-  if (WEBHOOK_SECRET) {
-    const secret = request.headers.get('x-telegram-bot-api-secret-token');
-    if (secret !== WEBHOOK_SECRET) {
-      return NextResponse.json({ ok: false }, { status: 403 });
-    }
+  // Fail closed: require webhook secret to be configured
+  if (!WEBHOOK_SECRET) {
+    logger.warn('TELEGRAM_WEBHOOK_SECRET not configured — rejecting webhook');
+    return NextResponse.json({ error: 'Not configured' }, { status: 503 });
+  }
+
+  const secret = request.headers.get('x-telegram-bot-api-secret-token');
+  if (secret !== WEBHOOK_SECRET) {
+    return NextResponse.json({ ok: false }, { status: 403 });
   }
 
   try {
@@ -181,7 +185,7 @@ export async function POST(request: NextRequest) {
 }
 
 function generateConnectToken(chatId: number): string {
-  const payload = `${chatId}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  const payload = `${chatId}:${Date.now()}:${crypto.randomUUID()}`;
   return Buffer.from(payload).toString('base64url');
 }
 

--- a/lib/api/epochRateLimit.ts
+++ b/lib/api/epochRateLimit.ts
@@ -56,11 +56,11 @@ export async function checkEpochRateLimit(
       limit,
     };
   } catch (error) {
-    // Redis unavailable — allow the action (fail open for epoch limits)
-    logger.warn('Epoch rate limit check failed — allowing', {
+    // Redis unavailable — deny the action (fail closed)
+    logger.warn('Epoch rate limit check failed — denying (fail-closed)', {
       action: config.action,
       error,
     });
-    return { allowed: true, remaining: limit, limit };
+    return { allowed: false, remaining: 0, limit };
   }
 }

--- a/lib/api/withRouteHandler.ts
+++ b/lib/api/withRouteHandler.ts
@@ -43,7 +43,20 @@ function getClientIp(request: NextRequest): string {
 
 // Simple in-process sliding window rate limiter.
 // Uses Upstash when available, falls back to in-memory.
+const MEMORY_STORE_MAX = 10_000;
+const MEMORY_STORE_EVICT = 1_000;
 const memoryStore = new Map<string, { count: number; resetAt: number }>();
+
+/** Evict the oldest entries when the map exceeds the size cap. */
+function evictOldest() {
+  if (memoryStore.size <= MEMORY_STORE_MAX) return;
+  let evicted = 0;
+  for (const key of memoryStore.keys()) {
+    if (evicted >= MEMORY_STORE_EVICT) break;
+    memoryStore.delete(key);
+    evicted++;
+  }
+}
 
 async function checkLimit(
   identifier: string,
@@ -70,6 +83,7 @@ async function checkLimit(
 
   if (!entry || now > entry.resetAt) {
     memoryStore.set(identifier, { count: 1, resetAt: now + windowMs });
+    evictOldest();
     return { allowed: true, remaining: config.max - 1 };
   }
 

--- a/lib/supabaseAuth.ts
+++ b/lib/supabaseAuth.ts
@@ -63,7 +63,9 @@ async function isSessionRevoked(jti: string): Promise<boolean> {
       .maybeSingle();
     return !!data;
   } catch {
-    return false;
+    // Both Redis and DB unavailable — fail closed (assume revoked)
+    logger.warn('Session revocation check failed — assuming revoked (fail-closed)', { jti });
+    return true;
   }
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,7 +33,7 @@ const nextConfig: NextConfig = {
       {
         source: '/((?!api).*)',
         headers: [
-          { key: 'Content-Security-Policy-Report-Only', value: csp },
+          { key: 'Content-Security-Policy', value: csp },
           {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',


### PR DESCRIPTION
## Summary
- `isSessionRevoked()`: fail closed when Redis+DB unavailable (return revoked, not allowed)
- `epochRateLimit`: fail closed when Redis down (deny, not allow)
- Telegram webhook: require `TELEGRAM_WEBHOOK_SECRET` (503 if unset), replace `Math.random()` with `crypto.randomUUID()`
- CSP: switch from `Report-Only` to enforced `Content-Security-Policy` (directives already cover PostHog, Sentry, Supabase, Koios)
- In-memory rate limiter: cap at 10k entries with LRU eviction of oldest 1k

5 files changed

## Impact
- **What changed**: Security error handling now defaults to "deny" instead of "allow" across 4 subsystems; CSP actively blocks XSS
- **User-facing**: No under normal conditions — only triggers during infrastructure failures (Redis down) or attacks
- **Risk**: Medium — fail-closed means legitimate users get denied during Redis outages; CSP enforcement could block unexpected third-party scripts
- **Scope**: `lib/supabaseAuth.ts`, `lib/api/epochRateLimit.ts`, `app/api/telegram/webhook/route.ts`, `next.config.ts`, `lib/api/withRouteHandler.ts`

## Audit Reference
Closes P1 gaps #8, #9, #14 from 2026-03-08 comprehensive audit (Security SEC1, SEC3, SEC5)

## Test plan
- [x] Preflight passes (510 tests, lint/format/types clean)
- [ ] Kill Redis → session check returns revoked (fail-closed)
- [ ] Kill Redis → rate limiter rejects (fail-closed)
- [ ] Telegram webhook without secret → 503
- [ ] Production loads without CSP console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>