### PR TITLE
feat: rebrand from DRepScore/Civica to Governada

### DIFF
--- a/.claude/agents/deploy-verifier.md
+++ b/.claude/agents/deploy-verifier.md
@@ -5,13 +5,13 @@ tools: Bash, Read
 model: haiku
 ---
 
-You are a deployment verification agent for Civica (drepscore.io). After a PR is merged to main, verify the deployment is healthy.
+You are a deployment verification agent for Governada (governada.io). After a PR is merged to main, verify the deployment is healthy.
 
 ## Steps
 
 1. Check Railway deployment status: `railway logs --tail 50`
 2. Poll until you see "Ready" or "Listening" in logs (max 5 minutes, check every 30s)
-3. Hit the health endpoint: `curl -s -o /dev/null -w "%{http_code}" https://drepscore.io/api/health`
+3. Hit the health endpoint: `curl -s -o /dev/null -w "%{http_code}" https://governada.io/api/health`
 4. If specific endpoints were provided in your prompt, verify each returns 200
 5. Run `npm run smoke-test` for comprehensive checks
 

--- a/.claude/agents/perf-auditor.md
+++ b/.claude/agents/perf-auditor.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You are a performance auditor for Civica. Collect concrete evidence for the Performance & Reliability dimension of the audit rubric.
+You are a performance auditor for Governada. Collect concrete evidence for the Performance & Reliability dimension of the audit rubric.
 
 ## Checks
 

--- a/.claude/agents/pre-ship-reviewer.md
+++ b/.claude/agents/pre-ship-reviewer.md
@@ -1,11 +1,11 @@
 ---
 name: pre-ship-reviewer
-description: Review changes before shipping to catch common Civica mistakes
+description: Review changes before shipping to catch common Governada mistakes
 tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You are a pre-ship reviewer for Civica. Before code is pushed, audit the diff for common production issues.
+You are a pre-ship reviewer for Governada. Before code is pushed, audit the diff for common production issues.
 
 ## Checks
 

--- a/.claude/commands/audit-all.md
+++ b/.claude/commands/audit-all.md
@@ -1,4 +1,4 @@
-Run a comprehensive audit of Civica by launching parallel subagents for all area audits and step verification. Each subagent gets its own full context window — no depth sacrificed.
+Run a comprehensive audit of Governada by launching parallel subagents for all area audits and step verification. Each subagent gets its own full context window — no depth sacrificed.
 
 ## Scope
 
@@ -32,7 +32,7 @@ Each subagent prompt tells the agent to read its audit command file and execute 
 **1. Sync Pipeline Audit**
 
 ```
-You are auditing the Civica sync pipeline. This is a READ-ONLY audit — do not modify any files.
+You are auditing the Governada sync pipeline. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-sync.md` for the full audit methodology
@@ -69,7 +69,7 @@ RAW_EVIDENCE: [2-3 sentences of the most important specific findings — numbers
 **2. Data Integrity Audit**
 
 ```
-You are auditing Civica's data integrity. This is a READ-ONLY audit — do not modify any files.
+You are auditing Governada's data integrity. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-data.md` for the full audit methodology
@@ -106,7 +106,7 @@ RAW_EVIDENCE: [2-3 sentences of the most important specific findings]
 **3. Scoring Methodology Audit**
 
 ```
-You are auditing Civica's scoring methodology. This is a READ-ONLY audit — do not modify any files.
+You are auditing Governada's scoring methodology. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-scoring.md` for the full audit methodology
@@ -143,7 +143,7 @@ RAW_EVIDENCE: [2-3 sentences of the most important specific findings — distrib
 **4. UX Quality Audit**
 
 ```
-You are auditing Civica's UX quality. This is a READ-ONLY audit — do not modify any files.
+You are auditing Governada's UX quality. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-ux.md` for the full audit methodology
@@ -183,7 +183,7 @@ RAW_EVIDENCE: [2-3 sentences — specific components, missing states, persona co
 **5. User Journey Audit**
 
 ```
-You are auditing Civica's user journeys end-to-end. This is a READ-ONLY audit — do not modify any files.
+You are auditing Governada's user journeys end-to-end. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-journeys.md` for the full audit methodology
@@ -226,7 +226,7 @@ RAW_EVIDENCE: [2-3 sentences — broken flows, friction measurements, edge case 
 **6. Security Audit**
 
 ```
-You are auditing Civica's security posture. This is a READ-ONLY audit — do not modify any files.
+You are auditing Governada's security posture. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `.claude/commands/audit-security.md` for the full audit methodology
@@ -270,7 +270,7 @@ These verify that completed vision steps are truly "flawless bedrock" for future
 **7. Engine Bedrock (Steps 0–2.5)**
 
 ```
-You are verifying that Civica's engine foundation (Steps 0, 1, 2, 2.5) is flawless bedrock for all future features. This is a READ-ONLY audit — do not modify any files.
+You are verifying that Governada's engine foundation (Steps 0, 1, 2, 2.5) is flawless bedrock for all future features. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `docs/strategy/context/build-manifest.md` for the checkbox list
@@ -317,7 +317,7 @@ BEDROCK_BLOCKERS:
 **8. Frontend Bedrock (Steps 3–6)**
 
 ```
-You are verifying that Civica's frontend and feature layers (Steps 3, 4, 5, 6) are solid enough to build Steps 7+ on. This is a READ-ONLY audit — do not modify any files.
+You are verifying that Governada's frontend and feature layers (Steps 3, 4, 5, 6) are solid enough to build Steps 7+ on. This is a READ-ONLY audit — do not modify any files.
 
 Instructions:
 1. Read `docs/strategy/context/build-manifest.md` for the checkbox list

--- a/.claude/commands/audit-journeys.md
+++ b/.claude/commands/audit-journeys.md
@@ -2,7 +2,7 @@ Audit user journeys end-to-end for task completion, friction, edge cases, and re
 
 ## Purpose
 
-Verify that each persona can complete their critical tasks through Civica with world-class efficiency and resilience. Unlike `/audit-ux` (which evaluates surfaces, intelligence leverage, and design), this audit tests **actual user flows** — clicking through the product as each persona would, measuring friction, catching broken paths, and establishing a regression baseline.
+Verify that each persona can complete their critical tasks through Governada with world-class efficiency and resilience. Unlike `/audit-ux` (which evaluates surfaces, intelligence leverage, and design), this audit tests **actual user flows** — clicking through the product as each persona would, measuring friction, catching broken paths, and establishing a regression baseline.
 
 This audit answers: **Can every persona accomplish what they came here to do, and does the experience get better, not worse, over time?**
 
@@ -33,7 +33,7 @@ The anchor persona (80%+ of users). Source spec: `docs/strategy/personas/citizen
 
 ### J-C1: First Visit → Understanding Value (The "Front Door")
 
-**Task:** An anonymous visitor arrives at drepscore.io. Within 60 seconds, they understand what Cardano governance is, why it matters to them, and what they can do about it.
+**Task:** An anonymous visitor arrives at governada.io. Within 60 seconds, they understand what Cardano governance is, why it matters to them, and what they can do about it.
 
 Walk the actual flow:
 
@@ -85,7 +85,7 @@ Walk the actual flow:
 
 ### J-C3: Returning Citizen → Epoch Briefing → Informed
 
-**Task:** A returning authenticated citizen opens Civica at an epoch boundary and leaves feeling informed about governance within 30 seconds.
+**Task:** A returning authenticated citizen opens Governada at an epoch boundary and leaves feeling informed about governance within 30 seconds.
 
 Walk the actual flow:
 
@@ -213,7 +213,7 @@ Source spec: `docs/strategy/personas/drep.md`
 
 ### J-D1: DRep → Inbox → "What Should I Do Right Now?"
 
-**Task:** A DRep opens Civica and within 5 seconds knows what needs their attention, prioritized by urgency and impact.
+**Task:** A DRep opens Governada and within 5 seconds knows what needs their attention, prioritized by urgency and impact.
 
 Walk the actual flow:
 

--- a/.claude/commands/audit-scoring.md
+++ b/.claude/commands/audit-scoring.md
@@ -2,7 +2,7 @@ Audit scoring methodology, calibration quality, and real-world impact.
 
 ## Purpose
 
-Evaluate whether Civica's scoring systems (DRep Score V3, SPO Score V3, GHI, CC Transparency Index, PCA alignment, matching engine) are achieving their intended goals:
+Evaluate whether Governada's scoring systems (DRep Score V3, SPO Score V3, GHI, CC Transparency Index, PCA alignment, matching engine) are achieving their intended goals:
 
 1. **Differentiation**: Do scores meaningfully separate good governance behavior from bad?
 2. **Defensibility**: Can the methodology withstand public scrutiny from the Cardano community?

--- a/.claude/commands/audit-security.md
+++ b/.claude/commands/audit-security.md
@@ -2,7 +2,7 @@ Audit security posture for pre-launch readiness and ongoing hardening.
 
 ## Purpose
 
-Verify that Civica is secure enough for public launch and ongoing operation. This is not a generic OWASP checklist — it's a Civica-specific audit that tests the actual authentication, authorization, data protection, API security, and infrastructure hardening patterns in this codebase.
+Verify that Governada is secure enough for public launch and ongoing operation. This is not a generic OWASP checklist — it's a Governada-specific audit that tests the actual authentication, authorization, data protection, API security, and infrastructure hardening patterns in this codebase.
 
 A governance intelligence platform handling wallet connections, on-chain transactions, and civic engagement data has a unique threat profile. A breach doesn't just leak data — it destroys the trust that makes the entire product viable. Cardano community trust is the product's foundation; security is existential, not optional.
 
@@ -431,7 +431,7 @@ npm audit
 
 ## Phase 7: Engagement Anti-Gaming
 
-Civica's engagement mechanisms are a unique attack surface. If sentiment, endorsements, or concern flags can be gamed, the intelligence engine is poisoned.
+Governada's engagement mechanisms are a unique attack surface. If sentiment, endorsements, or concern flags can be gamed, the intelligence engine is poisoned.
 
 ### 7.1 Anti-Spam Measures
 

--- a/.claude/commands/audit-sync.md
+++ b/.claude/commands/audit-sync.md
@@ -2,7 +2,7 @@ Audit the sync pipeline for performance, reliability, and hardening gaps.
 
 ## Purpose
 
-Evaluate the health and resilience of the Koios → Supabase sync pipeline. This is the plumbing that makes Civica's data trustworthy. If syncs fail silently or produce stale data, every surface in the product degrades.
+Evaluate the health and resilience of the Koios → Supabase sync pipeline. This is the plumbing that makes Governada's data trustworthy. If syncs fail silently or produce stale data, every surface in the product degrades.
 
 ## Scope
 

--- a/.claude/commands/audit-ux.md
+++ b/.claude/commands/audit-ux.md
@@ -2,7 +2,7 @@ Audit the user experience against the standard: "best governance UX in crypto, c
 
 ## Purpose
 
-Evaluate whether Civica's UX is fully leveraging the intelligence engine to deliver persona-appropriate, retention-driving, emotionally resonant experiences. The engine is the moat — but the UX is what users see, feel, and come back for. A world-class backend behind a mediocre frontend is an invisible advantage.
+Evaluate whether Governada's UX is fully leveraging the intelligence engine to deliver persona-appropriate, retention-driving, emotionally resonant experiences. The engine is the moat — but the UX is what users see, feel, and come back for. A world-class backend behind a mediocre frontend is an invisible advantage.
 
 This audit answers: **Is every surface earning the right to be called "best in industry"?**
 
@@ -22,7 +22,7 @@ Read `.claude/rules/product-vision.md` for design principles and UX rules. Every
 
 1. **The 30-second test.** Can each persona accomplish their primary task in 30 seconds? (Citizen: understand governance health. DRep: see what needs attention. SPO: check governance reputation.)
 2. **The "why should I come back?" test.** For each persona, is there a compelling reason to return at the epoch boundary? Not "there's new data" — but "this data changes my understanding or requires my action."
-3. **The "could this be any app?" test.** If you screenshot a page and remove the logo, would anyone know this is Civica? Every surface should be unmistakably a governance civic hub, not a generic dashboard.
+3. **The "could this be any app?" test.** If you screenshot a page and remove the logo, would anyone know this is Governada? Every surface should be unmistakably a governance civic hub, not a generic dashboard.
 4. **The storytelling test.** Does every number tell a story? Does every insight connect to an action? Does every status create an emotional response (pride, concern, curiosity)?
 
 ## Phase 1: Intelligence Leverage Audit
@@ -333,7 +333,7 @@ Dark mode is not just "invert the colors." Evaluate against the Vercel/Linear st
 
 ### 6.5 Data Visualization Craft
 
-Governance data is Civica's core differentiator. Visualizations must be exceptional:
+Governance data is Governada's core differentiator. Visualizations must be exceptional:
 
 - **Custom vs library:** What % of charts are custom D3/SVG vs Recharts/chart library defaults?
 - **Governance-specific:** Do visualizations communicate governance concepts that generic charts can't? (e.g., constellation for alignment, score ring for multi-pillar assessment, GHI gauge for health)
@@ -346,9 +346,9 @@ Governance data is Civica's core differentiator. Visualizations must be exceptio
 
 The ultimate design test — screenshot each major page and evaluate:
 
-- **Remove the logo.** Would anyone know this is Civica? What visual elements make it unmistakable?
+- **Remove the logo.** Would anyone know this is Governada? What visual elements make it unmistakable?
 - **Compare to shadcn templates.** How many components could exist unchanged in a generic shadcn/Next.js starter?
-- **Compare to competitors.** Screenshot GovTool, Tally, Snapshot side-by-side. Where does Civica look clearly more polished? Where does it look generic by comparison?
+- **Compare to competitors.** Screenshot GovTool, Tally, Snapshot side-by-side. Where does Governada look clearly more polished? Where does it look generic by comparison?
 - **The "pitch deck" test.** Would you put this screenshot in a presentation to investors/partners? If not, what's holding it back?
 
 Score the product overall: if 10 screenshots were shared on X with no context, would the reaction be "this looks incredible" or "this looks like another crypto dashboard"?
@@ -445,12 +445,12 @@ For each transition, rate: COMPELLING / ADEQUATE / WEAK / MISSING.
 
 ### U6: Visual Design Craft (10 pts)
 
-| Score | Anchor                                                                                                                                                                                                                                                                                                                                        |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1-3   | Stock shadcn components throughout, no visual identity, dark mode is just inverted colors, generic charts                                                                                                                                                                                                                                     |
-| 4-6   | Some custom components (hero sections, score ring), basic color system, dark mode functional but not polished, mix of custom and stock visualizations                                                                                                                                                                                         |
-| 7-8   | Coherent visual identity system (color, type, spacing, iconography), hero sections set a bar the app matches, dark mode is a first-class experience with depth and vibrancy, data visualizations are custom and governance-specific, most screenshots pass the "pitch deck" test, clear visual differentiation from competitors               |
-| 9-10  | Every component feels purpose-built, visual identity is instantly recognizable (remove logo and you still know it's Civica), dark mode rivals Vercel/Linear, visualizations are category-defining, design system documented and maintained, screenshots consistently provoke "this looks incredible" reactions, brand design could win awards |
+| Score | Anchor                                                                                                                                                                                                                                                                                                                                           |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1-3   | Stock shadcn components throughout, no visual identity, dark mode is just inverted colors, generic charts                                                                                                                                                                                                                                        |
+| 4-6   | Some custom components (hero sections, score ring), basic color system, dark mode functional but not polished, mix of custom and stock visualizations                                                                                                                                                                                            |
+| 7-8   | Coherent visual identity system (color, type, spacing, iconography), hero sections set a bar the app matches, dark mode is a first-class experience with depth and vibrancy, data visualizations are custom and governance-specific, most screenshots pass the "pitch deck" test, clear visual differentiation from competitors                  |
+| 9-10  | Every component feels purpose-built, visual identity is instantly recognizable (remove logo and you still know it's Governada), dark mode rivals Vercel/Linear, visualizations are category-defining, design system documented and maintained, screenshots consistently provoke "this looks incredible" reactions, brand design could win awards |
 
 ## Phase 9: Work Plan
 

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,4 +1,4 @@
-Perform a structured product audit of Civica against the vision and quality standards.
+Perform a structured product audit of Governada against the vision and quality standards.
 
 ## Scope
 
@@ -40,7 +40,7 @@ Use WebSearch to check the current state of competitors listed in `docs/strategy
 2. Note any new features, UX changes, or competitive moves since the last check
 3. Update the competitive-landscape.md file with findings and timestamps
 4. Search for latest best practices in key tech areas (Next.js patterns, React 19 features, Tailwind v4, D3 visualization trends)
-5. Flag any competitor moves that threaten or validate Civica's approach
+5. Flag any competitor moves that threaten or validate Governada's approach
 
 ## Phase 3: Scoring
 

--- a/.claude/commands/build-step.md
+++ b/.claude/commands/build-step.md
@@ -16,7 +16,7 @@ Launch all three simultaneously using the Agent tool. These are READ-ONLY resear
 ### 1A. Vision Analyst
 
 ```
-You are analyzing a Civica vision step to produce a comprehensive build specification. READ-ONLY — do not modify files.
+You are analyzing a Governada vision step to produce a comprehensive build specification. READ-ONLY — do not modify files.
 
 Instructions:
 1. Read `docs/strategy/ultimate-vision.md` — find the Step [N] section. Extract EVERY requirement, feature, success criteria, and cross-step dependency.
@@ -51,7 +51,7 @@ VISION_AMBIGUITY:
 ### 1B. Codebase Scout
 
 ```
-You are exploring the Civica codebase to map the technical landscape for building Step [N]. READ-ONLY — do not modify files.
+You are exploring the Governada codebase to map the technical landscape for building Step [N]. READ-ONLY — do not modify files.
 
 Instructions:
 1. Read `docs/strategy/context/build-manifest.md` to understand what Step [N] requires.
@@ -90,7 +90,7 @@ TECHNICAL_RISKS:
 ### 1C. Audit Pre-Screen
 
 ```
-You are pre-screening a Civica vision step against all audit dimensions to define quality targets BEFORE building. READ-ONLY — do not modify files.
+You are pre-screening a Governada vision step against all audit dimensions to define quality targets BEFORE building. READ-ONLY — do not modify files.
 
 Instructions:
 1. Read `docs/strategy/context/build-manifest.md` to understand what Step [N] requires.
@@ -217,7 +217,7 @@ Launch chunk agents in worktrees. Use `isolation: "worktree"` for each.
 Each chunk agent receives a prompt containing:
 
 ```
-You are building Chunk [N]: [Name] for Civica Step [S].
+You are building Chunk [N]: [Name] for Governada Step [S].
 
 ## Your Scope
 [Chunk description from the approved plan]
@@ -295,7 +295,7 @@ Process PR groups in the order determined in Phase 2.5. For each group:
 3. **Merge**: `gh api repos/drepscore/drepscore-app/pulls/<N>/merge -X PUT -f merge_method=squash`
 4. **Migrations**: If the chunk included database migrations, apply via Supabase MCP `apply_migration`, then `npm run gen:types`.
 5. **Deploy wait**: Poll Railway for ~5 minutes until the new commit is deployed.
-6. **Inngest sync**: If Inngest functions were added/modified, PUT `https://drepscore.io/api/inngest`.
+6. **Inngest sync**: If Inngest functions were added/modified, PUT `https://governada.io/api/inngest`.
 7. **Smoke test**: `npm run smoke-test` + hit any new/changed endpoints on production.
 8. **Verification gate**:
    - If smoke test PASSES: log success, proceed to next group.

--- a/.claude/commands/ci-watch.md
+++ b/.claude/commands/ci-watch.md
@@ -19,9 +19,9 @@ Poll CI on main every 60s until `success`. CI green does NOT mean deployed — b
 
 ## Post-Deploy Validation (ALL mandatory)
 
-1. Health check: `curl -s https://drepscore.io/api/health` — expect 200
-2. Inngest sync: `curl -X PUT https://drepscore.io/api/inngest`
+1. Health check: `curl -s https://governada.io/api/health` — expect 200
+2. Inngest sync: `curl -X PUT https://governada.io/api/inngest`
 3. Smoke tests: `npm run smoke-test`
-4. Feature-specific: hit the changed page/endpoint on `drepscore.io`
+4. Feature-specific: hit the changed page/endpoint on `governada.io`
 
 If ANY check fails: investigate, fix, push follow-up commit. Never report "done" until all 4 pass.

--- a/.claude/commands/fix-audit.md
+++ b/.claude/commands/fix-audit.md
@@ -104,7 +104,7 @@ Same pattern as `/build-step` Phase 4. Launch chunk agents in worktrees.
 Each fix agent receives:
 
 ```
-You are fixing audit gaps for Civica. This is a TARGETED FIX — not a feature build.
+You are fixing audit gaps for Governada. This is a TARGETED FIX — not a feature build.
 
 ## Gaps to Fix
 [List of gap IDs, descriptions, and affected files from the approved plan]

--- a/.claude/commands/hotfix.md
+++ b/.claude/commands/hotfix.md
@@ -9,7 +9,7 @@ Work directly on `main` (no branch/PR needed for single-commit hotfixes).
 3. **Commit + push**: `git commit` with `fix:` prefix → `git push origin main`
 4. **Monitor CI**: Poll `gh run list --branch main --limit 1` every 30s until green. If fails: read logs, fix, re-push
 5. **Railway deploy**: Wait ~5 min, poll until status shows success
-6. **Validate**: Health check (`/api/health`), smoke test, hit the fixed endpoint on `drepscore.io`
+6. **Validate**: Health check (`/api/health`), smoke test, hit the fixed endpoint on `governada.io`
 7. **Report**: Concise summary — what shipped, deploy time, validation results
 
 **CRITICAL: Do NOT send a summary until post-deploy validation passes. Pushing to main is step 3 of 7.**

--- a/.claude/commands/launch-readiness.md
+++ b/.claude/commands/launch-readiness.md
@@ -24,7 +24,7 @@ Launch all of the following simultaneously using the Agent tool.
 ### 1A. Security Launch Blockers
 
 ```
-You are checking Civica's security posture for launch readiness. READ-ONLY — do not modify files.
+You are checking Governada's security posture for launch readiness. READ-ONLY — do not modify files.
 
 Instructions:
 1. Read `.claude/commands/audit-security.md` — focus on the Pre-Launch Checklist section
@@ -52,7 +52,7 @@ SUMMARY: [1-2 sentence overall assessment]
 ### 1B. Critical Journey Regression
 
 ```
-You are running the Civica regression baseline to verify all critical user journeys work. READ-ONLY — do not modify files.
+You are running the Governada regression baseline to verify all critical user journeys work. READ-ONLY — do not modify files.
 
 Instructions:
 1. Read `.claude/commands/audit-journeys.md` — focus on the Regression Baseline section
@@ -79,7 +79,7 @@ SUMMARY: [1-2 sentence overall assessment]
 ### 1C. Performance Baseline
 
 ```
-You are assessing Civica's performance readiness for launch. READ-ONLY — do not modify files.
+You are assessing Governada's performance readiness for launch. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check `next.config.ts` for image optimization, compression, caching headers
@@ -112,7 +112,7 @@ SUMMARY: [1-2 sentence overall assessment]
 ### 1D. Data & Sync Health
 
 ```
-You are verifying Civica's data layer is healthy and ready for public traffic. READ-ONLY — do not modify files.
+You are verifying Governada's data layer is healthy and ready for public traffic. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check sync pipeline health: read `lib/sync/` and `inngest/functions/` for all sync types
@@ -149,13 +149,13 @@ Launch all of the following simultaneously. These check non-code aspects that ar
 ### 2A. Brand & Identity Audit
 
 ```
-You are auditing Civica's brand presence and visual identity for launch readiness. READ-ONLY — do not modify files.
+You are auditing Governada's brand presence and visual identity for launch readiness. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check `app/layout.tsx` for site title, description, metadata, OG defaults
 2. Check `public/` for logo files, favicon (all sizes), apple-touch-icon, OG images
 3. Check `app/api/og/` for dynamic OG image generation — are all entity types covered?
-4. Verify brand consistency: is it "Civica" everywhere or does "DRepScore" still appear in user-facing text?
+4. Verify brand consistency: is it "Governada" everywhere or does "DRepScore" still appear in user-facing text?
 5. Check footer component for social links, branding, copyright
 6. Check for a custom 404 page and error pages
 7. Search for any placeholder text ("Lorem ipsum", "TODO", "Coming soon", "TBD") in user-facing components
@@ -168,7 +168,7 @@ IDENTITY:
 - Meta description: [what it says]
 - Favicon: [present/missing, all sizes?]
 - OG images: [default + dynamic coverage]
-- Brand name consistency: [Civica everywhere? / lingering "DRepScore" references]
+- Brand name consistency: [Governada everywhere? / lingering "DRepScore" references]
 
 POLISH:
 - Custom 404: [yes/no]
@@ -186,7 +186,7 @@ SUMMARY: [1-2 sentence assessment]
 ### 2B. Legal & Compliance Check
 
 ```
-You are checking Civica's legal and compliance readiness for public launch. READ-ONLY — do not modify files.
+You are checking Governada's legal and compliance readiness for public launch. READ-ONLY — do not modify files.
 
 Instructions:
 1. Search `app/` for privacy policy, terms of service, cookie policy pages
@@ -224,7 +224,7 @@ SUMMARY: [1-2 sentence assessment]
 ### 2C. Monetization & Growth Infrastructure
 
 ```
-You are assessing Civica's monetization and growth infrastructure readiness. READ-ONLY — do not modify files.
+You are assessing Governada's monetization and growth infrastructure readiness. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check for any payment/subscription infrastructure: Stripe, payment pages, pricing page
@@ -268,7 +268,7 @@ SUMMARY: [1-2 sentence assessment with recommendations for post-launch priority]
 ### 2D. Community & Communication Readiness
 
 ```
-You are assessing Civica's community and external communication readiness for launch. READ-ONLY — do not modify files.
+You are assessing Governada's community and external communication readiness for launch. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check for social media links in the app (footer, about page, etc.)
@@ -312,7 +312,7 @@ SUMMARY: [1-2 sentence assessment]
 ### 2E. SEO & Discoverability
 
 ```
-You are assessing Civica's SEO and web discoverability for launch. READ-ONLY — do not modify files.
+You are assessing Governada's SEO and web discoverability for launch. READ-ONLY — do not modify files.
 
 Instructions:
 1. Check `public/robots.txt` — does it exist? What does it allow/disallow?
@@ -422,7 +422,7 @@ If NO-GO or CONDITIONAL GO, produce an action plan:
 ```
 ## Founder Action Items (non-code)
 
-- [ ] **Social accounts**: Create/verify Twitter, Discord, Telegram for Civica
+- [ ] **Social accounts**: Create/verify Twitter, Discord, Telegram for Governada
 - [ ] **Legal review**: Have privacy policy and ToS reviewed by legal counsel
 - [ ] **Announcement**: Draft launch announcement for Cardano community channels
 - [ ] **Monitoring**: Set up Sentry alerts, Railway notifications, Cloudflare alerts

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -13,8 +13,8 @@ All code changes compile clean. Execute the full deploy pipeline autonomously. D
 9. **Merge**: `gh pr merge <N> --squash --delete-branch` (or `gh api .../merge` from worktrees)
 10. **Migrations**: Apply pending via Supabase MCP `apply_migration` → `npm run gen:types`
 11. **Deploy monitor**: Wait ~5 min, poll Railway until deployed, verify health endpoint returns 200
-12. **Inngest sync**: PUT `https://drepscore.io/api/inngest` if functions changed → `npm run inngest:status`
-13. **Smoke test**: Hit new/changed endpoints on `drepscore.io`, run `npm run smoke-test`
+12. **Inngest sync**: PUT `https://governada.io/api/inngest` if functions changed → `npm run inngest:status`
+13. **Smoke test**: Hit new/changed endpoints on `governada.io`, run `npm run smoke-test`
 14. **Analytics**: `npm run posthog:check <event>` if new events
 15. **Cleanup**: Switch to main, pull, delete branch, update lessons if needed
 

--- a/.claude/rules/audit-integrity.md
+++ b/.claude/rules/audit-integrity.md
@@ -53,7 +53,7 @@ If the answer is no, the recommendation is LOW PRIORITY at best. It should not b
 
 ## Competitor Benchmark
 
-Don't compare against an imaginary ideal. Compare against what actually exists in the Cardano governance ecosystem and adjacent Web3 tools. If Civica is already ahead of every competitor on a dimension, that dimension needs maintenance, not improvement.
+Don't compare against an imaginary ideal. Compare against what actually exists in the Cardano governance ecosystem and adjacent Web3 tools. If Governada is already ahead of every competitor on a dimension, that dimension needs maintenance, not improvement.
 
 Reference `docs/strategy/context/competitive-landscape.md` for the current landscape.
 

--- a/.claude/rules/product-strategy.md
+++ b/.claude/rules/product-strategy.md
@@ -29,7 +29,7 @@ North star: `docs/strategy/ultimate-vision.md` (V2). All feature decisions align
 
 ## Vision
 
-Civica is the civic hub for the Cardano nation -- the one place where every ADA holder goes to understand what their stake is doing in governance, and where every governance participant goes to do their work.
+Governada is the civic hub for the Cardano nation -- the one place where every ADA holder goes to understand what their stake is doing in governance, and where every governance participant goes to do their work.
 
 ## Principles (Non-Negotiable)
 
@@ -37,7 +37,7 @@ Civica is the civic hub for the Cardano nation -- the one place where every ADA 
 2. **Free core, paid power tools** -- Never gate: discovery, basic scores, delegation, Quick Match, basic alerts, essential governance operations (voting, rationale submission). Monetize competitive advantage and growth analytics.
 3. **Data is the product** -- Open methodology builds trust. Historical data builds revenue. Citizen engagement data builds the moat no competitor can cross.
 4. **Persona-appropriate depth** -- Citizens get summary intelligence. DReps get a workspace. SPOs get an identity platform. Different personas need different products, not different depths of the same product.
-5. **Intelligence demands action** -- Every insight connects to something the user can do. Civica is where governance HAPPENS, not just where it is observed.
+5. **Intelligence demands action** -- Every insight connects to something the user can do. Governada is where governance HAPPENS, not just where it is observed.
 6. **Accountability is advantage** -- Transparency is rewarded, not imposed. DReps who provide rationales score higher. SPOs who participate get discovered. Treasury teams who deliver build reputation.
 7. **Structured signal over open discourse** -- Civic engagement generates analyzable data, not noise. No forums, no threads, no moderation burden.
 8. **DReps, SPOs, and Integration Partners are the sales force** -- Every shared score, every embedded widget is marketing.

--- a/.claude/rules/product-vision.md
+++ b/.claude/rules/product-vision.md
@@ -7,7 +7,7 @@ paths:
 
 # Product Vision & UX Execution Standards
 
-Core thesis: Civica is the **civic hub for the Cardano nation**. Users are citizens, not dashboard consumers. The product makes citizenship in a digital nation feel real.
+Core thesis: Governada is the **civic hub for the Cardano nation**. Users are citizens, not dashboard consumers. The product makes citizenship in a digital nation feel real.
 
 ## Design Principles
 
@@ -46,7 +46,7 @@ Every user-facing surface should look purpose-built, not assembled from a compon
 
 1. **Default to the most visually distinctive option.** Custom SVG over Recharts, physics-based animations (Framer Motion/spring) over CSS transitions, bespoke visualizations over chart libraries. The user must explicitly request the simpler option.
 2. **Performance is a constraint, not a goal.** Lazy-loading (`next/dynamic`, `ssr: false`), code splitting, and adaptive quality tiers handle bundle concerns. A 200KB lazy-loaded package with zero LCP impact is always acceptable for a premium result.
-3. **Every screenshot must be unmistakably Civica.** If a component could exist in any shadcn/Next.js app, it needs more work.
+3. **Every screenshot must be unmistakably Governada.** If a component could exist in any shadcn/Next.js app, it needs more work.
 4. **"Good enough" creates rework; "premium" ships once.** The constellation hero is React Three Fiber with WebGL bloom -- that's the baseline for hero-level visuals.
 
 **Applies to:** hero sections, profile pages, data visualizations, OG images, share cards, onboarding.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -4,7 +4,7 @@ description: Execute the full deploy pipeline from current changes to production
 disable-model-invocation: true
 ---
 
-Execute the full Civica deploy pipeline. Do NOT pause between steps.
+Execute the full Governada deploy pipeline. Do NOT pause between steps.
 
 1. `npm run preflight` -- fix ALL failures before proceeding
 2. `gh auth switch --user drepscore`
@@ -18,8 +18,8 @@ Execute the full Civica deploy pipeline. Do NOT pause between steps.
 10. Apply pending migrations via Supabase MCP `apply_migration`
 11. If migrations applied: `npm run gen:types`, commit and push updated `types/database.ts`
 12. Monitor Railway: poll `railway logs` until deploy completes (~3-7 min)
-13. If Inngest functions changed: `curl -X PUT https://drepscore.io/api/inngest` then `npm run inngest:status`
-14. Verify endpoints: `curl -s -o /dev/null -w "%{http_code}" https://drepscore.io/<path>` for each new/changed route
+13. If Inngest functions changed: `curl -X PUT https://governada.io/api/inngest` then `npm run inngest:status`
+14. Verify endpoints: `curl -s -o /dev/null -w "%{http_code}" https://governada.io/<path>` for each new/changed route
 15. `npm run smoke-test`
 16. If new analytics events: `npm run posthog:check <event>`
 17. Clean up: if worktree, switch to main worktree to verify

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ADMIN_WALLETS=
 # Generate with: npx web-push generate-vapid-keys
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
-VAPID_SUBJECT=mailto:hello@drepscore.com
+VAPID_SUBJECT=mailto:hello@governada.io
 
 # Supabase type generation (npm run gen:types)
 # Get from: https://supabase.com/dashboard/account/tokens

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
       NEXT_PUBLIC_KOIOS_BASE_URL: https://api.koios.rest/api/v1
-      NEXT_PUBLIC_APP_URL: https://drepscore.io
+      NEXT_PUBLIC_APP_URL: https://governada.io
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Civica (formerly DRepScore)
+# Governada (formerly DRepScore)
 
-The civic hub for the Cardano Nation -- governance intelligence and civic engagement for Cardano.
+Governance intelligence for the Cardano Nation.
 
 ## Autonomous Deployment Pipeline
 
@@ -14,8 +14,8 @@ Implementation is NOT complete until deployed and validated in production. Use `
 6. Merge: `gh api repos/drepscore/drepscore-app/pulls/<N>/merge -X PUT -f merge_method=squash`
 7. Apply migrations via Supabase MCP -> `npm run gen:types` if needed
 8. Monitor Railway (`railway logs`, poll ~5 min)
-9. PUT `https://drepscore.io/api/inngest` if Inngest functions changed
-10. Verify endpoints on `drepscore.io`, run `npm run smoke-test`
+9. PUT `https://governada.io/api/inngest` if Inngest functions changed
+10. Verify endpoints on `governada.io`, run `npm run smoke-test`
 11. Clean up worktree if applicable
 
 ## Hard Constraints
@@ -78,7 +78,7 @@ C:\Users\dalto\drepscore\
 
 ## Environment
 
-- **Production**: `https://drepscore.io` (NOT .com)
+- **Production**: `https://governada.io` (NOT .com)
 - **Supabase**: project `pbfprhbaayvcrxokgicr`
 - **CI**: lint/format/type-check/test (parallel) -> build. E2E post-merge only
 - **Release gating**: Hotfixes direct to main. Features/migrations/API changes via PR

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-# Civica Coding Conventions
+# Governada Coding Conventions
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Civica
+# Governada
 
-**The Civic Hub for the Cardano Nation**
+**Governance Intelligence for Cardano**
 
-Civica (formerly DRepScore) is the governance intelligence and civic engagement platform for Cardano. It serves every participant in the ecosystem — citizens (ADA holders), DReps, SPOs, Constitutional Committee, treasury proposal teams, and governance researchers — through one interconnected data engine.
+Governada (formerly DRepScore) is the governance intelligence platform for Cardano. It serves every participant in the ecosystem — citizens (ADA holders), DReps, SPOs, Constitutional Committee, treasury proposal teams, and governance researchers — through one interconnected data engine.
 
 ## What It Does
 

--- a/__tests__/api/auth.test.ts
+++ b/__tests__/api/auth.test.ts
@@ -3,7 +3,7 @@ import { createRequest, parseJson } from '../helpers';
 
 vi.mock('@/lib/nonce', () => ({
   createNonce: vi.fn().mockResolvedValue({
-    nonce: 'Sign in to DRepScore\nTime: Jan 1, 2025\nSession: abc123',
+    nonce: 'Sign in to Governada\nTime: Jan 1, 2025\nSession: abc123',
     signature: 'signed.jwt.token',
     expiresAt: Date.now() + 300_000,
   }),
@@ -57,7 +57,7 @@ describe('GET /api/auth/nonce', () => {
     const body = (await parseJson(res)) as any;
 
     expect(res.status).toBe(200);
-    expect(body.nonce).toContain('DRepScore');
+    expect(body.nonce).toContain('Governada');
     expect(body.signature).toBeTruthy();
     expect(body.expiresAt).toBeGreaterThan(Date.now());
   });
@@ -66,7 +66,7 @@ describe('GET /api/auth/nonce', () => {
 describe('POST /api/auth/wallet', () => {
   const validBody = {
     address: 'addr_test1qz...',
-    nonce: 'Sign in to DRepScore\nTime: Jan 1, 2025\nSession: abc123',
+    nonce: 'Sign in to Governada\nTime: Jan 1, 2025\nSession: abc123',
     nonceSignature: 'signed.jwt.token',
     signature: 'wallet_sig_hex',
     key: 'wallet_key_hex',

--- a/analytics/observablehq.config.ts
+++ b/analytics/observablehq.config.ts
@@ -1,5 +1,5 @@
 export default {
-  title: 'DRepScore Analytics',
+  title: 'Governada Analytics',
   root: 'src',
   theme: ['dashboard', 'near-midnight'],
   head: `<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>

--- a/analytics/src/drep-performance.md
+++ b/analytics/src/drep-performance.md
@@ -265,7 +265,7 @@ const rationaleTargets = activeDreps
 ```
 
 <div class="tip-box">
-  <strong>Rationale = 35% of DRepScore.</strong> These DReps have significant voting power but almost never explain their votes. "Potential Lift" estimates the score improvement if they reach 50% rationale rate.
+  <strong>Rationale = 35% of Governada Score.</strong> These DReps have significant voting power but almost never explain their votes. "Potential Lift" estimates the score improvement if they reach 50% rationale rate.
 </div>
 
 ```js

--- a/analytics/src/index.md
+++ b/analytics/src/index.md
@@ -174,7 +174,7 @@ const totalPolls = govEvents?.pollActivity?.reduce((s, d) => s + d.votes, 0) ?? 
   <div class="kpi">
     <span class="kpi-label">Avg Rationale Rate</span>
     <span class="kpi-value" style="color: ${scoreColor(avgRationale)}">${Math.round(avgRationale)}%</span>
-    <span class="kpi-sub">weighted at 35% of DRepScore — biggest lever</span>
+    <span class="kpi-sub">weighted at 35% of Governada Score — biggest lever</span>
     <div class="kpi-bar" style="background: ${scoreColor(avgRationale)}"></div>
   </div>
   <div class="kpi">
@@ -324,7 +324,7 @@ atRiskDreps.length > 0
       format: {
         Name: (d, i) =>
           html`<a
-            href="https://drepscore.io/drep/${atRiskDreps[i]._drepId}"
+            href="https://governada.io/drep/${atRiskDreps[i]._drepId}"
             target="_blank"
             style="color:var(--accent)"
             >${d}</a

--- a/analytics/src/rationale-quality.md
+++ b/analytics/src/rationale-quality.md
@@ -199,7 +199,7 @@ display(
         html`<span class="score-pill ${d >= 60 ? 'good' : d >= 30 ? 'warn' : 'bad'}">${d}</span>`,
       Name: (d, i) =>
         html`<a
-          href="https://drepscore.io/drep/${qualityTable[i].ID}"
+          href="https://governada.io/drep/${qualityTable[i].ID}"
           target="_blank"
           style="color:var(--accent)"
           >${d}</a

--- a/analytics/src/trends.md
+++ b/analytics/src/trends.md
@@ -83,7 +83,7 @@ function formatAda(v) {
 
 ## How is the network score trending?
 
-_The overall trajectory of DRepScore across all active DReps. Hover points for exact values._
+_The overall trajectory of Governada scores across all active DReps. Hover points for exact values._
 
 ```js
 const pillarFocus = view(

--- a/analytics/src/voting-power.md
+++ b/analytics/src/voting-power.md
@@ -144,7 +144,7 @@ display(
       Tier: (d) => html`<span class="badge badge-purple">${d}</span>`,
       Name: (d, i) =>
         html`<a
-          href="https://drepscore.io/drep/${top10Table[i].ID}"
+          href="https://governada.io/drep/${top10Table[i].ID}"
           target="_blank"
           style="color:var(--accent)"
           >${d}</a
@@ -250,7 +250,7 @@ if (prevEpoch != null) {
                   html`<span class="badge badge-green">+₳${formatAda(Math.abs(d))}</span>`,
                 Name: (d, i) =>
                   html`<a
-                    href="https://drepscore.io/drep/${gainers[i].ID}"
+                    href="https://governada.io/drep/${gainers[i].ID}"
                     target="_blank"
                     style="color:var(--accent)"
                     >${d}</a
@@ -273,7 +273,7 @@ if (prevEpoch != null) {
                   html`<span class="badge badge-red">-₳${formatAda(Math.abs(d))}</span>`,
                 Name: (d, i) =>
                   html`<a
-                    href="https://drepscore.io/drep/${losers[i].ID}"
+                    href="https://governada.io/drep/${losers[i].ID}"
                     target="_blank"
                     style="color:var(--accent)"
                     >${d}</a

--- a/app/api/admin/api-health/alert/route.ts
+++ b/app/api/admin/api-health/alert/route.ts
@@ -202,7 +202,7 @@ export const GET = withRouteHandler(async (request) => {
         eventType: 'api-health-alert',
         title: alertTitle,
         body: lines.join('\n'),
-        url: 'https://analytics.drepscore.io/api-analytics',
+        url: 'https://analytics.governada.io/api-analytics',
       }),
       criticalFailures.length > 0 ? alertEmail(alertTitle, lines.join('\n')) : Promise.resolve(),
     ]);

--- a/app/api/admin/inbox-alert/route.ts
+++ b/app/api/admin/inbox-alert/route.ts
@@ -157,7 +157,7 @@ export const GET = withRouteHandler(async (request) => {
           type: 'header',
           text: {
             type: 'plain_text',
-            text: `Civica Governance Alert — ${alerts.length} issue${alerts.length !== 1 ? 's' : ''}`,
+            text: `Governada Governance Alert — ${alerts.length} issue${alerts.length !== 1 ? 's' : ''}`,
           },
         },
         ...alerts.map((a) => ({
@@ -180,7 +180,7 @@ export const GET = withRouteHandler(async (request) => {
           title: `Governance Engagement Alert — ${alerts.length} issue${alerts.length !== 1 ? 's' : ''}`,
           description: lines.join('\n\n'),
           color: alerts.some((a) => a.level === 'critical') ? 0xff4444 : 0xf59e0b,
-          footer: { text: 'Civica Inbox Monitor' },
+          footer: { text: 'Governada Inbox Monitor' },
           timestamp: new Date().toISOString(),
         },
       ],

--- a/app/api/admin/integrity/alert/route.ts
+++ b/app/api/admin/integrity/alert/route.ts
@@ -501,7 +501,7 @@ export const GET = withRouteHandler(async (request) => {
         type: 'header',
         text: {
           type: 'plain_text',
-          text: `Civica: ${criticals.length} critical, ${warnings.length} warning`,
+          text: `Governada: ${criticals.length} critical, ${warnings.length} warning`,
         },
       },
       ...alerts.map((a) => ({
@@ -515,7 +515,7 @@ export const GET = withRouteHandler(async (request) => {
     body = { blocks };
   } else {
     const lines = alerts.map(formatAlertLine);
-    body = { content: `**Civica Integrity Alert**\n\n${lines.join('\n\n')}` };
+    body = { content: `**Governada Integrity Alert**\n\n${lines.join('\n\n')}` };
   }
 
   if (recoveries.length > 0) {

--- a/app/api/badge/[drepId]/route.tsx
+++ b/app/api/badge/[drepId]/route.tsx
@@ -22,13 +22,13 @@ function buildShieldSvg(score: number, tier: string, color: string): string {
   const totalWidth = labelWidth + scoreWidth;
   const height = 28;
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${height}">
-  <title>Civica ${score}/100 (${tier})</title>
+  <title>Governada ${score}/100 (${tier})</title>
   <rect width="${totalWidth}" height="${height}" rx="4" fill="#1e293b"/>
   <clipPath id="r"><rect width="${totalWidth}" height="${height}" rx="4"/></clipPath>
   <g clip-path="url(#r)">
     <rect x="${labelWidth}" width="${scoreWidth}" height="${height}" fill="${color}22"/>
   </g>
-  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="#e2e8f0" font-weight="600">Civica</text>
+  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="#e2e8f0" font-weight="600">Governada</text>
   <text x="${labelWidth + 8}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${color}" font-weight="700">${score}/100</text>
   <text x="${labelWidth + 56}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${color}cc">${tier}</text>
 </svg>`;
@@ -52,7 +52,7 @@ function buildCardSvg(
   const circ = 2 * Math.PI * ringR;
   const offset = circ * (1 - score / 100);
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
-  <title>${name} — Civica ${score}/100</title>
+  <title>${name} — Governada ${score}/100</title>
   <rect width="${w}" height="${h}" rx="8" fill="#0c1222"/>
   <rect x="1" y="1" width="${w - 2}" height="${h - 2}" rx="7" fill="none" stroke="${color}33" stroke-width="1"/>
   <circle cx="${cx}" cy="${cy}" r="${ringR}" fill="none" stroke="#1e293b" stroke-width="${sw}"/>
@@ -61,7 +61,7 @@ function buildCardSvg(
   <text x="${cx}" y="${cy + 1}" text-anchor="middle" dominant-baseline="central" font-family="sans-serif" font-size="18" fill="${color}" font-weight="700">${score}</text>
   <text x="84" y="30" font-family="sans-serif" font-size="14" fill="#e2e8f0" font-weight="600">${displayName}</text>
   <text x="84" y="50" font-family="sans-serif" font-size="11" fill="#94a3b8">${tier} · ${topPillar}: ${topPillarValue}%</text>
-  <text x="84" y="80" font-family="sans-serif" font-size="10" fill="#64748b">drepscore.io</text>
+  <text x="84" y="80" font-family="sans-serif" font-size="10" fill="#64748b">governada.io</text>
 </svg>`;
 }
 
@@ -97,7 +97,7 @@ function buildFullSvg(
     .join('\n');
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
-  <title>${name} — Civica ${score}/100</title>
+  <title>${name} — Governada ${score}/100</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0c1222"/>
@@ -114,8 +114,8 @@ function buildFullSvg(
   <text x="160" y="28" font-family="sans-serif" font-size="16" fill="#e2e8f0" font-weight="700">${displayName}</text>
   <text x="160" y="44" font-family="monospace" font-size="9" fill="#64748b">${shortId}</text>
   ${pillarBars}
-  <text x="8" y="${h - 10}" font-family="sans-serif" font-size="11" fill="#475569" font-weight="600">Civica</text>
-  <text x="${w - 8}" y="${h - 10}" text-anchor="end" font-family="sans-serif" font-size="9" fill="#475569">drepscore.io</text>
+  <text x="8" y="${h - 10}" font-family="sans-serif" font-size="11" fill="#475569" font-weight="600">Governada</text>
+  <text x="${w - 8}" y="${h - 10}" text-anchor="end" font-family="sans-serif" font-size="9" fill="#475569">governada.io</text>
 </svg>`;
 }
 

--- a/app/api/embed/drep/[drepId]/route.tsx
+++ b/app/api/embed/drep/[drepId]/route.tsx
@@ -89,7 +89,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ dre
         <div class="stat-value">${(drep.delegator_count ?? 0).toLocaleString()}</div>
       </div>
     </div>
-    <a href="https://drepscore.app/drep/${encodeURIComponent(drepId)}" target="_blank" class="cta">View full profile on Civica \u2197</a>
+    <a href="https://governada.io/drep/${encodeURIComponent(drepId)}" target="_blank" class="cta">View full profile on Governada \u2197</a>
   </div>
 </body>
 </html>`;

--- a/app/api/embed/ghi/route.ts
+++ b/app/api/embed/ghi/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
       <path d="${sparkPath}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <div style="color:#64748b;font-size:11px;margin-top:4px">Last 12 epochs</div>
-    <a href="https://drepscore.app/pulse" target="_blank" class="cta">View on Civica \u2197</a>
+    <a href="https://governada.io/pulse" target="_blank" class="cta">View on Governada \u2197</a>
   </div>
 </body>
 </html>`;

--- a/app/api/og/civic-identity/[stakeAddress]/route.tsx
+++ b/app/api/og/civic-identity/[stakeAddress]/route.tsx
@@ -102,7 +102,7 @@ export async function GET(
             <StatCard emoji="🏅" value={`${milestones}`} label="Milestones" />
           </div>
 
-          <OGFooter left="Civica" right="drepscore.io" />
+          <OGFooter left="Governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/cross-chain/route.tsx
+++ b/app/api/og/cross-chain/route.tsx
@@ -154,7 +154,7 @@ export async function GET() {
         )}
 
         <span style={{ fontSize: '14px', color: '#4b5563', marginTop: '24px' }}>
-          drepscore.io — Governance Intelligence for Crypto
+          governada.io — Governance Intelligence for Crypto
         </span>
       </div>,
       {

--- a/app/api/og/delegation/[stakeAddress]/route.tsx
+++ b/app/api/og/delegation/[stakeAddress]/route.tsx
@@ -69,7 +69,7 @@ export async function GET(
             >
               Delegation data syncing…
             </div>
-            <OGFooter left="$drepscore" right="drepscore.io" />
+            <OGFooter left="$governada" right="governada.io" />
           </div>
         </OGBackground>,
         {
@@ -204,7 +204,7 @@ export async function GET(
             ))}
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/delegator/route.tsx
+++ b/app/api/og/delegator/route.tsx
@@ -142,7 +142,7 @@ export async function GET(request: Request) {
             <div style={{ display: 'flex', fontSize: '32px', fontWeight: 700, color: OG.brand }}>
               Who&apos;s your DRep?
             </div>
-            <div style={{ display: 'flex', fontSize: '18px', color: OG.textDim }}>drepscore.io</div>
+            <div style={{ display: 'flex', fontSize: '18px', color: OG.textDim }}>governada.io</div>
           </div>
         </div>
       </OGBackground>,

--- a/app/api/og/governance-dna/route.tsx
+++ b/app/api/og/governance-dna/route.tsx
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest) {
             </div>
           ) : (
             <div style={{ display: 'flex', fontSize: '22px', color: OG.textMuted }}>
-              Take the quiz at drepscore.io to find your matches
+              Take the quiz at governada.io to find your matches
             </div>
           )}
 
@@ -152,10 +152,10 @@ export async function GET(request: NextRequest) {
               marginTop: '40px',
             }}
           >
-            Find your Governance DNA at drepscore.io
+            Find your Governance DNA at governada.io
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io/discover" />
+          <OGFooter left="$governada" right="governada.io/discover" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/governance-health/route.tsx
+++ b/app/api/og/governance-health/route.tsx
@@ -144,7 +144,7 @@ export async function GET() {
             </div>
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io/pulse" />
+          <OGFooter left="$governada" right="governada.io/pulse" />
         </div>
       </OGBackground>,
       {
@@ -173,7 +173,7 @@ export async function GET() {
           <div
             style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}
           >
-            drepscore.io
+            governada.io
           </div>
         </div>
       </OGBackground>,

--- a/app/api/og/governance-identity/route.tsx
+++ b/app/api/og/governance-identity/route.tsx
@@ -119,7 +119,7 @@ export async function GET(request: NextRequest) {
             marginTop: 'auto',
           }}
         >
-          drepscore.io — Governance Intelligence for Cardano
+          governada.io — Governance Intelligence for Cardano
         </span>
       </div>,
       {

--- a/app/api/og/governance-report/[epoch]/route.tsx
+++ b/app/api/og/governance-report/[epoch]/route.tsx
@@ -181,7 +181,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ epo
             </div>
           </div>
 
-          <OGFooter left="$drepscore" right={`drepscore.io/pulse/report/${epochNo}`} />
+          <OGFooter left="$governada" right={`governada.io/pulse/report/${epochNo}`} />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/leaderboard/route.tsx
+++ b/app/api/og/leaderboard/route.tsx
@@ -96,7 +96,7 @@ export async function GET() {
             })}
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io/pulse#leaderboard" />
+          <OGFooter left="$governada" right="governada.io/pulse#leaderboard" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/moment/milestone/[drepId]/[milestoneKey]/route.tsx
+++ b/app/api/og/moment/milestone/[drepId]/[milestoneKey]/route.tsx
@@ -110,12 +110,12 @@ export async function GET(
               <div
                 style={{ display: 'flex', fontSize: '16px', color: OG.textMuted, marginTop: '4px' }}
               >
-                Civica Score: {drep.drepScore}/100
+                Governada Score: {drep.drepScore}/100
               </div>
             </div>
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/moment/score-change/[drepId]/route.tsx
+++ b/app/api/og/moment/score-change/[drepId]/route.tsx
@@ -119,7 +119,7 @@ export async function GET(
             </div>
           )}
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/pulse/route.tsx
+++ b/app/api/og/pulse/route.tsx
@@ -101,7 +101,7 @@ export async function GET() {
             ))}
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io/pulse" />
+          <OGFooter left="$governada" right="governada.io/pulse" />
         </div>
       </OGBackground>,
       {
@@ -130,7 +130,7 @@ export async function GET() {
           <div
             style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}
           >
-            drepscore.io/pulse
+            governada.io/pulse
           </div>
         </div>
       </OGBackground>,

--- a/app/api/og/staking/[stakeAddress]/route.tsx
+++ b/app/api/og/staking/[stakeAddress]/route.tsx
@@ -156,7 +156,7 @@ export async function GET(
             ))}
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/treasury-accountability/route.tsx
+++ b/app/api/og/treasury-accountability/route.tsx
@@ -28,7 +28,7 @@ export async function GET() {
           <div
             style={{ display: 'flex', fontSize: '18px', color: OG.textMuted, marginBottom: '24px' }}
           >
-            Cardano Treasury Accountability — Civica
+            Cardano Treasury Accountability — Governada
           </div>
 
           <div

--- a/app/api/og/treasury-scenario/route.tsx
+++ b/app/api/og/treasury-scenario/route.tsx
@@ -24,7 +24,7 @@ export async function GET(request: NextRequest) {
         <div
           style={{ display: 'flex', fontSize: '18px', color: OG.textMuted, marginBottom: '24px' }}
         >
-          Treasury What-If Scenario — Civica
+          Treasury What-If Scenario — Governada
         </div>
 
         <div

--- a/app/api/og/wrapped/citizen/[stakeAddress]/route.tsx
+++ b/app/api/og/wrapped/citizen/[stakeAddress]/route.tsx
@@ -52,7 +52,7 @@ export async function GET(
                 marginBottom: '24px',
               }}
             >
-              $drepscore
+              $governada
             </div>
             <div
               style={{
@@ -76,7 +76,7 @@ export async function GET(
             >
               Connect your wallet to see your governance wrapped
             </div>
-            <OGFooter left="$drepscore" right="drepscore.io" />
+            <OGFooter left="$governada" right="governada.io" />
           </div>
         </OGBackground>,
         {
@@ -119,7 +119,7 @@ export async function GET(
                 marginBottom: '24px',
               }}
             >
-              $drepscore
+              $governada
             </div>
             <div
               style={{
@@ -131,7 +131,7 @@ export async function GET(
             >
               Connect your wallet to see your governance story
             </div>
-            <OGFooter left="$drepscore" right="drepscore.io" />
+            <OGFooter left="$governada" right="governada.io" />
           </div>
         </OGBackground>,
         {
@@ -304,7 +304,7 @@ export async function GET(
             </div>
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/wrapped/delegator/route.tsx
+++ b/app/api/og/wrapped/delegator/route.tsx
@@ -129,7 +129,7 @@ export async function GET(request: NextRequest) {
             Who&apos;s your DRep?
           </div>
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/wrapped/drep/[drepId]/route.tsx
+++ b/app/api/og/wrapped/drep/[drepId]/route.tsx
@@ -125,7 +125,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ drep
               marginBottom: '16px',
             }}
           >
-            {period ? 'My Civica Score This Epoch' : 'My Civica Score'}
+            {period ? 'My Governada Score This Epoch' : 'My Governada Score'}
           </div>
 
           <OGScoreRing score={drep.drepScore} size={280} />
@@ -214,7 +214,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ drep
             </div>
           )}
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {
@@ -225,7 +225,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ drep
     );
   } catch (error) {
     console.error('[OG Wrapped DRep] Error:', error);
-    return new ImageResponse(<OGFallback message="My Civica Score" />, {
+    return new ImageResponse(<OGFallback message="My Governada Score" />, {
       width: 1080,
       height: 1080,
     });

--- a/app/api/og/wrapped/spo/[poolId]/route.tsx
+++ b/app/api/og/wrapped/spo/[poolId]/route.tsx
@@ -218,7 +218,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ pool
             </div>
           )}
 
-          <OGFooter left="$drepscore" right="drepscore.io" />
+          <OGFooter left="$governada" right="governada.io" />
         </div>
       </OGBackground>,
       {

--- a/app/api/proposals/explain/route.ts
+++ b/app/api/proposals/explain/route.ts
@@ -63,7 +63,7 @@ export const POST = withRouteHandler(
       ? `This proposal requests ${(Number(proposal.withdrawal_amount) / 1_000_000).toLocaleString()} ADA from the Cardano treasury.`
       : '';
 
-    const prompt = `You are a governance analyst writing for Civica, a Cardano governance intelligence platform. Write a clear, informative explanation of this governance proposal for a crypto-literate audience.
+    const prompt = `You are a governance analyst writing for Governada, a Cardano governance intelligence platform. Write a clear, informative explanation of this governance proposal for a crypto-literate audience.
 
 PROPOSAL:
 Title: ${proposal.title || 'Untitled'}

--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -74,7 +74,7 @@ export const POST = withRouteHandler(
         payload = {
           eventType: 'platform-announcement',
           fallback: {
-            title: 'Civica Test Notification',
+            title: 'Governada Test Notification',
             body: 'Push notifications are working!',
             url: '/',
           },

--- a/app/api/telegram/connect/route.ts
+++ b/app/api/telegram/connect/route.ts
@@ -72,7 +72,7 @@ export const POST = withRouteHandler(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           chat_id: config.chatId,
-          text: "✅ <b>Wallet Connected!</b>\n\nYour Telegram is now linked to your Civica account. You'll receive governance alerts here.",
+          text: "✅ <b>Wallet Connected!</b>\n\nYour Telegram is now linked to your Governada account. You'll receive governance alerts here.",
           parse_mode: 'HTML',
         }),
       }).catch(() => {});

--- a/app/api/telegram/webhook/route.ts
+++ b/app/api/telegram/webhook/route.ts
@@ -6,7 +6,7 @@ import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
 
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 const WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
 async function sendMessage(chatId: number, text: string, parseMode = 'HTML') {
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       case '/start':
         await sendMessage(
           chatId,
-          `<b>Welcome to Civica Bot!</b>\n\n` +
+          `<b>Welcome to Governada Bot!</b>\n\n` +
             `Commands:\n` +
             `/connect — Link your wallet to receive alerts\n` +
             `/score &lt;drepId&gt; — Check a DRep's score\n` +
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
       case '/help':
         await sendMessage(
           chatId,
-          `<b>Civica Bot Commands:</b>\n\n` +
+          `<b>Governada Bot Commands:</b>\n\n` +
             `/connect — Get a link to verify your wallet and enable alerts\n` +
             `/score &lt;drepId&gt; — Look up any DRep's current score\n` +
             `/pending &lt;drepId&gt; — Check pending proposals for a DRep\n` +
@@ -96,7 +96,7 @@ export async function POST(request: NextRequest) {
           `<b>Connect Your Wallet</b>\n\n` +
             `Visit the link below and connect the wallet associated with your DRep:\n\n` +
             `<a href="${SITE_URL}/profile?telegram_connect=${token}">${SITE_URL}/profile</a>\n\n` +
-            `This will link your Telegram to your Civica account for alerts.`,
+            `This will link your Telegram to your Governada account for alerts.`,
         );
         break;
       }
@@ -121,7 +121,7 @@ export async function POST(request: NextRequest) {
             `Rationale: ${drep.rationaleRate}%\n` +
             `Reliability: ${drep.reliabilityScore}%\n` +
             `Profile: ${drep.profileCompleteness}%\n\n` +
-            `<a href="${SITE_URL}/drep/${encodeURIComponent(drepId)}">View on Civica</a>`,
+            `<a href="${SITE_URL}/drep/${encodeURIComponent(drepId)}">View on Governada</a>`,
         );
         break;
       }

--- a/app/api/user/email/route.ts
+++ b/app/api/user/email/route.ts
@@ -24,7 +24,7 @@ export const POST = withRouteHandler(
     const verifyUrl = generateVerificationUrl(wallet!, email);
     const sent = await sendEmail(
       email,
-      'Verify your email — Civica',
+      'Verify your email — Governada',
       React.createElement(EmailVerificationEmail, { verifyUrl }),
     );
 

--- a/app/api/user/email/verify/route.ts
+++ b/app/api/user/email/verify/route.ts
@@ -33,6 +33,6 @@ export async function GET(request: NextRequest) {
 
   captureServerEvent('email_verified', {}, parsed.userId);
 
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
   return NextResponse.redirect(`${baseUrl}/profile?email_verified=true`);
 }

--- a/app/api/user/unsubscribe/route.ts
+++ b/app/api/user/unsubscribe/route.ts
@@ -27,15 +27,15 @@ async function handleUnsubscribe(token: string | null): Promise<NextResponse> {
 
   return new NextResponse(
     `<!DOCTYPE html>
-<html><head><title>Unsubscribed — Civica</title>
+<html><head><title>Unsubscribed — Governada</title>
 <style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;background:#f6f9fc;margin:0}
 .card{background:#fff;padding:48px;border-radius:12px;text-align:center;max-width:400px;box-shadow:0 1px 3px rgba(0,0,0,.1)}
 h1{color:#1a1a2e;margin:0 0 12px}p{color:#6b7280;line-height:1.6}
 a{color:#6366f1;text-decoration:none}</style></head>
 <body><div class="card">
 <h1>Unsubscribed</h1>
-<p>You won't receive any more email digests from Civica.</p>
-<p>Changed your mind? <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io'}/profile">Update your preferences</a></p>
+<p>You won't receive any more email digests from Governada.</p>
+<p>Changed your mind? <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io'}/profile">Update your preferences</a></p>
 </div></body></html>`,
     { status: 200, headers: { 'Content-Type': 'text/html' } },
   );

--- a/app/api/v1/embed/[drepId]/route.ts
+++ b/app/api/v1/embed/[drepId]/route.ts
@@ -37,13 +37,13 @@ function renderBadgeSvg(name: string, score: number, theme: 'dark' | 'light'): s
   const height = 28;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="${height}">
-  <title>${name} — Civica ${score}/100 (${tier})</title>
+  <title>${name} — Governada ${score}/100 (${tier})</title>
   <rect width="${totalWidth}" height="${height}" rx="4" fill="${bg}"/>
   <clipPath id="r"><rect width="${totalWidth}" height="${height}" rx="4"/></clipPath>
   <g clip-path="url(#r)">
     <rect x="${labelWidth}" width="${scoreWidth}" height="${height}" fill="${color}22"/>
   </g>
-  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${textColor}" font-weight="600">Civica</text>
+  <text x="8" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${textColor}" font-weight="600">Governada</text>
   <text x="${labelWidth + 8}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${color}" font-weight="700">${score}/100</text>
   <text x="${labelWidth + 56}" y="18" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${color}cc">${tier}</text>
 </svg>`;
@@ -67,10 +67,10 @@ function renderCardSvg(
   const h = 140;
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
-  <title>${name} — Civica ${score}/100 (${tier})</title>
+  <title>${name} — Governada ${score}/100 (${tier})</title>
   <rect width="${w}" height="${h}" rx="8" fill="${bg}" stroke="${borderColor}" stroke-width="1"/>
   <text x="16" y="28" font-family="Verdana,Geneva,sans-serif" font-size="14" fill="${textColor}" font-weight="700">${displayName}</text>
-  <text x="16" y="50" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${mutedColor}">Civica</text>
+  <text x="16" y="50" font-family="Verdana,Geneva,sans-serif" font-size="11" fill="${mutedColor}">Governada</text>
   <text x="16" y="75" font-family="Verdana,Geneva,sans-serif" font-size="28" fill="${color}" font-weight="700">${score}</text>
   <text x="58" y="75" font-family="Verdana,Geneva,sans-serif" font-size="14" fill="${mutedColor}">/100</text>
   <text x="105" y="75" font-family="Verdana,Geneva,sans-serif" font-size="12" fill="${color}">${tier}</text>
@@ -78,7 +78,7 @@ function renderCardSvg(
   <text x="16" y="108" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${mutedColor}">Participation ${Math.round(drep.effectiveParticipation * 100)}%</text>
   <text x="120" y="108" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${mutedColor}">Rationale ${Math.round(drep.rationaleRate * 100)}%</text>
   <text x="215" y="108" font-family="Verdana,Geneva,sans-serif" font-size="9" fill="${mutedColor}">Reliability ${Math.round(drep.reliabilityScore * 100)}%</text>
-  <text x="16" y="128" font-family="Verdana,Geneva,sans-serif" font-size="8" fill="${mutedColor}">drepscore.io</text>
+  <text x="16" y="128" font-family="Verdana,Geneva,sans-serif" font-size="8" fill="${mutedColor}">governada.io</text>
 </svg>`;
 }
 
@@ -86,7 +86,7 @@ function renderMinimalSvg(score: number, theme: 'dark' | 'light'): string {
   const color = getTierColor(score);
   const bg = theme === 'dark' ? '#1e293b' : '#f1f5f9';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="52" height="28">
-  <title>Civica ${score}/100</title>
+  <title>Governada ${score}/100</title>
   <rect width="52" height="28" rx="4" fill="${bg}"/>
   <text x="26" y="18" text-anchor="middle" font-family="Verdana,Geneva,sans-serif" font-size="12" fill="${color}" font-weight="700">${score}</text>
 </svg>`;
@@ -123,14 +123,14 @@ a{color:inherit;text-decoration:none}
 </style></head><body>
 <div class="card">
 <div class="name">${name.length > 30 ? name.slice(0, 28) + '&hellip;' : name}</div>
-<div class="label">Civica</div>
+<div class="label">Governada</div>
 <div><span class="score">${score}<span>/100</span></span><span class="tier">${tier}</span></div>
 <div class="stats">
 <span>Participation ${Math.round(drep.effectiveParticipation * 100)}%</span>
 <span>Rationale ${Math.round(drep.rationaleRate * 100)}%</span>
 <span>Reliability ${Math.round(drep.reliabilityScore * 100)}%</span>
 </div>
-<div class="foot"><a href="https://drepscore.io/drep/${encodeURIComponent(drep.drepId)}" target="_blank">drepscore.io</a></div>
+<div class="foot"><a href="https://governada.io/drep/${encodeURIComponent(drep.drepId)}" target="_blank">governada.io</a></div>
 </div></body></html>`;
 }
 
@@ -187,7 +187,7 @@ async function handler(request: NextRequest, ctx: ApiContext, params?: Record<st
       snapshot_epoch: getCurrentEpoch(),
       snapshot_date: new Date().toISOString().split('T')[0],
       schema_version: 1,
-      image_url: `https://drepscore.io/api/v1/embed/${encodeURIComponent(drep.drepId)}?format=svg&style=${style}&theme=${theme}`,
+      image_url: `https://governada.io/api/v1/embed/${encodeURIComponent(drep.drepId)}?format=svg&style=${style}&theme=${theme}`,
     };
 
     return apiSuccess(metadata, {

--- a/app/claim/[drepId]/page.tsx
+++ b/app/claim/[drepId]/page.tsx
@@ -14,11 +14,11 @@ export async function generateMetadata({ params }: ClaimPageProps): Promise<Meta
   const drep = await getDRepById(decodeURIComponent(drepId));
 
   if (!drep) {
-    return { title: 'DRep Not Found — Civica' };
+    return { title: 'DRep Not Found — Governada' };
   }
 
   const name = getDRepPrimaryName(drep);
-  const title = `Claim your Civica profile — ${name} scored ${drep.drepScore}/100`;
+  const title = `Claim your Governada profile — ${name} scored ${drep.drepScore}/100`;
   const description = `${name} is ranked among Cardano DReps. Claim your profile to access your dashboard, governance inbox, and score tracking.`;
   const ogImageUrl = `${BASE_URL}/api/og/drep/${encodeURIComponent(drepId)}`;
 
@@ -29,7 +29,7 @@ export async function generateMetadata({ params }: ClaimPageProps): Promise<Meta
       title,
       description,
       type: 'profile',
-      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} Civica card` }],
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} Governada card` }],
     },
     twitter: {
       card: 'summary_large_image',

--- a/app/committee/[ccHotId]/page.tsx
+++ b/app/committee/[ccHotId]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const name = member?.author_name ?? `CC Member ${ccHotId.slice(0, 12)}...`;
   return {
-    title: `${name} — CC Transparency Index — Civica`,
+    title: `${name} — CC Transparency Index — Governada`,
     description: `Constitutional Committee member transparency score, voting record, and accountability metrics.`,
   };
 }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -37,11 +37,11 @@ export async function generateMetadata({ searchParams }: ComparePageProps): Prom
   const ids = drepsParam?.split(',').filter(Boolean) ?? [];
 
   if (ids.length < 2) {
-    return { title: 'Compare DReps — Civica' };
+    return { title: 'Compare DReps — Governada' };
   }
 
   return {
-    title: `Compare ${ids.length} DReps — Civica`,
+    title: `Compare ${ids.length} DReps — Governada`,
     description:
       'Side-by-side comparison of DRep governance scores, alignment, and voting records.',
   };

--- a/app/developers/page.tsx
+++ b/app/developers/page.tsx
@@ -4,11 +4,11 @@ import { DeveloperPage } from '@/components/DeveloperPage';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Developers — Civica API',
+  title: 'Developers — Governada API',
   description:
-    'Build on governance intelligence. Interactive API explorer, embeddable widgets, and documentation for the Civica v1 API.',
+    'Build on governance intelligence. Interactive API explorer, embeddable widgets, and documentation for the Governada v1 API.',
   openGraph: {
-    title: 'Civica Developer Platform',
+    title: 'Governada Developer Platform',
     description:
       'Build on governance intelligence. API explorer, embeddable widgets, and documentation.',
   },

--- a/app/discover/committee/page.tsx
+++ b/app/discover/committee/page.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 
 export const metadata: Metadata = {
-  title: 'CC Transparency Index — Civica',
+  title: 'CC Transparency Index — Governada',
   description:
     'Constitutional Committee Transparency Index: accountability scores, voting records, and rationale analysis for Cardano governance.',
 };

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -5,18 +5,18 @@ import { CivicaDiscover } from '@/components/civica/discover/CivicaDiscover';
 import { createClient } from '@/lib/supabase';
 
 export const metadata: Metadata = {
-  title: 'Civica — Discover',
+  title: 'Governada — Discover',
   description:
     'Find and compare Cardano DReps, governance-active stake pools, and Constitutional Committee members. Filter by score, tier, and alignment.',
   openGraph: {
-    title: 'Civica — Discover Governance',
+    title: 'Governada — Discover Governance',
     description:
       'Browse every DRep, stake pool, and Constitutional Committee member participating in Cardano governance.',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Civica — Discover Governance',
+    title: 'Governada — Discover Governance',
     description: 'Find the representative that matches your governance values.',
   },
 };

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -128,12 +128,12 @@ export async function generateMetadata({ params }: DRepDetailPageProps): Promise
 
   if (!drep) {
     return {
-      title: 'DRep Not Found — Civica',
+      title: 'DRep Not Found — Governada',
     };
   }
 
   const name = getDRepPrimaryName(drep);
-  const title = `${name} — Civica ${drep.drepScore}/100`;
+  const title = `${name} — Governada ${drep.drepScore}/100`;
   const description = `Participation: ${drep.effectiveParticipation}% · Rationale: ${drep.rationaleRate}% · Reliability: ${drep.reliabilityScore}% · Profile: ${drep.profileCompleteness}%`;
   const ogImageUrl = `${BASE_URL}/api/og/drep/${encodeURIComponent(drepId)}`;
 
@@ -144,7 +144,7 @@ export async function generateMetadata({ params }: DRepDetailPageProps): Promise
       title,
       description,
       type: 'profile',
-      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} Civica card` }],
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${name} Governada card` }],
     },
     twitter: {
       card: 'summary_large_image',
@@ -533,7 +533,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     ((drep as unknown as Record<string, unknown>).lastPersonalityLabel as string | null) ?? null;
   const identityLabel = getPersonalityLabelWithHysteresis(alignments, lastPersonalityLabel);
 
-  // Tier progress with recommended action (for Civica score analysis)
+  // Tier progress with recommended action (for Governada score analysis)
   const tierProgress = computeTierProgress(drep.drepScore, {
     engagementQuality: drep.engagementQuality,
     effectiveParticipation: drep.effectiveParticipationV3,
@@ -557,7 +557,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         entityName={drepName}
         enabled
         ogImageUrl={`/api/og/wrapped/drep/${encodeURIComponent(drep.drepId)}`}
-        shareUrl={`https://drepscore.io/drep/${encodeURIComponent(drep.drepId)}`}
+        shareUrl={`https://governada.io/drep/${encodeURIComponent(drep.drepId)}`}
       />
 
       <Link href="/">

--- a/app/engage/page.tsx
+++ b/app/engage/page.tsx
@@ -5,7 +5,7 @@ import { EngageClient } from './EngageClient';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Civic Engagement — Civica',
+  title: 'Civic Engagement — Governada',
   description:
     'Shape Cardano governance. Vote on priorities, participate in citizen assemblies, and make your voice heard.',
 };

--- a/app/globals.css
+++ b/app/globals.css
@@ -122,7 +122,7 @@
   --popover: oklch(0.11 0.015 260);
   --popover-foreground: oklch(0.96 0.005 260);
 
-  /* Primary: Electric Cyan — the Civica brand accent */
+  /* Primary: Electric Cyan — the Governada brand accent */
   --primary: oklch(0.72 0.14 200);
   --primary-foreground: oklch(0.07 0.015 260);
 
@@ -219,7 +219,7 @@
 }
 
 /* ============================================================
-   Motion tokens — consistent animation timing across Civica
+   Motion tokens — consistent animation timing across Governada
    ============================================================ */
 
 :root {
@@ -235,7 +235,7 @@
 }
 
 /* ============================================================
-   Civica font variables — set by CivicaShell layout
+   Governada font variables — set by CivicaShell layout
    ============================================================ */
 
 :root {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,9 +30,9 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  title: 'Civica — Cardano Governance Intelligence',
+  title: 'Governada — Cardano Governance Intelligence',
   description:
-    'The civic hub for the Cardano Nation. Find your DRep, track governance proposals, and participate in on-chain democracy.',
+    'Governance intelligence for Cardano. Find your DRep, track governance proposals, and participate in on-chain democracy.',
   keywords: [
     'Cardano',
     'DRep',
@@ -41,13 +41,13 @@ export const metadata: Metadata = {
     'ADA',
     'Blockchain',
     'Voting',
-    'Civica',
+    'Governada',
     'SPO',
   ],
   openGraph: {
-    title: 'Civica — Cardano Governance Intelligence',
+    title: 'Governada — Cardano Governance Intelligence',
     description:
-      'The civic hub for Cardano. Find your DRep, track proposals, and take action in governance.',
+      'Governance intelligence for Cardano. Find your DRep, track proposals, and take action in governance.',
     type: 'website',
   },
   manifest: '/manifest.json',
@@ -55,7 +55,7 @@ export const metadata: Metadata = {
     'mobile-web-app-capable': 'yes',
     'apple-mobile-web-app-capable': 'yes',
     'apple-mobile-web-app-status-bar-style': 'default',
-    'apple-mobile-web-app-title': 'Civica',
+    'apple-mobile-web-app-title': 'Governada',
   },
 };
 

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -3,11 +3,11 @@ import { PageViewTracker } from '@/components/PageViewTracker';
 import { LearnClient } from './LearnClient';
 
 export const metadata: Metadata = {
-  title: 'Civica — Learn Governance',
+  title: 'Governada — Learn Governance',
   description:
     'Understand Cardano governance: DReps, delegation, proposals, treasury, and how your voice shapes the network.',
   openGraph: {
-    title: 'Civica — Learn Governance',
+    title: 'Governada — Learn Governance',
     description: 'Everything you need to understand Cardano on-chain governance.',
     type: 'website',
   },

--- a/app/match/page.tsx
+++ b/app/match/page.tsx
@@ -4,7 +4,7 @@ import { QuickMatchFlow } from '@/components/civica/match/QuickMatchFlow';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Quick Match — Find Your DRep or SPO — Civica',
+  title: 'Quick Match — Find Your DRep or SPO — Governada',
   description:
     'Answer 3 questions about your governance values and find the Cardano DRep or Stake Pool Operator who represents you best. No wallet required.',
 };

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -7,13 +7,13 @@ import { SPO_PILLAR_WEIGHTS } from '@/lib/scoring/spoScore';
 import { cn } from '@/lib/utils';
 
 export const metadata: Metadata = {
-  title: 'Scoring Methodology — Civica',
+  title: 'Scoring Methodology — Governada',
   description:
-    'How Civica scores DReps, SPOs, and CC members. Transparent, reproducible scoring methodology for Cardano governance research.',
+    'How Governada scores DReps, SPOs, and CC members. Transparent, reproducible scoring methodology for Cardano governance research.',
   openGraph: {
-    title: 'Scoring Methodology — Civica',
+    title: 'Scoring Methodology — Governada',
     description:
-      'How Civica scores DReps, SPOs, and CC members. Transparent, reproducible scoring methodology for Cardano governance research.',
+      'How Governada scores DReps, SPOs, and CC members. Transparent, reproducible scoring methodology for Cardano governance research.',
     type: 'website',
   },
 };
@@ -314,12 +314,15 @@ export default function MethodologyPage() {
       <div className="max-w-3xl mx-auto px-4 py-12 space-y-16">
         {/* Hero */}
         <div className="space-y-4">
-          <h1 className="text-3xl font-bold text-foreground sm:text-4xl">How Civica Scores Work</h1>
+          <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
+            How Governada Scores Work
+          </h1>
           <p className="text-base text-muted-foreground leading-relaxed max-w-2xl">
-            Civica measures governance quality for DReps, Stake Pool Operators, and Constitutional
-            Committee members on the Cardano network. Every score is computed from on-chain data,
-            percentile-normalized across all active entities, and decayed over time to reflect
-            current behavior. Scores measure process and engagement, not political positions.
+            Governada measures governance quality for DReps, Stake Pool Operators, and
+            Constitutional Committee members on the Cardano network. Every score is computed from
+            on-chain data, percentile-normalized across all active entities, and decayed over time
+            to reflect current behavior. Scores measure process and engagement, not political
+            positions.
           </p>
           <TableOfContents />
         </div>
@@ -531,7 +534,7 @@ export default function MethodologyPage() {
           <SectionAnchor id="alignment" />
           <h2 className="text-xl font-bold">6D Alignment Model</h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Civica maps every DRep onto six governance dimensions derived from their voting
+            Governada maps every DRep onto six governance dimensions derived from their voting
             patterns. AI-classified proposal relevance scores determine which votes contribute to
             each dimension. Each dimension score ranges from 0 to 100, with 50 as neutral. Temporal
             decay and amount-weighting ensure recent, material votes carry more weight. The dominant
@@ -622,8 +625,8 @@ export default function MethodologyPage() {
               >
                 Koios API
               </a>
-              , a community-maintained, open-source query layer for Cardano. Civica does not run its
-              own indexer — we consume the same public data available to every researcher.
+              , a community-maintained, open-source query layer for Cardano. Governada does not run
+              its own indexer — we consume the same public data available to every researcher.
             </p>
             <div className="rounded-xl border border-border bg-card p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Sync pipeline</p>
@@ -666,36 +669,36 @@ export default function MethodologyPage() {
           <SectionAnchor id="citation" />
           <h2 className="text-xl font-bold">Citation Guide</h2>
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Researchers, journalists, and governance participants are welcome to reference Civica
+            Researchers, journalists, and governance participants are welcome to reference Governada
             scores in their work. We suggest the following formats:
           </p>
           <div className="space-y-3">
             <div className="rounded-xl border border-border bg-card p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Individual DRep score</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded">
-                &ldquo;[DRep Name] holds a Civica DRep Score of [X]/100 ([Tier] tier) as of epoch
-                [N]. Source: drepscore.io/drep/[drep_id]&rdquo;
+                &ldquo;[DRep Name] holds a Governada DRep Score of [X]/100 ([Tier] tier) as of epoch
+                [N]. Source: governada.io/drep/[drep_id]&rdquo;
               </code>
             </div>
             <div className="rounded-xl border border-border bg-card p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">GHI reference</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded">
-                &ldquo;Cardano governance health stands at [X]/100 ([Band]) per the Civica
-                Governance Health Index, epoch [N]. Source: drepscore.io/pulse&rdquo;
+                &ldquo;Cardano governance health stands at [X]/100 ([Band]) per the Governada
+                Governance Health Index, epoch [N]. Source: governada.io/pulse&rdquo;
               </code>
             </div>
             <div className="rounded-xl border border-border bg-card p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Academic citation</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded whitespace-pre-wrap">
-                Civica. (2026). Scoring Methodology: DRep Score V3, SPO Governance Score V3, CC
+                Governada. (2026). Scoring Methodology: DRep Score V3, SPO Governance Score V3, CC
                 Transparency Index, Governance Health Index. Retrieved from
-                https://drepscore.io/methodology
+                https://governada.io/methodology
               </code>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
             All scores are point-in-time snapshots. Always include the epoch number or date for
-            reproducibility. Score history is available via the Civica API for longitudinal
+            reproducibility. Score history is available via the Governada API for longitudinal
             analysis.
           </p>
         </section>

--- a/app/my-gov/identity/page.tsx
+++ b/app/my-gov/identity/page.tsx
@@ -4,11 +4,11 @@ import type { Metadata } from 'next';
 import { CivicIdentityProfile } from '@/components/civica/identity/CivicIdentityProfile';
 
 export const metadata: Metadata = {
-  title: 'Civica — Civic Identity',
+  title: 'Governada — Civic Identity',
   description:
     'Your civic identity — delegation history, governance footprint, milestones, and engagement stats.',
   openGraph: {
-    title: 'Civica — Civic Identity',
+    title: 'Governada — Civic Identity',
     description: 'Your civic identity on Cardano governance.',
     type: 'website',
   },

--- a/app/my-gov/inbox/page.tsx
+++ b/app/my-gov/inbox/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 import { CivicaInbox } from '@/components/civica/mygov/CivicaInbox';
 
 export const metadata: Metadata = {
-  title: 'Civica — Inbox',
+  title: 'Governada — Inbox',
   description: 'Your governance notifications and action items.',
 };
 

--- a/app/my-gov/page.tsx
+++ b/app/my-gov/page.tsx
@@ -4,18 +4,18 @@ import type { Metadata } from 'next';
 import { MyGovClient } from '@/components/civica/MyGovClient';
 
 export const metadata: Metadata = {
-  title: 'Civica — My Gov',
+  title: 'Governada — My Gov',
   description:
     'Your civic command center. Track your delegation, governance activity, and take action.',
   openGraph: {
-    title: 'Civica — My Gov',
+    title: 'Governada — My Gov',
     description:
       'Your civic command center. Track your delegation, governance activity, and take action.',
     type: 'website',
   },
   twitter: {
     card: 'summary',
-    title: 'Civica — My Gov',
+    title: 'Governada — My Gov',
     description: 'Your civic command center on Cardano.',
   },
 };

--- a/app/my-gov/profile/page.tsx
+++ b/app/my-gov/profile/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next';
 import { CivicaProfile } from '@/components/civica/mygov/CivicaProfile';
 
 export const metadata: Metadata = {
-  title: 'Civica — Profile & Settings',
+  title: 'Governada — Profile & Settings',
   description: 'Manage your governance identity, notification preferences, and account settings.',
 };
 

--- a/app/my-gov/wrapped/[period]/page.tsx
+++ b/app/my-gov/wrapped/[period]/page.tsx
@@ -198,7 +198,7 @@ function buildDRepSlides(data: DRepWrappedData, entityId: string, period: string
       label: 'Share your Governance Wrapped',
       isFinal: true,
       ogImageUrl: `${BASE}/api/og/wrapped/drep/${encodeURIComponent(entityId)}?period=${period}`,
-      shareText: `My Governance Wrapped ${period} — score ${data.score_end ?? '—'}/100, voted on ${data.votes_cast ?? 0} proposals. Check yours on Civica!`,
+      shareText: `My Governance Wrapped ${period} — score ${data.score_end ?? '—'}/100, voted on ${data.votes_cast ?? 0} proposals. Check yours on Governada!`,
     },
   ];
 }
@@ -235,7 +235,7 @@ function buildSPOSlides(data: SPOWrappedData, entityId: string, period: string):
       label: 'Share your Governance Wrapped',
       isFinal: true,
       ogImageUrl: `${BASE}/api/og/wrapped/spo/${encodeURIComponent(entityId)}?period=${period}`,
-      shareText: `My SPO Governance Wrapped ${period} — score ${data.score_end ?? '—'}/100. Check yours on Civica!`,
+      shareText: `My SPO Governance Wrapped ${period} — score ${data.score_end ?? '—'}/100. Check yours on Governada!`,
     },
   ];
 }
@@ -267,7 +267,7 @@ function buildCitizenSlides(data: CitizenWrappedData, entityId: string, period: 
       label: 'Share your governance story',
       isFinal: true,
       ogImageUrl: `${BASE}/api/og/wrapped/drep/${encodeURIComponent(data.delegated_drep_id ?? entityId)}?period=${period}`,
-      shareText: `My Governance Story ${period}. Check yours on Civica!`,
+      shareText: `My Governance Story ${period}. Check yours on Governada!`,
     },
   ];
 }
@@ -689,7 +689,7 @@ export default function WrappedPage() {
           open={shareOpen}
           onClose={() => setShareOpen(false)}
           ogImageUrl={currentSlide.ogImageUrl}
-          shareText={currentSlide.shareText ?? `My Governance Wrapped ${period} — Civica`}
+          shareText={currentSlide.shareText ?? `My Governance Wrapped ${period} — Governada`}
           shareUrl={`${process.env.NEXT_PUBLIC_APP_URL ?? ''}/wrapped/${entityType}/${encodeURIComponent(resolvedEntityId ?? '')}/${period}`}
           title="Share your Governance Wrapped"
         />

--- a/app/offline/OfflineClient.tsx
+++ b/app/offline/OfflineClient.tsx
@@ -9,8 +9,8 @@ export function OfflineClient() {
         </div>
         <h1 className="text-2xl font-bold tracking-tight">You&apos;re offline</h1>
         <p className="text-muted-foreground leading-relaxed">
-          Civica needs an internet connection for live governance data. Please check your connection
-          and refresh.
+          Governada needs an internet connection for live governance data. Please check your
+          connection and refresh.
         </p>
         <button
           onClick={() => window.location.reload()}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,18 +8,18 @@ import { CivicaHomePage } from '@/components/civica/CivicaHomePage';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Civica — Cardano Governance Intelligence',
+  title: 'Governada — Cardano Governance Intelligence',
   description:
     'Cardano has a government. Know who represents you. Find your DRep, track governance proposals, and participate in on-chain democracy.',
   openGraph: {
-    title: 'Civica — Cardano Governance Intelligence',
+    title: 'Governada — Cardano Governance Intelligence',
     description:
       'Know who represents your ADA in Cardano governance. Discover DReps, track proposals, and take action.',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Civica — Cardano Governance Intelligence',
+    title: 'Governada — Cardano Governance Intelligence',
     description: 'Cardano has a government. Know who represents you.',
   },
 };

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -51,7 +51,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!poolRow) {
     const short = poolId.slice(0, 12);
     return {
-      title: `SPO ${short}\u2026 Governance Profile \u2014 Civica`,
+      title: `SPO ${short}\u2026 Governance Profile \u2014 Governada`,
       description: `Governance participation and voting record for stake pool ${short}\u2026 on Cardano.`,
     };
   }
@@ -60,8 +60,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const tier = score != null ? computeTier(score) : null;
   const title =
     score != null && tier
-      ? `${name} \u2014 SPO Governance Score: ${score} (${tier}) \u2014 Civica`
-      : `${name} \u2014 SPO Governance Profile \u2014 Civica`;
+      ? `${name} \u2014 SPO Governance Score: ${score} (${tier}) \u2014 Governada`
+      : `${name} \u2014 SPO Governance Profile \u2014 Governada`;
   return {
     title,
     description: `SPO governance score, voting record, and alignment data for ${name} on Cardano.`,
@@ -757,7 +757,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
           entityName={displayName}
           enabled
           ogImageUrl={`/api/og/staking/${encodeURIComponent(poolId)}`}
-          shareUrl={`https://drepscore.io/pool/${encodeURIComponent(poolId)}`}
+          shareUrl={`https://governada.io/pool/${encodeURIComponent(poolId)}`}
         />
 
         <Link href="/discover">

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -44,8 +44,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const proposal = isNaN(proposalIndex) ? null : await getProposalByKey(txHash, proposalIndex);
   const title = proposal?.title || `Proposal ${txHash.slice(0, 12)}...`;
   return {
-    title: `${title} — Civica`,
-    description: `Governance proposal details, votes, and analysis on Civica.`,
+    title: `${title} — Governada`,
+    description: `Governance proposal details, votes, and analysis on Governada.`,
   };
 }
 

--- a/app/pulse/history/page.tsx
+++ b/app/pulse/history/page.tsx
@@ -5,7 +5,7 @@ import { EpochTimeline } from '@/components/EpochTimeline';
 import { ArrowLeft } from 'lucide-react';
 
 export const metadata: Metadata = {
-  title: 'Epoch Recaps | Civica',
+  title: 'Epoch Recaps | Governada',
   description: 'Browse the history of Cardano governance epoch by epoch',
 };
 

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -5,17 +5,17 @@ import { CivicaPulseOverview } from '@/components/civica/pulse/CivicaPulseOvervi
 import { Skeleton } from '@/components/ui/skeleton';
 
 export const metadata: Metadata = {
-  title: 'Civica — Pulse',
+  title: 'Governada — Pulse',
   description:
     "Real-time state of Cardano's on-chain governance — active proposals, treasury activity, DRep participation, and governance health.",
   openGraph: {
-    title: 'Civica — Governance Pulse',
+    title: 'Governada — Governance Pulse',
     description: "Real-time health of Cardano's on-chain governance.",
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Civica — Governance Pulse',
+    title: 'Governada — Governance Pulse',
     description: "Track the real-time state of Cardano's governance.",
   },
 };

--- a/app/pulse/report/[epoch]/page.tsx
+++ b/app/pulse/report/[epoch]/page.tsx
@@ -44,11 +44,11 @@ async function getReport(epochParam: string) {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { epoch } = await params;
   const report = await getReport(epoch);
-  if (!report) return { title: 'Report Not Found | Civica' };
+  if (!report) return { title: 'Report Not Found | Governada' };
 
   const reportData = report.report_data as unknown as ReportData;
   return {
-    title: `State of Governance — Epoch ${report.epoch_no} | Civica`,
+    title: `State of Governance — Epoch ${report.epoch_no} | Governada`,
     description: `Cardano governance health score: ${reportData.ghi.score}/100 (${GHI_BAND_LABELS[reportData.ghi.band as GHIBand]}). ${reportData.stats.activeDReps} active DReps governing ${reportData.stats.totalAdaGoverned} ADA.`,
     openGraph: {
       title: `State of Governance — Epoch ${report.epoch_no}`,
@@ -156,8 +156,8 @@ export default async function StateOfGovernancePage({ params }: Props) {
       {/* Share footer */}
       <div className="border-t pt-8 space-y-4">
         <ShareActions
-          url={`https://drepscore.io/pulse/report/${data.epoch}`}
-          text={`State of Governance — Epoch ${data.epoch}. GHI: ${data.ghi.score}/100. Via @CivicaGov`}
+          url={`https://governada.io/pulse/report/${data.epoch}`}
+          text={`State of Governance — Epoch ${data.epoch}. GHI: ${data.ghi.score}/100. Via @GovernadaIO`}
           imageUrl={`/api/og/governance-report/${data.epoch}`}
           surface="governance_report"
         />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/', '/admin/', '/my-gov/', '/claim/'],
       },
     ],
-    sitemap: 'https://drepscore.io/sitemap.xml',
+    sitemap: 'https://governada.io/sitemap.xml',
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,7 +4,7 @@ import { createClient } from '@/lib/supabase';
 export const dynamic = 'force-dynamic';
 export const revalidate = 3600;
 
-const BASE_URL = 'https://drepscore.io';
+const BASE_URL = 'https://governada.io';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const supabase = createClient();

--- a/app/wrapped/[entityType]/[entityId]/[period]/page.tsx
+++ b/app/wrapped/[entityType]/[entityId]/[period]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
   const { entityType, entityId, period } = await params;
   const label = entityLabel(entityType, entityId);
   const title = `${label}'s Governance Wrapped — ${period}`;
-  const description = `See ${label}'s governance activity for ${period} on Civica.`;
+  const description = `See ${label}'s governance activity for ${period} on Governada.`;
   const ogImageUrl = `${BASE_URL}/api/og/wrapped/${entityType}/${encodeURIComponent(entityId)}?period=${period}`;
 
   return {
@@ -265,7 +265,7 @@ export default async function PublicWrappedPage({ params }: { params: Promise<Pa
               participation.
             </p>
             <Button asChild className="w-full">
-              <Link href="/">Get started on Civica</Link>
+              <Link href="/">Get started on Governada</Link>
             </Button>
           </CardContent>
         </Card>

--- a/components/ApiExplorer.tsx
+++ b/components/ApiExplorer.tsx
@@ -152,7 +152,7 @@ export function ApiExplorer() {
   const [loading, setLoading] = useState(false);
 
   const endpoint = ENDPOINTS.find((e) => e.id === selected) ?? ENDPOINTS[0];
-  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io';
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://governada.io';
   const codeExamples = generateCodeExamples(endpoint, baseUrl);
 
   const tryEndpoint = useCallback(async () => {

--- a/components/BadgeEmbed.tsx
+++ b/components/BadgeEmbed.tsx
@@ -32,12 +32,12 @@ export function BadgeEmbed({ drepId, drepName }: BadgeEmbedProps) {
     posthog.capture('badge_embed_viewed', { drep_id: drepId });
   }, [drepId]);
 
-  const badgeUrl = `https://drepscore.io/api/badge/${encodeURIComponent(drepId)}?format=${format}`;
-  const profileUrl = `https://drepscore.io/drep/${encodeURIComponent(drepId)}`;
+  const badgeUrl = `https://governada.io/api/badge/${encodeURIComponent(drepId)}?format=${format}`;
+  const profileUrl = `https://governada.io/drep/${encodeURIComponent(drepId)}`;
 
   const embedSnippets = {
-    markdown: `[![DRepScore](${badgeUrl})](${profileUrl})`,
-    html: `<a href="${profileUrl}"><img src="${badgeUrl}" alt="${drepName} DRepScore" /></a>`,
+    markdown: `[![Governada](${badgeUrl})](${profileUrl})`,
+    html: `<a href="${profileUrl}"><img src="${badgeUrl}" alt="${drepName} Governada Score" /></a>`,
     bbcode: `[url=${profileUrl}][img]${badgeUrl}[/img][/url]`,
   };
 
@@ -61,7 +61,7 @@ export function BadgeEmbed({ drepId, drepName }: BadgeEmbedProps) {
           Embeddable Badge
         </CardTitle>
         <p className="text-xs text-muted-foreground">
-          Add your DRepScore badge to your website, forum signature, or X bio.
+          Add your Governada badge to your website, forum signature, or X bio.
         </p>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -91,7 +91,7 @@ export function BadgeEmbed({ drepId, drepName }: BadgeEmbedProps) {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={`/api/badge/${encodeURIComponent(drepId)}?format=${format}`}
-            alt={`${drepName} DRepScore badge`}
+            alt={`${drepName} Governada badge`}
             width={FORMAT_META[format].width}
             height={FORMAT_META[format].height}
             className="max-w-full"

--- a/components/ClaimCelebration.tsx
+++ b/components/ClaimCelebration.tsx
@@ -147,7 +147,7 @@ export function ClaimCelebration({
           <Check className="h-7 w-7 text-green-600 dark:text-green-400" />
         </div>
         <h1 className="text-2xl font-bold">Welcome, {name}!</h1>
-        <p className="text-sm text-muted-foreground">Your Civica command center is live.</p>
+        <p className="text-sm text-muted-foreground">Your Governada command center is live.</p>
       </div>
 
       <div className="space-y-1">

--- a/components/CrossProposalInsights.tsx
+++ b/components/CrossProposalInsights.tsx
@@ -190,7 +190,7 @@ function InsightShareButton({
   const [copied, setCopied] = useState(false);
 
   const copyShareText = useCallback(() => {
-    const text = insight.shareText || `${insight.headline}: ${insight.stat} — via DRepScore`;
+    const text = insight.shareText || `${insight.headline}: ${insight.stat} — via Governada`;
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/components/DRepDashboardWrapper.tsx
+++ b/components/DRepDashboardWrapper.tsx
@@ -22,8 +22,8 @@ export function DRepDashboardWrapper({ drepId, drepName, isClaimed }: DRepDashbo
 
   const handleShare = async () => {
     const shareData = {
-      title: `${drepName} — DRepScore`,
-      text: `Check out ${drepName}'s DRep scorecard on DRepScore`,
+      title: `${drepName} — Governada`,
+      text: `Check out ${drepName}'s DRep scorecard on Governada`,
       url: profileUrl,
     };
 

--- a/components/DRepReportCard.tsx
+++ b/components/DRepReportCard.tsx
@@ -30,7 +30,7 @@ export function DRepReportCard({
 }: DRepReportCardProps) {
   const url = buildDRepUrl(drepId);
   const ogImageUrl = `/api/og/drep/${encodeURIComponent(drepId)}`;
-  const shareText = `My DRepScore: ${score}/100\n\nParticipation: ${participation}%\nRationale: ${rationale}%\nReliability: ${reliability}%\n${rank ? `Ranked #${rank}` : ''}\n\n${delegators} delegators trust my governance.\n\nCheck your DRep's score:`;
+  const shareText = `My Governada Score: ${score}/100\n\nParticipation: ${participation}%\nRationale: ${rationale}%\nReliability: ${reliability}%\n${rank ? `Ranked #${rank}` : ''}\n\n${delegators} delegators trust my governance.\n\nCheck your DRep's score:`;
 
   return (
     <Card>
@@ -44,7 +44,7 @@ export function DRepReportCard({
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={ogImageUrl}
-          alt={`${name} DRepScore Card`}
+          alt={`${name} Governada Card`}
           className="w-full rounded-lg border"
           loading="lazy"
         />

--- a/components/DelegationCeremony.tsx
+++ b/components/DelegationCeremony.tsx
@@ -86,7 +86,7 @@ export function DelegationCeremony({
 
   const shareUrl = buildDRepUrl(drepId);
   const personalityText = personality ? ` — a ${personality} representative` : '';
-  const shareText = `I just delegated to ${drepName}${personalityText} on @drepscore. My voice in Cardano governance is now active! Who's your DRep?`;
+  const shareText = `I just delegated to ${drepName}${personalityText} on @GovernadaIO. My voice in Cardano governance is now active! Who's your DRep?`;
   const imageUrl = `/api/og/wrapped/delegator?drepId=${encodeURIComponent(drepId)}`;
 
   return (
@@ -133,7 +133,7 @@ export function DelegationCeremony({
           ) : (
             <div className="space-y-1">
               <p className="text-xs text-muted-foreground uppercase tracking-wider">
-                Their DRepScore
+                Their Governada Score
               </p>
               <span className="text-7xl font-bold tabular-nums text-foreground">{score}</span>
               <p className="text-sm text-muted-foreground">/100</p>

--- a/components/DelegatorGovernanceCard.tsx
+++ b/components/DelegatorGovernanceCard.tsx
@@ -50,8 +50,8 @@ export function DelegatorGovernanceCard() {
 
   const shareUrl = `${BASE_URL}/governance`;
   const shareText = identity.drepName
-    ? `I've been an active governance citizen for ${epochsActive ?? '?'} epochs, delegating to ${identity.drepName} (score: ${identity.drepScore ?? '?'}/100) on @drepscore.`
-    : `I'm participating in Cardano governance on @drepscore.`;
+    ? `I've been an active governance citizen for ${epochsActive ?? '?'} epochs, delegating to ${identity.drepName} (score: ${identity.drepScore ?? '?'}/100) on @GovernadaIO.`
+    : `I'm participating in Cardano governance on @GovernadaIO.`;
 
   return (
     <motion.div variants={fadeInUp} initial="hidden" animate="visible">

--- a/components/DelegatorShareCard.tsx
+++ b/components/DelegatorShareCard.tsx
@@ -150,8 +150,8 @@ export function DelegatorShareCard() {
   if (!data) return null;
 
   const ogImageUrl = `/api/og/delegator?wallet=${address}`;
-  const shareUrl = typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io';
-  const shareText = `I'm delegated to ${data.drepName} (Score: ${data.drepScore}/100) on Cardano. Who's your DRep? Find out at DRepScore!`;
+  const shareUrl = typeof window !== 'undefined' ? window.location.origin : 'https://governada.io';
+  const shareText = `I'm delegated to ${data.drepName} (Score: ${data.drepScore}/100) on Cardano. Who's your DRep? Find out at Governada!`;
 
   return (
     <Card className="overflow-hidden">

--- a/components/DeveloperPage.tsx
+++ b/components/DeveloperPage.tsx
@@ -22,7 +22,7 @@ import Link from 'next/link';
 const QUICK_START_CODE = {
   javascript: `// Get the top 5 DReps by score
 const response = await fetch(
-  "https://drepscore.io/api/v1/dreps?limit=5&sort=score"
+  "https://governada.io/api/v1/dreps?limit=5&sort=score"
 );
 const { data, meta } = await response.json();
 
@@ -33,7 +33,7 @@ data.forEach(drep => {
 
 # Get the top 5 DReps by score
 response = requests.get(
-    "https://drepscore.io/api/v1/dreps",
+    "https://governada.io/api/v1/dreps",
     params={"limit": 5, "sort": "score"}
 )
 data = response.json()
@@ -41,13 +41,13 @@ data = response.json()
 for drep in data["data"]:
     print(f'{drep["name"]}: {drep["score"]}/100')`,
   curl: `# Get the top 5 DReps by score
-curl "https://drepscore.io/api/v1/dreps?limit=5&sort=score"`,
+curl "https://governada.io/api/v1/dreps?limit=5&sort=score"`,
 };
 
 const EMBED_CODE = {
   html: `<!-- Embed a DRep score card -->
 <iframe
-  src="https://drepscore.io/embed/drep/DREP_ID?theme=dark"
+  src="https://governada.io/embed/drep/DREP_ID?theme=dark"
   width="320"
   height="200"
   frameBorder="0"
@@ -56,7 +56,7 @@ const EMBED_CODE = {
   javascript: `<!-- Or use the script loader -->
 <div id="drepscore-widget"></div>
 <script
-  src="https://drepscore.io/embed.js"
+  src="https://governada.io/embed.js"
   data-type="drep"
   data-id="DREP_ID"
   data-theme="dark"
@@ -217,7 +217,7 @@ export function DeveloperPage() {
                 <CodeExample
                   code={{
                     html: `<iframe
-  src="https://drepscore.io/embed/ghi?theme=dark"
+  src="https://governada.io/embed/ghi?theme=dark"
   width="280"
   height="160"
   frameBorder="0"
@@ -303,15 +303,15 @@ export function DeveloperPage() {
 
           <CodeExample
             code={{
-              curl: `curl "https://drepscore.io/api/v1/dreps?limit=5" \\
+              curl: `curl "https://governada.io/api/v1/dreps?limit=5" \\
   -H "Authorization: Bearer ds_live_YOUR_API_KEY"`,
-              javascript: `const response = await fetch("https://drepscore.io/api/v1/dreps?limit=5", {
+              javascript: `const response = await fetch("https://governada.io/api/v1/dreps?limit=5", {
   headers: {
     "Authorization": "Bearer ds_live_YOUR_API_KEY"
   }
 });`,
               python: `response = requests.get(
-    "https://drepscore.io/api/v1/dreps",
+    "https://governada.io/api/v1/dreps",
     headers={"Authorization": "Bearer ds_live_YOUR_API_KEY"},
     params={"limit": 5}
 )`,

--- a/components/EmbedCrossChain.tsx
+++ b/components/EmbedCrossChain.tsx
@@ -110,7 +110,7 @@ export function EmbedCrossChain({ theme }: EmbedCrossChainProps) {
 
       <div className="mt-3 flex items-center justify-between">
         <a
-          href="https://drepscore.io/pulse"
+          href="https://governada.io/pulse"
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-medium hover:underline"
@@ -119,7 +119,7 @@ export function EmbedCrossChain({ theme }: EmbedCrossChainProps) {
           View full Observatory →
         </a>
         <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
-          drepscore.io
+          governada.io
         </span>
       </div>
     </div>

--- a/components/EmbedDRepCard.tsx
+++ b/components/EmbedDRepCard.tsx
@@ -69,7 +69,7 @@ export function EmbedDRepCard({ drep, theme }: EmbedDRepCardProps) {
 
       <div className="mt-3 flex items-center justify-between">
         <a
-          href={`https://drepscore.io/drep/${encodeURIComponent(drep.drepId)}`}
+          href={`https://governada.io/drep/${encodeURIComponent(drep.drepId)}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-medium hover:underline"
@@ -78,7 +78,7 @@ export function EmbedDRepCard({ drep, theme }: EmbedDRepCardProps) {
           View full profile →
         </a>
         <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
-          drepscore.io
+          governada.io
         </span>
       </div>
     </div>

--- a/components/EmbedGHI.tsx
+++ b/components/EmbedGHI.tsx
@@ -106,7 +106,7 @@ export function EmbedGHI({ theme }: EmbedGHIProps) {
 
       <div className="mt-2 flex justify-between items-center">
         <a
-          href="https://drepscore.io/pulse"
+          href="https://governada.io/pulse"
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-medium hover:underline"
@@ -115,7 +115,7 @@ export function EmbedGHI({ theme }: EmbedGHIProps) {
           View full report →
         </a>
         <span className="text-[9px]" style={{ color: isDark ? '#374151' : '#d1d5db' }}>
-          drepscore.io
+          governada.io
         </span>
       </div>
     </div>

--- a/components/EpochReviewCard.tsx
+++ b/components/EpochReviewCard.tsx
@@ -58,7 +58,7 @@ export function EpochReviewCard() {
     const score = s.yourDRepScore ?? 0;
     const votes = s.drepVotesCast;
     const polls = s.yourPollsTaken;
-    const text = `My Epoch ${data.epoch} Review on @DRepScore: ${drepName} scored ${score}, ${votes} votes cast, ${polls} polls taken. #CardanoGovernance`;
+    const text = `My Epoch ${data.epoch} Review on @GovernadaIO: ${drepName} scored ${score}, ${votes} votes cast, ${polls} polls taken. #CardanoGovernance`;
     navigator.clipboard.writeText(text).then(() => {
       setShared(true);
       setTimeout(() => setShared(false), 2000);

--- a/components/EpochSummaryCard.tsx
+++ b/components/EpochSummaryCard.tsx
@@ -78,7 +78,7 @@ export function EpochSummaryCard({ epoch, summary }: EpochSummaryCardProps) {
         <CardAction>
           <ShareActions
             url={`${siteUrl}/?epoch=${epoch}`}
-            text={`Cardano Epoch ${epoch} governance recap via @DRepScore — ${summary.drepVoteCount} DRep votes, ${summary.proposalsOpened} proposals opened.`}
+            text={`Cardano Epoch ${epoch} governance recap via @GovernadaIO — ${summary.drepVoteCount} DRep votes, ${summary.proposalsOpened} proposals opened.`}
             imageUrl={`/api/og/epoch-summary?epoch=${epoch}&votes=${summary.drepVoteCount}&rationales=${summary.drepRationaleCount}&proposals=${summary.proposalsOpened}${summary.representationScore != null ? `&repScore=${summary.representationScore}` : ''}`}
             imageFilename={`epoch-${epoch}-summary.png`}
             surface="epoch_summary_card"
@@ -140,7 +140,7 @@ export function EpochSummaryCard({ epoch, summary }: EpochSummaryCardProps) {
       </CardContent>
 
       <CardFooter>
-        <p className="text-xs text-muted-foreground">drepscore.io</p>
+        <p className="text-xs text-muted-foreground">governada.io</p>
       </CardFooter>
     </Card>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -101,7 +101,7 @@ export function Footer() {
               </TooltipProvider>
             </div>
             <p className="text-xs text-muted-foreground/60">
-              &copy; {new Date().getFullYear()} DRepScore &middot; Built on Cardano
+              &copy; {new Date().getFullYear()} Governada &middot; Built on Cardano
             </p>
           </div>
         </div>

--- a/components/GovTerm.tsx
+++ b/components/GovTerm.tsx
@@ -138,7 +138,7 @@ export function GovTerm({ term, children, segmentOverride, className }: GovTermP
 
           <div className="px-3 py-1.5 border-t border-border/40 flex items-center gap-1">
             <HelpCircle className="h-3 w-3 text-muted-foreground/70" />
-            <span className="text-[10px] text-muted-foreground/70">Civica Glossary</span>
+            <span className="text-[10px] text-muted-foreground/70">Governada Glossary</span>
           </div>
         </TooltipContent>
       </Tooltip>

--- a/components/GovernanceDNAReveal.tsx
+++ b/components/GovernanceDNAReveal.tsx
@@ -227,8 +227,8 @@ export function GovernanceDNAReveal({ result, onRetake }: GovernanceDNARevealPro
                 {result.topMatches[0].matchScore}%)
               </p>
               <ShareActions
-                url="https://drepscore.io/discover"
-                text={`I took the Governance DNA Quiz on @drepscore! My top match: ${result.topMatches[0].name} (${result.topMatches[0].matchScore}%). Find your ideal DRep:`}
+                url="https://governada.io/discover"
+                text={`I took the Governance DNA Quiz on @GovernadaIO! My top match: ${result.topMatches[0].name} (${result.topMatches[0].matchScore}%). Find your ideal DRep:`}
                 imageUrl={`/api/og/governance-dna?votes=${result.votesCount}${result.topMatches
                   .slice(0, 3)
                   .map(

--- a/components/GovernanceObservatory.tsx
+++ b/components/GovernanceObservatory.tsx
@@ -126,7 +126,7 @@ export function GovernanceObservatory({
           </CardTitle>
           <ShareActions
             url={`${BASE_URL}/pulse`}
-            text="How does governance compare across Cardano, Ethereum, and Polkadot? Check the Observatory on @drepscore:"
+            text="How does governance compare across Cardano, Ethereum, and Polkadot? Check the Observatory on @GovernadaIO:"
             imageUrl={`${BASE_URL}/api/og/cross-chain`}
             imageFilename="cross-chain-governance.png"
             surface="cross_chain_observatory"

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -58,7 +58,7 @@ export function InstallPrompt() {
     <div className="fixed top-[68px] left-0 right-0 z-40 flex justify-center px-4 animate-fade-in-up">
       <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-popover/95 backdrop-blur-xl shadow-lg px-4 py-2.5 max-w-lg">
         <Download className="h-4 w-4 text-primary shrink-0" />
-        <p className="text-sm flex-1">Add DRepScore to your homescreen for instant access.</p>
+        <p className="text-sm flex-1">Add Governada to your homescreen for instant access.</p>
         <Button
           size="sm"
           variant="default"

--- a/components/MilestoneBadges.tsx
+++ b/components/MilestoneBadges.tsx
@@ -179,7 +179,7 @@ export function MilestoneBadges({ drepId, compact = false }: MilestoneBadgesProp
               </div>
               <ShareActions
                 url={buildDRepUrl(drepId)}
-                text={`Achievement Unlocked on @CivicaGov: ${celebratingMilestone.label}! ${celebratingMilestone.description}.`}
+                text={`Achievement Unlocked on @GovernadaIO: ${celebratingMilestone.label}! ${celebratingMilestone.description}.`}
                 imageUrl={`/api/og/moment/milestone/${encodeURIComponent(drepId)}/${celebratingMilestone.key}`}
                 imageFilename={`milestone-${celebratingMilestone.key}.png`}
                 surface="milestone_celebration"

--- a/components/MilestoneCelebration.tsx
+++ b/components/MilestoneCelebration.tsx
@@ -54,8 +54,8 @@ export function MilestoneCelebration({
 
   if (!milestone) return null;
 
-  const shareUrl = `https://drepscore.io/drep/${encodeURIComponent(drepId)}`;
-  const shareText = `${drepName} just unlocked "${milestone.label}" on @CivicaGov! ${milestone.description}`;
+  const shareUrl = `https://governada.io/drep/${encodeURIComponent(drepId)}`;
+  const shareText = `${drepName} just unlocked "${milestone.label}" on @GovernadaIO! ${milestone.description}`;
   const imageUrl = `/api/og/moment/milestone/${encodeURIComponent(drepId)}/${encodeURIComponent(milestoneKey)}`;
 
   return (

--- a/components/NotificationPreferences.tsx
+++ b/components/NotificationPreferences.tsx
@@ -453,7 +453,7 @@ export function NotificationPreferences() {
               <div>
                 <p className="text-sm font-medium">Telegram</p>
                 <p className="text-[10px] text-muted-foreground">
-                  {channels.telegram.connected ? 'Connected' : 'Message @DRepScoreBot to connect'}
+                  {channels.telegram.connected ? 'Connected' : 'Message @GovernadaBot to connect'}
                 </p>
               </div>
             </div>
@@ -473,7 +473,7 @@ export function NotificationPreferences() {
               </div>
             ) : (
               <Button variant="outline" size="sm" className="gap-1" asChild>
-                <a href="https://t.me/DRepScoreBot" target="_blank" rel="noopener noreferrer">
+                <a href="https://t.me/GovernadaBot" target="_blank" rel="noopener noreferrer">
                   Connect <ExternalLink className="h-3 w-3" />
                 </a>
               </Button>

--- a/components/OnboardingChecklist.tsx
+++ b/components/OnboardingChecklist.tsx
@@ -40,7 +40,7 @@ const ITEMS = [
   {
     key: 'share',
     label: 'Share your score',
-    desc: 'Let delegators know you are active on DRepScore',
+    desc: 'Let delegators know you are active on Governada',
     icon: Share2,
     href: null,
   },

--- a/components/ProposalOutcomeCard.tsx
+++ b/components/ProposalOutcomeCard.tsx
@@ -62,7 +62,7 @@ export function ProposalOutcomeCard({
     });
   }, [proposal.outcome, proposal.proposalType, isWinner]);
 
-  const shareText = `Proposal "${proposal.title}" was ${config.label.toLowerCase()}${drepVote ? ` — my DRep voted ${drepVote}` : ''}. Check it out on DRepScore!`;
+  const shareText = `Proposal "${proposal.title}" was ${config.label.toLowerCase()}${drepVote ? ` — my DRep voted ${drepVote}` : ''}. Check it out on Governada!`;
 
   return (
     <Card className="overflow-hidden">

--- a/components/ScoreCard.tsx
+++ b/components/ScoreCard.tsx
@@ -59,8 +59,8 @@ export function ScoreCard({
   const ogImageUrl = `/api/og/drep/${encodeURIComponent(drep.drepId)}`;
 
   const shareText = isOwnProfile
-    ? `My DRepScore is ${drep.drepScore}/100!\n\nParticipation: ${drep.effectiveParticipation}% | Rationale: ${adjustedRationale}% | Reliability: ${drep.reliabilityScore}%\n\nSee my full report on @drepscore:`
-    : `${drep.name || 'This DRep'} scored ${drep.drepScore}/100 on @drepscore!\n\nCheck out their governance track record:`;
+    ? `My Governada Score is ${drep.drepScore}/100!\n\nParticipation: ${drep.effectiveParticipation}% | Rationale: ${adjustedRationale}% | Reliability: ${drep.reliabilityScore}%\n\nSee my full report on @GovernadaIO:`
+    : `${drep.name || 'This DRep'} scored ${drep.drepScore}/100 on @GovernadaIO!\n\nCheck out their governance track record:`;
 
   const hints = [participationHint, rationaleHint, reliabilityHint, profileHint];
 

--- a/components/ScoreChangeMoment.tsx
+++ b/components/ScoreChangeMoment.tsx
@@ -46,8 +46,8 @@ export function ScoreChangeMoment({ drepId, drepName, currentScore }: ScoreChang
   const shareUrl = buildDRepUrl(drepId);
   const imageUrl = `/api/og/moment/score-change/${encodeURIComponent(drepId)}?prev=${change.previousScore}`;
   const shareText = isGain
-    ? `My DRepScore went up ${change.delta} points to ${currentScore}/100! Improving my governance game on @drepscore.`
-    : `My DRepScore changed by ${change.delta} points to ${currentScore}/100. Governance accountability in action on @drepscore.`;
+    ? `My Governada Score went up ${change.delta} points to ${currentScore}/100! Improving my governance game on @GovernadaIO.`
+    : `My Governada Score changed by ${change.delta} points to ${currentScore}/100. Governance accountability in action on @GovernadaIO.`;
 
   return (
     <Card className={`border ${isGain ? 'border-green-500/20' : 'border-red-500/20'}`}>

--- a/components/VoteExplanationEditor.tsx
+++ b/components/VoteExplanationEditor.tsx
@@ -140,7 +140,7 @@ export function VoteExplanationEditor({
                   </TooltipTrigger>
                   <TooltipContent className="max-w-[280px]">
                     <p className="text-xs">
-                      This explanation is stored on DRepScore and visible to your delegators. It
+                      This explanation is stored on Governada and visible to your delegators. It
                       does not affect your on-chain rationale score.
                     </p>
                   </TooltipContent>

--- a/components/WalletConnectModal.tsx
+++ b/components/WalletConnectModal.tsx
@@ -252,7 +252,7 @@ export function WalletConnectModal({
               <div className="p-3 bg-blue-50 dark:bg-blue-950/30 rounded-lg border border-blue-200 dark:border-blue-900 text-sm">
                 <p className="font-medium text-blue-800 dark:text-blue-200 mb-1">What to expect:</p>
                 <ul className="text-blue-700 dark:text-blue-300 space-y-1 text-xs">
-                  <li>• Your wallet will show &quot;Sign in to DRepScore&quot;</li>
+                  <li>• Your wallet will show &quot;Sign in to Governada&quot;</li>
                   <li>• This is free — no ADA will be sent</li>
                   <li>• You can ignore the technical hex codes</li>
                 </ul>

--- a/components/WrappedShareCard.tsx
+++ b/components/WrappedShareCard.tsx
@@ -44,8 +44,8 @@ export function WrappedShareCard({
 
   const shareText =
     variant === 'drep'
-      ? `My DRepScore: ${score}/100! ${rank ? `Ranked #${rank}. ` : ''}${delegators ? `${delegators} delegators trust my governance. ` : ''}Check your DRep's score on @drepscore:`
-      : `I'm delegated to ${drepName} on @drepscore — they scored ${score}/100 with ${participation || 0}% participation. Who's your DRep?`;
+      ? `My Governada Score: ${score}/100! ${rank ? `Ranked #${rank}. ` : ''}${delegators ? `${delegators} delegators trust my governance. ` : ''}Check your DRep's score on @GovernadaIO:`
+      : `I'm delegated to ${drepName} on @GovernadaIO — they scored ${score}/100 with ${participation || 0}% participation. Who's your DRep?`;
 
   const tierColor =
     score >= 80
@@ -67,7 +67,7 @@ export function WrappedShareCard({
         <div className="rounded-lg bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-transparent p-4">
           <div className="text-center space-y-2">
             <p className="text-xs text-muted-foreground">
-              {variant === 'drep' ? 'My DRepScore' : `I'm delegated to`}
+              {variant === 'drep' ? 'My Governada Score' : `I'm delegated to`}
             </p>
             {variant === 'delegator' && <p className="text-sm font-semibold">{drepName}</p>}
             <p className={`text-3xl font-bold tabular-nums ${tierColor}`}>

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -92,7 +92,7 @@ export function CivicaHeader() {
             href="/"
             className="font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
           >
-            Civica
+            Governada
           </Link>
 
           <nav className="flex items-center gap-1" aria-label="Main navigation">

--- a/components/civica/CivicaHomePage.tsx
+++ b/components/civica/CivicaHomePage.tsx
@@ -24,7 +24,7 @@ interface CivicaHomePageProps {
 }
 
 /**
- * Civica home page dispatcher — selects the correct variant based on
+ * Governada home page dispatcher — selects the correct variant based on
  * detected user segment. Renders anonymously until segment is resolved.
  */
 export function CivicaHomePage({

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -41,7 +41,7 @@ function DeepLinkHandler() {
 }
 
 /**
- * Civica layout shell — wraps children with 4-tab nav + providers.
+ * Governada layout shell — wraps children with 4-tab nav + providers.
  */
 export function CivicaShell({ children }: { children: React.ReactNode }) {
   return (

--- a/components/civica/cards/tierStyles.ts
+++ b/components/civica/cards/tierStyles.ts
@@ -1,5 +1,5 @@
 /**
- * Shared tier-color tokens for Civica card components.
+ * Shared tier-color tokens for Governada card components.
  * Single source of truth — import everywhere.
  * Each token provides light + dark mode classes.
  */

--- a/components/civica/identity/CitizenMilestoneCelebration.tsx
+++ b/components/civica/identity/CitizenMilestoneCelebration.tsx
@@ -80,8 +80,8 @@ export function CitizenMilestoneCelebration({
   const milestone = CITIZEN_MILESTONES.find((m) => m.key === celebrating);
   if (!milestone) return null;
 
-  const shareUrl = 'https://drepscore.io/my-gov/identity';
-  const shareText = `${milestone.shareText} @CivicaGov`;
+  const shareUrl = 'https://governada.io/my-gov/identity';
+  const shareText = `${milestone.shareText} @GovernadaIO`;
   const imageUrl = stakeAddress ? `/api/og/civic-identity/${encodeURIComponent(stakeAddress)}` : '';
 
   return (

--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -170,12 +170,12 @@ export function CivicIdentityProfile() {
   if (isLoading) return <ProfileSkeleton />;
 
   const shareUrl = stakeAddress
-    ? `https://drepscore.io/my-gov/identity`
-    : 'https://drepscore.io/my-gov/identity';
+    ? `https://governada.io/my-gov/identity`
+    : 'https://governada.io/my-gov/identity';
   const shareOgUrl = stakeAddress
     ? `/api/og/civic-identity/${encodeURIComponent(stakeAddress)}`
     : '';
-  const shareText = `Check out my Civic Identity on Cardano! ${earned.length} milestones earned. @CivicaGov`;
+  const shareText = `Check out my Civic Identity on Cardano! ${earned.length} milestones earned. @GovernadaIO`;
 
   return (
     <div className="space-y-8">

--- a/components/civica/mygov/CivicaProfile.tsx
+++ b/components/civica/mygov/CivicaProfile.tsx
@@ -424,7 +424,7 @@ export function CivicaProfile() {
             <span className="text-emerald-400 font-medium">Wallet connected</span>
           </div>
           <p className="text-xs text-muted-foreground">
-            Civica uses your Cardano wallet for authentication. No passwords or email required.
+            Governada uses your Cardano wallet for authentication. No passwords or email required.
           </p>
         </div>
       </Section>

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -682,8 +682,8 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
         open={shareOpen}
         onClose={() => setShareOpen(false)}
         ogImageUrl={`/api/og/wrapped/drep/${encodeURIComponent(drepId)}`}
-        shareText={`My governance score on @CivicaGov — check it out!`}
-        shareUrl={`${typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io'}/drep/${encodeURIComponent(drepId)}`}
+        shareText={`My governance score on @GovernadaIO — check it out!`}
+        shareUrl={`${typeof window !== 'undefined' ? window.location.origin : 'https://governada.io'}/drep/${encodeURIComponent(drepId)}`}
         title="Share your profile"
       />
     </div>

--- a/components/civica/mygov/SPOCommandCenter.tsx
+++ b/components/civica/mygov/SPOCommandCenter.tsx
@@ -842,8 +842,8 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
         open={shareOpen}
         onClose={() => setShareOpen(false)}
         ogImageUrl={`/api/og/wrapped/spo/${encodeURIComponent(poolId)}`}
-        shareText={`My pool's governance score on @CivicaGov \u2014 check it out!`}
-        shareUrl={`${typeof window !== 'undefined' ? window.location.origin : 'https://drepscore.io'}/pool/${encodeURIComponent(poolId)}`}
+        shareText={`My pool's governance score on @GovernadaIO \u2014 check it out!`}
+        shareUrl={`${typeof window !== 'undefined' ? window.location.origin : 'https://governada.io'}/pool/${encodeURIComponent(poolId)}`}
         title="Share your pool profile"
       />
     </div>

--- a/components/civica/profiles/DRepProfileTabsV2.tsx
+++ b/components/civica/profiles/DRepProfileTabsV2.tsx
@@ -22,7 +22,7 @@ interface DRepProfileTabsV2Props {
 }
 
 /**
- * Civica VP2 tabs — same as DRepProfileTabs but with Phase B "Statements" tab scaffold.
+ * Governada VP2 tabs — same as DRepProfileTabs but with Phase B "Statements" tab scaffold.
  * The Statements tab is conditionally rendered (caller gates it with drep_communication flag).
  */
 export function DRepProfileTabsV2({

--- a/components/civica/shared/ShareModal.tsx
+++ b/components/civica/shared/ShareModal.tsx
@@ -113,7 +113,7 @@ export function ShareModal({
           </div>
 
           <p className="text-center text-xs text-muted-foreground">
-            via Civica &mdash; governance intelligence for Cardano
+            via Governada &mdash; governance intelligence for Cardano
           </p>
         </div>
       </DialogContent>

--- a/components/civica/shared/TierCelebrationManager.tsx
+++ b/components/civica/shared/TierCelebrationManager.tsx
@@ -86,7 +86,7 @@ export function TierCelebrationManager({
   };
 
   if (change) {
-    const shareText = `${entityName} just reached the ${change.new_tier} tier on Civica! Score: ${change.new_score}`;
+    const shareText = `${entityName} just reached the ${change.new_tier} tier on Governada! Score: ${change.new_score}`;
     return (
       <CelebrationOverlay
         entityType={entityType}

--- a/components/engagement/AskYourDRep.tsx
+++ b/components/engagement/AskYourDRep.tsx
@@ -122,7 +122,7 @@ export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRe
               <TooltipContent side="left" className="max-w-[260px]">
                 <p className="text-xs">
                   Send a question to your delegated DRep about this proposal. They&apos;ll see it in
-                  their Civica inbox with a link to this proposal.
+                  their Governada inbox with a link to this proposal.
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/docs/adr/001-jwt-wallet-auth.md
+++ b/docs/adr/001-jwt-wallet-auth.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-DRepScore authenticates users via Cardano wallet signatures (CIP-30). Supabase Auth supports email/password, OAuth, and magic links but has no native wallet signature flow.
+Governada authenticates users via Cardano wallet signatures (CIP-30). Supabase Auth supports email/password, OAuth, and magic links but has no native wallet signature flow.
 
 ## Decision
 

--- a/docs/adr/002-inngest-over-vercel-cron.md
+++ b/docs/adr/002-inngest-over-vercel-cron.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-DRepScore needs 20+ background jobs: data sync (Koios), score calculation, notifications, report generation. Options: Vercel Cron (simple, limited), Inngest (durable, step functions, retries), BullMQ (self-hosted Redis queues).
+Governada needs 20+ background jobs: data sync (Koios), score calculation, notifications, report generation. Options: Vercel Cron (simple, limited), Inngest (durable, step functions, retries), BullMQ (self-hosted Redis queues).
 
 ## Decision
 

--- a/docs/adr/005-scoring-methodology.md
+++ b/docs/adr/005-scoring-methodology.md
@@ -6,7 +6,7 @@ Accepted — **V3 (current, Mar 2026)**. Supersedes earlier V1/V2 models.
 
 ## Context
 
-Civica needs a single 0-100 score per DRep that measures governance accountability. The score must be objective, transparent, and resistant to gaming.
+Governada needs a single 0-100 score per DRep that measures governance accountability. The score must be objective, transparent, and resistant to gaming.
 
 ## Decision (V3 — 4-Pillar Model)
 

--- a/docs/adr/006-spo-scoring-methodology.md
+++ b/docs/adr/006-spo-scoring-methodology.md
@@ -6,7 +6,7 @@ Accepted — **V2 (current, Mar 2026)**. Supersedes V1 3-pillar model.
 
 ## Context
 
-Civica needs a single 0-100 governance score per SPO that measures governance participation quality. The score exists so citizens can evaluate their stake pool's governance engagement — it is not for SPO vanity. The score must be objective, transparent, resistant to gaming, and structurally parallel to the DRep Score V3 (ADR-005) to enable fair cross-body comparison.
+Governada needs a single 0-100 governance score per SPO that measures governance participation quality. The score exists so citizens can evaluate their stake pool's governance engagement — it is not for SPO vanity. The score must be objective, transparent, resistant to gaming, and structurally parallel to the DRep Score V3 (ADR-005) to enable fair cross-body comparison.
 
 V1 used three pillars (Participation 45%, Consistency 30%, Reliability 25%). V2 adds a fourth pillar — Governance Identity — to incentivize SPOs to publicly communicate their governance stance and to create structural parity with DRep scoring.
 
@@ -65,7 +65,7 @@ Two sub-components:
 **Key fairness properties:**
 
 - Unclaimed pools score a baseline from on-chain metadata alone (ticker + name + hash = 25/100).
-- Claiming a profile on Civica unlocks up to 75 additional points via governance statement, description, social links, and homepage.
+- Claiming a profile on Governada unlocks up to 75 additional points via governance statement, description, social links, and homepage.
 - Pool size (live stake) is intentionally excluded — mirrors DRep Score's exclusion of voting power.
 
 ### Momentum

--- a/docs/adr/007-multi-wallet-identity.md
+++ b/docs/adr/007-multi-wallet-identity.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Civica's identity was wallet-address-centric: `users.wallet_address` was the PK, and every user-scoped table used it as the FK. This creates problems for engaged Cardano governance participants who routinely operate multiple wallets:
+Governada's identity was wallet-address-centric: `users.wallet_address` was the PK, and every user-scoped table used it as the FK. This creates problems for engaged Cardano governance participants who routinely operate multiple wallets:
 
 - A DRep with a separate cold storage wallet
 - An SPO who also has a personal delegation wallet

--- a/docs/observability-setup.md
+++ b/docs/observability-setup.md
@@ -1,6 +1,6 @@
 # Observability Setup Guide
 
-Dashboard and external service configurations for the Civica observability stack. These cannot be automated via code and must be set up manually.
+Dashboard and external service configurations for the Governada observability stack. These cannot be automated via code and must be set up manually.
 
 ---
 
@@ -131,7 +131,7 @@ Sign up at [betterstack.com](https://betterstack.com) (free tier: 5 monitors, 3-
 
 | Monitor     | URL                                    | Method | Interval | Expected                                  |
 | ----------- | -------------------------------------- | ------ | -------- | ----------------------------------------- |
-| Deep Health | `https://drepscore.io/api/health/deep` | GET    | 3 min    | status 200, body contains `"status":"ok"` |
+| Deep Health | `https://governada.io/api/health/deep` | GET    | 3 min    | status 200, body contains `"status":"ok"` |
 
 ### Heartbeat URLs
 

--- a/docs/plans/civica-frontend-redesign.md
+++ b/docs/plans/civica-frontend-redesign.md
@@ -1,6 +1,6 @@
-# Civica Frontend — Clean Sheet Redesign Plan
+# Governada Frontend — Clean Sheet Redesign Plan
 
-> Phase A, Task A7. Transforms the DRepScore data platform (32 pages, ~237 components) into a citizen-centric civic hub.
+> Phase A, Task A7. Transforms the Governada data platform (32 pages, ~237 components) into a citizen-centric governance hub.
 
 ---
 
@@ -62,7 +62,7 @@
 
 ```
 app/
-├── (civica)/                    # Route group — Civica layout shell
+├── (civica)/                    # Route group — Governada layout shell
 │   ├── layout.tsx               # CivicaShell: nav, segment provider, tier theme
 │   ├── page.tsx                 # Home (constellation + personalized feed)
 │   ├── discover/
@@ -101,7 +101,7 @@ app/
 Horizontal top bar with 4 primary destinations + wallet button:
 
 ```
-[Civica Logo]   Home   Discover   Pulse   My Gov        [⌘K] [Wallet]
+[Governada Logo]   Home   Discover   Pulse   My Gov        [⌘K] [Wallet]
 ```
 
 - Active state: bold + accent underline
@@ -245,7 +245,7 @@ For citizens viewing a DRep's profile: the profile page adopts that DRep's tier 
   1.8 — **Metadata architecture**
 
 - Every route in `(civica)` gets a `generateMetadata()` function with:
-  - Dynamic title: "Civica — [Page Name]"
+  - Dynamic title: "Governada — [Page Name]"
   - Description tailored to route (DRep profiles get DRep-specific descriptions)
   - OG image: route-specific (DRep/SPO profiles use existing OG generation, Pulse uses GHI OG, Home uses branded default)
   - Twitter card: `summary_large_image` for profiles and proposals
@@ -306,7 +306,7 @@ Technical: the existing `ConstellationHero.tsx` already has expanded/contracted 
 
 - Hero: "Cardano has a government. Know who represents you."
 - Constellation visualization (keep existing, polish — see constellation behavior above)
-- Social proof strip below constellation: "12,000+ delegators use DRepScore to track their governance | 300+ DReps scored | 2,800+ SPOs tracked" — numbers pulled from `/api/stats/claimed` and governance stats
+- Social proof strip below constellation: "12,000+ delegators use Governada to track their governance | 300+ DReps scored | 2,800+ SPOs tracked" — numbers pulled from `/api/stats/claimed` and governance stats
 - Live governance stats (total DReps, active proposals, participation rate) as ambient counters overlaid on constellation
 
 **Quick Match inline design:**
@@ -607,8 +607,8 @@ Leaderboards are discovery tools — users browse them to find DReps/SPOs. They 
 - One-tap share to X with pre-filled text
 - Copy link to profile with achievement highlighted
 - Download image for manual sharing
-- Every shareable card includes "via DRepScore" branding + URL
-- Share preview images (OG) always include the DRepScore logo — already enforced by `lib/og-utils.tsx` `OGFooter`
+- Every shareable card includes "via Governada" branding + URL
+- Share preview images (OG) always include the Governada logo — already enforced by `lib/og-utils.tsx` `OGFooter`
 
   6.3 — **Score impact micro-interactions**
 

--- a/docs/plans/phase-b-growth-engagement.md
+++ b/docs/plans/phase-b-growth-engagement.md
@@ -25,7 +25,7 @@
 
 - Clean-sheet redesign plan in `docs/plans/civica-frontend-redesign.md`
 - 4-destination navigation, segment detection, action feed, celebration/sharing system, tier visual identity
-- The Civica frontend plan creates the **surfaces** Phase B fills with content
+- The Governada frontend plan creates the **surfaces** Phase B fills with content
 
 ---
 
@@ -94,8 +94,8 @@ Extend OG image infrastructure:
   - `/api/og/wrapped/spo/[poolId]/[period]`
   - `/api/og/wrapped/stat/[statId]` — individual stat cards
 - Each route renders a purpose-built visual card (not a screenshot)
-- Cards branded with Civica identity + tier colors
-- Include CTA: "Find your governance story at civica.app"
+- Cards branded with Governada identity + tier colors
+- Include CTA: "Find your governance story at governada.io"
 
 **B1.3 — "Your Staking Governance" Card**
 
@@ -377,12 +377,12 @@ CREATE INDEX idx_notif_analytics_type ON notification_analytics (notification_ty
 
 Rich HTML email:
 
-- Civica branded header
+- Governada branded header
 - Personalized greeting with segment acknowledgment
 - Score/tier update section
 - Proposal highlights
 - Alignment status
-- "Open Civica" CTA buttons linking to deep-linked actions
+- "Open Governada" CTA buttons linking to deep-linked actions
 - Unsubscribe link
 
 **B3.7 — Push Notification Handling**
@@ -410,12 +410,12 @@ Service worker updates:
 | B-1   | B1             | Wrapped data aggregation engine + OG card generation                   | Epoch summary data (A), score snapshots      |
 | B-2   | B2             | Position statements + questions backend (API, data model)              | DRep profiles (A)                            |
 | B-3   | B3             | Weekly digest + epoch recap + deep-link resolution                     | Notification triggers (A), channel renderers |
-| B-4   | B1             | Wrapped frontend: story flow, share enhancement, public Wrapped page   | B-1, Civica frontend (A7)                    |
-| B-5   | B2             | Communication frontend: statement editor, feed integration, questions  | B-2, Civica frontend (A7)                    |
-| B-6   | B3             | Digest email template, push handling, in-app indicators, rate limiting | B-3, Civica frontend (A7)                    |
+| B-4   | B1             | Wrapped frontend: story flow, share enhancement, public Wrapped page   | B-1, Governada frontend (A7)                 |
+| B-5   | B2             | Communication frontend: statement editor, feed integration, questions  | B-2, Governada frontend (A7)                 |
+| B-6   | B3             | Digest email template, push handling, in-app indicators, rate limiting | B-3, Governada frontend (A7)                 |
 | B-7   | All            | Notification analytics, A/B testing hooks, polish                      | B-4, B-5, B-6                                |
 
-**Note:** Batches B-1, B-2, B-3 are backend-only and can proceed in parallel. Batches B-4, B-5, B-6 require the Civica frontend (Phase A7) to be at least partially shipped. B-7 is integration and polish.
+**Note:** Batches B-1, B-2, B-3 are backend-only and can proceed in parallel. Batches B-4, B-5, B-6 require the Governada frontend (Phase A7) to be at least partially shipped. B-7 is integration and polish.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,4 +1,4 @@
-# Civica Operational Runbook
+# Governada Operational Runbook
 
 ## Sync Pipeline Failure
 

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,4 +1,4 @@
-# Civica Strategy Documents
+# Governada Strategy Documents
 
 ## North Star
 

--- a/docs/strategy/catalyst-proposal.md
+++ b/docs/strategy/catalyst-proposal.md
@@ -1,8 +1,8 @@
-# Project Catalyst Funding Proposal — Civica
+# Project Catalyst Funding Proposal — Governada
 
 > **Status:** Active — Drafting for Fund 16
 > **Parent:** [monetization-strategy.md](monetization-strategy.md) — Section 3
-> **Last updated:** March 2026 (Civica rebrand, expanded vision)
+> **Last updated:** March 2026 (Governada rebrand, expanded vision)
 > **Target fund:** Fund 16 (estimated mid-2026, prepare proposal by May 2026)
 
 ## Fund Intelligence
@@ -18,7 +18,7 @@
 - Community review: Dec 2 - Jan 8, 2026
 - Voting: TBA
 
-### Target Categories for Civica
+### Target Categories for Governada
 
 1. **Cardano Open: Ecosystem** — Governance tooling, civic engagement, ecosystem growth. This is our primary fit.
 2. **Cardano Open: Developers** — If we open-source the scoring engine / API. Secondary option.
@@ -35,7 +35,7 @@
 
 ---
 
-## Proposal Draft: "Civica — The Civic Hub for the Cardano Nation"
+## Proposal Draft: "Governada — The Civic Hub for the Cardano Nation"
 
 ### Problem Statement
 
@@ -51,7 +51,7 @@ This undermines the entire premise of delegated governance. If citizens can't ev
 
 ### Solution
 
-Civica is the civic hub for the Cardano Nation:
+Governada is the civic hub for the Cardano Nation:
 
 1. **Scores every DRep and SPO (0-100)** based on transparent, verifiable metrics — participation, rationale quality, reliability, and governance identity. No subjective ratings; pure on-chain data.
 2. **Matches citizens to aligned representatives** through a PCA-based value-preference system across 6 governance dimensions. 60 seconds to delegation.
@@ -61,9 +61,9 @@ Civica is the civic hub for the Cardano Nation:
 
 ### What Already Exists (Traction)
 
-Civica is not a concept — it's a live, functioning platform with 90+ API routes and 22 background sync functions:
+Governada is not a concept — it's a live, functioning platform with 90+ API routes and 22 background sync functions:
 
-- **Production URL:** https://drepscore.io (domain transition planned)
+- **Production URL:** https://governada.io (domain transition planned)
 - **DRep Scoring V3** — 4-pillar model (Engagement Quality, Effective Participation, Reliability, Governance Identity) with percentile normalization
 - **SPO Governance Scoring** — 3-pillar model scoring ~3,000 pool operators on governance participation
 - **PCA Alignment System** — 6D alignment with AI proposal classification, temporal trajectories
@@ -79,7 +79,7 @@ This proposal funds the **next phase** — transforming a robust governance inte
 
 ### What Catalyst Funding Enables
 
-#### Phase 1: Civica Civic Experience (Months 1-3)
+#### Phase 1: Governada Civic Experience (Months 1-3)
 
 - Clean-sheet frontend redesign with citizen-centric UX (4-nav architecture, segment detection, action-first design)
 - Score tier system with emotional design (Emerging → Bronze → Silver → Gold → Diamond → Legendary)
@@ -102,12 +102,12 @@ This proposal funds the **next phase** — transforming a robust governance inte
 
 ### Milestones (for 75K-150K ADA ask)
 
-| Milestone | Deliverable                                                                                | Verification                                                  | Timeline |
-| --------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | -------- |
-| M1        | Civica frontend launched with citizen-centric UX; score tiers live; SPO profiles at parity | Live platform demo, user metrics, DRep + SPO profiles live    | Month 3  |
-| M2        | Governance Wrapped shipped; notification system live; growth loops operational             | Wrapped demo, sharing metrics, return visit data              | Month 5  |
-| M3        | DRep Pro + SPO Pro launched; API v2 with 1+ integration partner                            | Revenue metrics, API docs, integration demo                   | Month 7  |
-| Final     | Full project report; open-source scoring engine; sustainability plan                       | Report published, GitHub repo, revenue/sustainability metrics | Month 8  |
+| Milestone | Deliverable                                                                                   | Verification                                                  | Timeline |
+| --------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------- |
+| M1        | Governada frontend launched with citizen-centric UX; score tiers live; SPO profiles at parity | Live platform demo, user metrics, DRep + SPO profiles live    | Month 3  |
+| M2        | Governance Wrapped shipped; notification system live; growth loops operational                | Wrapped demo, sharing metrics, return visit data              | Month 5  |
+| M3        | DRep Pro + SPO Pro launched; API v2 with 1+ integration partner                               | Revenue metrics, API docs, integration demo                   | Month 7  |
+| Final     | Full project report; open-source scoring engine; sustainability plan                          | Report published, GitHub repo, revenue/sustainability metrics | Month 8  |
 
 ### Budget Breakdown (Estimated — Adjust Based on ADA Price)
 
@@ -140,7 +140,7 @@ This proposal funds the **next phase** — transforming a robust governance inte
 
 ### Sustainability Plan
 
-Civica is designed for long-term sustainability beyond Catalyst funding:
+Governada is designed for long-term sustainability beyond Catalyst funding:
 
 - **DRep Pro + SPO Pro tiers** — Premium features for representatives ($15-25/mo in ADA)
 - **Governance Data API** — Paid API access for wallets, pool comparison tools, and researchers
@@ -150,7 +150,7 @@ Civica is designed for long-term sustainability beyond Catalyst funding:
 
 ### Why This Matters for Cardano
 
-CIP-1694 created a decentralized nation but gave its citizens no civic infrastructure. Without accountability tooling, delegation becomes random noise. Without governance visibility for SPOs, staking and governance remain disconnected. Civica turns Cardano's governance experiment into a transparent, participatory democracy — the civic infrastructure the Cardano Nation needs to prove to the world that on-chain governance can work at scale.
+CIP-1694 created a decentralized nation but gave its citizens no civic infrastructure. Without accountability tooling, delegation becomes random noise. Without governance visibility for SPOs, staking and governance remain disconnected. Governada turns Cardano's governance experiment into a transparent, participatory democracy — the civic infrastructure the Cardano Nation needs to prove to the world that on-chain governance can work at scale.
 
 ---
 
@@ -163,7 +163,7 @@ Based on Catalyst scoring criteria (impact, feasibility, value for money, resour
 - [ ] Clearly quantify how many users benefit
 - [ ] Show how this improves governance participation rates
 - [ ] Reference CIP-1694 and governance health metrics
-- [ ] Demonstrate ecosystem-wide benefit (not just DRepScore users)
+- [ ] Demonstrate ecosystem-wide benefit (not just Governada users)
 
 ### Feasibility
 
@@ -197,7 +197,7 @@ Concrete pre-submission roadmap with deadlines. Monitor Fund 16 timeline via @Ca
 - Join Catalyst Discord and Telegram (do not pitch — participate)
 - Attend 1+ Catalyst Town Hall (schedule: check docs.projectcatalyst.io)
 - Register on app.projectcatalyst.io as a proposer
-- Publish 1 Cardano Forum post using DRepScore data to educate on governance (not a pitch)
+- Publish 1 Cardano Forum post using Governada data to educate on governance (not a pitch)
 - Reach out to 10-15 active DReps for feedback and relationship building
 
 ### Phase 2: Social Proof — by April 30, 2026
@@ -223,7 +223,7 @@ Concrete pre-submission roadmap with deadlines. Monitor Fund 16 timeline via @Ca
 - Submit within first 48 hours of window opening
 - Announce on X/Twitter, Cardano subreddit, Catalyst channels
 - Respond to every community reviewer comment during review period
-- Direct existing DRepScore users to vote for the proposal
+- Direct existing Governada users to vote for the proposal
 
 ## Open Questions
 

--- a/docs/strategy/context/audit-rubric.md
+++ b/docs/strategy/context/audit-rubric.md
@@ -1,4 +1,4 @@
-# Civica Audit Rubric
+# Governada Audit Rubric
 
 > **Purpose:** Anchored scoring criteria for reproducible, comparable audits across sessions.
 > **Usage:** Read by `/audit` command. Each dimension has specific criteria and a 1-10 scale with defined anchors.
@@ -145,7 +145,7 @@ How much of the vision is realized at the quality bar the vision demands?
 Every audit must produce:
 
 ```markdown
-## Civica Audit — [DATE] — Scope: [full | step:N | area:NAME]
+## Governada Audit — [DATE] — Scope: [full | step:N | area:NAME]
 
 ### Scores
 

--- a/docs/strategy/context/build-manifest.md
+++ b/docs/strategy/context/build-manifest.md
@@ -64,7 +64,7 @@
 - [x] Admin dashboard | `app/admin/`
 - [x] Quick Match flow | `app/match/`
 - [x] Delegation ceremony | `DelegationCeremony.tsx`
-- verify: production site loads at https://drepscore.io
+- verify: production site loads at https://governada.io
 
 ## Step 4: Citizen Experience [FOUNDATIONS SHIPPED]
 

--- a/docs/strategy/context/competitive-landscape.md
+++ b/docs/strategy/context/competitive-landscape.md
@@ -151,4 +151,4 @@ When running `/audit`, agents should:
 2. Update "Last checked" dates
 3. Note any new features, design changes, or competitive moves
 4. Add insights to the "Key Competitive Insights" section
-5. Flag any competitor moves that threaten Civica's advantages
+5. Flag any competitor moves that threaten Governada's advantages

--- a/docs/strategy/context/persona-quick-ref.md
+++ b/docs/strategy/context/persona-quick-ref.md
@@ -52,7 +52,7 @@
 
 ## Integration Partner -- wallets, exchanges, pool tools (B2B)
 
-**Experience:** Governance intelligence via API + embeddable widgets. Every integration extends Civica's reach.
+**Experience:** Governance intelligence via API + embeddable widgets. Every integration extends Governada's reach.
 **Monetization:** API tiers ($50-200/mo). Custom widget integrations.
 **Priority:** Eternl -> Lace -> PoolTool -> Vespr -> CardanoScan -> ADApools -> Exchanges.
 **Key components:** Embed routes (`/embed/*`), `/api/v1/`
@@ -62,4 +62,4 @@
 
 ## Segment Fluidity
 
-Users span multiple personas. Civica treats segments as additive facets of one identity (via `user_wallets` + segment detection). A DRep sees citizen experience PLUS governance workspace. Nobody loses the citizen layer.
+Users span multiple personas. Governada treats segments as additive facets of one identity (via `user_wallets` + segment detection). A DRep sees citizen experience PLUS governance workspace. Nobody loses the citizen layer.

--- a/docs/strategy/monetization-strategy.md
+++ b/docs/strategy/monetization-strategy.md
@@ -1,16 +1,16 @@
-# Civica Monetization, Growth & Ecosystem Strategy
+# Governada Monetization, Growth & Ecosystem Strategy
 
 > **Status:** Foundational business model document. For the overarching product vision and build sequence, see **[ultimate-vision.md](ultimate-vision.md)** which is the definitive north star.
 > **Created:** February 2026
-> **Last updated:** March 2026 (Civica rebrand)
+> **Last updated:** March 2026 (Governada rebrand)
 
 ## 1. Your Biggest Moat (Defend These Relentlessly)
 
-**Historical Data Monopoly** — Every day Civica runs, you accumulate governance data no competitor can replicate. Score snapshots, alignment shifts, voting pattern evolution across DReps AND SPOs. This compounds daily and becomes exponentially harder to catch up to. _Action: Never stop collecting, even before monetizing._
+**Historical Data Monopoly** — Every day Governada runs, you accumulate governance data no competitor can replicate. Score snapshots, alignment shifts, voting pattern evolution across DReps AND SPOs. This compounds daily and becomes exponentially harder to catch up to. _Action: Never stop collecting, even before monetizing._
 
 **Representative Reputation Lock-in** — Once a DRep or SPO builds score history on the platform, their "governance credit score" lives here. Switching costs are enormous. Think credit bureaus — nobody competes with Equifax by starting fresh. _Action: Make score history a central feature representatives reference publicly._
 
-**Integration Network Effects** — Every wallet, exchange, or Cardano tool that integrates your scoring API makes you harder to displace. If Lace shows "Civica Score: 82" in their delegation UI, you've won. _Action: Prioritize API/embed strategy._
+**Integration Network Effects** — Every wallet, exchange, or Cardano tool that integrates your scoring API makes you harder to displace. If Lace shows "Governada Score: 82" in their delegation UI, you've won. _Action: Prioritize API/embed strategy._
 
 **Mission Alignment as Brand Moat** — You deliberately excluded voting power from scoring because it conflicted with decentralization values. That kind of principled design builds trust that mercenary competitors can't replicate. _Action: Be vocal about methodology choices and why._
 
@@ -65,9 +65,9 @@ This might be the biggest revenue stream long-term:
 **Priority: Build userbase, prove value, secure non-revenue funding**
 
 - Keep everything free. Acquisition is the game right now.
-- **Apply for Catalyst Fund 16 funding** — Civica is exactly what Catalyst funds. A civic governance hub? That's a slam dunk proposal. Target $75-150K in ADA.
+- **Apply for Catalyst Fund 16 funding** — Governada is exactly what Catalyst funds. A civic governance hub? That's a slam dunk proposal. Target $75-150K in ADA.
 - **Cardano Foundation partnership exploration** — They have grants and partnership programs for governance tooling.
-- **IOG outreach** — Civica directly supports their governance vision. Potential for sponsored development.
+- **IOG outreach** — Governada directly supports their governance vision. Potential for sponsored development.
 - Ship DRep + SPO "Claim Your Profile" flows — Start building representative engagement even before charging.
 - **Ecosystem project sponsorships** — Tasteful "Powered by" or "Supported by" from Cardano ecosystem projects who want visibility among governance participants. $200-500/mo per sponsor.
 
@@ -93,7 +93,7 @@ Apply the same accountability framework to Project Catalyst:
 - Funded project completion tracking (did they deliver?)
 - Fund allocation analytics and ROI tracking
 - Catalyst distributes **tens of millions in ADA per fund** — the need for accountability tooling is enormous
-- Shared infrastructure with Civica (scoring engine, AI, UI patterns)
+- Shared infrastructure with Governada (scoring engine, AI, UI patterns)
 - _Revenue: Same Pro/API model, plus Catalyst funding itself_
 
 ### Play 2: Midnight Privacy Tools
@@ -125,7 +125,7 @@ Assuming target of ~$10-12K/month:
 
 - Catalyst grant: $75-150K (spread over delivery milestones)
 - Build to 500+ monthly active citizens, 50+ DReps + SPOs claiming profiles
-- Ship Civica clean-sheet frontend (Phase A of vision)
+- Ship Governada clean-sheet frontend (Phase A of vision)
 
 **Phase 2 (Months 6-12): First Revenue — $2-5K/mo**
 
@@ -163,7 +163,7 @@ Assuming target of ~$10-12K/month:
 
 ## 8. Risks and Mitigations
 
-- **Cardano governance participation declines** — Mitigate by making governance more accessible and engaging (Civica literally solves this)
+- **Cardano governance participation declines** — Mitigate by making governance more accessible and engaging (Governada literally solves this)
 - **Free competitors** — Mitigate with data moat, integrations, and brand trust. Open-source the scoring methodology to commoditize what you're not selling.
 - **Catalyst funding rejection** — Mitigate by applying to multiple funds and having sponsor revenue as backup
 - **Representative willingness to pay** — Mitigate by proving value with free tier first, then converting. Start with the top 50 most active DReps + SPOs as design partners.

--- a/docs/strategy/personas/cc-member.md
+++ b/docs/strategy/personas/cc-member.md
@@ -21,14 +21,14 @@ CC members are citizens first. They hold ADA, they stake, they have personal gov
 
 ### Why This Persona Is Different
 
-With only 7-10 members, the CC is not a growth market. Civica will never have 50 paying CC Pro subscribers. The value of serving this persona flows in the opposite direction: **CC transparency is enormously valuable to every other persona.**
+With only 7-10 members, the CC is not a growth market. Governada will never have 50 paying CC Pro subscribers. The value of serving this persona flows in the opposite direction: **CC transparency is enormously valuable to every other persona.**
 
 - Citizens want to know: are the constitutional guardians acting in good faith?
 - DReps want to know: will the CC ratify the proposal I'm voting on?
 - SPOs want to know: how does the CC's constitutional interpretation affect protocol parameters?
 - Researchers want to know: how does the CC's voting pattern evolve over time?
 
-The CC persona is primarily an **accountability surface** -- a public transparency layer that serves the entire ecosystem. Secondarily, Civica can offer CC members lightweight governance tooling if they choose to use it.
+The CC persona is primarily an **accountability surface** -- a public transparency layer that serves the entire ecosystem. Secondarily, Governada can offer CC members lightweight governance tooling if they choose to use it.
 
 ---
 
@@ -60,9 +60,9 @@ The CC persona is primarily an **accountability surface** -- a public transparen
 
 ### Philosophy
 
-The CC member experience on Civica is **80% public accountability surface, 20% lightweight governance tooling.** The primary audience for CC features is not the CC members themselves -- it's everyone else who needs to understand and trust what the CC is doing.
+The CC member experience on Governada is **80% public accountability surface, 20% lightweight governance tooling.** The primary audience for CC features is not the CC members themselves -- it's everyone else who needs to understand and trust what the CC is doing.
 
-If CC members choose to use Civica for their governance workflow, the same vote-casting and rationale tools available to DReps and SPOs are available to them. But the product doesn't depend on CC member adoption to deliver value. The accountability surface works regardless, built from on-chain data.
+If CC members choose to use Governada for their governance workflow, the same vote-casting and rationale tools available to DReps and SPOs are available to them. But the product doesn't depend on CC member adoption to deliver value. The accountability surface works regardless, built from on-chain data.
 
 ### The Public Accountability Surface
 
@@ -93,7 +93,7 @@ The CC's relationship to the other governance bodies is a key intelligence surfa
 
 - **CC vs. DRep alignment:** On which proposals do they agree? Where do they diverge? When the CC rejects something DReps overwhelmingly supported, what was the constitutional reasoning?
 - **CC vs. SPO alignment:** Same analysis for the SPO governance body
-- **CC vs. Citizen sentiment:** How do CC decisions align with what Civica's citizen engagement layer reveals about community preferences?
+- **CC vs. Citizen sentiment:** How do CC decisions align with what Governada's citizen engagement layer reveals about community preferences?
 - **Constitutional friction points:** Proposals where the CC's constitutional interpretation diverged from community consensus -- these are the governance moments that matter most and deserve the most visibility
 
 #### Historical Record
@@ -107,14 +107,14 @@ Because CC members serve terms and rotate, the historical record is uniquely imp
 
 ### Lightweight Governance Tooling (Optional)
 
-If CC members choose to use Civica, they get the same core governance tools as DReps and SPOs:
+If CC members choose to use Governada, they get the same core governance tools as DReps and SPOs:
 
 - **Vote casting** via MeshJS (CIP-95) -- same integrated flow
 - **Rationale authoring** with CIP-100 compliance -- particularly valuable for CC because constitutional reasoning benefits from structured, well-documented rationales
 - **Proposal workspace** with the full analysis layer -- AI summary, treasury impact, citizen sentiment, inter-body context, plus constitutional alignment analysis tailored to CC concerns
 - **Constitutional reference:** Quick access to the ratified constitution with AI-assisted search for relevant provisions per proposal
 
-The incentive for CC members to use Civica: their rationales appear on their profile automatically, improving their Transparency Index score. If the tool makes constitutional reasoning easier to publish, CC members who use it will appear more transparent and accountable.
+The incentive for CC members to use Governada: their rationales appear on their profile automatically, improving their Transparency Index score. If the tool makes constitutional reasoning easier to publish, CC members who use it will appear more transparent and accountable.
 
 ### Citizen Engagement with CC
 
@@ -142,7 +142,7 @@ A composite accountability score for CC members, designed to be simple, fair, an
 ### Design Principles
 
 - The index measures process, not outcomes. A CC member who votes against community sentiment but provides thorough constitutional reasoning scores well. A CC member who votes with the crowd but never explains why scores poorly.
-- All components are derived from on-chain data and Civica's engagement layer. No subjective editorial judgment.
+- All components are derived from on-chain data and Governada's engagement layer. No subjective editorial judgment.
 - The methodology is published and transparent. CC members know exactly how they're being evaluated.
 
 ---
@@ -177,19 +177,19 @@ The value of CC transparency flows to other personas: citizens trust the system,
 
 ## Metrics That Matter
 
-| Metric                             | What It Measures                                           | Target                                                           |
-| ---------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
-| **CC page views**                  | Is the accountability surface valuable?                    | Consistent traffic, spikes around controversial decisions        |
-| **CC member profile views**        | Are people checking individual accountability?             | Each member's profile viewed regularly                           |
-| **CC rationale submission rate**   | If CC members use Civica, are they providing rationales?   | Higher rationale rate than through other tools                   |
-| **Citizen questions to CC**        | Is the engagement layer working?                           | Meaningful question volume on significant governance actions     |
-| **Inter-body analysis engagement** | Do DReps/SPOs use CC data for decision-making?             | CC alignment data referenced in DRep/SPO rationales              |
-| **Trust correlation**              | Does CC transparency affect citizen governance confidence? | Citizen engagement metrics correlate with CC transparency levels |
+| Metric                             | What It Measures                                            | Target                                                           |
+| ---------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| **CC page views**                  | Is the accountability surface valuable?                     | Consistent traffic, spikes around controversial decisions        |
+| **CC member profile views**        | Are people checking individual accountability?              | Each member's profile viewed regularly                           |
+| **CC rationale submission rate**   | If CC members use Governada, are they providing rationales? | Higher rationale rate than through other tools                   |
+| **Citizen questions to CC**        | Is the engagement layer working?                            | Meaningful question volume on significant governance actions     |
+| **Inter-body analysis engagement** | Do DReps/SPOs use CC data for decision-making?              | CC alignment data referenced in DRep/SPO rationales              |
+| **Trust correlation**              | Does CC transparency affect citizen governance confidence?  | Citizen engagement metrics correlate with CC transparency levels |
 
 ---
 
 ## The One-Line Vision
 
-**Civica makes the Constitutional Committee the most transparent governance body in any blockchain -- not by requiring their participation, but by building the accountability surface the ecosystem needs to trust them.**
+**Governada makes the Constitutional Committee the most transparent governance body in any blockchain -- not by requiring their participation, but by building the accountability surface the ecosystem needs to trust them.**
 
-The CC page isn't for the CC. It's for the 700 DReps, 3,000 SPOs, and millions of ADA holders who need to trust that their constitutional guardians are doing their job. If CC members choose to use Civica's governance tools, they become more transparent. If they don't, the on-chain record still speaks.
+The CC page isn't for the CC. It's for the 700 DReps, 3,000 SPOs, and millions of ADA holders who need to trust that their constitutional guardians are doing their job. If CC members choose to use Governada's governance tools, they become more transparent. If they don't, the on-chain record still speaks.

--- a/docs/strategy/personas/citizen.md
+++ b/docs/strategy/personas/citizen.md
@@ -1,6 +1,6 @@
 # Persona: The Cardano Citizen
 
-> **Status:** Active -- defines the anchor persona and primary acquisition target for Civica.
+> **Status:** Active -- defines the anchor persona and primary acquisition target for Governada.
 > **Created:** March 2026
 > **Companion to:** `docs/strategy/ultimate-vision.md`
 
@@ -8,7 +8,7 @@
 
 ## Who They Are
 
-The Cardano Citizen is anyone who holds ADA. Not governance experts, not DReps, not pool operators -- just people who own a stake in the Cardano network. They range from the ultra-passive investor who only cares about price to the moderately engaged holder who follows ecosystem news. They are 80%+ of Civica's potential userbase and the foundation the entire product is built on.
+The Cardano Citizen is anyone who holds ADA. Not governance experts, not DReps, not pool operators -- just people who own a stake in the Cardano network. They range from the ultra-passive investor who only cares about price to the moderately engaged holder who follows ecosystem news. They are 80%+ of Governada's potential userbase and the foundation the entire product is built on.
 
 Most Cardano Citizens today:
 
@@ -21,7 +21,7 @@ Most Cardano Citizens today:
 
 ### The Identity Shift
 
-The fundamental job of Civica is to transform the Citizen's self-perception from **"I own tokens"** to **"I'm a citizen of a digital nation."**
+The fundamental job of Governada is to transform the Citizen's self-perception from **"I own tokens"** to **"I'm a citizen of a digital nation."**
 
 This is not marketing language. Cardano has a ratified constitution, a treasury worth billions of ADA, elected representatives (DReps), three branches of governance, and a 5-day legislative cycle. It is structurally more democratic than most countries. Every ADA holder has governance rights whether they exercise them or not.
 
@@ -66,7 +66,7 @@ Progressive depth is available for the curious. Every summary has a path to more
 
 ### Pre-Connection: The Front Door
 
-Before connecting a wallet, Civica should feel like an invitation, not a dashboard. The anonymous experience has one job: convince the visitor that being an active Cardano citizen is easy, valuable, and risk-free.
+Before connecting a wallet, Governada should feel like an invitation, not a dashboard. The anonymous experience has one job: convince the visitor that being an active Cardano citizen is easy, valuable, and risk-free.
 
 **What they see:**
 
@@ -151,7 +151,7 @@ Structured mechanisms for citizens to participate beyond delegation. Every inter
 
 1. **Proposal Sentiment**
    - On every active proposal: "Do you support this? Yes / No / Not sure"
-   - Aggregate shown publicly: "72% of Civica citizens support this proposal"
+   - Aggregate shown publicly: "72% of Governada citizens support this proposal"
    - Divergence highlighted: "Citizens support this 80%, but DReps are voting 55% Yes"
    - Creates accountability signal and citizen voice without formal governance weight
 
@@ -310,8 +310,8 @@ The cadence is natural: Cardano epochs are ~5 days. Every epoch is a new briefin
 
 ## The One-Line Vision
 
-**Civica tells Cardano citizens what their ADA is doing in governance, so they don't have to follow it themselves.**
+**Governada tells Cardano citizens what their ADA is doing in governance, so they don't have to follow it themselves.**
 
 Not analytics. Not research. Not deep intelligence. Just: "Here's what happened. Here's what your representative did. Here's whether you should care. And here's how to make your voice heard if you want to."
 
-The deeper intelligence, DRep/SPO analytics, research tools, and power features serve the other personas and eventually monetize. But the thing that makes Civica a _hub_ for every Cardano citizen is the 30-second epoch check-in that nobody else provides, wrapped in a civic identity that grows over time and a community layer that gives every citizen a voice.
+The deeper intelligence, DRep/SPO analytics, research tools, and power features serve the other personas and eventually monetize. But the thing that makes Governada the go-to for every Cardano citizen is the 30-second epoch check-in that nobody else provides, wrapped in a civic identity that grows over time and a community layer that gives every citizen a voice.

--- a/docs/strategy/personas/drep.md
+++ b/docs/strategy/personas/drep.md
@@ -14,7 +14,7 @@ They range from highly professional governance participants treating it as a car
 
 **A DRep is a citizen first.** They hold ADA, they stake, they have their own governance values and delegation preferences (many delegate to themselves, some to other DReps). Everything in the Citizen experience applies to them -- the briefing, the civic identity, the treasury transparency, the engagement mechanisms. The DRep layer adds professional governance tooling on top of that foundation.
 
-The analogy is a politician who is also a citizen. They vote in elections, they pay taxes, they use public services. But they also have a professional workspace for doing the work of governance. Civica serves both roles in one product.
+The analogy is a politician who is also a citizen. They vote in elections, they pay taxes, they use public services. But they also have a professional workspace for doing the work of governance. Governada serves both roles in one product.
 
 ### Current Population
 
@@ -40,7 +40,7 @@ The analogy is a politician who is also a citizen. They vote in elections, they 
 ### What would delight them
 
 - Casting a vote and submitting a CIP-100 rationale in the same flow, in under 2 minutes
-- Opening Civica and seeing exactly what needs their attention, prioritized by urgency and impact
+- Opening Governada and seeing exactly what needs their attention, prioritized by urgency and impact
 - Watching their governance score improve as they participate more effectively
 - Getting a notification that says "15 new delegators this epoch -- here's why they chose you"
 - An AI that drafts their rationale from the proposal text + their voting history + their governance philosophy
@@ -51,7 +51,7 @@ The analogy is a politician who is also a citizen. They vote in elections, they 
 
 ### Philosophy
 
-The DRep experience is a **professional governance workspace** -- Civica is to DReps what VS Code is to developers. They open it, see what needs attention, do the work, track their performance, and communicate with constituents. The intelligence layer (AI analysis, citizen sentiment, treasury context) makes them better at governance without requiring extra effort.
+The DRep experience is a **professional governance workspace** -- Governada is to DReps what VS Code is to developers. They open it, see what needs attention, do the work, track their performance, and communicate with constituents. The intelligence layer (AI analysis, citizen sentiment, treasury context) makes them better at governance without requiring extra effort.
 
 The citizen experience runs underneath. The DRep layer adds to it; it never replaces it.
 
@@ -59,7 +59,7 @@ The citizen experience runs underneath. The DRep layer adds to it; it never repl
 
 #### Inbox / Action Queue (Primary Surface)
 
-When a DRep opens Civica, they see what needs their attention, prioritized:
+When a DRep opens Governada, they see what needs their attention, prioritized:
 
 - **Urgent votes:** Proposals expiring soon that they haven't voted on
 - **New proposals:** Recently submitted governance actions awaiting review
@@ -80,7 +80,7 @@ The DRep's primary work surface. Everything they need to make an informed vote a
 - AI-generated plain-English summary of the proposal
 - Treasury impact: amount requested, percentage of treasury, spending category
 - Similar past proposals and their outcomes (delivered, partial, failed)
-- Citizen sentiment from Civica's engagement layer: support %, concern flags, priority alignment
+- Citizen sentiment from Governada's engagement layer: support %, concern flags, priority alignment
 - Citizen questions: "31 citizens want to know your position on this"
 - Inter-body context: how SPOs and CC members are leaning
 - Constitutional alignment: AI analysis of whether the proposal conflicts with the ratified constitution
@@ -89,7 +89,7 @@ The DRep's primary work surface. Everything they need to make an informed vote a
 
 **Action layer:**
 
-- **Vote casting** directly from Civica. The DRep selects Yes / No / Abstain, the app constructs the governance transaction via MeshJS (CIP-95), the DRep signs with their governance wallet, and the vote is submitted on-chain.
+- **Vote casting** directly from Governada. The DRep selects Yes / No / Abstain, the app constructs the governance transaction via MeshJS (CIP-95), the DRep signs with their governance wallet, and the vote is submitted on-chain.
 - **Rationale authoring** integrated with the vote flow:
   - Rich-text editor for writing the rationale
   - AI-assisted drafting: generates a first draft from the proposal text, the DRep's voting history, and their stated governance philosophy
@@ -99,7 +99,7 @@ The DRep's primary work surface. Everything they need to make an informed vote a
   - The rationale automatically appears on the DRep's profile
 - **Information requests** to proposal authors: structured asks for clarification, aggregated with other DRep requests ("4 DReps requested clarification on milestones"), proposal authors respond publicly
 
-**Why this matters:** Today, voting and rationale submission are separate, tedious processes across multiple tools. Making them a single 2-minute flow inside the analysis workspace fundamentally changes DRep behavior. DReps who use Civica will provide more rationales, score higher, and attract more delegation. The tool makes them better at governance.
+**Why this matters:** Today, voting and rationale submission are separate, tedious processes across multiple tools. Making them a single 2-minute flow inside the analysis workspace fundamentally changes DRep behavior. DReps who use Governada will provide more rationales, score higher, and attract more delegation. The tool makes them better at governance.
 
 #### Reputation Dashboard
 
@@ -132,8 +132,8 @@ Structured governance communication -- not a blog, not a forum:
 **Vote explanations:**
 
 - Every vote + rationale is automatically visible to delegators on the DRep's profile
-- Civica surfaces these as "Your DRep voted Yes on Proposal X" in delegator briefings
-- The rationale IS the communication -- Civica just makes it visible where it matters
+- Governada surfaces these as "Your DRep voted Yes on Proposal X" in delegator briefings
+- The rationale IS the communication -- Governada just makes it visible where it matters
 
 **Position statements:**
 
@@ -180,7 +180,7 @@ The free tier gives DReps everything they need to govern effectively. Pro gives 
 
 Everything a DRep needs to do their job:
 
-- **Vote casting** from within Civica
+- **Vote casting** from within Governada
 - **Rationale authoring + submission** (editor, CIP-100 formatting, hosting, bundled submission)
 - **Proposal workspace** (full analysis: AI summary, treasury impact, citizen sentiment, similar proposals, constitutional alignment)
 - **Basic delegation stats** (total delegators, voting power, recent changes)
@@ -208,10 +208,10 @@ Tools for DReps who want to actively grow their reputation and delegation:
 
 The free tier is generous because DRep usage IS the product:
 
-- Every vote cast through Civica feeds the intelligence engine
+- Every vote cast through Governada feeds the intelligence engine
 - Every rationale submitted improves the citizen experience
-- Every DRep managing their profile through Civica creates better data
-- The more DReps use free Civica, the more valuable the platform is for everyone
+- Every DRep managing their profile through Governada creates better data
+- The more DReps use free Governada, the more valuable the platform is for everyone
 
 Pro monetizes the competitive layer. DReps who want to _win_ -- attract more delegation, climb rankings, outperform peers -- will pay for the edge. The free tier makes them effective. Pro makes them strategic.
 
@@ -231,22 +231,22 @@ Pro monetizes the competitive layer. DReps who want to _win_ -- attract more del
 
 ## The Rationale Revolution
 
-The single most impactful thing Civica can do for DRep governance quality is make rationale submission effortless. Today:
+The single most impactful thing Governada can do for DRep governance quality is make rationale submission effortless. Today:
 
 - CIP-100 rationale submission requires manual JSON creation, self-hosting, and anchor hash submission
 - Most DReps skip it because the friction is too high
 - Citizens have no idea why their DRep voted the way they did
 - Rationale quality is a major scoring factor, but the tooling punishes DReps for trying
 
-If Civica reduces rationale submission to "write (or edit an AI draft) and click submit," the effects cascade:
+If Governada reduces rationale submission to "write (or edit an AI draft) and click submit," the effects cascade:
 
 - More rationales exist on-chain (better for the entire ecosystem)
-- DReps who use Civica score higher (better for them)
+- DReps who use Governada score higher (better for them)
 - Citizens can see why their DRep voted a certain way (better citizen experience)
 - The AI gets more training data for governance analysis (better intelligence)
 - Governance transparency improves measurably (better for Cardano's reputation)
 
-This is the feature that could make Civica indispensable for DReps overnight. It solves a real pain point that no other tool addresses, and the benefits compound across every persona.
+This is the feature that could make Governada indispensable for DReps overnight. It solves a real pain point that no other tool addresses, and the benefits compound across every persona.
 
 ---
 
@@ -283,20 +283,20 @@ This is the feature that could make Civica indispensable for DReps overnight. It
 
 ## Metrics That Matter
 
-| Metric                                 | What It Measures                      | Target                                                   |
-| -------------------------------------- | ------------------------------------- | -------------------------------------------------------- |
-| **DReps using Civica for voting**      | Workspace adoption                    | >30% of active DReps within 6 months                     |
-| **Rationale submission rate**          | Did we solve the friction problem?    | 2x increase in rationale rate for Civica-using DReps     |
-| **Time from proposal to vote**         | Workspace efficiency                  | Measurable reduction vs. multi-tool workflow             |
-| **DRep Pro conversion**                | Monetization                          | 50-100 paying DReps at $15-25/mo                         |
-| **DRep Pro retention**                 | Is Pro actually valuable?             | >80% monthly retention                                   |
-| **Delegation growth for Civica DReps** | Does the platform help DReps succeed? | Civica-using DReps grow delegation faster than non-users |
-| **Citizen question response rate**     | Is the accountability loop working?   | >50% of aggregated questions get DRep responses          |
+| Metric                                    | What It Measures                      | Target                                                      |
+| ----------------------------------------- | ------------------------------------- | ----------------------------------------------------------- |
+| **DReps using Governada for voting**      | Workspace adoption                    | >30% of active DReps within 6 months                        |
+| **Rationale submission rate**             | Did we solve the friction problem?    | 2x increase in rationale rate for Governada-using DReps     |
+| **Time from proposal to vote**            | Workspace efficiency                  | Measurable reduction vs. multi-tool workflow                |
+| **DRep Pro conversion**                   | Monetization                          | 50-100 paying DReps at $15-25/mo                            |
+| **DRep Pro retention**                    | Is Pro actually valuable?             | >80% monthly retention                                      |
+| **Delegation growth for Governada DReps** | Does the platform help DReps succeed? | Governada-using DReps grow delegation faster than non-users |
+| **Citizen question response rate**        | Is the accountability loop working?   | >50% of aggregated questions get DRep responses             |
 
 ---
 
 ## The One-Line Vision
 
-**Civica is where DReps do governance -- review proposals, cast votes, explain their reasoning, and build their reputation, all in one place.**
+**Governada is where DReps do governance -- review proposals, cast votes, explain their reasoning, and build their reputation, all in one place.**
 
 The intelligence layer makes them better at governance. The citizen engagement layer keeps them accountable. The reputation system rewards quality participation. And underneath it all, they're citizens too -- receiving the same briefing, building the same civic identity, participating in the same community as the people they represent.

--- a/docs/strategy/personas/integration-partner.md
+++ b/docs/strategy/personas/integration-partner.md
@@ -8,7 +8,7 @@
 
 ## Who They Are
 
-Integration Partners are the businesses, platforms, and projects that serve Cardano users and need governance intelligence they don't want to build themselves. They embed Civica's data, scores, and experiences into their own products -- extending Civica's reach to users who may never visit the site directly.
+Integration Partners are the businesses, platforms, and projects that serve Cardano users and need governance intelligence they don't want to build themselves. They embed Governada's data, scores, and experiences into their own products -- extending Governada's reach to users who may never visit the site directly.
 
 ### Partner Types
 
@@ -17,17 +17,17 @@ Integration Partners are the businesses, platforms, and projects that serve Card
 - The highest-value integration target. Wallets are where delegation actually happens.
 - Need: DRep scores, matching API, SPO governance scores, delegation health indicators, embeddable Quick Match widget.
 - What they don't want to build: scoring engines, alignment models, matching algorithms, proposal intelligence.
-- Impact: Every wallet embedding Civica's intelligence is distribution to every wallet user.
+- Impact: Every wallet embedding Governada's intelligence is distribution to every wallet user.
 
 **Crypto Exchanges** (Binance, Coinbase, Kraken)
 
 - Custody billions in ADA. Face growing pressure (regulatory and competitive) to participate in governance on behalf of users or enable user participation.
 - Need: governance data for informed delegation decisions, DRep/SPO scoring for user-facing displays, governance health dashboards for compliance reporting.
-- Emerging use case: "Your ADA on Coinbase is delegated to DRep X, who scored 85 on Civica" -- making custodied governance transparent.
+- Emerging use case: "Your ADA on Coinbase is delegated to DRep X, who scored 85 on Governada" -- making custodied governance transparent.
 
 **Stake Pool Comparison Tools** (PoolTool, ADApools)
 
-- Deep infrastructure metrics but zero governance data. Civica's SPO governance scores are a completely new dimension for pool comparison.
+- Deep infrastructure metrics but zero governance data. Governada's SPO governance scores are a completely new dimension for pool comparison.
 - Need: SPO governance scores, alignment data, governance participation rates.
 - Low-friction integration: adding a "Governance Score" column to existing pool listings.
 
@@ -39,14 +39,14 @@ Integration Partners are the businesses, platforms, and projects that serve Card
 
 **Block Explorers** (CardanoScan, Cexplorer)
 
-- Show raw governance transactions but no intelligence. A vote is data; Civica makes it meaning.
+- Show raw governance transactions but no intelligence. A vote is data; Governada makes it meaning.
 - Need: DRep profiles, scores, and analysis to embed alongside existing governance data views.
 
 **Governance Tools** (GovTool, Summon)
 
 - Handle voting mechanics but lack the intelligence layer.
 - Need: proposal analysis, DRep context, citizen sentiment, constitutional alignment analysis.
-- Partially competitive (Civica builds its own vote-casting flow), but the intelligence layer is complementary.
+- Partially competitive (Governada builds its own vote-casting flow), but the intelligence layer is complementary.
 
 **Institutional Delegators and Funds**
 
@@ -77,7 +77,7 @@ Integration Partners are the businesses, platforms, and projects that serve Card
 
 ### 1. Distribution Without Acquisition Cost
 
-Every wallet embedding Civica's DRep score is marketing to every wallet user. Every pool tool showing governance scores introduces governance reputation to staking delegators. Every exchange displaying governance health makes custodied ADA holders aware of governance. Civica doesn't need to acquire those users -- the partners already have them.
+Every wallet embedding Governada's DRep score is marketing to every wallet user. Every pool tool showing governance scores introduces governance reputation to staking delegators. Every exchange displaying governance health makes custodied ADA holders aware of governance. Governada doesn't need to acquire those users -- the partners already have them.
 
 This is potentially the most efficient growth channel in the entire product strategy.
 
@@ -85,9 +85,9 @@ This is potentially the most efficient growth channel in the entire product stra
 
 Integrations create feedback loops:
 
-- A wallet using Civica's matching API generates delegation data (which recommendations led to delegations)
+- A wallet using Governada's matching API generates delegation data (which recommendations led to delegations)
 - An exchange providing governance reporting validates data quality at institutional scale
-- Pool tools linking to Civica profiles drive traffic that generates engagement data
+- Pool tools linking to Governada profiles drive traffic that generates engagement data
 - More integrations produce more data, which improves the intelligence, which makes integrations more valuable
 
 ### 3. Revenue at Scale
@@ -96,7 +96,7 @@ Individual consumers pay $15-25/mo. Integration partners pay $50-200/mo for API 
 
 ### 4. Ecosystem Lock-In
 
-When a wallet's delegation picker depends on Civica's scoring API, switching costs are high. When a pool tool displays Civica's governance scores, removing them means removing a feature their users value. Each integration deepens Civica's position as infrastructure.
+When a wallet's delegation picker depends on Governada's scoring API, switching costs are high. When a pool tool displays Governada's governance scores, removing them means removing a feature their users value. Each integration deepens Governada's position as infrastructure.
 
 ---
 
@@ -124,11 +124,11 @@ Partners pull governance intelligence via REST API. Lowest integration effort, b
 | Pro        | 100,000 req/day | $200/mo | Production integrations, exchanges     |
 | Enterprise | Custom          | Custom  | Institutional, high-volume, SLA-backed |
 
-**Requirements:** API key registration. "Powered by Civica" attribution encouraged but not required at this tier.
+**Requirements:** API key registration. "Powered by Governada" attribution encouraged but not required at this tier.
 
 ### Tier 2: Widget Embedders (UI Components)
 
-Partners embed pre-built Civica UI components directly in their products. Moderate integration effort, higher value.
+Partners embed pre-built Governada UI components directly in their products. Moderate integration effort, higher value.
 
 **Available widgets:**
 
@@ -142,7 +142,7 @@ Partners embed pre-built Civica UI components directly in their products. Modera
 
 **Pricing:** Premium tier pricing or revenue share model. Negotiated per partner.
 
-**Requirements:** "Powered by Civica" attribution required. Links back to full profiles on Civica.
+**Requirements:** "Powered by Governada" attribution required. Links back to full profiles on Governada.
 
 ### Tier 3: Deep Integrations (Strategic Partnerships)
 
@@ -150,42 +150,42 @@ Custom, co-developed experiences for high-value partners. Highest integration ef
 
 **Examples:**
 
-- Eternl embeds Civica's full delegation flow: quiz, match, compare, delegate -- all inside the wallet
-- Coinbase integrates governance reporting: custodied ADA governance transparency powered by Civica
-- PoolTool co-brands governance metrics: "Governance data by Civica" as a first-class section in pool profiles
+- Eternl embeds Governada's full delegation flow: quiz, match, compare, delegate -- all inside the wallet
+- Coinbase integrates governance reporting: custodied ADA governance transparency powered by Governada
+- PoolTool co-brands governance metrics: "Governance data by Governada" as a first-class section in pool profiles
 
-**What Civica provides:**
+**What Governada provides:**
 
 - Custom data feeds optimized for the partner's use case
 - Co-branded UI components
-- Shared user flows (e.g., wallet connect -> Civica quiz -> delegation -> back to wallet)
+- Shared user flows (e.g., wallet connect -> Governada quiz -> delegation -> back to wallet)
 - Dedicated integration support and developer relations
 - Custom pricing, potentially including revenue share
 
 **What partners provide:**
 
 - Distribution to their user base
-- Data feedback (anonymized usage data that improves Civica's intelligence)
+- Data feedback (anonymized usage data that improves Governada's intelligence)
 - Brand amplification and co-marketing
-- Real-world validation of Civica's data quality at scale
+- Real-world validation of Governada's data quality at scale
 
 ---
 
-## The "Powered by Civica" Brand Strategy
+## The "Powered by Governada" Brand Strategy
 
 Every integration is a brand touchpoint. The strategy:
 
-- **API consumers:** Attribution encouraged. "Governance data from Civica" link in footnotes or tooltips.
-- **Widget embedders:** Attribution required. "Powered by Civica" with link. The widget itself is a brand impression.
-- **Deep integrations:** Co-branding negotiated per partnership. "Governance intelligence by Civica" or equivalent.
+- **API consumers:** Attribution encouraged. "Governance data from Governada" link in footnotes or tooltips.
+- **Widget embedders:** Attribution required. "Powered by Governada" with link. The widget itself is a brand impression.
+- **Deep integrations:** Co-branding negotiated per partnership. "Governance intelligence by Governada" or equivalent.
 
 **The flywheel:** More integrations -> more brand recognition -> more direct users -> more data -> better intelligence -> more integration value -> more integrations.
 
-**The end state:** "Civica" becomes synonymous with Cardano governance intelligence the way "Powered by Google" became synonymous with search or "Charts by TradingView" became synonymous with financial data. Not everyone visits Civica directly, but everyone encounters Civica's intelligence through the products they already use.
+**The end state:** "Governada" becomes synonymous with Cardano governance intelligence the way "Powered by Google" became synonymous with search or "Charts by TradingView" became synonymous with financial data. Not everyone visits Governada directly, but everyone encounters Governada's intelligence through the products they already use.
 
 ---
 
-## What Partners Need From Civica
+## What Partners Need From Governada
 
 ### Technical Requirements
 
@@ -199,20 +199,20 @@ Every integration is a brand touchpoint. The strategy:
 
 - **Developer relations:** Dedicated support for integration partners. Not a support ticket queue -- a relationship.
 - **Attribution guidelines:** Clear branding specs that work across partner UIs. Logo assets, placement guidelines, color variations.
-- **Usage analytics:** Partners want to know how their users interact with Civica's data. Aggregate metrics, not individual tracking.
-- **Roadmap visibility:** Partners building on Civica's API need confidence that the data they depend on will continue to exist and improve.
+- **Usage analytics:** Partners want to know how their users interact with Governada's data. Aggregate metrics, not individual tracking.
+- **Roadmap visibility:** Partners building on Governada's API need confidence that the data they depend on will continue to exist and improve.
 
 ---
 
 ## How Integration Partners Connect to Other Personas
 
-| Persona            | How Partners Serve Them                                                                                                                                                                                                                                                                                                                          |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Citizens**       | Every integration ultimately serves citizens. A wallet embedding Quick Match means more citizens find aligned DReps. A pool tool showing governance scores means governance-informed staking decisions. An exchange displaying governance health means custodied holders see governance. Partners are Civica's distribution channel to citizens. |
-| **DReps**          | Wallet integrations surface DRep scores and profiles to potential delegators inside the tools where delegation happens. This drives delegation to high-scoring DReps.                                                                                                                                                                            |
-| **SPOs**           | Pool comparison tools embedding governance scores create market pressure for SPO governance participation. SPOs who participate are visible; those who don't are invisible on a new competitive dimension.                                                                                                                                       |
-| **Treasury Teams** | Explorer integrations that show Civica's proposal intelligence and project tracking extend treasury transparency beyond Civica's direct user base.                                                                                                                                                                                               |
-| **Researchers**    | Researchers and integration partners share the API surface. Researcher needs drive API depth; partner needs drive API reliability. Both benefit from the same infrastructure investment.                                                                                                                                                         |
+| Persona            | How Partners Serve Them                                                                                                                                                                                                                                                                                                                             |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Citizens**       | Every integration ultimately serves citizens. A wallet embedding Quick Match means more citizens find aligned DReps. A pool tool showing governance scores means governance-informed staking decisions. An exchange displaying governance health means custodied holders see governance. Partners are Governada's distribution channel to citizens. |
+| **DReps**          | Wallet integrations surface DRep scores and profiles to potential delegators inside the tools where delegation happens. This drives delegation to high-scoring DReps.                                                                                                                                                                               |
+| **SPOs**           | Pool comparison tools embedding governance scores create market pressure for SPO governance participation. SPOs who participate are visible; those who don't are invisible on a new competitive dimension.                                                                                                                                          |
+| **Treasury Teams** | Explorer integrations that show Governada's proposal intelligence and project tracking extend treasury transparency beyond Governada's direct user base.                                                                                                                                                                                            |
+| **Researchers**    | Researchers and integration partners share the API surface. Researcher needs drive API depth; partner needs drive API reliability. Both benefit from the same infrastructure investment.                                                                                                                                                            |
 
 ---
 
@@ -231,20 +231,20 @@ Every integration is a brand touchpoint. The strategy:
 
 ## Metrics That Matter
 
-| Metric                                   | What It Measures           | Target                                                            |
-| ---------------------------------------- | -------------------------- | ----------------------------------------------------------------- |
-| **Active API keys**                      | Developer adoption         | 20+ registered, 5-10 active integrations                          |
-| **API request volume**                   | Usage depth                | Growing monthly request volume                                    |
-| **Paid API subscriptions**               | Monetization               | $1,500-4,000/mo from 5-10 partners                                |
-| **Widget deployments**                   | Embedded distribution      | Quick Match or score cards in 3+ wallets/tools                    |
-| **Delegations via partner integrations** | Distribution effectiveness | Measurable delegation flow from embedded Quick Match              |
-| **"Powered by Civica" impressions**      | Brand reach                | Civica attribution visible to 100K+ monthly users across partners |
-| **Partner retention**                    | Integration stickiness     | >90% annual retention of paying partners                          |
+| Metric                                   | What It Measures           | Target                                                               |
+| ---------------------------------------- | -------------------------- | -------------------------------------------------------------------- |
+| **Active API keys**                      | Developer adoption         | 20+ registered, 5-10 active integrations                             |
+| **API request volume**                   | Usage depth                | Growing monthly request volume                                       |
+| **Paid API subscriptions**               | Monetization               | $1,500-4,000/mo from 5-10 partners                                   |
+| **Widget deployments**                   | Embedded distribution      | Quick Match or score cards in 3+ wallets/tools                       |
+| **Delegations via partner integrations** | Distribution effectiveness | Measurable delegation flow from embedded Quick Match                 |
+| **"Powered by Governada" impressions**   | Brand reach                | Governada attribution visible to 100K+ monthly users across partners |
+| **Partner retention**                    | Integration stickiness     | >90% annual retention of paying partners                             |
 
 ---
 
 ## The One-Line Vision
 
-**Civica becomes the governance intelligence engine underneath every Cardano product -- wallets, exchanges, explorers, and pool tools all surface Civica's data because building it themselves would take years and never catch up.**
+**Governada becomes the governance intelligence engine underneath every Cardano product -- wallets, exchanges, explorers, and pool tools all surface Governada's data because building it themselves would take years and never catch up.**
 
-Not every Cardano user will visit Civica. But every Cardano user will encounter Civica's intelligence through the products they already use. The API and widget ecosystem turns Civica from a destination into infrastructure -- the canonical source of governance truth for the entire ecosystem.
+Not every Cardano user will visit Governada. But every Cardano user will encounter Governada's intelligence through the products they already use. The API and widget ecosystem turns Governada from a destination into infrastructure -- the canonical source of governance truth for the entire ecosystem.

--- a/docs/strategy/personas/researcher.md
+++ b/docs/strategy/personas/researcher.md
@@ -19,9 +19,9 @@ They span several sub-segments:
 
 ### What Makes This Persona Different
 
-Researchers are the only persona that doesn't directly interact with the governance system through Civica. They don't vote, delegate, submit proposals, or manage reputation. They observe, analyze, and publish. Their relationship with the platform is extractive in the best sense: they take data out and return credibility and insight.
+Researchers are the only persona that doesn't directly interact with the governance system through Governada. They don't vote, delegate, submit proposals, or manage reputation. They observe, analyze, and publish. Their relationship with the platform is extractive in the best sense: they take data out and return credibility and insight.
 
-When an academic paper cites Civica's DRep scoring methodology or a governance report uses Civica's historical alignment data, it legitimizes the entire platform. That credibility flows to every other persona -- citizens trust the scores because researchers validated them, DReps respect the methodology because it withstands academic scrutiny.
+When an academic paper cites Governada's DRep scoring methodology or a governance report uses Governada's historical alignment data, it legitimizes the entire platform. That credibility flows to every other persona -- citizens trust the scores because researchers validated them, DReps respect the methodology because it withstands academic scrutiny.
 
 ---
 
@@ -88,7 +88,7 @@ The consumer surfaces (DRep profiles, proposal pages, Pulse) serve as visual ref
 
 ### API Surface
 
-The research API exposes the full depth of Civica's intelligence engine:
+The research API exposes the full depth of Governada's intelligence engine:
 
 **Entity data:**
 
@@ -158,7 +158,7 @@ Researchers generate intelligence that flows back to other personas:
 - Cross-chain governance comparisons (using EDI data) attract attention from outside Cardano
 - Identified anomalies or governance risks surface as intelligence for the platform
 
-Civica can amplify this: feature notable research on the Pulse page, cite academic papers in methodology documentation, reference published findings in AI-generated narratives.
+Governada can amplify this: feature notable research on the Pulse page, cite academic papers in methodology documentation, reference published findings in AI-generated narratives.
 
 ---
 
@@ -181,7 +181,7 @@ Civica can amplify this: feature notable research on the Pulse page, cite academ
 | ------------------------------- | --------------------------- | ------------------------------------------------------------ |
 | **API registrations**           | Interest in governance data | Growing developer/researcher signups                         |
 | **Paid research subscriptions** | Monetization                | 5-10 paying subscribers at $50-200/mo                        |
-| **Academic citations**          | Credibility impact          | Civica data cited in governance research papers              |
+| **Academic citations**          | Credibility impact          | Governada data cited in governance research papers           |
 | **API usage patterns**          | What data is valuable?      | Identifies which datasets to expand or prioritize            |
 | **Export downloads**            | Bulk data demand            | Steady usage of export endpoints                             |
 | **Research feedback**           | Methodology improvement     | Researcher reports that lead to scoring or data improvements |
@@ -190,6 +190,6 @@ Civica can amplify this: feature notable research on the Pulse page, cite academ
 
 ## The One-Line Vision
 
-**Civica provides the most comprehensive, well-documented governance dataset in blockchain -- the canonical source for anyone studying how decentralized governance works.**
+**Governada provides the most comprehensive, well-documented governance dataset in blockchain -- the canonical source for anyone studying how decentralized governance works.**
 
-Researchers don't need a pretty interface. They need deep data, transparent methodology, and reliable access. Every paper published using Civica's data validates the platform for every other persona. The data moat that compounds daily is the same moat that makes this dataset irreplaceable for research.
+Researchers don't need a pretty interface. They need deep data, transparent methodology, and reliable access. Every paper published using Governada's data validates the platform for every other persona. The data moat that compounds daily is the same moat that makes this dataset irreplaceable for research.

--- a/docs/strategy/personas/spo.md
+++ b/docs/strategy/personas/spo.md
@@ -57,9 +57,9 @@ Competition for delegation is fierce. Most pools look identical on existing tool
 
 ### Philosophy
 
-Civica helps SPOs build a **complete identity that makes delegators choose them.** Governance participation is the differentiating layer -- the new competitive dimension that no pool comparison tool touches. But the identity extends beyond governance into who they are, what they stand for, and how they communicate with their community.
+Governada helps SPOs build a **complete identity that makes delegators choose them.** Governance participation is the differentiating layer -- the new competitive dimension that no pool comparison tool touches. But the identity extends beyond governance into who they are, what they stand for, and how they communicate with their community.
 
-**Civica is NOT a second PoolTool.** It does not monitor infrastructure, track block production, calculate ROI projections, or manage pool configuration. PoolTool handles operations. Civica handles identity, reputation, governance, communication, and growth.
+**Governada is NOT a second PoolTool.** It does not monitor infrastructure, track block production, calculate ROI projections, or manage pool configuration. PoolTool handles operations. Governada handles identity, reputation, governance, communication, and growth.
 
 The citizen experience runs underneath. The SPO layer adds professional governance tooling, pool identity management, and delegator relations.
 
@@ -71,7 +71,7 @@ Like DReps, SPOs see what needs their governance attention:
 
 - **Proposals requiring SPO votes:** Not all proposals involve SPOs. The inbox filters to governance actions where SPO votes carry weight (protocol parameters, hard forks), while surfacing other proposals for optional participation.
 - **Urgency indicators:** What's expiring soon, what's new, what they've already voted on.
-- **Citizen context:** How their staking delegators feel about active proposals (from Civica's citizen engagement layer).
+- **Citizen context:** How their staking delegators feel about active proposals (from Governada's citizen engagement layer).
 
 **Design principle:** Governance should feel like a 10-minute weekly task, not a second job. The inbox makes that possible by surfacing exactly what matters and nothing else.
 
@@ -79,11 +79,11 @@ Like DReps, SPOs see what needs their governance attention:
 
 The same integrated flow as DReps, adapted for SPOs:
 
-- **Vote casting** directly from Civica via MeshJS (CIP-95). SPOs connect their pool governance key, review the proposal workspace, and vote.
+- **Vote casting** directly from Governada via MeshJS (CIP-95). SPOs connect their pool governance key, review the proposal workspace, and vote.
 - **Rationale authoring** with AI assistance. Even more valuable for SPOs than DReps because SPO governance rationales are extremely rare today. The friction of CIP-100 compliance is too high when governance is your secondary function.
-- **Governance statement** setup: A guided, one-time flow for SPOs to publish their governance philosophy. "Tell your delegators what you stand for in governance." Very few SPOs have one because the tooling doesn't exist. Civica makes it a 5-minute setup.
+- **Governance statement** setup: A guided, one-time flow for SPOs to publish their governance philosophy. "Tell your delegators what you stand for in governance." Very few SPOs have one because the tooling doesn't exist. Governada makes it a 5-minute setup.
 
-**Why this matters for SPOs specifically:** SPO governance participation rates are lower than DRep participation because governance feels like an extra burden on top of infrastructure work. If Civica reduces the entire governance workflow to 10 minutes per epoch, participation rates rise. Every SPO who starts voting through Civica improves Cardano's overall governance health.
+**Why this matters for SPOs specifically:** SPO governance participation rates are lower than DRep participation because governance feels like an extra burden on top of infrastructure work. If Governada reduces the entire governance workflow to 10 minutes per epoch, participation rates rise. Every SPO who starts voting through Governada improves Cardano's overall governance health.
 
 #### Proposal Workspace
 
@@ -93,13 +93,13 @@ The same analysis environment as DReps, with SPO-relevant context:
 - Treasury impact analysis
 - SPO-specific relevance: does this proposal affect protocol parameters, staking mechanics, or pool operations?
 - Inter-body context: how are DReps and CC voting on this?
-- Citizen sentiment from Civica's engagement layer
+- Citizen sentiment from Governada's engagement layer
 - Constitutional alignment analysis
 - Vote + rationale submission integrated at the bottom
 
 ### Pool Identity (The Rich Profile)
 
-This is where Civica goes beyond governance into the broader SPO identity. The pool profile on Civica should be the richest SPO presence on the internet -- the page SPOs share everywhere as their home page.
+This is where Governada goes beyond governance into the broader SPO identity. The pool profile on Governada should be the richest SPO presence on the internet -- the page SPOs share everywhere as their home page.
 
 #### Who They Are
 
@@ -130,13 +130,13 @@ This is where Civica goes beyond governance into the broader SPO identity. The p
 - Domain-specific trust: "Endorsed for governance" / "Endorsed for community contribution"
 - Delegation trend: growing, stable, or declining
 
-**The positioning:** PoolTool answers "is this pool technically reliable?" Civica answers "who are these people and do they share my values?"
+**The positioning:** PoolTool answers "is this pool technically reliable?" Governada answers "who are these people and do they share my values?"
 
 ### Delegator Communication Hub
 
 SPOs currently have no native way to reach their staking delegators. If they need to announce maintenance, share a governance vote, or engage their community, they post on Twitter and hope someone sees it.
 
-Civica solves this because citizens are already checking in every epoch:
+Governada solves this because citizens are already checking in every epoch:
 
 #### Pool Updates
 
@@ -159,13 +159,13 @@ Civica solves this because citizens are already checking in every epoch:
 
 ### Delegation Growth Intelligence
 
-This is where Civica directly addresses the SPO's #1 need: growing their pool.
+This is where Governada directly addresses the SPO's #1 need: growing their pool.
 
 #### The Governance-Growth Connection
 
 - Empirical data: "Pools that participate in governance attract X% more delegation than pools that don't"
 - Personal insight: "Your pool is ranked 145th by delegation but 23rd by governance score -- your governance reputation is an underutilized growth lever"
-- Retention data: "Delegators who found your pool through Civica's governance-based discovery retained at 2x the rate"
+- Retention data: "Delegators who found your pool through Governada's governance-based discovery retained at 2x the rate"
 
 #### Competitive Position
 
@@ -192,8 +192,8 @@ This is where Civica directly addresses the SPO's #1 need: growing their pool.
 
 The self-reinforcing loop that benefits SPOs, citizens, and Cardano governance:
 
-1. SPO participates in governance (votes through Civica)
-2. They score higher on Civica's SPO governance score
+1. SPO participates in governance (votes through Governada)
+2. They score higher on Governada's SPO governance score
 3. They rank better in governance-based pool discovery
 4. Governance-conscious delegators find and stake with them
 5. Their delegation grows
@@ -205,7 +205,7 @@ The self-reinforcing loop that benefits SPOs, citizens, and Cardano governance:
 11. More citizens choose pools through governance-based discovery
 12. Return to step 4
 
-Civica doesn't just serve SPOs -- it creates market pressure for governance participation across the entire SPO ecosystem.
+Governada doesn't just serve SPOs -- it creates market pressure for governance participation across the entire SPO ecosystem.
 
 ---
 
@@ -215,7 +215,7 @@ Civica doesn't just serve SPOs -- it creates market pressure for governance part
 
 Everything an SPO needs to participate in governance and establish their identity:
 
-- **Vote casting** from within Civica
+- **Vote casting** from within Governada
 - **Rationale submission** (editor, CIP-100 formatting, hosting, bundled submission)
 - **Governance statement** setup (guided flow, one-time)
 - **Proposal workspace** (full analysis for proposals relevant to SPOs)
@@ -243,9 +243,9 @@ Tools for SPOs who want to actively grow their delegation and build their brand:
 
 The free tier is generous because SPO adoption drives the flywheel:
 
-- Every SPO voting through Civica generates governance data that enriches the intelligence engine
+- Every SPO voting through Governada generates governance data that enriches the intelligence engine
 - Every governance statement published improves citizen pool discovery
-- Every pool profile created makes Civica's SPO discovery more comprehensive
+- Every pool profile created makes Governada's SPO discovery more comprehensive
 - The more SPOs participate, the more valuable governance-based pool discovery becomes for citizens
 
 Pro monetizes the growth and competitive layer. SPOs who want to actively grow their delegation -- attract more stakers, outperform peers, build their brand -- will pay for the edge. The free tier makes them governance-active. Pro makes them strategically competitive.
@@ -254,13 +254,13 @@ Pro monetizes the growth and competitive layer. SPOs who want to actively grow t
 
 ## The Staking-Governance Bridge
 
-SPOs occupy a unique position in the Civica ecosystem: they're the bridge between the familiar world of staking and the unfamiliar world of governance.
+SPOs occupy a unique position in the Governada ecosystem: they're the bridge between the familiar world of staking and the unfamiliar world of governance.
 
-**For citizens:** SPO discovery is the comfortable entry point. "Find a stake pool" is something ADA holders already understand. Civica's twist -- "find a pool that represents your values in governance" -- reframes staking from a purely financial decision to a civic one. The SPO relationship becomes the gateway to governance engagement.
+**For citizens:** SPO discovery is the comfortable entry point. "Find a stake pool" is something ADA holders already understand. Governada's twist -- "find a pool that represents your values in governance" -- reframes staking from a purely financial decision to a civic one. The SPO relationship becomes the gateway to governance engagement.
 
 **For the ecosystem:** SPOs who communicate governance through their delegator channel become an organic onboarding funnel for DRep delegation. A staking delegator who sees their pool operator's governance updates thinks: "I should probably delegate my governance too." The SPO-citizen relationship seeds governance participation across the network.
 
-**For Cardano's governance health:** SPO governance participation strengthens the inter-body balance. When SPOs vote actively, the three-body governance system (DReps + SPOs + CC) functions as designed. Civica's incentive to drive SPO participation through discovery and growth tools directly serves Cardano's constitutional design.
+**For Cardano's governance health:** SPO governance participation strengthens the inter-body balance. When SPOs vote actively, the three-body governance system (DReps + SPOs + CC) functions as designed. Governada's incentive to drive SPO participation through discovery and growth tools directly serves Cardano's constitutional design.
 
 ---
 
@@ -278,7 +278,7 @@ SPOs occupy a unique position in the Civica ecosystem: they're the bridge betwee
 
 ## Scope Boundaries
 
-**In scope (Civica's SPO offering):**
+**In scope (Governada's SPO offering):**
 
 - Governance participation (voting, rationales, governance statements)
 - Pool identity and reputation (profile, story, governance values)
@@ -295,27 +295,27 @@ SPOs occupy a unique position in the Civica ecosystem: they're the bridge betwee
 - Node setup and maintenance guides
 - Detailed financial analytics beyond basic delegation metrics
 
-**The line:** Civica helps SPOs with identity, reputation, governance, communication, and growth. Not with operations. SPOs use PoolTool for infrastructure monitoring and Civica for everything people-facing.
+**The line:** Governada helps SPOs with identity, reputation, governance, communication, and growth. Not with operations. SPOs use PoolTool for infrastructure monitoring and Governada for everything people-facing.
 
 ---
 
 ## Metrics That Matter
 
-| Metric                                     | What It Measures                 | Target                                                                           |
-| ------------------------------------------ | -------------------------------- | -------------------------------------------------------------------------------- |
-| **SPOs voting through Civica**             | Governance workspace adoption    | >15% of governance-active SPOs within 6 months                                   |
-| **SPO governance participation rate**      | Is Civica driving participation? | Measurable increase in overall SPO vote rates                                    |
-| **Governance statements published**        | Identity adoption                | >200 SPOs with published governance statements                                   |
-| **Pool profiles created**                  | Platform as home page            | >500 SPOs with complete Civica profiles                                          |
-| **SPO Pro conversion**                     | Monetization                     | 50-100 paying SPOs at $15-25/mo                                                  |
-| **Delegator-SPO communication engagement** | Is the channel valuable?         | >40% of staking delegators view their SPO's updates                              |
-| **Governance-based discovery conversions** | Is the differentiator working?   | Measurable delegation flow from Civica discovery to pools                        |
-| **Staking delegator -> DRep delegation**   | Is the bridge working?           | SPO delegators who also delegate to a DRep at higher rates than non-Civica users |
+| Metric                                     | What It Measures                    | Target                                                                              |
+| ------------------------------------------ | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| **SPOs voting through Governada**          | Governance workspace adoption       | >15% of governance-active SPOs within 6 months                                      |
+| **SPO governance participation rate**      | Is Governada driving participation? | Measurable increase in overall SPO vote rates                                       |
+| **Governance statements published**        | Identity adoption                   | >200 SPOs with published governance statements                                      |
+| **Pool profiles created**                  | Platform as home page               | >500 SPOs with complete Governada profiles                                          |
+| **SPO Pro conversion**                     | Monetization                        | 50-100 paying SPOs at $15-25/mo                                                     |
+| **Delegator-SPO communication engagement** | Is the channel valuable?            | >40% of staking delegators view their SPO's updates                                 |
+| **Governance-based discovery conversions** | Is the differentiator working?      | Measurable delegation flow from Governada discovery to pools                        |
+| **Staking delegator -> DRep delegation**   | Is the bridge working?              | SPO delegators who also delegate to a DRep at higher rates than non-Governada users |
 
 ---
 
 ## The One-Line Vision
 
-**Civica is where SPOs build their governance reputation, communicate with their delegators, and grow their pool through the one competitive dimension nobody else measures.**
+**Governada is where SPOs build their governance reputation, communicate with their delegators, and grow their pool through the one competitive dimension nobody else measures.**
 
-PoolTool tells delegators a pool is reliable. Civica tells them the pool operator shares their values. In a market where 500 pools have identical financial metrics, governance reputation becomes the differentiator -- and Civica is the only place it exists.
+PoolTool tells delegators a pool is reliable. Governada tells them the pool operator shares their values. In a market where 500 pools have identical financial metrics, governance reputation becomes the differentiator -- and Governada is the only place it exists.

--- a/docs/strategy/personas/treasury-team.md
+++ b/docs/strategy/personas/treasury-team.md
@@ -33,7 +33,7 @@ The treasury funding process today is broken on both sides:
 - There's no structured way to verify if funded projects actually ship
 - Bad actors can get funded and disappear without consequence to their reputation
 
-Both sides need Civica. The key insight: **accountability and advantage are the same thing for teams that deliver.**
+Both sides need Governada. The key insight: **accountability and advantage are the same thing for teams that deliver.**
 
 ---
 
@@ -57,7 +57,7 @@ Both sides need Civica. The key insight: **accountability and advantage are the 
 
 - Testing a proposal concept with citizens and DReps before writing the full proposal -- and getting signal that it's wanted
 - Walking into their fourth proposal with a track record that speaks for itself: "3 of 3 delivered, 88% citizen impact score"
-- Shipping a product and seeing citizens tag it as "essential" on their Civica project page
+- Shipping a product and seeing citizens tag it as "essential" on their Governada project page
 - AI-powered proposal guidance: "proposals like yours with quarterly milestones have 80% approval rates"
 - Their funded project becoming discoverable to citizens who would actually use it
 
@@ -67,16 +67,16 @@ Both sides need Civica. The key insight: **accountability and advantage are the 
 
 ### Philosophy
 
-Civica doesn't impose accountability on treasury teams. **It rewards accountability by making it a competitive advantage.** Teams that engage transparently build reputation. Reputation gets them funded. Getting funded grows their work. Their work generates citizen impact. Impact builds more reputation.
+Governada doesn't impose accountability on treasury teams. **It rewards accountability by making it a competitive advantage.** Teams that engage transparently build reputation. Reputation gets them funded. Getting funded grows their work. Their work generates citizen impact. Impact builds more reputation.
 
-The teams that deliver WANT accountability because it separates them from teams that don't. Civica makes that separation visible and valuable.
+The teams that deliver WANT accountability because it separates them from teams that don't. Governada makes that separation visible and valuable.
 
 ### The Trust Ladder
 
-The relationship between treasury teams and Civica is a voluntary progression. Each step provides tangible benefit:
+The relationship between treasury teams and Governada is a voluntary progression. Each step provides tangible benefit:
 
-1. **Anonymous team:** On-chain proposal, no Civica presence. DReps and citizens evaluate blind. Lowest trust signal.
-2. **Registered team:** Claimed their project page on Civica, added team info and description. Basic trust signal established.
+1. **Anonymous team:** On-chain proposal, no Governada presence. DReps and citizens evaluate blind. Lowest trust signal.
+2. **Registered team:** Claimed their project page on Governada, added team info and description. Basic trust signal established.
 3. **Active team:** Posting progress updates, tracking milestones, engaging with citizen feedback. Growing reputation.
 4. **Verified team:** Identity verified, full accountability tools active, spending transparency published. Maximum trust signal.
 5. **Established team:** Multiple delivered proposals, strong citizen impact scores, proven track record. Their next proposal is nearly pre-approved on reputation alone.
@@ -85,7 +85,7 @@ No step is mandatory. Every step is advantageous. Teams climb the ladder because
 
 ### Pre-Proposal: Validation and Intelligence
 
-Before spending weeks on a formal proposal, teams can use Civica to validate their concept and optimize their approach.
+Before spending weeks on a formal proposal, teams can use Governada to validate their concept and optimize their approach.
 
 #### Concept Testing
 
@@ -97,18 +97,18 @@ Before spending weeks on a formal proposal, teams can use Civica to validate the
 
 #### Proposal Drafting Intelligence
 
-Civica has unique data about what makes proposals succeed:
+Governada has unique data about what makes proposals succeed:
 
 - Historical voting patterns: what types of proposals do DReps support? At what budget levels? With what milestone structures?
 - Citizen priority alignment: does this concept match what the community says it wants?
 - Similar proposals: what's been funded before in this space? What delivered and what didn't?
 - AI-powered guidance: "Proposals in the developer tooling category with budgets under 5M ADA and quarterly milestones have an 80% approval rate. Similar proposals that included user adoption metrics scored higher on citizen impact."
 
-This turns Civica into a strategic advisor for proposal teams.
+This turns Governada into a strategic advisor for proposal teams.
 
 ### During Funding: The Project Page
 
-Every funded proposal gets a project page on Civica -- the canonical home for the project's lifecycle.
+Every funded proposal gets a project page on Governada -- the canonical home for the project's lifecycle.
 
 #### Project Identity
 
@@ -120,7 +120,7 @@ Every funded proposal gets a project page on Civica -- the canonical home for th
 
 #### Milestone Management
 
-- Teams declare milestones when funded (or Civica extracts them from the proposal)
+- Teams declare milestones when funded (or Governada extracts them from the proposal)
 - As they deliver, they mark milestones complete with evidence: links, demos, documentation, screenshots
 - Public progress display: "Milestone 3 of 5 complete"
 - Citizen verification: community members who expressed interest confirm they can see or use the deliverable
@@ -162,7 +162,7 @@ After a project delivers, the accountability story shifts to impact measurement.
 
 #### Impact Amplification
 
-- When a funded project ships, Civica surfaces it to the citizen community
+- When a funded project ships, Governada surfaces it to the citizen community
 - "This project was funded by Cardano governance. Here's the team, here's the product, try it."
 - Project page becomes a living showcase, not a forgotten proposal
 - DReps and SPOs who voted for it can reference the outcome: "I voted Yes, and it delivered"
@@ -191,7 +191,7 @@ The aggregate view that helps the entire ecosystem:
 
 ### Cross-Project Intelligence
 
-Civica's proposal analysis creates a collaboration and landscape layer:
+Governada's proposal analysis creates a collaboration and landscape layer:
 
 - **Similar project discovery:** "3 other teams are working on developer tooling -- here's how your projects compare and complement each other"
 - **Duplication detection:** Before a team submits, they can see what's already funded in their space
@@ -202,7 +202,7 @@ Civica's proposal analysis creates a collaboration and landscape layer:
 
 ## The Proposer Profile
 
-Each team (or individual) who has submitted treasury proposals accumulates a proposer profile on Civica:
+Each team (or individual) who has submitted treasury proposals accumulates a proposer profile on Governada:
 
 - **Proposal history:** Every proposal submitted, with outcomes (approved, rejected, withdrawn)
 - **Delivery track record:** Milestone completion rates, timeliness, citizen impact scores across all projects
@@ -263,10 +263,10 @@ The ROI is straightforward: better trust signals = better chance of getting fund
 
 The self-reinforcing loop that improves treasury spending quality over time:
 
-1. Team submits a proposal with concept validation from Civica
+1. Team submits a proposal with concept validation from Governada
 2. DReps evaluate using the team's proposer profile and delivery track record
 3. Proposal is funded
-4. Team posts structured progress updates on their Civica project page
+4. Team posts structured progress updates on their Governada project page
 5. Citizens follow progress and provide feedback during development
 6. Team delivers and citizens tag impact: "I use this, it's essential"
 7. Delivery score and citizen impact score are recorded on the proposer profile
@@ -280,21 +280,21 @@ Bad actors are naturally filtered: a team that takes funding and disappears has 
 
 ## Metrics That Matter
 
-| Metric                              | What It Measures                              | Target                                                                             |
-| ----------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Teams with Civica project pages** | Platform adoption among proposers             | >50% of funded proposals have claimed pages                                        |
-| **Pre-proposal concept tests**      | Is validation valuable?                       | Growing usage, measurable correlation between validation scores and approval rates |
-| **Progress update frequency**       | Are teams engaging?                           | Average of at least 1 update per quarter for active projects                       |
-| **Citizen impact tag volume**       | Is the feedback loop working?                 | >30% of delivered projects have citizen impact ratings                             |
-| **Verified Project conversions**    | Monetization                                  | Steady growth toward $200-500/mo                                                   |
-| **Delivery score distribution**     | Is accountability improving treasury quality? | Upward trend in average delivery scores over time                                  |
-| **DRep reference rate**             | Do DReps use proposer profiles when voting?   | DReps cite track records in their rationales                                       |
-| **Repeat proposer success rate**    | Does reputation compound?                     | Teams with strong track records see higher approval rates on subsequent proposals  |
+| Metric                                 | What It Measures                              | Target                                                                             |
+| -------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Teams with Governada project pages** | Platform adoption among proposers             | >50% of funded proposals have claimed pages                                        |
+| **Pre-proposal concept tests**         | Is validation valuable?                       | Growing usage, measurable correlation between validation scores and approval rates |
+| **Progress update frequency**          | Are teams engaging?                           | Average of at least 1 update per quarter for active projects                       |
+| **Citizen impact tag volume**          | Is the feedback loop working?                 | >30% of delivered projects have citizen impact ratings                             |
+| **Verified Project conversions**       | Monetization                                  | Steady growth toward $200-500/mo                                                   |
+| **Delivery score distribution**        | Is accountability improving treasury quality? | Upward trend in average delivery scores over time                                  |
+| **DRep reference rate**                | Do DReps use proposer profiles when voting?   | DReps cite track records in their rationales                                       |
+| **Repeat proposer success rate**       | Does reputation compound?                     | Teams with strong track records see higher approval rates on subsequent proposals  |
 
 ---
 
 ## The One-Line Vision
 
-**Civica turns treasury accountability from a burden into a competitive advantage -- teams that deliver build reputation that gets them funded again, while the entire ecosystem gains visibility into where its collective ADA goes.**
+**Governada turns treasury accountability from a burden into a competitive advantage -- teams that deliver build reputation that gets them funded again, while the entire ecosystem gains visibility into where its collective ADA goes.**
 
 Accountability isn't surveillance. It's the mechanism that rewards quality, filters bad actors, and gives every Cardano citizen confidence that their treasury is being spent well. The teams that engage benefit the most, because their track record becomes the strongest argument for their next proposal.

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -1,4 +1,4 @@
-# Civica: The Definitive Product Vision (V2)
+# Governada: The Definitive Product Vision (V2)
 
 > **Status:** Active north star -- all build decisions, monetization timing, and architecture choices should align with this document.
 > **Created:** March 2026
@@ -11,13 +11,13 @@
 
 ## The Vision in One Sentence
 
-**Civica is the civic hub for the Cardano nation -- the one place where every ADA holder goes to understand what their stake is doing in governance, and where every governance participant goes to do their work.**
+**Governada is the governance intelligence platform for Cardano -- the one place where every ADA holder goes to understand what their stake is doing in governance, and where every governance participant goes to do their work.**
 
 ---
 
 ## The Thesis
 
-Civica is not a dashboard and not just an intelligence layer. It is the **civic hub** for Cardano -- the place where citizenship in a digital nation becomes real. Underneath, a governance intelligence engine ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. But the engine is not the product. The product is the experience of being a Cardano citizen: informed, represented, engaged, and empowered.
+Governada is not a dashboard and not just an intelligence layer. It is the **governance intelligence platform** for Cardano -- the place where citizenship in a digital nation becomes real. Underneath, a governance intelligence engine ingests every governance action on-chain, layers opinionated analysis on top, and delivers personalized, actionable insight to every participant in the ecosystem. But the engine is not the product. The product is the experience of being a Cardano citizen: informed, represented, engaged, and empowered.
 
 The product moat is not code -- it is the compounding historical dataset that grows every epoch and becomes impossible to replicate. And increasingly, it is the community engagement data -- citizen sentiment, priority signals, endorsements, impact reports -- that no competitor collects because no competitor has built the civic hub where citizens participate.
 
@@ -25,19 +25,19 @@ The architectural insight that makes this possible: **every data point feeds eve
 
 ### The Identity Shift
 
-The fundamental transformation Civica drives: ADA holders go from thinking **"I own tokens"** to feeling **"I'm a citizen of a digital nation."**
+The fundamental transformation Governada drives: ADA holders go from thinking **"I own tokens"** to feeling **"I'm a citizen of a digital nation."**
 
-Cardano has a ratified constitution, a treasury worth billions of ADA, elected representatives (DReps), three branches of governance, and a 5-day legislative cycle. It is structurally more democratic than most countries. Every ADA holder has governance rights whether they exercise them or not. Civica makes that citizenship tangible, valuable, and effortless.
+Cardano has a ratified constitution, a treasury worth billions of ADA, elected representatives (DReps), three branches of governance, and a 5-day legislative cycle. It is structurally more democratic than most countries. Every ADA holder has governance rights whether they exercise them or not. Governada makes that citizenship tangible, valuable, and effortless.
 
 ---
 
 ## Personas
 
-Civica serves six distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data and intelligence engine. The Citizen is the anchor -- every other persona either serves citizens or is accountable to them.
+Governada serves six distinct personas. Each sees a product tailored to their needs, all powered by the same interconnected data and intelligence engine. The Citizen is the anchor -- every other persona either serves citizens or is accountable to them.
 
 > **Detailed persona documents** live in `docs/strategy/personas/`. Each document covers: who they are, what they want, their complete product experience, free vs. paid boundaries, connections to other personas, and success metrics. The summaries below provide the essential frame; the persona docs are the authoritative reference for product decisions.
 
-| Persona                  | Role in Ecosystem                                                  | Civica Experience                                                                                                                                                       | Monetization                                                      | Persona Doc                                               |
+| Persona                  | Role in Ecosystem                                                  | Governada Experience                                                                                                                                                    | Monetization                                                      | Persona Doc                                               |
 | ------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
 | **Citizen** (ADA Holder) | The foundation. 80%+ of users.                                     | Civic hub: epoch briefing, treasury transparency, civic identity, community engagement, smart alerts. Summary intelligence, not analytics.                              | Free core. Premium Delegator (Step 6).                            | [citizen.md](personas/citizen.md)                         |
 | **DRep**                 | Elected governance representatives (~700). Supply side.            | Governance workspace: vote casting, rationale submission, proposal analysis, reputation management, delegator communication. Citizens first, professional layer on top. | Free governance operations. DRep Pro for analytics + growth.      | [drep.md](personas/drep.md)                               |
@@ -45,7 +45,7 @@ Civica serves six distinct personas. Each sees a product tailored to their needs
 | **CC Member**            | Constitutional guardians (~7-10). Highest authority.               | 80% public accountability surface, 20% optional tooling. Transparency Index, voting record, inter-body dynamics. Not a user product -- an ecosystem trust layer.        | Free (no Pro tier).                                               | [cc-member.md](personas/cc-member.md)                     |
 | **Treasury Team**        | Builders who seek governance funding. Accountability subjects.     | Mutual benefit: proposer reputation, pre-proposal validation, milestone tracking, citizen impact reports. Accountability as competitive advantage.                      | Verified Project badge ($10-25/project).                          | [treasury-team.md](personas/treasury-team.md)             |
 | **Researcher**           | Governance scholars, analysts, data journalists.                   | API-first data platform: historical datasets, methodology docs, bulk exports, versioned data. Credibility flows back to all personas.                                   | Research API subscriptions ($50-200/mo).                          | [researcher.md](personas/researcher.md)                   |
-| **Integration Partner**  | Wallets, exchanges, pool tools, DeFi, explorers. B2B distribution. | Governance intelligence engine via API + embeddable widgets. Every integration extends Civica's reach without acquisition cost.                                         | API tiers ($50-200/mo). Widgets + deep integrations custom.       | [integration-partner.md](personas/integration-partner.md) |
+| **Integration Partner**  | Wallets, exchanges, pool tools, DeFi, explorers. B2B distribution. | Governance intelligence engine via API + embeddable widgets. Every integration extends Governada's reach without acquisition cost.                                      | API tiers ($50-200/mo). Widgets + deep integrations custom.       | [integration-partner.md](personas/integration-partner.md) |
 
 ### Citizen-Centric Architecture
 
@@ -64,7 +64,7 @@ Every feature decision should pass the citizen test: **"Does this ultimately mak
 
 Most governance participants span multiple personas simultaneously. A DRep is also a citizen. An SPO may also be a DRep. A CC member has personal delegation and may operate a pool. A treasury team member is also an ADA holder tracking their own governance health.
 
-Civica treats segments as **additive facets of one identity**, not separate user types. The product adapts to the union of all segments detected across a user's linked wallets. A DRep sees the citizen experience PLUS the governance workspace. An SPO sees the citizen experience PLUS pool identity management. Nobody loses the citizen layer; personas add professional capabilities on top.
+Governada treats segments as **additive facets of one identity**, not separate user types. The product adapts to the union of all segments detected across a user's linked wallets. A DRep sees the citizen experience PLUS the governance workspace. An SPO sees the citizen experience PLUS pool identity management. Nobody loses the citizen layer; personas add professional capabilities on top.
 
 See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified-experience) and [ADR 007](../adr/007-multi-wallet-identity.md) for the technical model.
 
@@ -72,7 +72,7 @@ See [Multi-Wallet Identity & Unified Experience](#multi-wallet-identity--unified
 
 ## The Civic Hub: Three Product Pillars
 
-The civic hub rests on three pillars that together make Civica a destination citizens return to every epoch. Each pillar is described in detail in the [Citizen persona doc](personas/citizen.md). The summaries below establish the concepts that all persona experiences build on.
+The civic hub rests on three pillars that together make Governada a destination citizens return to every epoch. Each pillar is described in detail in the [Citizen persona doc](personas/citizen.md). The summaries below establish the concepts that all persona experiences build on.
 
 ### Pillar 1: The Briefing (Summary Intelligence)
 
@@ -118,7 +118,7 @@ The layer that gives every citizen a voice without creating a forum. Seven mecha
 
 ## Treasury Accountability
 
-Treasury transparency is elevated to a first-class product pillar, not just a data layer. The Cardano treasury holds billions of ADA -- citizens' collective wealth -- and the governance process allocates it. Civica makes every aspect of that process visible, understandable, and accountable.
+Treasury transparency is elevated to a first-class product pillar, not just a data layer. The Cardano treasury holds billions of ADA -- citizens' collective wealth -- and the governance process allocates it. Governada makes every aspect of that process visible, understandable, and accountable.
 
 **For citizens:**
 
@@ -137,7 +137,7 @@ Treasury transparency is elevated to a first-class product pillar, not just a da
 
 - Proposer reputation that compounds: delivery scores, citizen impact, milestone completion across all projects.
 - Pre-proposal validation: test concepts with citizen interest and DRep support signals before investing in a full proposal.
-- Impact amplification: when funded projects ship, Civica surfaces them to citizens.
+- Impact amplification: when funded projects ship, Governada surfaces them to citizens.
 - The trust ladder: anonymous -> registered -> active -> verified -> established. Each step voluntary, each step advantageous.
 
 See [Treasury Team persona doc](personas/treasury-team.md) for the full mutual benefit model.
@@ -146,17 +146,17 @@ See [Treasury Team persona doc](personas/treasury-team.md) for the full mutual b
 
 ## The Governance Workspace
 
-Civica is not just where governance is observed -- it is **where governance happens.** DReps, SPOs, and CC members can perform their core governance operations directly within Civica, eliminating the fragmented multi-tool workflow that characterizes governance today.
+Governada is not just where governance is observed -- it is **where governance happens.** DReps, SPOs, and CC members can perform their core governance operations directly within Governada, eliminating the fragmented multi-tool workflow that characterizes governance today.
 
 ### Vote Casting
 
-DReps, SPOs, and CC members cast votes directly from Civica via MeshJS (CIP-95). The vote is cast from the same page where they reviewed the proposal analysis -- AI summary, treasury impact, citizen sentiment, inter-body context, constitutional alignment. No context switch. The analysis feeds directly into the action.
+DReps, SPOs, and CC members cast votes directly from Governada via MeshJS (CIP-95). The vote is cast from the same page where they reviewed the proposal analysis -- AI summary, treasury impact, citizen sentiment, inter-body context, constitutional alignment. No context switch. The analysis feeds directly into the action.
 
 ### Rationale Submission (The Killer Feature)
 
-The single most impactful capability Civica can offer. Today, CIP-100 rationale submission requires manual JSON creation, self-hosting, and anchor hash submission. Most governance participants skip it because the friction is too high.
+The single most impactful capability Governada can offer. Today, CIP-100 rationale submission requires manual JSON creation, self-hosting, and anchor hash submission. Most governance participants skip it because the friction is too high.
 
-Civica's flow:
+Governada's flow:
 
 1. Rich-text editor for writing the rationale (or AI-assisted first draft from proposal + voting history + governance philosophy)
 2. Auto-format to CIP-100 compliant JSON behind the scenes
@@ -166,7 +166,7 @@ Civica's flow:
 Effects cascade across every persona:
 
 - More rationales on-chain (better for Cardano governance)
-- DReps/SPOs who use Civica score higher (rationale quality is a scoring factor)
+- DReps/SPOs who use Governada score higher (rationale quality is a scoring factor)
 - Citizens see WHY their representative voted a certain way (better citizen experience)
 - AI gets more training data (better governance intelligence)
 - Governance transparency improves measurably (better for Cardano's reputation)
@@ -336,14 +336,14 @@ flowchart TB
 
 Growth comes from three channels, operating in parallel:
 
-### 1. Direct Acquisition (Citizens Come to Civica)
+### 1. Direct Acquisition (Citizens Come to Governada)
 
 - Simplified anonymous experience: two paths in (Stake / Govern), education woven in, gentle wallet connect prompts
 - Quick Match as primary conversion funnel: 3 questions, 60 seconds, delegation
 - Epoch briefing as retention driver: fresh content every ~5 days
 - Civic identity as attachment mechanism: growing footprint creates switching cost
 
-### 2. Viral Distribution (Personas Share Civica)
+### 2. Viral Distribution (Personas Share Governada)
 
 - DReps share scores, profiles, and Wrapped to attract delegation
 - SPOs share governance reputation to differentiate their pools
@@ -351,13 +351,13 @@ Growth comes from three channels, operating in parallel:
 - Every share is a billboard. DReps and SPOs are the unpaid sales force (Principle #5).
 - Wrapped (Step 4) is the dedicated viral engine
 
-### 3. B2B Distribution (Partners Embed Civica)
+### 3. B2B Distribution (Partners Embed Governada)
 
 - Wallet providers embed Quick Match, DRep scores, delegation health
 - Pool comparison tools add SPO governance scores as a new column
 - Exchanges display governance data for custodied ADA
 - Block explorers add intelligence layer to raw governance data
-- "Powered by Civica" brand touchpoints across every integration
+- "Powered by Governada" brand touchpoints across every integration
 - See [Integration Partner persona doc](personas/integration-partner.md) for full strategy
 
 **B2B distribution should begin before Step 7.** Early API access and widget prototypes for high-value partners (Eternl, PoolTool) can start as soon as the data is trustworthy (after Steps 0-2.5). The formal API product (Step 7) is the scalable version, but partnerships should not wait.
@@ -474,7 +474,7 @@ The on-ramp. Without a clear, unintimidating path from "I hold ADA" to "I'm a Ca
 > **Primary persona:** DRep, SPO
 > **Secondary impact:** Citizen (more rationales = better transparency), Researcher (richer data)
 
-The capability that makes Civica indispensable: governance operations happen here, not somewhere else. Citizens are now using the platform (Step 4). DReps and SPOs need a reason to make it their daily tool.
+The capability that makes Governada indispensable: governance operations happen here, not somewhere else. Citizens are now using the platform (Step 4). DReps and SPOs need a reason to make it their daily tool.
 
 **What gets built:**
 
@@ -516,10 +516,10 @@ The capability that makes Civica indispensable: governance operations happen her
 | `lib/cip100.ts`                     | CIP-100 JSON-LD document construction and validation                                   |
 | `lib/metadataAnchor.ts`             | Document hosting (Supabase Storage) + URI generation                                   |
 | MeshJS + `@meshsdk/core` dependency | Wallet interaction for governance transactions                                         |
-| `governance_actions` table          | Track votes cast through Civica (analytics + verification)                             |
+| `governance_actions` table          | Track votes cast through Governada (analytics + verification)                          |
 | `rationale_documents` table         | Hosted CIP-100 documents with URIs and on-chain anchors                                |
 
-**Key metric:** If Civica 2x's the ecosystem rationale rate for its users, the value proposition is proven.
+**Key metric:** If Governada 2x's the ecosystem rationale rate for its users, the value proposition is proven.
 
 ---
 
@@ -547,7 +547,7 @@ Seven engagement mechanisms, each producing structured data that feeds the intel
 
 6. **Citizen Questions:** Directed questions to DReps about specific proposals or positions. Structured format, delivered to DRep inbox, answered asynchronously. Not a chat -- a query/response system.
 
-7. **Citizen Assemblies (lightweight):** Time-bounded structured consultations. "Should governance prioritize X or Y this quarter?" Multiple-choice, 1-week duration, results published. 1-2 per epoch, curated by Civica.
+7. **Citizen Assemblies (lightweight):** Time-bounded structured consultations. "Should governance prioritize X or Y this quarter?" Multiple-choice, 1-week duration, results published. 1-2 per epoch, curated by Governada.
 
 **What exists (reuse/modify):**
 
@@ -689,7 +689,7 @@ DReps and SPOs are now using the free workspace daily. Community is engaged. Pro
 
 3. **Research tier:** Academic pricing ($50-100/mo), bulk exports (CSV/JSON), versioned datasets, methodology documentation.
 
-4. **Embeddable widgets:** Quick Match, DRep Score card, SPO Governance badge, Governance Health gauge, Delegation Health indicator. Themeable, "Powered by Civica" attribution.
+4. **Embeddable widgets:** Quick Match, DRep Score card, SPO Governance badge, Governance Health gauge, Delegation Health indicator. Themeable, "Powered by Governada" attribution.
 
 5. **Developer experience:** OpenAPI spec, SDK generation (TypeScript, Python), interactive API explorer, sandbox environment, webhook system for real-time partner notifications.
 
@@ -789,7 +789,7 @@ Two major features that require the full data picture:
   - Confidential delegation analytics
 - ENS/.ada integration for governance identity
 
-**Why last:** Genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, Civica's reputation and data moat make it the natural home for governance identity.
+**Why last:** Genuinely novel and depends on protocol-level support (Midnight, DID standards, cross-chain bridges). The value is enormous but the execution risk is highest. By this point, Governada's reputation and data moat make it the natural home for governance identity.
 
 **Monetization angle:** The "Stripe for blockchain governance" play -- other chains and protocols pay to access governance reputation data.
 
@@ -821,7 +821,7 @@ Two major features that require the full data picture:
 
 The wow score is an emergent property of how well these systems connect. Here is how each capability contributes:
 
-**A citizen who gets it in 30 seconds:** A new visitor sees two paths: Stake or Govern. They choose Govern, answer 3 questions, see a radar chart form in real-time, match with a DRep who shares their values, and delegate. 90 seconds from stranger to citizen. The next epoch, they open Civica and see: "Your DRep voted Yes on a developer toolkit proposal. Everything's healthy." They close the app, informed and confident. That is the entire citizen product, and it is enough. (Foundation + Step 4)
+**A citizen who gets it in 30 seconds:** A new visitor sees two paths: Stake or Govern. They choose Govern, answer 3 questions, see a radar chart form in real-time, match with a DRep who shares their values, and delegate. 90 seconds from stranger to citizen. The next epoch, they open Governada and see: "Your DRep voted Yes on a developer toolkit proposal. Everything's healthy." They close the app, informed and confident. That is the entire citizen product, and it is enough. (Foundation + Step 4)
 
 **Scores that matter (not a vibe):** A DRep profile shows a score reflecting actual governance behavior -- rationale quality assessed by AI, voting patterns weighted by importance, reliability measured by responsiveness. The user trusts this score because it means something specific and defensible. (Foundation)
 
@@ -910,7 +910,7 @@ This is the silent engine. Every day the product runs, the moat deepens.
 
 ## Competitive Position
 
-No governance product in crypto does what Civica does -- and no competitor CAN, because no competitor has the civic hub where citizens engage and the compounding dataset that makes the intelligence possible.
+No governance product in crypto does what Governada does -- and no competitor CAN, because no competitor has the platform where citizens engage and the compounding dataset that makes the intelligence possible.
 
 The closest comparators:
 
@@ -921,7 +921,7 @@ The closest comparators:
 - **PoolTool / ADApools:** Stake pool metrics (uptime, rewards, fees). Zero governance data. The SPO governance layer is a completely untapped opportunity.
 - **GovTool:** Cardano's official governance tool. Handles voting mechanics but has no intelligence layer, no scoring, no matching, no citizen experience, no community engagement. Complementary infrastructure, not a competitor.
 
-Civica's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the community engagement engine feeds the notification engine feeds the growth engine. Six personas served by one interconnected data flywheel, powered by community engagement data no competitor collects. No one can replicate this by copying one feature.
+Governada's advantage is not any single feature -- it is the system. The scoring engine feeds the matching engine feeds the intelligence engine feeds the community engagement engine feeds the notification engine feeds the growth engine. Six personas served by one interconnected data flywheel, powered by community engagement data no competitor collects. No one can replicate this by copying one feature.
 
 **The civic hub moat:** Even if a competitor replicated every algorithm, they would still lack: (a) the compounding historical dataset, (b) the citizen engagement data, (c) the proposer reputation records, (d) the integration partner ecosystem, and (e) the governance workspace adoption. The moat is not code -- it is the system operating over time.
 
@@ -937,7 +937,7 @@ Civica's advantage is not any single feature -- it is the system. The scoring en
 
 4. **Persona-appropriate depth.** Citizens get summary intelligence. DReps get a workspace. SPOs get an identity platform. CC members get a transparency surface. Each persona's primary experience must be emotionally complete for their needs. Different personas need different products, not different depths of the same product.
 
-5. **Intelligence demands action.** Every insight must connect to something the user can do. A score without a delegation button is just a number. A health warning without a "fix this" CTA is just anxiety. A proposal without a vote button is a missed opportunity. Civica is where governance HAPPENS, not just where it is observed.
+5. **Intelligence demands action.** Every insight must connect to something the user can do. A score without a delegation button is just a number. A health warning without a "fix this" CTA is just anxiety. A proposal without a vote button is a missed opportunity. Governada is where governance HAPPENS, not just where it is observed.
 
 6. **Accountability is advantage.** Transparency is not imposed -- it is rewarded. DReps who provide rationales score higher. SPOs who participate in governance get discovered. Treasury teams who deliver build reputation. The system creates natural incentives for good governance behavior.
 

--- a/docs/strategy/world-class-packages.md
+++ b/docs/strategy/world-class-packages.md
@@ -233,7 +233,7 @@ PR Group I (QP-13)        ─── depends on all other QPs (validate final sta
 
 ### QP-4: Error Recovery + Resilience
 
-**Problem:** Async failures surface as gray text with no retry mechanism. No graceful degradation. No offline detection. A citizen who opens Civica during a Koios outage sees a broken page with no explanation.
+**Problem:** Async failures surface as gray text with no retry mechanism. No graceful degradation. No offline detection. A citizen who opens Governada during a Koios outage sees a broken page with no explanation.
 
 **Goal:** Every async surface has a complete loading → content → error lifecycle with retry and graceful degradation.
 
@@ -464,7 +464,7 @@ These are not reconciled. A DRep's PCA position may contradict their manual dime
    - Trigger on:
      - First delegation completed (DelegationCeremony flow)
      - Milestone achieved (citizen-level-up notification)
-     - First vote cast through Civica
+     - First vote cast through Governada
      - First rationale submitted
      - Match confidence reaching 100%
 
@@ -501,7 +501,7 @@ These are not reconciled. A DRep's PCA position may contradict their manual dime
 
 **Problem:** The product assumes governance literacy. Treasury section uses "runway months" and "proportional share" without explanation. Quick Match assumes delegation is understood. New citizens from other crypto ecosystems (or non-crypto) get lost.
 
-**Goal:** Progressive disclosure of governance concepts. First-time users get contextual education. Returning users see clean UI. Nobody needs to leave Civica to understand what they're looking at.
+**Goal:** Progressive disclosure of governance concepts. First-time users get contextual education. Returning users see clean UI. Nobody needs to leave Governada to understand what they're looking at.
 
 **Scope:**
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Smoke tests', () => {
   test('homepage loads and shows heading', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveTitle(/Civica/i);
+    await expect(page).toHaveTitle(/Governada/i);
     await expect(page.locator('#main-content')).toBeVisible();
   });
 

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -1,19 +1,19 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Visual regression tests for key Civica pages.
+ * Visual regression tests for key Governada pages.
  *
  * Usage:
  *   npx playwright test e2e/visual-regression.spec.ts
  *   npx playwright test e2e/visual-regression.spec.ts --update-snapshots  # to update baselines
  *
  * Snapshots are stored in e2e/__snapshots__/ and should be committed to git.
- * Run against production (PLAYWRIGHT_BASE_URL=https://drepscore.io) for stable baselines.
+ * Run against production (PLAYWRIGHT_BASE_URL=https://governada.io) for stable baselines.
  */
 
-const PRODUCTION_URL = 'https://drepscore.io';
+const PRODUCTION_URL = 'https://governada.io';
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? PRODUCTION_URL;
-const isProduction = baseURL.includes('drepscore.io');
+const isProduction = baseURL.includes('governada.io');
 
 test.describe('Visual Regression - Key Pages', () => {
   test.skip(!isProduction, 'Visual regression runs against production only');

--- a/emails/templates/governance-digest.ts
+++ b/emails/templates/governance-digest.ts
@@ -17,7 +17,7 @@ interface DigestData {
 
 export function renderGovernanceDigestEmail(
   data: DigestData,
-  baseUrl = 'https://drepscore.app',
+  baseUrl = 'https://governada.io',
 ): string {
   const {
     recipientName,
@@ -35,7 +35,7 @@ export function renderGovernanceDigestEmail(
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Your Governance Digest — DRepScore</title>
+  <title>Your Governance Digest — Governada</title>
   <style>
     body { font-family: -apple-system, sans-serif; background: #0c1222; color: #e2e8f0; margin: 0; padding: 20px; }
     .container { max-width: 600px; margin: 0 auto; }
@@ -57,7 +57,7 @@ export function renderGovernanceDigestEmail(
 <body>
   <div class="container">
     <div class="header">
-      <h1>DRepScore</h1>
+      <h1>Governada</h1>
       <p style="color: #64748b; margin: 8px 0 0;">Your Governance Digest</p>
     </div>
 
@@ -109,10 +109,10 @@ export function renderGovernanceDigestEmail(
       <p style="margin: 0; color: #94a3b8;">${insight}</p>
     </div>
 
-    <a href="${baseUrl}/my-gov" class="cta-button">Open Civica</a>
+    <a href="${baseUrl}/my-gov" class="cta-button">Open Governada</a>
 
     <div class="footer">
-      <p>DRepScore · Cardano Governance Intelligence</p>
+      <p>Governada · Cardano Governance Intelligence</p>
       <p><a href="${baseUrl}/my-gov/profile#notifications" class="unsubscribe">Manage notifications</a></p>
     </div>
   </div>

--- a/inngest/functions/check-notifications.ts
+++ b/inngest/functions/check-notifications.ts
@@ -54,7 +54,7 @@ interface CitizenDRepRow {
 
 const SCORE_CHANGE_THRESHOLD = 3;
 const INACTIVITY_EPOCH_THRESHOLD = 3;
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://drepscore.io';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://governada.io';
 
 export const checkNotifications = inngest.createFunction(
   {
@@ -150,7 +150,7 @@ export const checkNotifications = inngest.createFunction(
             await notifyUser(user.id, {
               eventType: 'score-change',
               title: `Score ${delta > 0 ? 'increased' : 'decreased'} by ${Math.abs(delta)} points`,
-              body: `Your DRepScore is now ${history[0].score}/100.`,
+              body: `Your Governada Score is now ${history[0].score}/100.`,
               url: `${BASE_URL}/dashboard`,
             });
             stats.scoreChange++;

--- a/inngest/functions/generate-citizen-assembly.ts
+++ b/inngest/functions/generate-citizen-assembly.ts
@@ -117,7 +117,7 @@ export const generateCitizenAssembly = inngest.createFunction(
         ? `${Math.round(context.treasury.balance_ada / 1_000_000)}M ADA`
         : 'Unknown';
 
-      const prompt = `You are the civic editor for Civica, the civic hub for Cardano governance. Generate 1-2 citizen assembly questions for this epoch.
+      const prompt = `You are the civic editor for Governada, the civic hub for Cardano governance. Generate 1-2 citizen assembly questions for this epoch.
 
 CONTEXT:
 - Current epoch: ${currentEpoch}

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -3,7 +3,7 @@
  * Every public API error has a stable code, human message, actionable hint, and docs link.
  */
 
-const DOCS_BASE = 'https://drepscore.io/developers/errors';
+const DOCS_BASE = 'https://governada.io/developers/errors';
 
 export interface ApiErrorDef {
   code: string;
@@ -33,7 +33,7 @@ const ERROR_REGISTRY: Record<string, Omit<ApiErrorDef, 'code'>> = {
   revoked_api_key: {
     status: 401,
     message: 'This API key has been revoked.',
-    hint: 'Generate a new key at drepscore.io/developers.',
+    hint: 'Generate a new key at governada.io/developers.',
   },
 
   // Rate limiting (429)
@@ -83,7 +83,7 @@ const ERROR_REGISTRY: Record<string, Omit<ApiErrorDef, 'code'>> = {
     status: 403,
     message:
       "This endpoint requires '{required_tier}' tier or above. Your key is '{current_tier}'.",
-    hint: 'Upgrade at drepscore.io/developers/upgrade.',
+    hint: 'Upgrade at governada.io/developers/upgrade.',
   },
 
   // Server (500)

--- a/lib/channelRenderers.ts
+++ b/lib/channelRenderers.ts
@@ -124,7 +124,7 @@ export function renderDiscord(payload: NotificationPayload): DiscordContent {
         description: content.body,
         color,
         url: content.url,
-        footer: { text: 'Civica' },
+        footer: { text: 'Governada' },
         timestamp: new Date().toISOString(),
       },
     ],
@@ -134,7 +134,7 @@ export function renderDiscord(payload: NotificationPayload): DiscordContent {
 export function renderTelegram(payload: NotificationPayload): TelegramContent {
   const content = resolveContent(payload);
   let text = `*${escapeMarkdown(content.title)}*\n${escapeMarkdown(content.body)}`;
-  if (content.url) text += `\n[View on Civica](${content.url})`;
+  if (content.url) text += `\n[View on Governada](${content.url})`;
   return { text, parseMode: 'MarkdownV2' };
 }
 

--- a/lib/cube.ts
+++ b/lib/cube.ts
@@ -1,5 +1,5 @@
 /**
- * Cube.js Client Configuration for Civica Analytics
+ * Cube.js Client Configuration for Governada Analytics
  *
  * Provides the Cube API client for querying the semantic layer.
  * Used by both server components (via direct API calls) and

--- a/lib/delegation.ts
+++ b/lib/delegation.ts
@@ -156,7 +156,7 @@ function validateMainnet(rewardAddress: string): void {
     throw new DelegationError(
       'wrong_network',
       'Wallet is not on Cardano mainnet.',
-      'Switch your wallet to mainnet to delegate on DRepScore.',
+      'Switch your wallet to mainnet to delegate on Governada.',
     );
   }
 }

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -20,8 +20,8 @@ function getResend(): Resend {
   if (!_resend) _resend = new Resend(process.env.RESEND_API_KEY);
   return _resend;
 }
-const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'DRepScore <onboarding@resend.dev>';
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'Governada <onboarding@resend.dev>';
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 
 // ── Core Send ─────────────────────────────────────────────────────────────────
 

--- a/lib/emailTemplates.tsx
+++ b/lib/emailTemplates.tsx
@@ -1,5 +1,5 @@
 /**
- * React Email Templates for DRepScore notifications.
+ * React Email Templates for Governada notifications.
  * Each template is a React component that Resend renders to HTML.
  */
 
@@ -18,7 +18,7 @@ import {
 } from '@react-email/components';
 import * as React from 'react';
 
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 
 // ── Shared Styles ────────────────────────────────────────────────────────────
 
@@ -99,15 +99,15 @@ function EmailLayout({
               margin: '0 0 24px',
             }}
           >
-            DREPSCORE
+            GOVERNADA
           </Text>
           {children}
           <Hr style={hr} />
           <Text style={footer}>
-            DRepScore — Cardano Governance Intelligence
+            Governada — Cardano Governance Intelligence
             <br />
             <Link href={BASE_URL} style={{ color: '#6366f1' }}>
-              drepscore.io
+              governada.io
             </Link>
             {unsubscribeUrl && (
               <>
@@ -144,7 +144,7 @@ export function GenericNotificationEmail({
       {url && (
         <Section style={{ textAlign: 'center', margin: '24px 0' }}>
           <Button style={button} href={url.startsWith('http') ? url : `${BASE_URL}${url}`}>
-            View on DRepScore
+            View on Governada
           </Button>
         </Section>
       )}
@@ -156,11 +156,11 @@ export function GenericNotificationEmail({
 
 export function EmailVerificationEmail({ verifyUrl }: { verifyUrl: string }) {
   return (
-    <EmailLayout preview="Verify your email address for DRepScore governance notifications">
+    <EmailLayout preview="Verify your email address for Governada governance notifications">
       <Heading style={heading}>Verify Your Email</Heading>
       <Text style={paragraph}>
         Click the button below to verify your email address and start receiving governance
-        notifications from DRepScore.
+        notifications from Governada.
       </Text>
       <Section style={{ textAlign: 'center', margin: '24px 0' }}>
         <Button style={button} href={verifyUrl}>
@@ -197,12 +197,12 @@ export function ScoreChangeEmail({
 
   return (
     <EmailLayout
-      preview={`Your DRepScore ${direction} by ${Math.abs(delta)} points`}
+      preview={`Your Governada score ${direction} by ${Math.abs(delta)} points`}
       unsubscribeUrl={unsubscribeUrl}
     >
       <Heading style={heading}>Score {direction === 'increased' ? 'Up' : 'Down'}</Heading>
       <Text style={paragraph}>
-        {drepName}&apos;s DRepScore {direction} from <strong>{oldScore}</strong> to{' '}
+        {drepName}&apos;s Governada score {direction} from <strong>{oldScore}</strong> to{' '}
         <strong style={{ color }}>{newScore}</strong> (
         <span style={{ color }}>
           {delta > 0 ? '+' : ''}
@@ -325,7 +325,7 @@ export function GovernanceDigestEmail({
 }) {
   return (
     <EmailLayout
-      preview="Your weekly governance brief from DRepScore"
+      preview="Your weekly governance brief from Governada"
       unsubscribeUrl={unsubscribeUrl}
     >
       <Heading style={heading}>Weekly Governance Brief</Heading>

--- a/lib/governanceBrief.ts
+++ b/lib/governanceBrief.ts
@@ -316,7 +316,7 @@ function generateHolderBriefTemplate(ctx: HolderBriefContext): GeneratedBrief {
   }
 
   return {
-    greeting: "Here's your weekly governance roundup from DRepScore.",
+    greeting: "Here's your weekly governance roundup from Governada.",
     sections,
     ctaText: 'Explore DReps',
     ctaUrl: '/discover',

--- a/lib/microcopy.ts
+++ b/lib/microcopy.ts
@@ -145,7 +145,7 @@ export const GOV_TERMS: Record<string, GovTermDef> = {
     whyItMatters: {
       citizen:
         'The more ADA holders delegate to your DRep, the greater their weight in deciding governance outcomes.',
-      drep: 'Civica deliberately excludes voting power from your score — governance quality, not whale capture, is what we reward.',
+      drep: 'Governada deliberately excludes voting power from your score — governance quality, not whale capture, is what we reward.',
       default:
         "Voting power determines how much weight a DRep's vote carries. High voting power doesn't mean high quality.",
     },
@@ -165,7 +165,7 @@ export const GOV_TERMS: Record<string, GovTermDef> = {
   drepScore: {
     label: 'DRep Score',
     definition:
-      "Civica's composite 0–100 governance quality score, combining Engagement Quality (35%), Effective Participation (25%), Reliability (25%), and Governance Identity (15%).",
+      "Governada's composite 0–100 governance quality score, combining Engagement Quality (35%), Effective Participation (25%), Reliability (25%), and Governance Identity (15%).",
     whyItMatters: {
       citizen:
         'The score compresses hundreds of governance data points into one number — but always drill into the pillars to understand the story behind it.',

--- a/lib/milestones.ts
+++ b/lib/milestones.ts
@@ -20,7 +20,7 @@ export const MILESTONES: MilestoneDefinition[] = [
   {
     key: 'claimed-profile',
     label: 'Profile Claimed',
-    description: 'Claimed your DRepScore profile',
+    description: 'Claimed your Governada profile',
     icon: 'Shield',
     category: 'profile',
   },

--- a/lib/nonce.ts
+++ b/lib/nonce.ts
@@ -23,7 +23,7 @@ export async function createNonce(): Promise<{
   });
 
   // Human-readable message shown in wallet signing popup
-  const nonce = `Sign in to DRepScore\nTime: ${timeStr}\nSession: ${sessionId}`;
+  const nonce = `Sign in to Governada\nTime: ${timeStr}\nSession: ${sessionId}`;
 
   const signature = await new jose.SignJWT({ nonce, timestamp })
     .setProtectedHeader({ alg: 'HS256' })

--- a/lib/notificationRegistry.ts
+++ b/lib/notificationRegistry.ts
@@ -33,7 +33,7 @@ export const EVENT_REGISTRY: EventDefinition[] = [
     audience: 'drep',
     urgency: 'batched',
     label: 'Score Changes',
-    description: 'When your DRepScore changes by 3+ points',
+    description: 'When your Governada Score changes by 3+ points',
     defaultChannels: ['push', 'email'],
     channels: ['push', 'email', 'discord', 'telegram'],
   },

--- a/lib/og-utils.tsx
+++ b/lib/og-utils.tsx
@@ -208,10 +208,10 @@ export function OGFooter({ left, right }: { left?: string; right?: string }) {
       }}
     >
       <div style={{ display: 'flex', fontSize: '24px', fontWeight: 700, color: OG.brand }}>
-        {left || '$drepscore'}
+        {left || '$governada'}
       </div>
       <div style={{ display: 'flex', fontSize: '18px', color: OG.textDim }}>
-        {right || 'drepscore.io'}
+        {right || 'governada.io'}
       </div>
     </div>
   );
@@ -231,7 +231,7 @@ export function OGFallback({ message }: { message: string }) {
         }}
       >
         <div style={{ display: 'flex', fontSize: '48px', fontWeight: 700, color: OG.brand }}>
-          $drepscore
+          $governada
         </div>
         <div style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}>
           {message}

--- a/lib/proposalIntelligence.ts
+++ b/lib/proposalIntelligence.ts
@@ -92,7 +92,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
             category: 'behavior',
             methodology:
               'Compares the No-vote rate among votes with published rationale vs votes without.',
-            shareText: `On @DRepScore: DReps who explain their votes are ${ratio.toFixed(1)}x more likely to vote No. Accountability breeds independence.`,
+            shareText: `On @GovernadaIO: DReps who explain their votes are ${ratio.toFixed(1)}x more likely to vote No. Accountability breeds independence.`,
           });
         }
       }
@@ -131,7 +131,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
           category: 'treasury',
           methodology:
             'Pass rate = (ratified + enacted) / (ratified + enacted + dropped + expired) for each proposal type.',
-          shareText: `Treasury proposals on Cardano pass at just ${fmtPct(treasuryPassRate)}. DReps take money decisions seriously. Via @DRepScore`,
+          shareText: `Treasury proposals on Cardano pass at just ${fmtPct(treasuryPassRate)}. DReps take money decisions seriously. Via @GovernadaIO`,
         });
       }
     }
@@ -185,7 +185,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
             category: 'voting',
             methodology:
               'Pairwise agreement rate across all proposals where at least 2 of the top 10 scored DReps voted.',
-            shareText: `Cardano's top 10 DReps agree on ${fmtPct(agreementRate)} of votes. Consensus or groupthink? Via @DRepScore`,
+            shareText: `Cardano's top 10 DReps agree on ${fmtPct(agreementRate)} of votes. Consensus or groupthink? Via @GovernadaIO`,
           });
         }
       }
@@ -226,7 +226,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
             category: 'participation',
             methodology:
               'Sum of voting power (lovelace) held by the top 10 DReps divided by total active voting power.',
-            shareText: `The top 10 Cardano DReps control ${fmtPct(concentration)} of voting power. How distributed is governance really? Via @DRepScore`,
+            shareText: `The top 10 Cardano DReps control ${fmtPct(concentration)} of voting power. How distributed is governance really? Via @GovernadaIO`,
           });
         }
       }
@@ -266,7 +266,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
           stat: `${fmtPct(highestRate)} vs ${fmtPct(lowestRate)}`,
           category: 'voting',
           methodology: 'Pass rate by proposal_type for types with at least 2 resolved proposals.',
-          shareText: `On Cardano, ${highestName} proposals pass at ${fmtPct(highestRate)} while ${lowestName} is just ${fmtPct(lowestRate)}. Via @DRepScore`,
+          shareText: `On Cardano, ${highestName} proposals pass at ${fmtPct(highestRate)} while ${lowestName} is just ${fmtPct(lowestRate)}. Via @GovernadaIO`,
         });
       }
     }
@@ -309,7 +309,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
             category: 'behavior',
             methodology:
               'Average score of DReps whose rationales average 300+ characters vs those under 300.',
-            shareText: `DReps who write detailed rationales score ${delta} points higher on @DRepScore. Words matter in governance.`,
+            shareText: `DReps who write detailed rationales score ${delta} points higher on @GovernadaIO. Words matter in governance.`,
           });
         }
       }
@@ -362,7 +362,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
                 : undefined,
             methodology:
               'Abstain votes as a percentage of total votes, compared across recent (last 3) vs earlier (prior 3) epochs.',
-            shareText: `Abstention rate in Cardano governance is ${direction} at ${fmtPct(recentRate)}. Via @DRepScore`,
+            shareText: `Abstention rate in Cardano governance is ${direction} at ${fmtPct(recentRate)}. Via @GovernadaIO`,
           });
         }
       }
@@ -427,7 +427,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
             category: 'voting',
             methodology:
               'Compares the majority vote direction of DReps scoring 70+ vs under 40 on proposals where each group has 2+ voters.',
-            shareText: `High-scoring vs low-scoring DReps disagree on ${fmtPct(disagreementRate)} of Cardano proposals. Score ≠ ideology. Via @DRepScore`,
+            shareText: `High-scoring vs low-scoring DReps disagree on ${fmtPct(disagreementRate)} of Cardano proposals. Score ≠ ideology. Via @GovernadaIO`,
           });
         }
       }
@@ -471,7 +471,7 @@ export async function computeInsights(): Promise<GovernanceInsight[]> {
           category: 'participation',
           methodology:
             'Votes cast within 1 epoch of proposal expiration vs earlier votes, for proposals with known expiration epochs.',
-          shareText: `${fmtPct(lateRate)} of Cardano governance votes come in the final epoch. Deadline-driven or deliberate? Via @DRepScore`,
+          shareText: `${fmtPct(lateRate)} of Cardano governance votes come in the final epoch. Deadline-driven or deliberate? Via @GovernadaIO`,
         });
       }
     }

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -14,7 +14,7 @@ import { logger } from '@/lib/logger';
 
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
 const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
-const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:hello@drepscore.com';
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:hello@governada.io';
 
 let vapidConfigured = false;
 function ensureVapid() {

--- a/lib/scoring/index.ts
+++ b/lib/scoring/index.ts
@@ -1,5 +1,5 @@
 /**
- * Civica Scoring Engine — barrel export.
+ * Governada Scoring Engine — barrel export.
  * DRep Score V3 + SPO Score V3.
  */
 

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,6 +1,6 @@
 import { posthog } from '@/lib/posthog';
 
-const SITE_URL = 'https://drepscore.io';
+const SITE_URL = 'https://governada.io';
 
 export function shareToX(text: string, url: string) {
   const tweetUrl = `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;

--- a/lib/stateOfGovernance.ts
+++ b/lib/stateOfGovernance.ts
@@ -205,7 +205,7 @@ export async function generateReportNarrative(data: ReportData): Promise<string 
   const gainersSummary = data.movers.gainers.map((m) => `${m.name} (+${m.delta})`).join(', ');
   const losersSummary = data.movers.losers.map((m) => `${m.name} (${m.delta})`).join(', ');
 
-  const prompt = `You are the editorial voice of DRepScore, writing the "State of Governance" report for Cardano Epoch ${data.epoch}. Write an engaging 600-800 word editorial narrative.
+  const prompt = `You are the editorial voice of Governada, writing the "State of Governance" report for Cardano Epoch ${data.epoch}. Write an engaging 600-800 word editorial narrative.
 
 Tone: authoritative yet accessible. Like a Bloomberg governance correspondent who genuinely cares about decentralization. Use specific numbers from the data. Do NOT fabricate any statistics.
 

--- a/lib/sync-utils.ts
+++ b/lib/sync-utils.ts
@@ -314,7 +314,7 @@ export async function alertDiscord(title: string, details: string): Promise<void
               title: `⚠️ ${title}`,
               description: details,
               color: 0xf59e0b,
-              footer: { text: 'DRepScore Sync Monitor' },
+              footer: { text: 'Governada Sync Monitor' },
               timestamp: new Date().toISOString(),
             },
           ],
@@ -342,9 +342,9 @@ export async function alertEmail(subject: string, body: string): Promise<void> {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        from: 'DRepScore Alerts <alerts@drepscore.io>',
-        to: ['admin@drepscore.io'],
-        subject: `[DRepScore Alert] ${subject}`,
+        from: 'Governada Alerts <alerts@governada.io>',
+        to: ['admin@governada.io'],
+        subject: `[Governada Alert] ${subject}`,
         text: body,
       }),
     });

--- a/lib/sync/proposals.ts
+++ b/lib/sync/proposals.ts
@@ -310,7 +310,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
 
         if (critical.length > 0) {
           const newest = critical[0];
-          const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+          const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
           const { broadcastEvent, broadcastDiscord } = await import('@/lib/notifications');
           const event = {
             eventType: 'critical-proposal-open' as const,

--- a/lib/sync/slow.ts
+++ b/lib/sync/slow.ts
@@ -346,7 +346,7 @@ async function runSocialLinkChecks(supabase: SupabaseClient) {
         method: 'HEAD',
         redirect: 'follow',
         signal: controller.signal,
-        headers: { 'User-Agent': 'DRepScore-LinkChecker/1.0' },
+        headers: { 'User-Agent': 'Governada-LinkChecker/1.0' },
       });
       clearTimeout(timeout);
       httpStatus = res.status;
@@ -626,7 +626,7 @@ async function runCriticalProposalNotifications(supabase: SupabaseClient) {
   if (critical.length === 0) return { sent: 0, skipped: false };
 
   const newest = critical[0];
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 
   const event = {
     eventType: 'critical-proposal-open' as const,

--- a/public/embed.js
+++ b/public/embed.js
@@ -1,13 +1,13 @@
 /**
- * DRepScore Embed Script Loader
+ * Governada Embed Script Loader
  *
  * Usage:
- *   <script src="https://drepscore.io/embed.js" data-type="drep" data-id="drep1..." data-theme="dark"></script>
- *   <script src="https://drepscore.io/embed.js" data-type="ghi" data-theme="dark"></script>
- *   <script src="https://drepscore.io/embed.js" data-type="cross-chain" data-theme="dark"></script>
+ *   <script src="https://governada.io/embed.js" data-type="drep" data-id="drep1..." data-theme="dark"></script>
+ *   <script src="https://governada.io/embed.js" data-type="ghi" data-theme="dark"></script>
+ *   <script src="https://governada.io/embed.js" data-type="cross-chain" data-theme="dark"></script>
  */
 (function () {
-  var BASE = 'https://drepscore.io';
+  var BASE = 'https://governada.io';
   var scripts = document.querySelectorAll('script[src*="embed.js"]');
 
   scripts.forEach(function (script) {
@@ -45,7 +45,7 @@
     iframe.style.borderRadius = '12px';
     iframe.style.overflow = 'hidden';
     iframe.setAttribute('loading', 'lazy');
-    iframe.setAttribute('title', 'Civica ' + type + ' widget');
+    iframe.setAttribute('title', 'Governada ' + type + ' widget');
 
     script.parentNode.insertBefore(iframe, script.nextSibling);
   });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Civica — Cardano Governance Intelligence",
-  "short_name": "Civica",
+  "name": "Governada — Cardano Governance Intelligence",
+  "short_name": "Governada",
   "description": "The civic hub for the Cardano Nation. Find your DRep, track governance proposals, and participate in on-chain democracy.",
   "start_url": "/",
   "display": "standalone",

--- a/public/offline.html
+++ b/public/offline.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Civica — Offline</title>
+  <title>Governada — Offline</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -55,9 +55,9 @@
 </head>
 <body>
   <div class="container">
-    <div class="logo">Civica</div>
+    <div class="logo">Governada</div>
     <h1>You're offline</h1>
-    <p>Civica requires an internet connection to show live governance data. Please check your connection and try again.</p>
+    <p>Governada requires an internet connection to show live governance data. Please check your connection and try again.</p>
     <button onclick="window.location.reload()">Retry</button>
   </div>
 </body>

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,5 +1,5 @@
 /**
- * DRepScore Service Worker
+ * Governada Service Worker
  * Handles push notifications, notification click routing, and offline fallback.
  */
 
@@ -39,10 +39,10 @@ self.addEventListener('push', (event) => {
   try {
     payload = event.data.json();
   } catch {
-    payload = { title: 'DRepScore', body: event.data.text() };
+    payload = { title: 'Governada', body: event.data.text() };
   }
 
-  const { title = 'DRepScore', body = '', url = '/', icon = '/favicon.ico', badge = '/favicon.ico' } = payload;
+  const { title = 'Governada', body = '', url = '/', icon = '/favicon.ico', badge = '/favicon.ico' } = payload;
 
   event.waitUntil(
     self.registration.showNotification(title, {

--- a/scripts/bootstrap-sync.ts
+++ b/scripts/bootstrap-sync.ts
@@ -111,7 +111,7 @@ async function batchUpsert(
 async function main() {
   const startTime = Date.now();
   console.log('╔══════════════════════════════════════════════╗');
-  console.log('║       DRepScore Bootstrap Sync               ║');
+  console.log('║       Governada Bootstrap Sync               ║');
   console.log('╚══════════════════════════════════════════════╝\n');
 
   const supabase = getSupabaseAdmin();

--- a/scripts/inngest-status.ts
+++ b/scripts/inngest-status.ts
@@ -17,7 +17,7 @@ config({ path: '.env.local' });
 
 const INNGEST_API = 'https://api.inngest.com/v1';
 const SIGNING_KEY = process.env.INNGEST_SIGNING_KEY;
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 
 if (!SIGNING_KEY) {
   console.error('INNGEST_SIGNING_KEY is not set');

--- a/scripts/outreach-extract.ts
+++ b/scripts/outreach-extract.ts
@@ -11,7 +11,7 @@ config({ path: resolve(process.cwd(), '.env.local') });
 import { getSupabaseAdmin } from '../lib/supabase';
 import { writeFileSync } from 'fs';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://drepscore.io';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
 
 interface DRepRow {
   id: string;

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -4,7 +4,7 @@
  * Exit 0 = all pass, non-zero = failure details printed.
  */
 
-const BASE_URL = process.argv[2] || process.env.SMOKE_TEST_URL || 'https://drepscore.io';
+const BASE_URL = process.argv[2] || process.env.SMOKE_TEST_URL || 'https://governada.io';
 
 interface Check {
   name: string;
@@ -121,7 +121,7 @@ async function runCheck(check: Check): Promise<{ pass: boolean; name: string; de
   try {
     const res = await fetch(url, {
       method: check.method || 'GET',
-      headers: { 'User-Agent': 'DRepScore-SmokeTest/1.0' },
+      headers: { 'User-Agent': 'Governada-SmokeTest/1.0' },
       signal: AbortSignal.timeout(15_000),
     });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,4 @@
-# Civica — Active Work
+# Governada — Active Work
 
 ## Current Phase: Phase 3B (My Gov Completion + DRep Profile Redesign)
 
@@ -7,7 +7,7 @@ See `.cursor/plans/civica_phase_3b_eab7f1b4.plan.md` for this phase's detailed p
 
 ## Completed
 
-- [x] Civica Shell Foundation (Phase 1A) — PR #77 merged
+- [x] Governada Shell Foundation (Phase 1A) — PR #77 merged
   - Feature flag `civica_frontend` in feature_flags table
   - SegmentProvider + useSegment() hook
   - TierThemeProvider + useTierTheme() hook
@@ -16,10 +16,10 @@ See `.cursor/plans/civica_phase_3b_eab7f1b4.plan.md` for this phase's detailed p
   - Root layout branching (old shell when flag off, CivicaShell when on)
   - /my-gov stub page (auth-gated)
 
-- [x] Civica Phase 1B — GovTerm, Metadata, Home Pages
+- [x] Governada Phase 1B — GovTerm, Metadata, Home Pages
   - GovTerm component (localStorage progressive dismissal, segment-aware tooltips)
   - 12 governance terms in lib/microcopy.ts GOV_TERMS
-  - generateMetadata() on /, /discover, /pulse, /my-gov (Civica-branded)
+  - generateMetadata() on /, /discover, /pulse, /my-gov (Governada-branded)
   - Home/anonymous: constellation hero + value prop + Quick Match CTA + SSR stats
   - Home/citizen: DRep report card, pillar bars, epoch callout
   - Home/DRep: score hero, sparkline, quick win card, competitive context
@@ -27,7 +27,7 @@ See `.cursor/plans/civica_phase_3b_eab7f1b4.plan.md` for this phase's detailed p
   - CivicaHomePage segment dispatcher
   - useDRepReportCard, useDashboardCompetitive, useSPOPoolCompetitive hooks
 
-- [x] Civica Phase 2A — Discover, Cards, Leaderboard
+- [x] Governada Phase 2A — Discover, Cards, Leaderboard
   - CivicaDRepCard: tier-colored browse card with score, tier badge, 6-axis alignment mini-bars, hover expansion
   - CivicaSPOCard: tier-colored pool card with governance score, participation/consistency/reliability bars, claimed badge
   - tierStyles.ts: shared token map (border/bg/glow/badge per tier)
@@ -38,20 +38,20 @@ See `.cursor/plans/civica_phase_3b_eab7f1b4.plan.md` for this phase's detailed p
   - CivicaLeaderboard: ranked DRep table with tier filter chips, delta trend arrows, 7-day movers strip, 25/page pagination
   - app/discover/page.tsx + app/pulse/page.tsx: civica_frontend flag-gated rendering
 
-- [x] Civica Phase 2B — Pulse deep dive + My Gov action feed
+- [x] Governada Phase 2B — Pulse deep dive + My Gov action feed
   - CivicaPulse: full Pulse page with GHI, cross-chain observatory, AI State of Governance narrative, governance calendar
   - Action feed architecture (lib/actionFeed.ts + ActionFeed component)
   - CitizenCommandCenter: delegation health card, recent DRep votes, action feed
   - DRepCommandCenter: score gauge, stats row, pending votes widget, action feed
 
-- [x] Civica Phase 3A — Pulse completion + SPO command center + SPO claim flow
+- [x] Governada Phase 3A — Pulse completion + SPO command center + SPO claim flow
   - EDI-driven Cross-Chain Observatory in Pulse
   - AI "State of Governance" narrative
   - Governance Calendar
   - SPOCommandCenter: score gauge, pool stats, governance activity, action feed
   - SPO claim flow (wallet-verified pool ownership)
 
-- [x] Civica Phase 3B — My Gov completion + DRep Profile Redesign
+- [x] Governada Phase 3B — My Gov completion + DRep Profile Redesign
   - Feature flag audit: restored civica_frontend, drep_communication, score_tiers, alignment_drift,
     spo_claim_flow, spo_governance_identity flags deleted by migration 039
   - My Gov Inbox (4.5): multi-segment notification hub, filter tabs (All/Proposals/Score/Alignment/System),
@@ -80,7 +80,7 @@ See `.cursor/plans/civica_phase_3b_eab7f1b4.plan.md` for this phase's detailed p
 - [x] Proposal Detail Redesign (5.3): "Proposal cards that connect everything" — AI category badge,
       tri-body vote bars, treasury impact, similar proposals, your DRep's vote highlighted,
       Phase B scaffold "What representatives are saying" section.
-- [x] CC Members Civica Integration: /discover/committee — server-rendered page with CC transparency
+- [x] CC Members Governada Integration: /discover/committee — server-rendered page with CC transparency
       scores (participation rate + DRep alignment), alignment tension detection, route redirects
       (/committee → /discover/committee, /proposals/:txHash/:index → /proposal/:txHash/:index),
       CommandPalette entry added.


### PR DESCRIPTION
## Summary
- Update all user-facing brand references across 195 files (670+ line changes)
- Production URL `drepscore.io` → `governada.io` across app metadata, OG images, email templates, push notifications, deploy scripts, CI config
- Social handles updated to `@GovernadaIO` / `@GovernadaBot`
- Strategy docs, persona docs, ADRs, audit commands, and agent configs all updated
- Internal identifiers preserved (component names, CSS classes, scoring function names, `package.json`) — zero functional changes

## Impact
- **What changed**: Every user-facing brand string and URL across the entire codebase
- **User-facing**: Yes — app title, metadata, emails, push notifications, OG images, badges all show "Governada" and link to governada.io
- **Risk**: Low — text-only changes, no logic/data/schema modifications. All 535 tests pass.
- **Scope**: 195 files across app/, components/, lib/, docs/, scripts/, .claude/, .github/

## Test plan
- [x] All 535 unit tests pass
- [x] Prettier formatting clean
- [x] ESLint clean (1 pre-existing warning, unrelated)
- [x] TypeScript compiles clean
- [ ] CI pipeline (automated)
- [ ] Post-merge: verify governada.io serves updated metadata
- [ ] Post-merge: verify OG images show Governada branding
- [ ] Post-merge: sync Inngest to governada.io/api/inngest

🤖 Generated with [Claude Code](https://claude.com/claude-code)