### PR TITLE
feat: add score narrative context and integrate ScoreSimulator into DRep workspace

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -28,6 +28,10 @@ const ScoreHistoryChart = nextDynamic(
   () => import('@/components/ScoreHistoryChart').then((m) => m.ScoreHistoryChart),
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
 );
+const ScoreSimulator = nextDynamic(
+  () => import('@/components/ScoreSimulator').then((m) => m.ScoreSimulator),
+  { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
+);
 import { ScoreCard } from '@/components/ScoreCard';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -73,6 +77,12 @@ import {
   getPersonalityLabelWithHysteresis,
 } from '@/lib/drepIdentity';
 import { computeTierProgress } from '@/lib/scoring/tiers';
+import {
+  getScoreNarrative,
+  getParticipationNarrative,
+  getRationaleNarrative,
+  getGovernanceStyleNarrative,
+} from '@/lib/scoring/scoreNarratives';
 import { getFeatureFlag } from '@/lib/featureFlags';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { DRepProfileTabsV2 } from '@/components/civica/profiles/DRepProfileTabsV2';
@@ -100,6 +110,7 @@ import {
   getDRepDelegationTrend,
   getSocialLinkChecks,
   isDRepClaimed,
+  getOpenProposalsForDRep,
 } from '@/lib/data';
 import { createClient } from '@/lib/supabase';
 import { BASE_URL } from '@/lib/constants';
@@ -396,17 +407,24 @@ function KeyFact({
   value,
   subtext,
   tooltip,
+  narrative,
 }: {
   label: string;
   value: string;
   subtext?: string;
   tooltip?: string;
+  narrative?: string;
 }) {
   const content = (
     <div className="flex flex-col items-center text-center min-w-[80px]">
       <span className="text-xs text-muted-foreground">{label}</span>
       <span className="text-sm font-semibold font-mono tabular-nums">{value}</span>
       {subtext && <span className="text-[10px] text-muted-foreground">{subtext}</span>}
+      {narrative && (
+        <span className="text-[10px] text-muted-foreground/80 italic max-w-[140px] leading-tight">
+          {narrative}
+        </span>
+      )}
     </div>
   );
 
@@ -446,6 +464,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     isClaimed,
     spoAlignPct,
     drepCommunicationEnabled,
+    openProposals,
   ] = await Promise.all([
     getScoreHistory(drep.drepId),
     getDRepPercentile(drep.drepScore),
@@ -455,7 +474,10 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     isDRepClaimed(drep.drepId),
     getSpoAlignment(drep.votes),
     getFeatureFlag('drep_communication', true),
+    getOpenProposalsForDRep(drep.drepId),
   ]);
+
+  const pendingProposalCount = openProposals.length;
 
   const brokenLinks = new Set(linkChecks.filter((c) => c.status === 'broken').map((c) => c.uri));
 
@@ -637,21 +659,25 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           value={`${drep.drepScore}/100`}
           subtext={percentile > 0 ? `Top ${100 - percentile}%` : undefined}
           tooltip="Overall quality score based on participation, rationale, reliability, and profile completeness"
+          narrative={getScoreNarrative({ score: drep.drepScore, percentile })}
         />
         <KeyFact
           label="Votes Cast"
           value={`${drep.effectiveParticipation}%`}
           tooltip="How often this DRep votes on proposals, adjusted for voting pattern diversity"
+          narrative={getParticipationNarrative(drep.effectiveParticipation)}
         />
         <KeyFact
           label="Explains Votes"
           value={`${drep.rationaleRate}%`}
           tooltip="How often this DRep provides written reasoning for their votes"
+          narrative={getRationaleNarrative(drep.rationaleRate)}
         />
         <KeyFact
           label="Governance Style"
           value={identityLabel}
           tooltip="Dominant governance philosophy based on voting patterns across 6 dimensions"
+          narrative={getGovernanceStyleNarrative(identityLabel)}
         />
         {spoAlignPct !== null && (
           <KeyFact
@@ -832,6 +858,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
                 )}
               </div>
             )}
+            <ScoreSimulator drepId={drep.drepId} pendingCount={pendingProposalCount} />
             <ScoreDeepDive
               score={drep.drepScore}
               engagementQuality={drep.engagementQuality}

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -45,6 +45,7 @@ import { computeTier } from '@/lib/scoring/tiers';
 import { generateActions } from '@/lib/actionFeed';
 import { ActionFeed } from './ActionFeed';
 import { DRepQuestionsInbox } from '@/components/DRepQuestionsInbox';
+import { ScoreSimulator } from '@/components/ScoreSimulator';
 import type {
   DRepReportCardData,
   PulseData,
@@ -387,6 +388,9 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
           )}
         </div>
       )}
+
+      {/* Score Simulator */}
+      {!summaryLoading && <ScoreSimulator drepId={drepId} pendingCount={pendingCount} />}
 
       {/* 6D Alignment */}
       {!summaryLoading && hasAlignment && (

--- a/lib/scoring/scoreNarratives.ts
+++ b/lib/scoring/scoreNarratives.ts
@@ -1,0 +1,75 @@
+/**
+ * Score Narrative Context — generates concise, human-readable labels
+ * for numeric scores displayed in the DRep profile key facts strip.
+ *
+ * Maps score ranges + tier + percentile into 1-line contextual descriptions
+ * so users understand "what this number means" at a glance.
+ */
+
+import { computeTier, type TierName } from './tiers';
+
+interface ScoreNarrativeInput {
+  score: number;
+  percentile: number;
+}
+
+/**
+ * Generate a 1-line narrative for the overall governance score.
+ * Combines tier name with percentile ranking for immediate context.
+ */
+export function getScoreNarrative({ score, percentile }: ScoreNarrativeInput): string {
+  const tier = computeTier(score);
+  const topPct = 100 - percentile;
+
+  const tierDescriptions: Record<TierName, string> = {
+    Emerging: 'Early-stage representative',
+    Bronze: 'Developing governance track record',
+    Silver: 'Solid governance participation',
+    Gold: 'Strong governance track record',
+    Diamond: 'Exceptional governance quality',
+    Legendary: 'Elite governance standard',
+  };
+
+  const tierDesc = tierDescriptions[tier];
+
+  if (topPct <= 5 && topPct > 0) return `${tierDesc}, top ${topPct}% of DReps`;
+  if (topPct <= 15 && topPct > 0) return `${tierDesc}, top ${topPct}% of DReps`;
+  if (topPct <= 30 && topPct > 0) return `${tierDesc}, top ${topPct}%`;
+  return tierDesc;
+}
+
+/**
+ * Generate a 1-line narrative for participation rate.
+ */
+export function getParticipationNarrative(rate: number): string {
+  if (rate >= 90) return 'Votes on nearly every proposal';
+  if (rate >= 70) return 'Consistent voter';
+  if (rate >= 50) return 'Moderate participation';
+  if (rate >= 25) return 'Selective voter';
+  if (rate > 0) return 'Limited participation so far';
+  return 'No votes recorded yet';
+}
+
+/**
+ * Generate a 1-line narrative for rationale rate.
+ */
+export function getRationaleNarrative(rate: number): string {
+  if (rate >= 90) return 'Explains nearly every vote';
+  if (rate >= 70) return 'Strong transparency';
+  if (rate >= 50) return 'Explains most votes';
+  if (rate >= 25) return 'Occasionally provides reasoning';
+  if (rate > 0) return 'Rarely explains votes';
+  return 'No rationales provided yet';
+}
+
+/**
+ * Generate a 1-line narrative for governance style / identity label.
+ */
+export function getGovernanceStyleNarrative(identityLabel: string): string {
+  // The identity label itself is already descriptive (e.g. "Fiscal Conservative",
+  // "Innovation Advocate"), so we add minimal context
+  if (identityLabel === 'Balanced' || identityLabel === 'Neutral') {
+    return 'No dominant governance philosophy';
+  }
+  return `Dominant governance philosophy`;
+}


### PR DESCRIPTION
## Summary
- New `lib/scoring/scoreNarratives.ts` with 4 narrative generators mapping scores to human-readable context
- Add narrative descriptions beneath key facts on DRep profile (e.g., "Strong governance track record, top 12% of DReps")
- Integrate `ScoreSimulator` into DRep Command Center (after pillar breakdown)
- Integrate `ScoreSimulator` into DRep profile Score Analysis tab (between Recommended Action and ScoreDeepDive)
- Add `getOpenProposalsForDRep` to parallel data fetch for accurate pending count

## Impact
- **What changed**: Score displays now tell a story instead of just showing numbers; DReps can simulate "what if" scenarios
- **User-facing**: Yes — contextual narratives on all DRep profile key facts + ScoreSimulator accessible from two surfaces
- **Risk**: Low — additive UI changes, no scoring logic modified
- **Scope**: `lib/scoring/scoreNarratives.ts` (new), `app/drep/[drepId]/page.tsx`, `components/civica/mygov/DRepCommandCenter.tsx`

## Audit Reference
Closes P2 gaps #24, #28 from 2026-03-08 audit (UX U3, Journeys J-D3)

## Test plan
- [x] Preflight passes (533 tests, lint/format/types clean)
- [ ] DRep profile key facts show narrative text beneath numeric values
- [ ] ScoreSimulator renders in DRep Command Center
- [ ] ScoreSimulator renders in DRep profile Score Analysis tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>