### PR TITLE
fix: resolve sync output_too_large and improve proposals error resilience

### DIFF
--- a/inngest/functions/sync-dreps.ts
+++ b/inngest/functions/sync-dreps.ts
@@ -5,12 +5,10 @@
  * across Inngest step boundaries — those objects can exceed the 4MB step output limit.
  *
  *   0. init-sync — create sync_log entry, reset Koios metrics
- *   1. fetch-proposals — fetch + classify governance proposals (non-fatal)
- *      (returns only lightweight proposalContextEntries; classifiedProposals stay in memory)
- *   2. core-sync — fetch DReps, upsert, post-sync (alignment, snapshots, history)
- *      (rawVotesMap never leaves this step)
- *   3. finalize — write sync_log, emit analytics
- *   4. heartbeat + follow-on events
+ *   1. core-sync — fetch proposals, fetch DReps, upsert, post-sync (alignment, snapshots, history)
+ *      (classifiedProposals + rawVotesMap never leave this step)
+ *   2. finalize — write sync_log, emit analytics
+ *   3. heartbeat + follow-on events
  */
 
 import { inngest } from '@/lib/inngest';
@@ -37,13 +35,18 @@ export const syncDreps = inngest.createFunction(
     onFailure: async ({ error }) => {
       const sb = getSupabaseAdmin();
       const msg = errMsg(error);
-      logger.error('[dreps] Function failed permanently', { error });
+      const errorName =
+        error && typeof error === 'object'
+          ? (error as unknown as Record<string, unknown>).name
+          : undefined;
+      const detail = msg || errorName || JSON.stringify(error);
+      logger.error('[dreps] Function failed permanently', { error: detail });
       await sb
         .from('sync_log')
         .update({
           finished_at: new Date().toISOString(),
           success: false,
-          error_message: capMsg(`onFailure: ${msg}`),
+          error_message: capMsg(`onFailure: ${detail}`),
         })
         .eq('sync_type', 'dreps')
         .is('finished_at', null);
@@ -69,26 +72,24 @@ export const syncDreps = inngest.createFunction(
         return { syncLogId: logRow?.id ?? null, startTime: Date.now() };
       });
 
-      // Step 1: Fetch + classify proposals (non-fatal)
-      // Only serializes lightweight proposalContextEntries across step boundary
-      const proposalResult = await step.run('fetch-proposals', async () => {
+      // Step 1: Core sync — fetch proposals + DReps, upsert, post-sync (alignment, snapshots, history)
+      // All large data (classifiedProposals, rawVotesMap) stays in memory within this step
+      // and never crosses an Inngest step boundary (they can exceed the 4MB output limit).
+      const coreSyncResult = await step.run('core-sync', async () => {
+        // Fetch + classify proposals (non-fatal)
+        let proposalResult;
         try {
-          return await phaseFetchProposals();
+          proposalResult = await phaseFetchProposals();
         } catch (err) {
-          logger.error('[dreps] Proposal fetch step failed', { error: err });
-          return {
+          logger.error('[dreps] Proposal fetch failed (non-fatal)', { error: err });
+          proposalResult = {
             classifiedProposals: [],
             proposalContextEntries: [],
             errors: [errMsg(err)],
             durationMs: 0,
           };
         }
-      });
 
-      // Step 2: Core sync — fetch DReps, upsert to DB, run post-sync (alignment, snapshots, history)
-      // Combined into a single step so rawVotesMap + classifiedProposals stay in memory
-      // and never cross an Inngest step boundary (they can exceed the 4MB output limit).
-      const coreSyncResult = await step.run('core-sync', async () => {
         const drepData = await phaseFetchDReps(proposalResult.proposalContextEntries);
 
         const upsertResult = await phaseUpsertDReps(drepData.dreps, drepData.delegatorCounts);
@@ -111,19 +112,21 @@ export const syncDreps = inngest.createFunction(
             durationMs: postSyncResult.durationMs,
           } satisfies PostSyncResult,
           handlesResolved: drepData.handlesResolved,
+          proposalErrors: proposalResult.errors,
+          proposalDurationMs: proposalResult.durationMs,
           fetchErrors: drepData.errors,
           fetchDurationMs: drepData.durationMs,
         };
       });
 
-      // Step 3: Finalize sync_log, emit analytics
+      // Step 2: Finalize sync_log, emit analytics
       const allErrors = [
-        ...proposalResult.errors,
+        ...coreSyncResult.proposalErrors,
         ...coreSyncResult.fetchErrors,
         ...coreSyncResult.postSyncResult.errors,
       ];
       const phaseTiming: Record<string, number> = {
-        step1_proposals_ms: proposalResult.durationMs,
+        step1_proposals_ms: coreSyncResult.proposalDurationMs,
         step2_enrich_ms: coreSyncResult.fetchDurationMs,
         step4_upsert_ms: coreSyncResult.upsertResult.durationMs,
         step56_parallel_ms: coreSyncResult.postSyncResult.durationMs,

--- a/inngest/functions/sync-proposals.ts
+++ b/inngest/functions/sync-proposals.ts
@@ -17,13 +17,18 @@ export const syncProposals = inngest.createFunction(
     onFailure: async ({ error }) => {
       const sb = getSupabaseAdmin();
       const msg = errMsg(error);
-      logger.error('[proposals] Function failed permanently', { error });
+      const errorName =
+        error && typeof error === 'object'
+          ? (error as unknown as Record<string, unknown>).name
+          : undefined;
+      const detail = msg || errorName || JSON.stringify(error);
+      logger.error('[proposals] Function failed permanently', { error: detail });
       await sb
         .from('sync_log')
         .update({
           finished_at: new Date().toISOString(),
           success: false,
-          error_message: capMsg(`onFailure: ${msg}`),
+          error_message: capMsg(`onFailure: ${detail}`),
         })
         .eq('sync_type', 'proposals')
         .is('finished_at', null);

--- a/lib/sync/proposals.ts
+++ b/lib/sync/proposals.ts
@@ -22,7 +22,8 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
     const syncLog = new SyncLogger(supabase, 'proposals');
     await syncLog.start();
 
-    const errors: string[] = [];
+    const fatalErrors: string[] = [];
+    const warnings: string[] = [];
     let proposalCount = 0;
     let voteCount = 0;
     let summaryCount = 0;
@@ -42,7 +43,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
         } = validateArray(rawProposals, KoiosProposalSchema, 'proposals');
 
         if (invalidCount > 0) {
-          errors.push(...validationErrors);
+          warnings.push(...validationErrors);
           emitPostHog(true, 'proposals', 0, {
             event_override: 'sync_validation_error',
             record_type: 'proposal',
@@ -89,7 +90,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
             .from('proposals')
             .upsert(batch, { onConflict: 'tx_hash,proposal_index', ignoreDuplicates: false });
           if (error) {
-            errors.push(`Proposal upsert: ${error.message}`);
+            fatalErrors.push(`Proposal upsert: ${error.message}`);
             logger.error(`${TAG} Proposal upsert error`, { error: error.message });
           }
         }
@@ -105,7 +106,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
           open: openProposals.length,
         });
       } catch (err) {
-        errors.push(`Proposals: ${errMsg(err)}`);
+        fatalErrors.push(`Proposals: ${errMsg(err)}`);
         logger.error(`${TAG} Proposal fetch failed`, { error: errMsg(err) });
       }
 
@@ -140,8 +141,8 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
               .from('drep_votes')
               .upsert(batch, { onConflict: 'vote_tx_hash', ignoreDuplicates: false });
             if (error) {
-              errors.push(`Vote upsert: ${error.message}`);
-              logger.error(`${TAG} Vote upsert error`, { error: error.message });
+              warnings.push(`Vote upsert: ${error.message}`);
+              logger.warn(`${TAG} Vote upsert error (non-fatal)`, { error: error.message });
             }
           }
 
@@ -151,8 +152,8 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
             openProposals: openProposals.length,
           });
         } catch (err) {
-          errors.push(`Votes: ${errMsg(err)}`);
-          logger.error(`${TAG} Vote fetch failed`, { error: errMsg(err) });
+          warnings.push(`Votes: ${errMsg(err)}`);
+          logger.warn(`${TAG} Vote fetch failed (non-fatal)`, { error: errMsg(err) });
         }
       }
 
@@ -326,24 +327,26 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
         logger.warn(`${TAG} Notification broadcast skipped`, { error: err });
       }
     } catch (err) {
-      errors.push(`Unhandled: ${errMsg(err)}`);
+      fatalErrors.push(`Unhandled: ${errMsg(err)}`);
       logger.error(`${TAG} Unhandled error`, { error: errMsg(err) });
     }
 
-    const success = errors.length === 0;
+    const allIssues = [...fatalErrors, ...warnings];
+    const success = fatalErrors.length === 0;
     const metrics = {
       proposals_synced: proposalCount,
       votes_synced: voteCount,
       summaries_refreshed: summaryCount,
       vote_snapshots: voteSnapshotCount,
       push_sent: pushSent,
+      warning_count: warnings.length,
     };
 
-    await syncLog.finalize(success, errors.length > 0 ? errors.join('; ') : null, metrics);
+    await syncLog.finalize(success, allIssues.length > 0 ? allIssues.join('; ') : null, metrics);
     await emitPostHog(success, 'proposals', syncLog.elapsed, metrics);
 
     if (!success) {
-      throw new Error(errors.join('; '));
+      throw new Error(fatalErrors.join('; '));
     }
 
     return {
@@ -353,6 +356,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
       summariesRefreshed: summaryCount,
       voteSnapshots: voteSnapshotCount,
       pushSent,
+      warnings: warnings.length,
       durationSeconds: (syncLog.elapsed / 1000).toFixed(1),
       timestamp: new Date().toISOString(),
     };


### PR DESCRIPTION
## Summary
- **DReps sync**: Merged `fetch-proposals` step into `core-sync` so `classifiedProposals` array never crosses the Inngest 4MB step output boundary — fixes `output_too_large` failures (20/175 runs)
- **Proposals sync**: Separated fatal errors (proposal fetch/upsert) from non-fatal warnings (vote upsert, validation) so transient vote issues don't fail the entire sync — reduces 30/467 failure rate
- **Both syncs**: Improved `onFailure` error capture with fallback chain (`msg || errorName || JSON.stringify`) for Inngest errors with empty `message` fields

## Impact
- **What changed**: DReps sync step structure consolidated; proposals sync error classification split into fatal vs warnings
- **User-facing**: No — backend sync reliability improvement. DRep data and proposals will sync more consistently
- **Risk**: Low — no schema changes, no new dependencies, same business logic with better step boundaries
- **Scope**: `inngest/functions/sync-dreps.ts`, `inngest/functions/sync-proposals.ts`, `lib/sync/proposals.ts`

## Test plan
- [x] Preflight passes (format, lint, types, 535 tests)
- [ ] CI passes
- [ ] Deploy to Railway, PUT Inngest endpoint to re-register functions
- [ ] Monitor next DReps sync run (triggered via Inngest Cloud) — should complete without `output_too_large`
- [ ] Monitor proposals sync over 2-3 cycles — failure rate should drop significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)