### PR TITLE
feat: add governance-themed hero section to Discover page

### DIFF
--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -42,12 +42,6 @@ export default async function DiscoverPage() {
   return (
     <div className="container mx-auto px-4 sm:px-6 py-6">
       <PageViewTracker event="discover_page_viewed" />
-      <div className="space-y-1 mb-5">
-        <h1 className="text-2xl font-bold tracking-tight">Discover</h1>
-        <p className="text-sm text-muted-foreground">
-          Browse DReps, stake pools, proposals, and Constitutional Committee members.
-        </p>
-      </div>
       <CivicaDiscover
         dreps={allDReps}
         totalAvailable={totalAvailable}

--- a/components/civica/discover/DiscoverHero.tsx
+++ b/components/civica/discover/DiscoverHero.tsx
@@ -1,28 +1,54 @@
 'use client';
 
 import Link from 'next/link';
-import { ChevronRight, Compass, Vote, Shield, Users } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { ChevronRight, Compass, Vote, Shield, Users, FileText, Scale, Search } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useWallet } from '@/utils/wallet-context';
+import { fadeInUp, staggerContainer } from '@/lib/animations';
 
 interface DiscoverHeroProps {
   totalDreps: number;
   proposalCount: number;
 }
 
-export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
+/* ── Stat pill shown in the hero ────────────────────────── */
+function StatPill({
+  icon: Icon,
+  value,
+  label,
+}: {
+  icon: React.FC<{ className?: string }>;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-white/10 dark:border-white/10 border-primary/15 bg-white/60 dark:bg-white/[0.06] backdrop-blur-sm px-3 py-1.5">
+      <Icon className="h-3.5 w-3.5 text-primary dark:text-cyan-400 shrink-0" />
+      <span className="text-xs font-bold tabular-nums text-foreground dark:text-white/90">
+        {value}
+      </span>
+      <span className="text-[10px] text-muted-foreground dark:text-white/50 uppercase tracking-wider">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/* ── Segment-aware contextual banner ────────────────────── */
+function SegmentBanner({ totalDreps }: { totalDreps: number }) {
   const { segment, delegatedDrep, isLoading } = useSegment();
   const { connected } = useWallet();
 
   if (isLoading) return null;
 
-  // Anonymous — encourage connection
+  // Anonymous -- encourage connection
   if (!connected || segment === 'anonymous') {
     return (
-      <div className="rounded-xl border border-primary/20 bg-gradient-to-r from-primary/5 to-transparent p-5 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 rounded-lg border border-primary/20 bg-card/80 backdrop-blur-sm p-4">
         <div className="flex items-center gap-3 shrink-0">
-          <div className="w-10 h-10 rounded-full bg-primary/15 flex items-center justify-center">
-            <Compass className="h-5 w-5 text-primary" />
+          <div className="w-9 h-9 rounded-full bg-primary/15 flex items-center justify-center">
+            <Compass className="h-4 w-4 text-primary" />
           </div>
         </div>
         <div className="flex-1 min-w-0">
@@ -43,11 +69,11 @@ export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
     );
   }
 
-  // Citizen — delegation context
+  // Citizen -- delegation context
   if (segment === 'citizen') {
     if (delegatedDrep) {
       return (
-        <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+        <div className="flex items-center gap-4 rounded-lg border border-border bg-card/80 backdrop-blur-sm p-4">
           <div className="w-9 h-9 rounded-full bg-emerald-500/10 flex items-center justify-center shrink-0">
             <Vote className="h-4.5 w-4.5 text-emerald-500" />
           </div>
@@ -69,7 +95,7 @@ export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
       );
     }
     return (
-      <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4 flex items-center gap-4">
+      <div className="flex items-center gap-4 rounded-lg border border-amber-500/20 bg-amber-500/5 backdrop-blur-sm p-4">
         <div className="w-9 h-9 rounded-full bg-amber-500/10 flex items-center justify-center shrink-0">
           <Users className="h-4.5 w-4.5 text-amber-500" />
         </div>
@@ -89,10 +115,10 @@ export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
     );
   }
 
-  // DRep — peer context
+  // DRep -- peer context
   if (segment === 'drep') {
     return (
-      <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+      <div className="flex items-center gap-4 rounded-lg border border-border bg-card/80 backdrop-blur-sm p-4">
         <div className="w-9 h-9 rounded-full bg-violet-500/10 flex items-center justify-center shrink-0">
           <Shield className="h-4.5 w-4.5 text-violet-500" />
         </div>
@@ -114,7 +140,7 @@ export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
 
   // SPO
   return (
-    <div className="rounded-xl border border-border bg-card p-4 flex items-center gap-4">
+    <div className="flex items-center gap-4 rounded-lg border border-border bg-card/80 backdrop-blur-sm p-4">
       <div className="w-9 h-9 rounded-full bg-sky-500/10 flex items-center justify-center shrink-0">
         <Shield className="h-4.5 w-4.5 text-sky-500" />
       </div>
@@ -131,5 +157,90 @@ export function DiscoverHero({ totalDreps }: DiscoverHeroProps) {
         Dashboard <ChevronRight className="h-3 w-3" />
       </Link>
     </div>
+  );
+}
+
+/* ── Main hero component ────────────────────────────────── */
+export function DiscoverHero({ totalDreps, proposalCount }: DiscoverHeroProps) {
+  const formattedDreps =
+    totalDreps >= 1000 ? `${(totalDreps / 1000).toFixed(1)}k` : totalDreps.toLocaleString();
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className="space-y-4"
+    >
+      {/* ── Gradient hero panel ────────────────────────── */}
+      <motion.div variants={fadeInUp} className="relative overflow-hidden rounded-2xl">
+        {/* Gradient background */}
+        <div
+          className="absolute inset-0 bg-gradient-to-br from-primary/8 via-secondary/6 to-primary/4 dark:from-cyan-950/80 dark:via-indigo-950/60 dark:to-violet-950/40"
+          aria-hidden="true"
+        />
+
+        {/* Decorative grid pattern */}
+        <div
+          className="absolute inset-0 opacity-[0.03] dark:opacity-[0.05]"
+          aria-hidden="true"
+          style={{
+            backgroundImage:
+              'linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)',
+            backgroundSize: '40px 40px',
+          }}
+        />
+
+        {/* Radial glow accents */}
+        <div
+          className="absolute -top-20 -right-20 w-60 h-60 rounded-full bg-primary/10 dark:bg-cyan-500/8 blur-3xl"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute -bottom-16 -left-16 w-48 h-48 rounded-full bg-secondary/8 dark:bg-violet-500/6 blur-3xl"
+          aria-hidden="true"
+        />
+
+        {/* Content */}
+        <div className="relative px-6 py-8 sm:px-8 sm:py-10">
+          {/* Headline */}
+          <div className="space-y-2 mb-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Search className="h-4 w-4 text-primary dark:text-cyan-400" />
+              <span className="text-[10px] font-bold uppercase tracking-[0.15em] text-primary dark:text-cyan-400">
+                Discover
+              </span>
+            </div>
+            <h1 className="font-display text-2xl sm:text-3xl font-bold tracking-tight text-foreground">
+              Explore Cardano&apos;s Governance Landscape
+            </h1>
+            <p className="text-sm sm:text-base text-muted-foreground max-w-xl leading-relaxed">
+              Browse DReps, stake pools, proposals, and Constitutional Committee members. Every
+              participant scored on real voting behavior.
+            </p>
+          </div>
+
+          {/* Live stat pills */}
+          <div className="flex flex-wrap gap-2">
+            <StatPill icon={Users} value={formattedDreps} label="DReps" />
+            {proposalCount > 0 && (
+              <StatPill icon={FileText} value={proposalCount.toString()} label="Proposals" />
+            )}
+            <StatPill icon={Scale} value="CC" label="Members" />
+          </div>
+        </div>
+
+        {/* Bottom border glow */}
+        <div
+          className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/20 dark:via-cyan-500/20 to-transparent"
+          aria-hidden="true"
+        />
+      </motion.div>
+
+      {/* ── Segment-aware contextual banner ────────────── */}
+      <motion.div variants={fadeInUp}>
+        <SegmentBanner totalDreps={totalDreps} />
+      </motion.div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace plain text header with full hero section: governance-themed gradient, grid pattern overlay, radial glow accents
- Live stat pills showing DRep count, proposal count, and CC Members
- Framer Motion animations using existing stagger/fadeInUp presets
- Preserved all segment-aware contextual banners (anonymous, citizen, DRep, SPO) below hero
- Full dark mode support with distinct dark gradient palette

2 files changed, +123/-18 lines

## Impact
- **What changed**: Discover page now matches the visual bar set by homepage constellation and profile heroes
- **User-facing**: Yes — the primary browsing surface now has a distinctive, governance-themed visual treatment
- **Risk**: Low — UI enhancement, no data or logic changes
- **Scope**: `components/civica/discover/DiscoverHero.tsx`, `app/discover/page.tsx`

## Audit Reference
Closes P2 gap #25 from 2026-03-08 audit (UX U6 — visual design craft)

## Test plan
- [x] Preflight passes (533 tests, lint/format/types clean)
- [ ] Discover page shows gradient hero with live stats
- [ ] Segment banners still render correctly below hero
- [ ] Dark mode gradient looks distinct and intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>