### PR TITLE
Homepage polish: bug fix + craft improvements

### DIFF
--- a/app/api/governance/pools/[poolId]/competitive/route.ts
+++ b/app/api/governance/pools/[poolId]/competitive/route.ts
@@ -17,7 +17,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const { data: pool } = await supabase
     .from('pools')
     .select(
-      'pool_id, ticker, pool_name, governance_score, vote_count, current_tier, score_momentum',
+      'pool_id, ticker, pool_name, governance_score, vote_count, current_tier, score_momentum, claimed_by',
     )
     .eq('pool_id', poolId)
     .single();

--- a/components/civica/home/EpochBriefing.tsx
+++ b/components/civica/home/EpochBriefing.tsx
@@ -40,7 +40,6 @@ import {
 /* ── Types ──────────────────────────────────────────────────────── */
 
 interface EpochBriefingProps {
-  drepId: string | null | undefined;
   wallet: string | null | undefined;
 }
 
@@ -715,7 +714,12 @@ function EpochBriefingContent({
   const civicIdentityStrip = identity ? (
     <Link
       href="/my-gov/identity"
-      className="group block pt-5 hover:bg-muted/30 -mx-4 px-4 rounded-lg transition-colors"
+      className={cn(
+        'group block pt-5 -mx-4 px-4 rounded-lg transition-colors',
+        identity.delegationStreak != null && (identity.delegationStreak as number) >= 5
+          ? 'bg-amber-500/5 hover:bg-amber-500/10'
+          : 'hover:bg-muted/30',
+      )}
     >
       <div className="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">
         {identity.citizenSinceEpoch != null && (
@@ -726,7 +730,17 @@ function EpochBriefingContent({
         )}
         {identity.delegationStreak != null && (identity.delegationStreak as number) > 0 && (
           <span className="inline-flex items-center gap-1.5 min-h-[36px]">
-            <Flame className="h-3.5 w-3.5 text-amber-500 animate-pulse" aria-hidden="true" />
+            <Flame
+              className={cn(
+                'text-amber-500 animate-pulse',
+                (identity.delegationStreak as number) >= 8
+                  ? 'h-5 w-5'
+                  : (identity.delegationStreak as number) >= 4
+                    ? 'h-4 w-4'
+                    : 'h-3.5 w-3.5',
+              )}
+              aria-hidden="true"
+            />
             {identity.delegationStreak as React.ReactNode} epoch streak
           </span>
         )}
@@ -745,13 +759,13 @@ function EpochBriefingContent({
       </div>
       {(identity.recentMilestone as string | undefined) && (
         <div className="mt-2 flex items-center gap-2 text-xs">
-          <Trophy className="h-3.5 w-3.5 text-amber-500" aria-hidden="true" />
+          <Trophy className="h-3.5 w-3.5 text-amber-500 animate-bounce" aria-hidden="true" />
           <span className="font-medium text-foreground">
             {identity.recentMilestone as React.ReactNode}
           </span>
         </div>
       )}
-      <div className="mt-2 flex items-center gap-1 text-xs text-primary opacity-0 group-hover:opacity-100 transition-opacity">
+      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground group-hover:text-primary transition-colors">
         View your civic identity
         <ArrowRight className="h-3 w-3" />
       </div>

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef } from 'react';
 import Link from 'next/link';
 import {
   ArrowRight,
@@ -11,10 +12,26 @@ import {
   HelpCircle,
   Coins,
 } from 'lucide-react';
+import { useInView, useSpring, useTransform, motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { posthog } from '@/lib/posthog';
 import { ConstellationScene } from '@/components/ConstellationScene';
+
+function AnimatedNumber({ value, className }: { value: number; className?: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true, margin: '-50px' });
+  const spring = useSpring(0, { stiffness: 75, damping: 15 });
+  const display = useTransform(spring, (v) => Math.round(v).toLocaleString());
+
+  if (isInView) spring.set(value);
+
+  return (
+    <motion.span ref={ref} className={className}>
+      {display}
+    </motion.span>
+  );
+}
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -241,7 +258,12 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
           ].map((s) => (
             <div
               key={s.label}
-              className="rounded-xl border border-border bg-card/60 backdrop-blur-sm p-4 space-y-1"
+              className={cn(
+                'rounded-xl border bg-card/60 backdrop-blur-sm p-4 space-y-1',
+                s.label === 'Open Proposals' && (s.value as number) > 0
+                  ? 'border-primary/40'
+                  : 'border-border',
+              )}
             >
               <div className="flex items-center gap-1.5 mb-1">
                 <s.icon className="h-3.5 w-3.5 text-primary/50" />
@@ -250,7 +272,7 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
                 </p>
               </div>
               <p className="font-display text-2xl font-bold text-foreground tabular-nums">
-                {s.value}
+                {typeof s.value === 'number' ? <AnimatedNumber value={s.value} /> : s.value}
               </p>
               <p className="text-[10px] text-muted-foreground">{s.sub}</p>
             </div>
@@ -259,7 +281,7 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
       </section>
 
       {/* ── Social proof strip ──────────────────────────────────────── */}
-      <section className="mx-auto w-full max-w-4xl px-4 pb-16">
+      <section className="mx-auto w-full max-w-4xl px-4 pb-8">
         <div className="rounded-xl border border-border/50 bg-muted/30 px-6 py-4 space-y-2">
           <p className="text-center text-xs font-medium text-muted-foreground uppercase tracking-wider">
             Citizens are already shaping Cardano&apos;s future
@@ -268,22 +290,45 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
             <span className="flex items-center gap-2">
               <Users className="h-4 w-4 text-primary/60 shrink-0" />
               <strong className="text-foreground">
-                {pulseData.totalDReps.toLocaleString()}
+                <AnimatedNumber value={pulseData.totalDReps} />
               </strong>{' '}
               DReps scored
             </span>
             <span className="flex items-center gap-2">
               <ShieldCheck className="h-4 w-4 text-primary/60 shrink-0" />
-              <strong className="text-foreground">{pulseData.claimedDReps}</strong> profiles claimed
+              <strong className="text-foreground">
+                <AnimatedNumber value={pulseData.claimedDReps} />
+              </strong>{' '}
+              profiles claimed
             </span>
             <span className="flex items-center gap-2">
               <Activity className="h-4 w-4 text-primary/60 shrink-0" />
               <strong className="text-foreground">
-                {pulseData.votesThisWeek.toLocaleString()}
+                <AnimatedNumber value={pulseData.votesThisWeek} />
               </strong>{' '}
               votes cast this week
             </span>
           </div>
+        </div>
+      </section>
+
+      {/* ── Final CTA ────────────────────────────────────────────────── */}
+      <section className="mx-auto w-full max-w-2xl px-4 pb-16">
+        <div className="text-center space-y-4">
+          <p className="text-lg font-semibold text-foreground">Ready to use your voice?</p>
+          <Link
+            href="/match"
+            onClick={() => posthog?.capture('citizen_path_clicked', { path: 'govern_bottom' })}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3',
+              'text-sm font-semibold text-primary-foreground',
+              'hover:bg-primary/90 transition-colors',
+            )}
+          >
+            <Zap className="h-4 w-4" />
+            Find My DRep — 60 Seconds
+            <ArrowRight className="h-4 w-4" />
+          </Link>
         </div>
       </section>
     </div>

--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -174,7 +174,7 @@ export function HomeCitizen({ pulseData, ssrHolderData, ssrWalletAddress }: Home
     <div className="flex flex-col pb-16">
       {/* Epoch Briefing — the citizen's entire home experience */}
       <section className="mx-auto w-full max-w-2xl px-4 sm:px-6 pt-4 sm:pt-6">
-        <EpochBriefing drepId={drepId} wallet={wallet} />
+        <EpochBriefing wallet={wallet} />
       </section>
     </div>
   );

--- a/components/civica/home/HomeDRep.tsx
+++ b/components/civica/home/HomeDRep.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   ChevronRight,
   Trophy,
+  CheckCircle2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -167,13 +168,33 @@ export function HomeDRep() {
               </div>
             ) : (
               <div className="flex items-end justify-center gap-3">
-                <span
-                  className={cn(
-                    'font-display text-6xl sm:text-7xl font-bold tabular-nums leading-none drop-shadow-lg hero-text-shadow',
-                    TIER_HERO_COLORS[tier] ?? 'text-white',
-                  )}
-                >
-                  {score}
+                <span className="relative">
+                  <span
+                    className="absolute inset-0 -inset-x-4 -inset-y-2 rounded-full blur-2xl opacity-30 animate-pulse"
+                    style={{
+                      background:
+                        tier === 'Diamond'
+                          ? 'radial-gradient(circle, rgba(34,211,238,0.4), transparent 70%)'
+                          : tier === 'Legendary'
+                            ? 'radial-gradient(circle, rgba(167,139,250,0.4), transparent 70%)'
+                            : tier === 'Gold'
+                              ? 'radial-gradient(circle, rgba(234,179,8,0.3), transparent 70%)'
+                              : tier === 'Silver'
+                                ? 'radial-gradient(circle, rgba(148,163,184,0.3), transparent 70%)'
+                                : tier === 'Bronze'
+                                  ? 'radial-gradient(circle, rgba(217,119,6,0.3), transparent 70%)'
+                                  : 'radial-gradient(circle, rgba(255,255,255,0.1), transparent 70%)',
+                    }}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className={cn(
+                      'relative font-display text-6xl sm:text-7xl font-bold tabular-nums leading-none drop-shadow-lg hero-text-shadow',
+                      TIER_HERO_COLORS[tier] ?? 'text-white',
+                    )}
+                  >
+                    {score}
+                  </span>
                 </span>
                 <div className="pb-1.5 space-y-0.5 text-left">
                   <span
@@ -333,6 +354,17 @@ export function HomeDRep() {
         )}
 
         {urgentLoading && <Skeleton className="h-24 rounded-xl" />}
+
+        {!urgentLoading && urgentItems.length === 0 && (
+          <div className="rounded-xl border border-emerald-800/30 bg-emerald-950/10 p-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+              <p className="text-sm font-medium text-foreground">
+                All caught up — no urgent votes this epoch
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* ── Competitive context ──────────────────────────────────── */}
         {!compLoading && (competitive?.nearbyAbove?.length ?? 0) > 0 && (

--- a/components/civica/home/HomeSPO.tsx
+++ b/components/civica/home/HomeSPO.tsx
@@ -100,7 +100,7 @@ export function HomeSPO() {
   const score: number = (pool?.governance_score as number) ?? 0;
   const tier: string = (pool?.tier as string) ?? 'Emerging';
   const ticker: string = (pool?.ticker as string) ?? '';
-  const isClaimed = false; // Server-side claim status deferred; always show soft claim prompt
+  const isClaimed = !!pool?.claimed_by;
 
   const momentumLabel =
     momentum !== null && momentum > 0.5
@@ -138,13 +138,33 @@ export function HomeSPO() {
               </div>
             ) : (
               <div className="flex items-end justify-center gap-3">
-                <span
-                  className={cn(
-                    'font-display text-6xl sm:text-7xl font-bold tabular-nums leading-none drop-shadow-lg hero-text-shadow',
-                    TIER_HERO_COLORS[tier] ?? 'text-white',
-                  )}
-                >
-                  {score}
+                <span className="relative">
+                  <span
+                    className="absolute inset-0 -inset-x-4 -inset-y-2 rounded-full blur-2xl opacity-30 animate-pulse"
+                    style={{
+                      background:
+                        tier === 'Diamond'
+                          ? 'radial-gradient(circle, rgba(34,211,238,0.4), transparent 70%)'
+                          : tier === 'Legendary'
+                            ? 'radial-gradient(circle, rgba(167,139,250,0.4), transparent 70%)'
+                            : tier === 'Gold'
+                              ? 'radial-gradient(circle, rgba(234,179,8,0.3), transparent 70%)'
+                              : tier === 'Silver'
+                                ? 'radial-gradient(circle, rgba(148,163,184,0.3), transparent 70%)'
+                                : tier === 'Bronze'
+                                  ? 'radial-gradient(circle, rgba(217,119,6,0.3), transparent 70%)'
+                                  : 'radial-gradient(circle, rgba(255,255,255,0.1), transparent 70%)',
+                    }}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className={cn(
+                      'relative font-display text-6xl sm:text-7xl font-bold tabular-nums leading-none drop-shadow-lg hero-text-shadow',
+                      TIER_HERO_COLORS[tier] ?? 'text-white',
+                    )}
+                  >
+                    {score}
+                  </span>
                 </span>
                 <div className="pb-1.5 space-y-0.5 text-left">
                   <span


### PR DESCRIPTION
## Summary
- Fix SPO isClaimed bug (hardcoded false → reads actual claimed_by from API)
- Animated stat reveals on anonymous homepage (framer-motion spring)
- Tier-colored radial glow on DRep/SPO score hero
- Enhanced civic identity strip (scaled flame, bouncing trophy, always-visible link)
- "All caught up" state for DRep quick win
- Closing CTA on anonymous homepage
- Remove dead drepId prop from EpochBriefing

## Impact
- **What changed**: 1 bug fix (SPO claim prompt), 5 craft improvements across all homepage variants
- **User-facing**: Yes — SPOs no longer see incorrect claim prompt; animated stats, tier glow, and enhanced civic identity are visible improvements
- **Risk**: Low — all changes are frontend styling/display + one API field addition (read-only)
- **Scope**: 6 component files + 1 API route. No migrations, no env vars, no Inngest changes

## Test plan
- [ ] Anonymous homepage: stats animate on scroll, Open Proposals has subtle border glow, closing CTA appears at bottom
- [ ] DRep homepage: score in hero has tier-colored glow, "all caught up" card shows when no urgent votes
- [ ] SPO homepage: claim prompt hidden for claimed pools, score has tier-colored glow
- [ ] Delegated citizen: civic identity flame scales with streak, trophy bounces, link always visible
- [ ] Mobile: all animations work, no layout shift, carousel still swipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)