### PR TITLE
feat: add AI-assisted epoch update drafting for DReps

### DIFF
--- a/app/api/drep/[drepId]/draft-update/route.ts
+++ b/app/api/drep/[drepId]/draft-update/route.ts
@@ -1,0 +1,154 @@
+/**
+ * AI Epoch Update Draft API
+ * Generates an AI-drafted epoch update summarizing the DRep's governance
+ * activity for a given epoch (defaults to the current epoch).
+ *
+ * POST /api/drep/[drepId]/draft-update
+ * Body: { sessionToken: string; epoch?: number }
+ * Returns: { draft: string; voteSummary: { total: number; yes: number; no: number; abstain: number } }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getDRepById, getVotesByDRepId } from '@/lib/data';
+import { generateText } from '@/lib/ai';
+import { validateSessionToken } from '@/lib/supabaseAuth';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { z } from 'zod';
+import { SessionTokenSchema } from '@/lib/api/schemas/common';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+// Epoch derivation (same constants as lib/data.ts and lib/api/response.ts)
+const SHELLEY_GENESIS = 1596491091;
+const EPOCH_LEN = 432000;
+const SHELLEY_BASE = 209;
+
+function getCurrentEpoch(): number {
+  return Math.floor((Date.now() / 1000 - SHELLEY_GENESIS) / EPOCH_LEN) + SHELLEY_BASE;
+}
+
+const DraftUpdateSchema = z.object({
+  sessionToken: SessionTokenSchema,
+  epoch: z.coerce.number().int().min(0).optional(),
+});
+
+export const POST = withRouteHandler(
+  async (request: NextRequest) => {
+    const drepId = decodeURIComponent(request.nextUrl.pathname.split('/')[3]);
+    const body = await request.json();
+    const { sessionToken, epoch } = DraftUpdateSchema.parse(body);
+
+    // --- Auth: verify session and ownership ---
+    const session = await validateSessionToken(sessionToken);
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { data: user } = await supabase
+      .from('users')
+      .select('claimed_drep_id')
+      .eq('wallet_address', session.walletAddress)
+      .single();
+
+    if (!user || user.claimed_drep_id !== drepId) {
+      return NextResponse.json({ error: 'Not authorized for this DRep' }, { status: 403 });
+    }
+
+    // --- Determine epoch ---
+    const targetEpoch = epoch ?? getCurrentEpoch();
+
+    // --- Fetch vote data ---
+    const allVotes = await getVotesByDRepId(drepId);
+    const epochVotes = allVotes.filter((v) => v.epoch_no === targetEpoch);
+
+    const voteSummary = {
+      total: epochVotes.length,
+      yes: epochVotes.filter((v) => v.vote === 'Yes').length,
+      no: epochVotes.filter((v) => v.vote === 'No').length,
+      abstain: epochVotes.filter((v) => v.vote === 'Abstain').length,
+    };
+
+    // --- Fetch DRep metadata for context ---
+    const drep = await getDRepById(drepId);
+    const metadata = drep?.metadata || {};
+    const objectives = (metadata.objectives as string) || '';
+    const motivations = (metadata.motivations as string) || '';
+    const drepName = (metadata.givenName as string) || drep?.name || drep?.drepId || drepId;
+
+    // --- Fetch proposal titles for voted proposals ---
+    const proposalKeys = epochVotes.map((v) => `${v.proposal_tx_hash}#${v.proposal_index}`);
+    const proposalTitles: Record<string, string> = {};
+
+    if (proposalKeys.length > 0) {
+      const txHashes = [...new Set(epochVotes.map((v) => v.proposal_tx_hash))];
+      const { data: proposals } = await supabase
+        .from('proposals')
+        .select('tx_hash, index, title')
+        .in('tx_hash', txHashes);
+
+      if (proposals) {
+        for (const p of proposals) {
+          proposalTitles[`${p.tx_hash}#${p.index}`] = p.title || 'Untitled proposal';
+        }
+      }
+    }
+
+    // Build vote details for the prompt
+    const voteDetails = epochVotes
+      .map((v) => {
+        const key = `${v.proposal_tx_hash}#${v.proposal_index}`;
+        const title = proposalTitles[key] || 'Governance proposal';
+        return `- ${title}: voted ${v.vote}`;
+      })
+      .join('\n');
+
+    // --- Generate AI draft ---
+    const drepContext = [
+      objectives && `Stated objectives: ${objectives}`,
+      motivations && `Motivations: ${motivations}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const prompt = `You are helping a Cardano DRep (Delegated Representative) named "${drepName}" write a concise epoch update for Epoch ${targetEpoch} to share with their delegators.
+
+VOTING ACTIVITY THIS EPOCH:
+Total votes cast: ${voteSummary.total}
+Yes: ${voteSummary.yes} | No: ${voteSummary.no} | Abstain: ${voteSummary.abstain}
+${voteDetails ? `\nDetailed votes:\n${voteDetails}` : '\nNo votes were cast this epoch.'}
+
+${drepContext ? `DREP CONTEXT:\n${drepContext}\n` : ''}
+Write a 2-3 paragraph epoch update that:
+1. Summarizes the DRep's governance activity this epoch in a professional, first-person tone
+2. Mentions specific proposals voted on and the rationale direction (without fabricating reasons — keep it factual based on the vote direction)
+3. If no votes were cast, acknowledge it and note any relevant context (e.g., no active proposals, or a commitment to review upcoming ones)
+
+Keep the tone professional but approachable, like a DRep communicating with their delegators. Under 250 words. Output only the update text, no preamble or headers.`;
+
+    const draft = await generateText(prompt, {
+      model: 'DRAFT',
+      maxTokens: 1024,
+      temperature: 0.7,
+    });
+
+    if (!draft) {
+      return NextResponse.json(
+        { error: 'AI features are currently unavailable. Please try again later.' },
+        { status: 503 },
+      );
+    }
+
+    captureServerEvent(
+      'drep_epoch_update_ai_drafted',
+      { drep_id: drepId, epoch: targetEpoch },
+      drepId,
+    );
+
+    return NextResponse.json({ draft, voteSummary });
+  },
+  { auth: 'none', rateLimit: { max: 10, window: 60 } },
+);

--- a/components/civica/shared/StatementComposer.tsx
+++ b/components/civica/shared/StatementComposer.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Sparkles, Loader2 } from 'lucide-react';
 import { getStoredSession } from '@/lib/supabaseAuth';
 
 interface StatementComposerProps {
@@ -21,8 +22,39 @@ interface StatementComposerProps {
 export function StatementComposer({ open, onClose, drepId, onSuccess }: StatementComposerProps) {
   const [text, setText] = useState('');
   const [loading, setLoading] = useState(false);
+  const [drafting, setDrafting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const MAX_CHARS = 1000;
+
+  const handleDraftWithAI = async () => {
+    const sessionToken = getStoredSession();
+    if (!sessionToken) {
+      setError('Please connect your wallet first');
+      return;
+    }
+
+    setDrafting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/draft-update`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionToken }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setText(data.draft.slice(0, MAX_CHARS));
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Failed to generate draft');
+      }
+    } catch (err) {
+      console.error('Error generating AI draft', err);
+      setError('Network error, please try again');
+    } finally {
+      setDrafting(false);
+    }
+  };
 
   const handleSubmit = async () => {
     if (!text.trim() || loading) return;
@@ -82,6 +114,7 @@ export function StatementComposer({ open, onClose, drepId, onSuccess }: Statemen
               onChange={(e) => setText(e.target.value.slice(0, MAX_CHARS))}
               placeholder="Share your perspective on current governance activity..."
               className="min-h-[120px] resize-none"
+              disabled={drafting}
             />
             <span
               className={`absolute bottom-2 right-2 text-xs ${
@@ -93,13 +126,29 @@ export function StatementComposer({ open, onClose, drepId, onSuccess }: Statemen
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
-        <DialogFooter>
-          <Button variant="ghost" onClick={onClose} disabled={loading}>
-            Cancel
+        <DialogFooter className="flex-col gap-2 sm:flex-row">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleDraftWithAI}
+            disabled={drafting || loading}
+          >
+            {drafting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5" />
+            )}
+            {drafting ? 'Drafting...' : 'Draft with AI'}
           </Button>
-          <Button onClick={handleSubmit} disabled={loading || !text.trim()}>
-            {loading ? 'Sharing...' : 'Share statement'}
-          </Button>
+          <div className="flex gap-2 sm:ml-auto">
+            <Button variant="ghost" onClick={onClose} disabled={loading || drafting}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={loading || drafting || !text.trim()}>
+              {loading ? 'Sharing...' : 'Share statement'}
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- New API route `POST /api/drep/[drepId]/draft-update` that generates AI-drafted epoch updates from the DRep's voting data
- "Draft with AI" button added to the StatementComposer dialog (sparkle icon, loading spinner)
- DReps can generate a draft, edit it, then publish via the existing statement flow
- Uses existing `lib/ai.ts` shared AI layer (DRAFT model), rate-limited to 10 req/60s

## Impact
- **What changed**: DReps can now generate AI-drafted epoch updates in seconds instead of writing from scratch
- **User-facing**: Yes — DReps see "Draft with AI" button when composing statements
- **Risk**: Low — additive feature, existing statement flow unchanged. AI generation is optional.
- **Scope**: 1 new API route, 1 modified component (StatementComposer)

## Test plan
- [ ] As a DRep owner, open StatementComposer → click "Draft with AI"
- [ ] Verify draft populates textarea with epoch voting summary
- [ ] Edit the draft and publish → verify it saves correctly
- [ ] Test rate limiting (10 requests per minute)
- [ ] Test when no votes exist for current epoch (should return helpful message)
- [ ] Test as non-owner → should 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)