### PR TITLE
fix: improve ARIA accessibility and soften proposal sentiment auth friction

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -234,7 +234,10 @@ export function CommandPalette() {
           </Command.List>
 
           {/* Footer */}
-          <div className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[10px] text-muted-foreground">
+          <div
+            className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[10px] text-muted-foreground"
+            aria-hidden="true"
+          >
             <span>
               <kbd className="font-mono">↑↓</kbd> navigate <kbd className="font-mono">↵</kbd> select{' '}
               <kbd className="font-mono">esc</kbd> close

--- a/components/ScoreCard.tsx
+++ b/components/ScoreCard.tsx
@@ -72,7 +72,8 @@ export function ScoreCard({
             <CardTitle>DRep Score</CardTitle>
             <div
               className="flex items-center gap-1"
-              title={`${pillarStatuses.filter((s) => s === 'strong').length} of 4 pillars at Strong`}
+              role="group"
+              aria-label={`${pillarStatuses.filter((s) => s === 'strong').length} of 4 pillars at Strong`}
             >
               {pillarStatuses.map((s, i) => (
                 <span
@@ -84,6 +85,8 @@ export function ScoreCard({
                         ? 'bg-amber-500'
                         : 'bg-red-500'
                   }`}
+                  role="img"
+                  aria-label={`Pillar ${i + 1}: ${s === 'strong' ? 'Strong' : s === 'needs-work' ? 'Needs work' : 'Weak'}`}
                 />
               ))}
             </div>

--- a/components/ScoreRing.tsx
+++ b/components/ScoreRing.tsx
@@ -20,8 +20,16 @@ export function ScoreRing({ score, size = 140, strokeWidth = 10 }: ScoreRingProp
   const { stroke, label } = getTierColor(score);
 
   return (
-    <div className="relative flex-shrink-0" style={{ width: size, height: size }}>
-      <svg width={size} height={size} className="-rotate-90">
+    <div
+      className="relative flex-shrink-0"
+      style={{ width: size, height: size }}
+      role="meter"
+      aria-valuenow={score}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={`Score: ${score} out of 100, ${label}`}
+    >
+      <svg width={size} height={size} className="-rotate-90" aria-hidden="true">
         {/* Background track */}
         <circle
           cx={size / 2}

--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -40,9 +40,11 @@ export function CivicaBottomNav() {
               href={href}
               className={cn(
                 'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors [touch-action:manipulation]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
                 active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
               )}
               aria-current={active ? 'page' : undefined}
+              aria-label={label}
             >
               <div className="relative inline-flex">
                 <Icon className="h-5 w-5" />

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -90,7 +90,7 @@ export function CivicaHeader() {
         <div className="flex items-center gap-1">
           <Link
             href="/"
-            className="font-display text-lg font-bold tracking-tight mr-6 text-foreground"
+            className="font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
           >
             Civica
           </Link>
@@ -105,6 +105,7 @@ export function CivicaHeader() {
                   className={cn(
                     'relative flex items-center gap-2 px-3 py-2 min-h-[44px] text-sm font-medium rounded-md transition-colors',
                     'hover:bg-accent hover:text-accent-foreground',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
                     active ? 'text-foreground' : 'text-muted-foreground',
                   )}
                   aria-current={active ? 'page' : undefined}
@@ -161,10 +162,12 @@ export function CivicaHeader() {
                 <button
                   className={cn(
                     'flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-full transition-colors cursor-pointer',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
                     hasOverride
                       ? 'bg-amber-500/15 text-amber-600 dark:text-amber-400 hover:bg-amber-500/25'
                       : 'text-muted-foreground bg-muted hover:bg-accent hover:text-accent-foreground',
                   )}
+                  aria-label="User menu"
                 >
                   {hasOverride ? <Eye className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
                   {segment !== 'anonymous' && SEGMENT_LABELS[segment]}

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -60,9 +60,11 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
   return (
     <Link
       href={`/drep/${drep.drepId}`}
+      aria-label={`${displayName}, DRep score ${score}, ${tier} tier${matchScore != null ? `, ${matchScore}% match` : ''}`}
       className={cn(
         'group relative flex flex-col rounded-xl border p-4 transition-all duration-200',
         'hover:shadow-lg hover:-translate-y-0.5',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],
         TIER_BORDER[tier],
         TIER_GLOW[tier],
@@ -193,12 +195,19 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
         </span>
         <span className="flex items-center gap-0.5">
           {momentum !== null && momentum > 0.5 ? (
-            <TrendingUp className="h-3 w-3 text-emerald-400" />
+            <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
           ) : momentum !== null && momentum < -0.5 ? (
-            <TrendingDown className="h-3 w-3 text-rose-400" />
+            <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
           ) : (
-            <Minus className="h-3 w-3 text-muted-foreground" />
+            <Minus className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
           )}
+          <span className="sr-only">
+            {momentum !== null && momentum > 0.5
+              ? 'Trending up'
+              : momentum !== null && momentum < -0.5
+                ? 'Trending down'
+                : 'Stable'}
+          </span>
         </span>
       </div>
 

--- a/components/civica/cards/CivicaSPOCard.tsx
+++ b/components/civica/cards/CivicaSPOCard.tsx
@@ -66,9 +66,11 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
   return (
     <Link
       href={`/pool/${pool.poolId}`}
+      aria-label={`${pool.ticker || pool.poolName || pool.poolId.slice(0, 16)}, governance score ${score}, ${tier} tier`}
       className={cn(
         'group relative flex flex-col rounded-xl border p-4 transition-all duration-200',
         'hover:shadow-lg hover:-translate-y-0.5',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],
         TIER_BORDER[tier],
         TIER_GLOW[tier],
@@ -168,7 +170,14 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
                   </span>
                   <span className="tabular-nums">{pct}%</span>
                 </div>
-                <div className="h-0.5 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-0.5 rounded-full bg-muted overflow-hidden"
+                  role="progressbar"
+                  aria-valuenow={pct}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`${label}: ${pct}%`}
+                >
                   <div
                     className="h-full rounded-full transition-all duration-500"
                     style={{

--- a/components/civica/charts/CrossChainRadar.tsx
+++ b/components/civica/charts/CrossChainRadar.tsx
@@ -182,10 +182,14 @@ export function CrossChainRadar({ chains, axes, className }: CrossChainRadarProp
             key={chain.chain}
             className={cn(
               'flex items-center gap-1.5 text-xs font-medium transition-opacity',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
               hoveredChain && hoveredChain !== chain.chain ? 'opacity-40' : 'opacity-100',
             )}
             onMouseEnter={() => setHoveredChain(chain.chain)}
             onMouseLeave={() => setHoveredChain(null)}
+            onFocus={() => setHoveredChain(chain.chain)}
+            onBlur={() => setHoveredChain(null)}
+            aria-label={`Highlight ${chain.chain} data`}
           >
             <span
               className="inline-block h-2 w-2 rounded-full"

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -392,6 +392,7 @@ function IntroScreen({
           aria-checked={matchType === 'drep'}
           className={cn(
             'px-4 py-1.5 rounded-md text-sm font-medium transition-all',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
             matchType === 'drep'
               ? 'bg-background text-foreground shadow-sm'
               : 'text-muted-foreground hover:text-foreground',
@@ -406,6 +407,7 @@ function IntroScreen({
           aria-checked={matchType === 'spo'}
           className={cn(
             'px-4 py-1.5 rounded-md text-sm font-medium transition-all',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
             matchType === 'spo'
               ? 'bg-background text-foreground shadow-sm'
               : 'text-muted-foreground hover:text-foreground',
@@ -425,7 +427,7 @@ function IntroScreen({
       {storedProfile && (
         <button
           onClick={onViewPrevious}
-          className="flex items-center gap-2 mx-auto text-sm text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-2 mx-auto text-sm text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
         >
           <History className="h-4 w-4" />
           View your previous {storedProfile.matchType === 'spo' ? 'SPO' : 'DRep'} match results
@@ -464,10 +466,12 @@ function QuestionScreen({
               key={opt.value}
               onClick={() => !selected && onSelect(opt.value)}
               disabled={!!selected}
+              aria-label={`${opt.label}: ${opt.description}`}
+              aria-pressed={isSelected}
               className={cn(
                 'w-full text-left rounded-xl border p-4 sm:p-5 transition-all duration-200',
                 'hover:border-primary/50 hover:bg-primary/5',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
                 isSelected
                   ? 'border-primary bg-primary/10 scale-[0.98]'
                   : selected
@@ -483,6 +487,7 @@ function QuestionScreen({
                       ? 'bg-primary text-primary-foreground'
                       : 'bg-muted text-muted-foreground',
                   )}
+                  aria-hidden="true"
                 >
                   <Icon className="h-5 w-5" />
                 </div>
@@ -635,11 +640,14 @@ function QuickMatchResultCard({
     : `/drep/${encodeURIComponent(match.drepId)}`;
 
   return (
-    <Card className="overflow-hidden hover:border-primary/30 transition-colors">
+    <Card
+      className="overflow-hidden hover:border-primary/30 transition-colors"
+      aria-label={`Rank ${rank}: ${displayName}, ${match.matchScore}% match`}
+    >
       <CardContent className="p-4">
         <div className="flex gap-4">
           {/* Radar overlay (desktop) */}
-          <div className="hidden sm:block shrink-0">
+          <div className="hidden sm:block shrink-0" aria-hidden="true">
             <RadarOverlay
               userAlignments={userAlignments}
               drepAlignments={match.alignments}

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -109,14 +109,16 @@ function StatCard({
       href={href as string}
       className={cn(
         'rounded-xl border border-border bg-card p-4 space-y-2 transition-colors',
-        href && 'hover:border-primary/30 cursor-pointer group',
+        href &&
+          'hover:border-primary/30 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
       )}
+      {...(href ? { 'aria-label': `${label}: ${value}${sub ? `, ${sub}` : ''}` } : {})}
     >
       <div className="flex items-center justify-between">
         <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">
           {label}
         </p>
-        <Icon className={cn('h-4 w-4', accentClass)} />
+        <Icon className={cn('h-4 w-4', accentClass)} aria-hidden="true" />
       </div>
       <div className={cn('font-display text-3xl font-bold leading-none tabular-nums', accentClass)}>
         {value}
@@ -197,13 +199,21 @@ export function CivicaPulseOverview() {
         message="The big picture. How healthy is Cardano governance right now? Track participation, treasury, and trends over time."
       />
       {/* ── Tab bar ─────────────────────────────────────────── */}
-      <div className="flex gap-1 border-b border-border -mb-2 overflow-x-auto">
+      <div
+        className="flex gap-1 border-b border-border -mb-2 overflow-x-auto"
+        role="tablist"
+        aria-label="Pulse view"
+      >
         {TABS.map((tab) => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`pulse-tabpanel-${tab.id}`}
             className={cn(
               'px-4 py-2 text-sm font-medium shrink-0 border-b-2 transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
               activeTab === tab.id
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground',
@@ -214,11 +224,15 @@ export function CivicaPulseOverview() {
         ))}
       </div>
 
-      {activeTab === 'observatory' && <CivicaObservatory />}
+      {activeTab === 'observatory' && (
+        <div role="tabpanel" id="pulse-tabpanel-observatory" aria-label="Observatory">
+          <CivicaObservatory />
+        </div>
+      )}
 
       {/* ── History tab: epoch report + trends + calendar ───── */}
       {activeTab === 'history' && (
-        <div className="space-y-8">
+        <div className="space-y-8" role="tabpanel" id="pulse-tabpanel-history" aria-label="History">
           <CivicaEpochReport />
           <CivicaGovernanceTrends />
           <CivicaGovernanceCalendar />
@@ -227,7 +241,7 @@ export function CivicaPulseOverview() {
 
       {/* ── Now tab ─────────────────────────────────────────── */}
       {activeTab === 'now' && (
-        <>
+        <div role="tabpanel" id="pulse-tabpanel-now" aria-label="Now">
           {/* ── State of Governance narrative ───────────────────── */}
           <StateOfGovernance />
 
@@ -574,7 +588,7 @@ export function CivicaPulseOverview() {
               </Link>
             </div>
           )}
-        </>
+        </div>
       )}
     </div>
   );

--- a/components/civica/shared/ScoreImpactChip.tsx
+++ b/components/civica/shared/ScoreImpactChip.tsx
@@ -22,8 +22,13 @@ export function ScoreImpactChip({ points, size = 'sm' }: ScoreImpactChipProps) {
           ? 'bg-green-500/10 text-green-500 border border-green-500/20'
           : 'bg-red-500/10 text-red-500 border border-red-500/20',
       )}
+      role="status"
+      aria-label={`Score impact: ${isPositive ? 'positive' : 'negative'} ${Math.abs(points)} points`}
     >
-      <Zap className={cn('shrink-0', size === 'sm' ? 'h-2.5 w-2.5' : 'h-3.5 w-3.5')} />
+      <Zap
+        className={cn('shrink-0', size === 'sm' ? 'h-2.5 w-2.5' : 'h-3.5 w-3.5')}
+        aria-hidden="true"
+      />
       {label}
     </span>
   );

--- a/components/civica/shared/ShareModal.tsx
+++ b/components/civica/shared/ShareModal.tsx
@@ -73,27 +73,42 @@ export function ShareModal({
 
           {/* Action buttons */}
           <div className="flex gap-2">
-            <Button variant="default" className="flex-1 gap-2" onClick={handleShareX}>
-              <Share2 className="h-4 w-4" />
+            <Button
+              variant="default"
+              className="flex-1 gap-2"
+              onClick={handleShareX}
+              aria-label="Share on X (Twitter)"
+            >
+              <Share2 className="h-4 w-4" aria-hidden="true" />
               Share on X
             </Button>
 
-            <Button variant="outline" className="flex-1 gap-2" onClick={handleCopy}>
+            <Button
+              variant="outline"
+              className="flex-1 gap-2"
+              onClick={handleCopy}
+              aria-label={copied ? 'Link copied' : 'Copy share link'}
+            >
               {copied ? (
                 <>
-                  <Check className="h-4 w-4 text-green-500" />
+                  <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
                   Copied!
                 </>
               ) : (
                 <>
-                  <Copy className="h-4 w-4" />
+                  <Copy className="h-4 w-4" aria-hidden="true" />
                   Copy link
                 </>
               )}
             </Button>
 
-            <Button variant="outline" size="icon" onClick={handleDownload} aria-label="Download">
-              <Download className="h-4 w-4" />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleDownload}
+              aria-label="Download share image"
+            >
+              <Download className="h-4 w-4" aria-hidden="true" />
             </Button>
           </div>
 

--- a/components/engagement/ConcernFlagBanner.tsx
+++ b/components/engagement/ConcernFlagBanner.tsx
@@ -51,8 +51,10 @@ export function ConcernFlagBanner({ txHash, proposalIndex, outcome }: ConcernFla
         'rounded-lg border px-4 py-3 flex items-start gap-3',
         isNegativeOutcome ? 'bg-amber-500/5 border-amber-500/20' : 'bg-muted/50 border-border',
       )}
+      role="alert"
+      aria-label={`Community concern: ${topCount} citizens flagged this as ${topLabel}`}
     >
-      <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+      <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" aria-hidden="true" />
       <div className="min-w-0 text-sm">
         <p className="text-foreground">
           <span className="font-semibold tabular-nums">{topCount}</span> citizens flagged this as{' '}

--- a/components/engagement/ConcernFlags.tsx
+++ b/components/engagement/ConcernFlags.tsx
@@ -142,11 +142,11 @@ export function ConcernFlags({ txHash, proposalIndex, isOpen }: ConcernFlagsProp
   });
 
   return (
-    <Card>
+    <Card aria-label="Citizen concerns about this proposal">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base flex items-center gap-2">
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            <AlertTriangle className="h-4 w-4 text-amber-500" aria-hidden="true" />
             Citizen Concerns
             {totalFlags > 0 && (
               <Badge variant="secondary" className="text-xs">
@@ -209,6 +209,7 @@ export function ConcernFlags({ txHash, proposalIndex, isOpen }: ConcernFlagsProp
                 className={`
                   inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
                   transition-all duration-150 border
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                   ${
                     isUserFlag
                       ? 'bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-300'

--- a/components/engagement/EngagementSummary.tsx
+++ b/components/engagement/EngagementSummary.tsx
@@ -52,11 +52,11 @@ export function EngagementSummary({ txHash, proposalIndex }: EngagementSummaryPr
   };
 
   return (
-    <Card className="bg-muted/30">
+    <Card className="bg-muted/30" aria-label="Community engagement signals summary">
       <CardContent className="py-3">
         <div className="flex flex-wrap items-center gap-3 text-xs">
           <span className="font-medium text-muted-foreground flex items-center gap-1">
-            <BarChart3 className="h-3.5 w-3.5" />
+            <BarChart3 className="h-3.5 w-3.5" aria-hidden="true" />
             Community Signals
           </span>
 

--- a/components/engagement/PrioritySignals.tsx
+++ b/components/engagement/PrioritySignals.tsx
@@ -180,7 +180,14 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
                           {item.firstChoiceCount} first-choice
                         </span>
                       </div>
-                      <div className="h-2 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-2 rounded-full bg-muted overflow-hidden"
+                        role="progressbar"
+                        aria-valuenow={pct}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-label={`${info?.label ?? item.priority}: ${pct}%`}
+                      >
                         <div
                           className="h-full rounded-full bg-primary transition-all duration-700"
                           style={{ width: `${pct}%` }}
@@ -244,7 +251,7 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
                           {i > 0 && (
                             <button
                               onClick={() => moveUp(i)}
-                              className="p-1 rounded hover:bg-primary/10 transition-colors"
+                              className="p-1 rounded hover:bg-primary/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                               aria-label={`Move ${info.label} up in ranking`}
                             >
                               <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
@@ -252,7 +259,7 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
                           )}
                           <button
                             onClick={() => togglePriority(area)}
-                            className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                            className="text-xs text-muted-foreground hover:text-destructive transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
                             aria-label={`Remove ${info.label} from your selection`}
                           >
                             Remove
@@ -279,8 +286,9 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
                           key={area}
                           onClick={() => togglePriority(area)}
                           disabled={disabled}
-                          aria-label={info.label}
+                          aria-label={`Select ${info.label} as a priority`}
                           className={`flex items-center gap-2 p-3 rounded-lg border text-sm text-left transition-all
+                            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                             ${disabled ? 'opacity-40 cursor-not-allowed' : 'hover:border-primary/50 hover:bg-primary/5 cursor-pointer motion-safe:hover:scale-[1.02] motion-safe:active:scale-[0.98]'}
                             border-border/50`}
                         >

--- a/components/engagement/ProposalSentiment.tsx
+++ b/components/engagement/ProposalSentiment.tsx
@@ -170,11 +170,11 @@ export function ProposalSentiment({ txHash, proposalIndex, isOpen }: ProposalSen
   const showButtons = isOpen && (!hasVoted || changingVote);
 
   return (
-    <Card className="ring-1 ring-primary/10">
+    <Card className="ring-1 ring-primary/10" aria-label="Citizen sentiment on this proposal">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-base flex items-center gap-2">
-            <BarChart3 className="h-4 w-4 text-primary" />
+            <BarChart3 className="h-4 w-4 text-primary" aria-hidden="true" />
             Citizen Sentiment
           </CardTitle>
           <TooltipProvider>
@@ -221,23 +221,24 @@ export function ProposalSentiment({ txHash, proposalIndex, isOpen }: ProposalSen
           />
         )}
 
-        {/* CTA for unconnected users */}
+        {/* Gentle CTA for unconnected users */}
         {!connected && isOpen && !hasVoted && (
-          <div className="relative">
-            <div className="opacity-30 pointer-events-none blur-[1px]">
+          <div className="relative" role="region" aria-label="Connect wallet to vote on sentiment">
+            <div className="opacity-30 pointer-events-none blur-[1px]" aria-hidden="true">
               <SentimentButtons onVote={() => {}} voting={false} currentVote={null} />
             </div>
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2">
-              <p className="text-sm font-medium">Share your opinion</p>
+              <p className="text-sm font-medium">Want to share your opinion?</p>
               <Button
                 size="sm"
-                className="gap-1.5"
+                variant="outline"
+                className="gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
                 onClick={() => {
                   const event = new CustomEvent('open-wallet-modal');
                   window.dispatchEvent(event);
                 }}
               >
-                <Wallet className="h-3.5 w-3.5" />
+                <Wallet className="h-3.5 w-3.5" aria-hidden="true" />
                 Connect Wallet to Vote
               </Button>
             </div>
@@ -303,7 +304,7 @@ function SentimentButtons({
           variant="outline"
           role="radio"
           aria-checked={currentVote === vote}
-          className={`flex-1 gap-1.5 h-11 transition-all duration-150 motion-safe:hover:scale-[1.02] motion-safe:active:scale-[0.98] ${
+          className={`flex-1 gap-1.5 h-11 transition-all duration-150 motion-safe:hover:scale-[1.02] motion-safe:active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
             currentVote === vote ? activeClass : hoverClass
           }`}
           disabled={voting}
@@ -414,7 +415,7 @@ function ResultsView({
       {isOpen && userSentiment && onChangeVote && (
         <button
           onClick={onChangeVote}
-          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors"
+          className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
         >
           Change your vote
         </button>


### PR DESCRIPTION
## Summary
- Add ARIA attributes to 17 high-traffic components: `role="meter"` on ScoreRing, `role="tablist/tab/tabpanel"` on Pulse tabs, `aria-pressed` on Quick Match options, `role="progressbar"` on pillar bars, `role="alert"` on concern flag banners
- Add `focus-visible` rings to all interactive elements in CivicaHeader, CivicaBottomNav, DRep/SPO cards, Quick Match, engagement components
- Mark decorative icons `aria-hidden="true"` throughout
- Soften proposal sentiment CTA for unauthenticated users (outline button, friendlier copy)

17 files changed, +142/-47 lines

## Impact
- **What changed**: Improved WCAG 2.1 AA compliance across navigation, score displays, data visualizations, and engagement components
- **User-facing**: Yes — screen reader users get meaningful labels; keyboard users see focus indicators
- **Risk**: Low — additive attributes, no behavior changes
- **Scope**: Components across civica/, engagement/, and shared UI

## Audit Reference
Closes P2 gaps #26, #27 from 2026-03-08 audit (UX U4, Journeys J-C5)

## Test plan
- [x] Preflight passes (533 tests, lint/format/types clean)
- [ ] Screen reader announces score values, navigation labels, tab states
- [ ] Keyboard tab navigation shows visible focus rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>