### PR TITLE
fix: QA batches 1-3 — brand, data accuracy, UX gating

### DIFF
--- a/app/api/dreps/[drepId]/similar/route.ts
+++ b/app/api/dreps/[drepId]/similar/route.ts
@@ -70,7 +70,14 @@ export const GET = withRouteHandler(async (request) => {
     }
   }
 
-  const similar = similarities.map((s) => {
+  // Filter to DReps with metadata names for quality results
+  const namedSimilarities = similarities.filter((s) => {
+    const info = infoMap.get(s.drepId);
+    return info?.name != null;
+  });
+  const finalSimilarities = namedSimilarities.length >= 3 ? namedSimilarities : similarities;
+
+  const similar = finalSimilarities.map((s) => {
     const info = infoMap.get(s.drepId);
     return {
       drepId: s.drepId,

--- a/app/api/governance/pulse/route.ts
+++ b/app/api/governance/pulse/route.ts
@@ -56,10 +56,12 @@ export const GET = withRouteHandler(async () => {
     formattedAda = `${Math.round(totalAdaGoverned).toLocaleString()}`;
   }
 
-  const participationRates = dreps
+  const participationRates = activeDReps
     .map((d) => (d.effective_participation as number) || 0)
     .filter((r) => r > 0);
-  const rationaleRates = dreps.map((d) => (d.rationale_rate as number) || 0).filter((r) => r > 0);
+  const rationaleRates = activeDReps
+    .map((d) => (d.rationale_rate as number) || 0)
+    .filter((r) => r > 0);
   const avgParticipation =
     participationRates.length > 0
       ? Math.round(participationRates.reduce((a, b) => a + b, 0) / participationRates.length)

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -145,7 +145,7 @@ export const POST = withRouteHandler(async (request) => {
           differDimensions: dimAgreement.differDimensions,
         };
       })
-      .sort((a, b) => b.matchScore - a.matchScore)
+      .sort((a, b) => b.matchScore - a.matchScore || b.entityScore - a.entityScore)
       .slice(0, 5);
 
     const personalityLabel = getPersonalityLabel(userAlignments);
@@ -224,8 +224,11 @@ export const POST = withRouteHandler(async (request) => {
         differDimensions: dimAgreement.differDimensions,
       };
     })
-    .sort((a, b) => b.matchScore - a.matchScore)
-    .slice(0, 5);
+    .sort((a, b) => b.matchScore - a.matchScore || b.drepScore - a.drepScore);
+
+  // Prefer named DReps in results; fall back to unnamed if fewer than 3 named
+  const namedRanked = ranked.filter((r) => r.drepName);
+  const topRanked = (namedRanked.length >= 3 ? namedRanked : ranked).slice(0, 5);
 
   const personalityLabel = getPersonalityLabel(userAlignments);
   const dominant = getDominantDimension(userAlignments);
@@ -246,12 +249,12 @@ export const POST = withRouteHandler(async (request) => {
     transparency,
     match_type: 'drep',
     personality_label: personalityLabel,
-    top_match_score: ranked[0]?.matchScore ?? null,
-    matches_count: ranked.length,
+    top_match_score: topRanked[0]?.matchScore ?? null,
+    matches_count: topRanked.length,
   });
 
   return NextResponse.json({
-    matches: ranked.map((r) => ({
+    matches: topRanked.map((r) => ({
       drepId: r.drepId,
       drepName: r.drepName,
       drepScore: r.drepScore,

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -5,6 +5,7 @@
  */
 
 import { notFound } from 'next/navigation';
+import { cookies } from 'next/headers';
 import Link from 'next/link';
 import nextDynamic from 'next/dynamic';
 import type { Metadata } from 'next';
@@ -479,6 +480,13 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
 
   const pendingProposalCount = openProposals.length;
 
+  // Check if viewer is authenticated (hide certain elements for anonymous visitors)
+  let isViewerAuthenticated = false;
+  try {
+    const cookieStore = await cookies();
+    isViewerAuthenticated = !!cookieStore.get('drepscore_session')?.value;
+  } catch {}
+
   const brokenLinks = new Set(linkChecks.filter((c) => c.status === 'broken').map((c) => c.uri));
 
   const adjustedRationale = applyRationaleCurve(drep.rationaleRate);
@@ -606,7 +614,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       />
 
       {/* 3. Tier Progress + Momentum */}
-      {tierProgress.pointsToNext != null && (
+      {isViewerAuthenticated && tierProgress.pointsToNext != null && (
         <div className="flex items-center justify-between rounded-xl border border-border bg-card px-5 py-3">
           <div className="flex items-center gap-3">
             <span className="text-sm font-medium">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,7 +49,7 @@ async function getGovernancePulse() {
         .select('wallet_address', { count: 'exact', head: true })
         .not('claimed_drep_id', 'is', null),
       supabase.from('spo_votes').select('pool_id').limit(1000),
-      supabase.from('cc_votes').select('cc_hot_id').limit(100),
+      supabase.from('committee_members').select('cc_hot_id, status'),
     ]);
 
   const dreps = drepsResult.data || [];
@@ -74,7 +74,9 @@ async function getGovernancePulse() {
   );
 
   const spoPoolIds = new Set((spoResult.data || []).map((v) => v.pool_id));
-  const ccIds = new Set((ccResult.data || []).map((v) => v.cc_hot_id));
+  const ccMemberRows = (ccResult.data || []).filter(
+    (m) => !m.status || m.status.toLowerCase() === 'active',
+  );
 
   return {
     totalAdaGoverned: formattedAda,
@@ -84,7 +86,7 @@ async function getGovernancePulse() {
     votesThisWeek: votesResult.count || 0,
     claimedDReps: claimedResult.count || 0,
     activeSpOs: spoPoolIds.size,
-    ccMembers: ccIds.size,
+    ccMembers: ccMemberRows.length,
   };
 }
 

--- a/components/GovernanceRadar.tsx
+++ b/components/GovernanceRadar.tsx
@@ -23,7 +23,9 @@ interface GovernanceRadarProps {
 }
 
 const SIZE_MAP: Record<RadarSize, number> = { full: 220, medium: 80, mini: 32 };
-const PADDING_MAP: Record<RadarSize, number> = { full: 44, medium: 8, mini: 2 };
+const PADDING_MAP: Record<RadarSize, number> = { full: 52, medium: 8, mini: 2 };
+// Label area extends beyond the SVG polygon — use overflow visible to prevent clipping
+const LABEL_OVERFLOW: Record<RadarSize, number> = { full: 36, medium: 0, mini: 0 };
 
 function getPolygonPoints(scores: number[], cx: number, cy: number, maxR: number): string {
   return scores
@@ -194,9 +196,10 @@ export function GovernanceRadar({
     <div role="img" aria-label="Governance alignment radar" className={cn('shrink-0', className)}>
       <svg
         ref={ref}
-        viewBox={`0 0 ${svgSize} ${svgSize}`}
-        width={svgSize}
-        height={svgSize}
+        viewBox={`${-LABEL_OVERFLOW[size]} ${-LABEL_OVERFLOW[size]} ${svgSize + LABEL_OVERFLOW[size] * 2} ${svgSize + LABEL_OVERFLOW[size] * 2}`}
+        width={svgSize + LABEL_OVERFLOW[size] * 2}
+        height={svgSize + LABEL_OVERFLOW[size] * 2}
+        style={{ overflow: 'visible' }}
         aria-hidden="true"
       >
         <defs>

--- a/components/InstallPrompt.tsx
+++ b/components/InstallPrompt.tsx
@@ -17,8 +17,14 @@ export function InstallPrompt() {
     const dismissed = localStorage.getItem('pwa-install-dismissed');
     if (dismissed) return;
 
-    const visits = parseInt(localStorage.getItem('pwa-visit-count') || '0', 10) + 1;
-    localStorage.setItem('pwa-visit-count', String(visits));
+    // Only count once per session to avoid prompting on every page navigation
+    const alreadyCounted = sessionStorage.getItem('pwa-visit-counted');
+    let visits = parseInt(localStorage.getItem('pwa-visit-count') || '0', 10);
+    if (!alreadyCounted) {
+      visits += 1;
+      localStorage.setItem('pwa-visit-count', String(visits));
+      sessionStorage.setItem('pwa-visit-counted', '1');
+    }
 
     if (visits < 3) return;
 

--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -31,36 +31,38 @@ export function CivicaBottomNav() {
       aria-label="Mobile navigation"
     >
       <div className="flex items-center justify-around h-14">
-        {NAV_ITEMS.map(({ href, label, icon: Icon, ...rest }) => {
-          const active = isActive(href);
-          const showBadge = 'showBadge' in rest && rest.showBadge;
-          return (
-            <Link
-              key={href}
-              href={href}
-              className={cn(
-                'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors [touch-action:manipulation]',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
-                active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
-              )}
-              aria-current={active ? 'page' : undefined}
-              aria-label={label}
-            >
-              <div className="relative inline-flex">
-                <Icon className="h-5 w-5" />
-                {showBadge && unreadCount > 0 && (
-                  <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-500 text-[10px] text-white flex items-center justify-center font-bold">
-                    {unreadCount > 9 ? '9+' : unreadCount}
-                  </span>
+        {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || !!stakeAddress).map(
+          ({ href, label, icon: Icon, ...rest }) => {
+            const active = isActive(href);
+            const showBadge = 'showBadge' in rest && rest.showBadge;
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={cn(
+                  'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors [touch-action:manipulation]',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
+                  active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
                 )}
-              </div>
-              <span className="text-[10px] font-medium leading-tight">{label}</span>
-              {active && (
-                <span className="absolute bottom-[calc(env(safe-area-inset-bottom)+2px)] h-0.5 w-6 rounded-full bg-primary" />
-              )}
-            </Link>
-          );
-        })}
+                aria-current={active ? 'page' : undefined}
+                aria-label={label}
+              >
+                <div className="relative inline-flex">
+                  <Icon className="h-5 w-5" />
+                  {showBadge && unreadCount > 0 && (
+                    <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-500 text-[10px] text-white flex items-center justify-center font-bold">
+                      {unreadCount > 9 ? '9+' : unreadCount}
+                    </span>
+                  )}
+                </div>
+                <span className="text-[10px] font-medium leading-tight">{label}</span>
+                {active && (
+                  <span className="absolute bottom-[calc(env(safe-area-inset-bottom)+2px)] h-0.5 w-6 rounded-full bg-primary" />
+                )}
+              </Link>
+            );
+          },
+        )}
       </div>
     </nav>
   );

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -92,39 +92,41 @@ export function CivicaHeader() {
             href="/"
             className="font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
           >
-            Governada
+            governada
           </Link>
 
           <nav className="flex items-center gap-1" aria-label="Main navigation">
-            {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-              const active = isActive(href);
-              return (
-                <Link
-                  key={href}
-                  href={href}
-                  className={cn(
-                    'relative flex items-center gap-2 px-3 py-2 min-h-[44px] text-sm font-medium rounded-md transition-colors',
-                    'hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                    active ? 'text-foreground' : 'text-muted-foreground',
-                  )}
-                  aria-current={active ? 'page' : undefined}
-                >
-                  <span className="relative inline-flex">
-                    <Icon className="h-4 w-4" />
-                    {href === '/my-gov' && unreadCount > 0 && (
-                      <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
-                        {unreadCount > 9 ? '9+' : unreadCount}
-                      </span>
+            {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || connected).map(
+              ({ href, label, icon: Icon }) => {
+                const active = isActive(href);
+                return (
+                  <Link
+                    key={href}
+                    href={href}
+                    className={cn(
+                      'relative flex items-center gap-2 px-3 py-2 min-h-[44px] text-sm font-medium rounded-md transition-colors',
+                      'hover:bg-accent hover:text-accent-foreground',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                      active ? 'text-foreground' : 'text-muted-foreground',
                     )}
-                  </span>
-                  {label}
-                  {active && (
-                    <span className="absolute bottom-0 left-3 right-3 h-0.5 rounded-full bg-primary" />
-                  )}
-                </Link>
-              );
-            })}
+                    aria-current={active ? 'page' : undefined}
+                  >
+                    <span className="relative inline-flex">
+                      <Icon className="h-4 w-4" />
+                      {href === '/my-gov' && unreadCount > 0 && (
+                        <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
+                          {unreadCount > 9 ? '9+' : unreadCount}
+                        </span>
+                      )}
+                    </span>
+                    {label}
+                    {active && (
+                      <span className="absolute bottom-0 left-3 right-3 h-0.5 rounded-full bg-primary" />
+                    )}
+                  </Link>
+                );
+              },
+            )}
           </nav>
         </div>
 

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -216,14 +216,20 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
           innovation: b.alignmentInnovation,
           transparency: b.alignmentTransparency,
         };
-        return alignmentDistance(userAlign, aAlign) - alignmentDistance(userAlign, bAlign);
+        const distDiff =
+          alignmentDistance(userAlign, aAlign) - alignmentDistance(userAlign, bAlign);
+        if (distDiff !== 0) return distDiff;
+        return (b.drepScore ?? 0) - (a.drepScore ?? 0);
       });
     }
 
     return result;
   }, [dreps, filters, sortMode, matchProfile]);
 
-  const allScores = useMemo(() => dreps.map((d) => d.drepScore ?? 0), [dreps]);
+  const allScores = useMemo(
+    () => dreps.filter((d) => d.isActive).map((d) => d.drepScore ?? 0),
+    [dreps],
+  );
 
   const totalPages = Math.ceil(filtered.length / pageSize);
   const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -12,6 +12,7 @@ import {
   Coins,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { posthog } from '@/lib/posthog';
 import { ConstellationScene } from '@/components/ConstellationScene';
 
@@ -47,17 +48,55 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
 
         {/* Live data overlay on constellation */}
         <div className="absolute top-16 sm:top-20 left-4 right-4 flex justify-center pointer-events-none">
-          <div className="flex items-center gap-3 sm:gap-6 text-white/60 text-[10px] sm:text-xs tracking-wider uppercase">
+          <div className="flex items-center gap-3 sm:gap-6 text-white/80 text-[10px] sm:text-xs tracking-wider uppercase rounded-full bg-black/40 backdrop-blur-sm px-4 py-1.5 shadow-lg pointer-events-auto">
             <span className="tabular-nums">
-              <strong className="text-white/90">{pulseData.activeDReps}</strong> DReps
+              <strong className="text-emerald-400 font-bold">{pulseData.activeDReps}</strong>{' '}
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="underline decoration-dotted cursor-help">DReps</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs max-w-[200px]">
+                      Delegated Representatives who vote on governance proposals on behalf of ADA
+                      holders
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </span>
             <span className="text-white/30">&middot;</span>
             <span className="tabular-nums">
-              <strong className="text-white/90">{pulseData.activeSpOs}</strong> SPOs
+              <strong className="text-sky-400 font-bold">{pulseData.activeSpOs}</strong>{' '}
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="underline decoration-dotted cursor-help">SPOs</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs max-w-[200px]">
+                      Stake Pool Operators who run the network and vote on protocol changes
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </span>
             <span className="text-white/30">&middot;</span>
             <span className="tabular-nums">
-              <strong className="text-white/90">{pulseData.ccMembers}</strong> CC Members
+              <strong className="text-amber-400 font-bold">{pulseData.ccMembers}</strong>{' '}
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="underline decoration-dotted cursor-help">CC Members</span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-xs max-w-[200px]">
+                      Constitutional Committee members who ensure proposals comply with the Cardano
+                      Constitution
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </span>
           </div>
         </div>

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -157,7 +157,7 @@ type Step = 'intro' | 0 | 1 | 2 | 'loading' | 'results' | 'error';
 type MatchType = 'drep' | 'spo';
 
 export function QuickMatchFlow() {
-  const [step, setStep] = useState<Step>('intro');
+  const [step, setStep] = useState<Step>(0);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [selected, setSelected] = useState<string | null>(null);
   const [drepResults, setDrepResults] = useState<QuickMatchResponse | null>(null);

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -185,7 +185,8 @@ export async function getAllDReps(): Promise<{
     const { data: rows, error: supabaseError } = await supabase
       .from('dreps')
       .select('*')
-      .order('score', { ascending: false });
+      .order('score', { ascending: false })
+      .range(0, 9999);
 
     if (supabaseError) {
       logger.error('[Data] Supabase query failed', { error: supabaseError.message });


### PR DESCRIPTION
## Summary
- **Batch 1** (quick fixes): Brand casing, hero stat readability with pill backgrounds + tooltips, radar label clipping fix, match sort tiebreaker, PWA install prompt session-based counting
- **Batch 2** (data fixes): CC Members count from committee_members table (7 not 3), DRep count past PostgREST 1000 limit, score distribution + avg rates filtered to active DReps only, named DRep preference in match/similar results
- **Batch 3** (UX): Skip match intro to start on Q1, tier progress + alignment trajectory gated behind auth, My Gov nav hidden when disconnected

## Impact
- **What changed**: 13 files across frontend components, API routes, and data layer to fix data accuracy bugs, improve UX gating, and polish visual presentation
- **User-facing**: Yes — correct DRep/CC counts, cleaner hero stats, better match results, auth-gated features hidden from anonymous users
- **Risk**: Low — no schema changes, no new dependencies, all existing tests pass
- **Scope**: 3 API routes, 5 components, 1 data layer file, 1 page

## Test plan
- [ ] Verify hero stats show correct DRep count (>1000), CC Members = 7
- [ ] Verify radar chart labels not clipped on /drep/[id] pages
- [ ] Verify /match starts on Q1 (no intro screen)
- [ ] Verify My Gov hidden in nav when wallet disconnected
- [ ] Verify tier progress section hidden on DRep profiles for anonymous visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)