### PR TITLE
fix: CC member count, tooltip UX, persona icons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,9 +81,17 @@ async function getGovernancePulse() {
   );
 
   const spoPoolIds = new Set((spoResult.data || []).map((v) => v.pool_id));
-  const ccMemberRows = (ccResult.data || []).filter(
+  let ccMemberCount = (ccResult.data || []).filter(
     (m) => !m.status || m.status.toLowerCase() === 'active',
-  );
+  ).length;
+
+  // Fallback: if committee_members table is empty, count distinct voters from cc_votes
+  if (ccMemberCount === 0) {
+    const { data: ccVoters } = await supabase.from('cc_votes').select('cc_hot_id').limit(1000);
+    if (ccVoters && ccVoters.length > 0) {
+      ccMemberCount = new Set(ccVoters.map((v) => v.cc_hot_id)).size;
+    }
+  }
 
   return {
     totalAdaGoverned: formattedAda,
@@ -93,7 +101,7 @@ async function getGovernancePulse() {
     votesThisWeek: votesResult.count || 0,
     claimedDReps: claimedResult.count || 0,
     activeSpOs: spoPoolIds.size,
-    ccMembers: ccMemberRows.length,
+    ccMembers: ccMemberCount,
   };
 }
 

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -13,11 +13,13 @@ import {
   BookOpen,
   Search,
   User,
+  Users,
   LogOut,
   Sun,
   Moon,
   Eye,
   Shield,
+  ShieldCheck,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { useTheme } from 'next-themes';
@@ -58,6 +60,13 @@ const SEGMENT_LABELS: Record<UserSegment, string> = {
   citizen: 'Citizen',
   drep: 'DRep',
   spo: 'SPO',
+};
+
+const SEGMENT_ICONS: Record<UserSegment, typeof User> = {
+  anonymous: User,
+  citizen: User,
+  drep: Users,
+  spo: ShieldCheck,
 };
 
 export function CivicaHeader() {
@@ -171,7 +180,11 @@ export function CivicaHeader() {
                   )}
                   aria-label="User menu"
                 >
-                  {hasOverride ? <Eye className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+                  {(() => {
+                    if (hasOverride) return <Eye className="h-3.5 w-3.5" />;
+                    const SegmentIcon = SEGMENT_ICONS[segment];
+                    return <SegmentIcon className="h-3.5 w-3.5" />;
+                  })()}
                   {segment !== 'anonymous' && SEGMENT_LABELS[segment]}
                 </button>
               </DropdownMenuTrigger>

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -65,57 +65,62 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
 
         {/* Live data overlay on constellation */}
         <div className="absolute top-16 sm:top-20 left-4 right-4 flex justify-center pointer-events-none">
-          <div className="flex items-center gap-3 sm:gap-6 text-white/80 text-[10px] sm:text-xs tracking-wider uppercase rounded-full bg-black/40 backdrop-blur-sm px-4 py-1.5 shadow-lg pointer-events-auto">
-            <span className="tabular-nums">
-              <strong className="text-emerald-400 font-bold">{pulseData.activeDReps}</strong>{' '}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="underline decoration-dotted cursor-help">DReps</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="text-xs max-w-[200px]">
-                      Delegated Representatives who vote on governance proposals on behalf of ADA
-                      holders
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </span>
-            <span className="text-white/30">&middot;</span>
-            <span className="tabular-nums">
-              <strong className="text-sky-400 font-bold">{pulseData.activeSpOs}</strong>{' '}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="underline decoration-dotted cursor-help">SPOs</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="text-xs max-w-[200px]">
-                      Stake Pool Operators who run the network and vote on protocol changes
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </span>
-            <span className="text-white/30">&middot;</span>
-            <span className="tabular-nums">
-              <strong className="text-amber-400 font-bold">{pulseData.ccMembers}</strong>{' '}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="underline decoration-dotted cursor-help">CC Members</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="text-xs max-w-[200px]">
-                      Constitutional Committee members who ensure proposals comply with the Cardano
-                      Constitution
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </span>
-          </div>
+          <TooltipProvider delayDuration={100}>
+            <div className="flex items-center gap-3 sm:gap-6 text-white/60 text-[10px] sm:text-xs tracking-wider uppercase rounded-full bg-black/40 backdrop-blur-sm px-4 py-1.5 shadow-lg pointer-events-auto">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="tabular-nums hover:text-white/90 transition-colors duration-200 cursor-default">
+                    <strong className="text-emerald-400 font-bold">{pulseData.activeDReps}</strong>{' '}
+                    DReps
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="bg-black/90 border-white/10 backdrop-blur-md max-w-[220px]"
+                >
+                  <p className="text-xs text-white/90 leading-relaxed">
+                    <strong className="text-emerald-400">Delegated Representatives</strong> who vote
+                    on governance proposals on behalf of ADA holders
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+              <span className="text-white/20">&middot;</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="tabular-nums hover:text-white/90 transition-colors duration-200 cursor-default">
+                    <strong className="text-sky-400 font-bold">{pulseData.activeSpOs}</strong> SPOs
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="bg-black/90 border-white/10 backdrop-blur-md max-w-[220px]"
+                >
+                  <p className="text-xs text-white/90 leading-relaxed">
+                    <strong className="text-sky-400">Stake Pool Operators</strong> who run the
+                    network and vote on protocol changes
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+              <span className="text-white/20">&middot;</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="tabular-nums hover:text-white/90 transition-colors duration-200 cursor-default">
+                    <strong className="text-amber-400 font-bold">{pulseData.ccMembers}</strong> CC
+                    Members
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="bottom"
+                  className="bg-black/90 border-white/10 backdrop-blur-md max-w-[220px]"
+                >
+                  <p className="text-xs text-white/90 leading-relaxed">
+                    <strong className="text-amber-400">Constitutional Committee</strong> members who
+                    ensure proposals comply with the Cardano Constitution
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
         </div>
 
         {/* Value prop overlay */}


### PR DESCRIPTION
## Summary
- **CC Members count**: Add `cc_votes` fallback when `committee_members` table is empty — fixes the 0 count showing on homepage (actual count: 6-7 active CC members)
- **Tooltip UX**: Redesign constellation stats bar tooltips — remove dotted underline, single `TooltipProvider`, subtle white/60→white/90 hover transition, dark glass tooltip content with colored role names
- **Persona icons**: Show segment-specific icons in header badge (DRep → Users icon, SPO → ShieldCheck icon) instead of generic User icon for all personas

## Impact
- **What changed**: Homepage stats accuracy fix + tooltip visual polish + header personalization
- **User-facing**: Yes — CC Members shows correct count, tooltips feel more premium, header reflects detected persona
- **Risk**: Low — styling changes + data fallback query, no schema changes
- **Scope**: `app/page.tsx`, `components/civica/home/HomeAnonymous.tsx`, `components/civica/CivicaHeader.tsx`

## Test plan
- [ ] Verify CC Members count shows 6-7 (not 0) on homepage
- [ ] Hover DReps/SPOs/CC Members in constellation bar — tooltip appears with colored role name, no dotted underline
- [ ] Connect wallet as DRep → header shows Users icon + "DRep" label
- [ ] Connect wallet as SPO → header shows ShieldCheck icon + "SPO" label
- [ ] Connect wallet as citizen → header shows User icon + "Citizen" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)