### PR TITLE
feat: feature-flagged governance display font (Space Grotesk)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -243,6 +243,12 @@
   --font-civica-body: var(--font-geist-sans);
 }
 
+/* Governance font — feature-flagged via data-font attribute on body.
+   Toggle via /admin/flags → governance_font or FF_GOVERNANCE_FONT env var. */
+body[data-font='governance'] {
+  --font-civica-display: var(--font-space-grotesk), var(--font-geist-sans);
+}
+
 /* ============================================================
    Base layer
    ============================================================ */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist, Geist_Mono, Space_Grotesk } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Providers } from '@/components/Providers';
@@ -11,6 +11,7 @@ import { ShortcutsHelpOverlay } from '@/components/ShortcutsHelpOverlay';
 import { InstallPrompt } from '@/components/InstallPrompt';
 import { OfflineBanner } from '@/components/OfflineBanner';
 import { CivicaShell } from '@/components/civica/CivicaShell';
+import { GovernanceFontProvider } from '@/components/GovernanceFontProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -20,6 +21,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
   subsets: ['latin'],
+});
+
+const spaceGrotesk = Space_Grotesk({
+  variable: '--font-space-grotesk',
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
 });
 
 export const metadata: Metadata = {
@@ -68,7 +75,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${spaceGrotesk.variable} antialiased`}
         suppressHydrationWarning
       >
         <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
@@ -81,6 +88,7 @@ export default function RootLayout({
               >
                 Skip to main content
               </a>
+              <GovernanceFontProvider />
               <CivicaShell>{children}</CivicaShell>
               <CommandPalette />
               <KeyboardShortcuts />

--- a/components/GovernanceFontProvider.tsx
+++ b/components/GovernanceFontProvider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useFeatureFlag } from '@/components/FeatureGate';
+
+/**
+ * Feature-flagged governance font switcher.
+ *
+ * When the `governance_font` flag is enabled, sets a `data-font="governance"`
+ * attribute on <body>. CSS in globals.css uses this to swap
+ * --font-civica-display from Geist Sans to Space Grotesk.
+ *
+ * Toggle via /admin/flags or env var FF_GOVERNANCE_FONT=true.
+ */
+export function GovernanceFontProvider() {
+  const enabled = useFeatureFlag('governance_font');
+
+  useEffect(() => {
+    if (enabled === null) return;
+    if (enabled) {
+      document.body.setAttribute('data-font', 'governance');
+    } else {
+      document.body.removeAttribute('data-font');
+    }
+    return () => {
+      document.body.removeAttribute('data-font');
+    };
+  }, [enabled]);
+
+  return null;
+}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -23,6 +23,7 @@
  * governance_footprint     — Wallet governance footprint feature
  * cc_page                  — Constitutional Committee transparency page
  * spo_profiles             — SPO governance profile pages
+ * governance_font          — Custom display font (Space Grotesk) for headings
  *
  * ---------------------------------------------------------------------------
  * RETIRED FLAGS (deleted in migration 039 — code checks removed or hardcoded)


### PR DESCRIPTION
## Summary
- Add Space Grotesk as an optional governance display font for headings (`font-display`)
- Controlled by `governance_font` feature flag (default: off)
- GovernanceFontProvider sets `data-font="governance"` on body; CSS swaps `--font-civica-display`
- Toggle via /admin/flags or `FF_GOVERNANCE_FONT=true` — no redeploy needed

## Impact
- **What changed**: New font option for display headings, zero visual change until flag is enabled
- **User-facing**: No (flag defaults to off). Enable to compare Space Grotesk vs Geist Sans.
- **Risk**: Low — font is loaded but only applied when flag is on. Fallback to Geist Sans.
- **Scope**: layout.tsx, globals.css, new GovernanceFontProvider.tsx, featureFlags.ts doc comment, migration for flag row

## Test plan
- [x] Preflight passes (535 tests, lint, types, format)
- [ ] With flag off: headings render in Geist Sans (unchanged)
- [ ] Enable governance_font via /admin/flags: headings switch to Space Grotesk
- [ ] Toggle off again: headings revert to Geist Sans instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)