### PR TITLE
fix: vote sync validation schema mismatch

### DIFF
--- a/__tests__/sync/integration.test.ts
+++ b/__tests__/sync/integration.test.ts
@@ -75,7 +75,7 @@ const REALISTIC_VOTE = {
 
 const REALISTIC_VOTE_LIST = {
   ...REALISTIC_VOTE,
-  voter_id: 'drep1qg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5z',
+  drep_id: 'drep1qg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5zg5z',
   epoch_no: 520,
 };
 

--- a/__tests__/sync/koios-schemas.test.ts
+++ b/__tests__/sync/koios-schemas.test.ts
@@ -79,7 +79,7 @@ describe('Koios Schema Validation', () => {
   describe('KoiosVoteListSchema', () => {
     const validVote = {
       vote_tx_hash: 'vtx1',
-      voter_id: 'drep1',
+      drep_id: 'drep1',
       proposal_tx_hash: 'tx1',
       proposal_index: 0,
       epoch_no: 100,

--- a/utils/koios-schemas.ts
+++ b/utils/koios-schemas.ts
@@ -45,10 +45,10 @@ export const KoiosVoteSchema = z
 export const KoiosVoteListSchema = z
   .object({
     vote_tx_hash: z.string(),
-    voter_id: z.string(),
+    drep_id: z.string(),
     proposal_tx_hash: z.string(),
     proposal_index: z.number(),
-    epoch_no: z.number(),
+    epoch_no: z.number().nullable(),
     block_time: z.number(),
     vote: z.enum(['Yes', 'No', 'Abstain']),
     meta_url: z.string().nullable(),


### PR DESCRIPTION
## Summary
- Fixed `KoiosVoteListSchema` field mismatch: `voter_id` → `drep_id` and `epoch_no` made nullable
- The schema was being applied to transformed Supabase rows (which use `drep_id`), not raw Koios data (which uses `voter_id`), causing 100% of vote records to fail validation every sync run
- No data loss — existing votes in DB are intact, sync was just silently dropping all records as invalid

## Impact
- **What changed**: Vote sync validation schema now matches the actual row shape being validated
- **User-facing**: No — votes were already in DB from prior successful syncs. Prevents future data staleness.
- **Risk**: Low — schema-only change, validated by 49 sync tests passing
- **Scope**: `utils/koios-schemas.ts`, 2 test fixtures

## Test plan
- [x] All 533 unit tests pass
- [x] Confirmed 15,608 existing votes in DB are intact
- [ ] Post-deploy: verify next vote sync completes with 0 validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)