### PR TITLE
feat: storytelling polish — GHI narratives, social proof, proposal skeleton

### DIFF
--- a/app/proposal/[txHash]/[index]/loading.tsx
+++ b/app/proposal/[txHash]/[index]/loading.tsx
@@ -1,0 +1,106 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+export default function ProposalLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      {/* Back button */}
+      <Skeleton className="h-9 w-32" />
+
+      {/* Hero section */}
+      <div className="rounded-xl border bg-card p-6 space-y-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-6 w-24 rounded-full" />
+          <Skeleton className="h-6 w-20 rounded-full" />
+        </div>
+        <Skeleton className="h-8 w-3/4" />
+        <div className="flex gap-4">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-5 w-28" />
+          <Skeleton className="h-5 w-36" />
+        </div>
+      </div>
+
+      {/* Engagement summary */}
+      <div className="flex gap-3">
+        <Skeleton className="h-10 w-28 rounded-full" />
+        <Skeleton className="h-10 w-28 rounded-full" />
+        <Skeleton className="h-10 w-28 rounded-full" />
+      </div>
+
+      {/* Dimension tags */}
+      <div className="flex gap-2 flex-wrap">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-7 w-24 rounded-full" />
+        ))}
+      </div>
+
+      {/* Lifecycle timeline */}
+      <div className="rounded-xl border bg-card p-5 space-y-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+
+      {/* AI Summary */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-32" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-3/4" />
+        </CardContent>
+      </Card>
+
+      {/* Description */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-28" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </CardContent>
+      </Card>
+
+      {/* Threshold meter */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-40" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-12 w-full rounded-lg" />
+          <Skeleton className="h-4 w-48 mx-auto" />
+        </CardContent>
+      </Card>
+
+      {/* Vote adoption curve */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-32" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-48 w-full" />
+        </CardContent>
+      </Card>
+
+      {/* Voter tabs */}
+      <div className="space-y-4">
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-20" />
+          <Skeleton className="h-9 w-20" />
+          <Skeleton className="h-9 w-20" />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton key={i} className="h-14 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ShareActions.tsx
+++ b/components/ShareActions.tsx
@@ -70,7 +70,7 @@ export function ShareActions({
   const handleDownload = useCallback(async () => {
     if (!imageUrl) return;
     try {
-      await downloadImage(imageUrl, imageFilename || 'drepscore-card.png');
+      await downloadImage(imageUrl, imageFilename || 'civica-card.png');
       trackShare(surface, 'download', metadata, 'success');
     } catch {
       trackShare(surface, 'download', metadata, 'failed');

--- a/components/civica/charts/GovernanceHealthGauge.tsx
+++ b/components/civica/charts/GovernanceHealthGauge.tsx
@@ -7,6 +7,7 @@ interface GovernanceHealthGaugeProps {
   score: number;
   band: string;
   delta?: number;
+  narrative?: string;
   className?: string;
 }
 
@@ -62,6 +63,7 @@ export function GovernanceHealthGauge({
   score,
   band,
   delta,
+  narrative,
   className,
 }: GovernanceHealthGaugeProps) {
   const [animatedScore, setAnimatedScore] = useState(0);
@@ -205,29 +207,36 @@ export function GovernanceHealthGauge({
       </svg>
 
       {/* Band label below */}
-      <div className="flex items-center gap-2 -mt-2">
-        <span
-          className={cn(
-            'text-xs font-semibold px-2.5 py-0.5 rounded-full',
-            band === 'Healthy'
-              ? 'bg-emerald-900/30 text-emerald-400'
-              : band === 'Moderate'
-                ? 'bg-amber-900/30 text-amber-400'
-                : 'bg-rose-900/30 text-rose-400',
-          )}
-        >
-          {band}
-        </span>
-        {delta != null && delta !== 0 && (
+      <div className="flex flex-col items-center gap-1.5 -mt-2">
+        <div className="flex items-center gap-2">
           <span
             className={cn(
-              'text-xs font-medium tabular-nums',
-              delta > 0 ? 'text-emerald-400' : 'text-rose-400',
+              'text-xs font-semibold px-2.5 py-0.5 rounded-full',
+              band === 'Healthy'
+                ? 'bg-emerald-900/30 text-emerald-400'
+                : band === 'Moderate'
+                  ? 'bg-amber-900/30 text-amber-400'
+                  : 'bg-rose-900/30 text-rose-400',
             )}
           >
-            {delta > 0 ? '+' : ''}
-            {delta.toFixed(1)}
+            {band}
           </span>
+          {delta != null && delta !== 0 && (
+            <span
+              className={cn(
+                'text-xs font-medium tabular-nums',
+                delta > 0 ? 'text-emerald-400' : 'text-rose-400',
+              )}
+            >
+              {delta > 0 ? '+' : ''}
+              {delta.toFixed(1)}
+            </span>
+          )}
+        </div>
+        {narrative && (
+          <p className="text-[11px] text-muted-foreground text-center max-w-[200px] leading-snug">
+            {narrative}
+          </p>
         )}
       </div>
     </div>

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -221,7 +221,10 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
 
       {/* ── Social proof strip ──────────────────────────────────────── */}
       <section className="mx-auto w-full max-w-4xl px-4 pb-16">
-        <div className="rounded-xl border border-border/50 bg-muted/30 px-6 py-4">
+        <div className="rounded-xl border border-border/50 bg-muted/30 px-6 py-4 space-y-2">
+          <p className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            Citizens are already shaping Cardano&apos;s future
+          </p>
           <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-sm text-muted-foreground">
             <span className="flex items-center gap-2">
               <Users className="h-4 w-4 text-primary/60 shrink-0" />

--- a/components/civica/home/TreasuryCitizenView.tsx
+++ b/components/civica/home/TreasuryCitizenView.tsx
@@ -113,7 +113,11 @@ export function TreasuryCitizenView({ className }: { className?: string }) {
             </div>
           </div>
           <p className="text-xs text-muted-foreground mt-1">
-            Funded by protocol reserves and transaction fees. Spent through governance votes.
+            {treasury.trend === 'growing'
+              ? 'Growing \u2014 incoming reserves and fees are outpacing withdrawals this period.'
+              : treasury.trend === 'shrinking'
+                ? 'Shrinking \u2014 active withdrawals are exceeding incoming reserves this period.'
+                : 'Funded by protocol reserves and transaction fees. Spent through governance votes.'}
           </p>
         </div>
 

--- a/components/civica/pulse/CivicaGovernanceTrends.tsx
+++ b/components/civica/pulse/CivicaGovernanceTrends.tsx
@@ -168,6 +168,15 @@ export function CivicaGovernanceTrends() {
 
   const isLoading = sparklinesLoading || ghiLoading;
 
+  // Build a human-readable narrative for the GHI gauge
+  const ghiNarrative = (() => {
+    if (!trend?.delta || trend.delta === 0) return undefined;
+    const dir = trend.delta > 0 ? 'Improving' : 'Declining';
+    const abs = Math.abs(trend.delta).toFixed(1);
+    const streak = (trend.streakEpochs ?? 0) > 1 ? ` over ${trend.streakEpochs} epochs` : '';
+    return `${dir}: ${trend.delta > 0 ? '+' : '-'}${abs} pts${streak}`;
+  })();
+
   const TrendIcon =
     trend?.direction === 'up' ? TrendingUp : trend?.direction === 'down' ? TrendingDown : Minus;
   const trendColor =
@@ -237,6 +246,7 @@ export function CivicaGovernanceTrends() {
                 score={ghi.current.score}
                 band={ghi.current.band ?? 'Unknown'}
                 delta={trend?.delta ?? undefined}
+                narrative={ghiNarrative}
               />
             )}
 

--- a/components/civica/shared/ShareModal.tsx
+++ b/components/civica/shared/ShareModal.tsx
@@ -112,7 +112,9 @@ export function ShareModal({
             </Button>
           </div>
 
-          <p className="text-center text-xs text-muted-foreground">via Civica</p>
+          <p className="text-center text-xs text-muted-foreground">
+            via Civica &mdash; governance intelligence for Cardano
+          </p>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- Add trend-aware narrative to Governance Health Gauge ("Improving: +2.1 pts over 3 epochs")
- Add social proof header to anonymous landing page
- Add trend-aware treasury description (growing/shrinking/stable)
- Update share surfaces with governance-themed branding
- Add proposal page loading skeleton (eliminates layout shift on /proposal/[txHash]/[index])

## Impact
- **What changed**: 7 files across storytelling polish, share branding, and loading UX
- **User-facing**: Yes — GHI gauge now explains trends in plain language, treasury widget describes what's happening, proposal pages show skeleton instead of blank while loading
- **Risk**: Low — styling and narrative-only changes, no data flow changes
- **Scope**: HomeAnonymous, TreasuryCitizenView, ShareModal, ShareActions, GovernanceHealthGauge, CivicaGovernanceTrends, new proposal loading.tsx

## Test plan
- [x] Preflight passes (535 tests, lint, types, format)
- [ ] Verify GHI narrative appears below gauge on /pulse when trend data exists
- [ ] Verify proposal page shows skeleton while loading
- [ ] Verify social proof header appears on anonymous landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)