### PR TITLE
feat: identity-colored progress bar + loading visualization + shared answer vectors

### DIFF
--- a/__tests__/matching/quickMatchHelpers.test.ts
+++ b/__tests__/matching/quickMatchHelpers.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { buildAlignmentFromAnswers, ANSWER_VECTORS } from '@/lib/matching/answerVectors';
+
+// Import narrative helpers — they're module-scoped functions in QuickMatchFlow,
+// so we test them indirectly through buildAlignmentFromAnswers + inline logic.
+// The pure functions we CAN test directly are in answerVectors.ts.
+
+describe('ANSWER_VECTORS', () => {
+  it('has entries for all 3 question IDs', () => {
+    expect(Object.keys(ANSWER_VECTORS)).toEqual(['treasury', 'protocol', 'transparency']);
+  });
+
+  it('treasury has 3 options', () => {
+    expect(Object.keys(ANSWER_VECTORS.treasury)).toEqual(['conservative', 'growth', 'balanced']);
+  });
+
+  it('protocol has 3 options', () => {
+    expect(Object.keys(ANSWER_VECTORS.protocol)).toEqual(['caution', 'innovation', 'case_by_case']);
+  });
+
+  it('transparency has 3 options', () => {
+    expect(Object.keys(ANSWER_VECTORS.transparency)).toEqual([
+      'essential',
+      'nice_to_have',
+      'doesnt_matter',
+    ]);
+  });
+});
+
+describe('buildAlignmentFromAnswers', () => {
+  it('returns neutral (50) for all dimensions with no answers', () => {
+    const result = buildAlignmentFromAnswers({});
+    expect(result).toEqual({
+      treasuryConservative: 50,
+      treasuryGrowth: 50,
+      decentralization: 50,
+      security: 50,
+      innovation: 50,
+      transparency: 50,
+    });
+  });
+
+  it('applies treasury conservative answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ treasury: 'conservative' });
+    expect(result.treasuryConservative).toBe(85);
+    expect(result.treasuryGrowth).toBe(20);
+    // Other dimensions remain at 50
+    expect(result.security).toBe(50);
+    expect(result.innovation).toBe(50);
+  });
+
+  it('applies treasury growth answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ treasury: 'growth' });
+    expect(result.treasuryConservative).toBe(20);
+    expect(result.treasuryGrowth).toBe(85);
+  });
+
+  it('applies treasury balanced answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ treasury: 'balanced' });
+    expect(result.treasuryConservative).toBe(55);
+    expect(result.treasuryGrowth).toBe(55);
+  });
+
+  it('applies protocol caution answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ protocol: 'caution' });
+    expect(result.security).toBe(85);
+    expect(result.innovation).toBe(25);
+  });
+
+  it('applies protocol innovation answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ protocol: 'innovation' });
+    expect(result.security).toBe(25);
+    expect(result.innovation).toBe(85);
+  });
+
+  it('applies transparency essential answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ transparency: 'essential' });
+    expect(result.transparency).toBe(90);
+    expect(result.decentralization).toBe(70);
+  });
+
+  it('applies transparency doesnt_matter answer correctly', () => {
+    const result = buildAlignmentFromAnswers({ transparency: 'doesnt_matter' });
+    expect(result.transparency).toBe(20);
+    expect(result.decentralization).toBe(35);
+  });
+
+  it('combines all 3 answers correctly', () => {
+    const result = buildAlignmentFromAnswers({
+      treasury: 'conservative',
+      protocol: 'innovation',
+      transparency: 'essential',
+    });
+    expect(result).toEqual({
+      treasuryConservative: 85,
+      treasuryGrowth: 20,
+      decentralization: 70,
+      security: 25,
+      innovation: 85,
+      transparency: 90,
+    });
+  });
+
+  it('ignores unknown question IDs', () => {
+    const result = buildAlignmentFromAnswers({ unknown: 'value' });
+    expect(result.treasuryConservative).toBe(50);
+  });
+
+  it('ignores unknown answer values', () => {
+    const result = buildAlignmentFromAnswers({ treasury: 'unknown' });
+    expect(result.treasuryConservative).toBe(50);
+  });
+
+  it('produces correct scores for all 27 answer combinations', () => {
+    const treasuryOpts = ['conservative', 'growth', 'balanced'];
+    const protocolOpts = ['caution', 'innovation', 'case_by_case'];
+    const transparencyOpts = ['essential', 'nice_to_have', 'doesnt_matter'];
+
+    let count = 0;
+    for (const t of treasuryOpts) {
+      for (const p of protocolOpts) {
+        for (const tr of transparencyOpts) {
+          const result = buildAlignmentFromAnswers({
+            treasury: t,
+            protocol: p,
+            transparency: tr,
+          });
+          // All dimensions should be numbers between 0 and 100
+          for (const val of Object.values(result)) {
+            expect(val).toBeGreaterThanOrEqual(0);
+            expect(val).toBeLessThanOrEqual(100);
+          }
+          count++;
+        }
+      }
+    }
+    expect(count).toBe(27);
+  });
+});

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -16,27 +16,10 @@ import {
 import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
 import { computeDimensionAgreement } from '@/lib/matching/dimensionAgreement';
 import { calculateProgressiveConfidence } from '@/lib/matching/confidence';
+import { ANSWER_VECTORS } from '@/lib/matching/answerVectors';
 import { captureServerEvent } from '@/lib/posthog-server';
 
 export const dynamic = 'force-dynamic';
-
-const ANSWER_VECTORS: Record<string, Record<string, Partial<AlignmentScores>>> = {
-  treasury: {
-    conservative: { treasuryConservative: 85, treasuryGrowth: 20 },
-    growth: { treasuryConservative: 20, treasuryGrowth: 85 },
-    balanced: { treasuryConservative: 55, treasuryGrowth: 55 },
-  },
-  protocol: {
-    caution: { security: 85, innovation: 25 },
-    innovation: { security: 25, innovation: 85 },
-    case_by_case: { security: 55, innovation: 55 },
-  },
-  transparency: {
-    essential: { transparency: 90, decentralization: 70 },
-    nice_to_have: { transparency: 55, decentralization: 50 },
-    doesnt_matter: { transparency: 20, decentralization: 35 },
-  },
-};
 
 const DIMENSIONS: AlignmentDimension[] = [
   'treasuryConservative',

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import {
   Shield,
@@ -13,7 +13,6 @@ import {
   Eye,
   ArrowRight,
   ArrowLeft,
-  Loader2,
   ChevronRight,
   Zap,
   RotateCcw,
@@ -31,6 +30,8 @@ import { usePostHog } from 'posthog-js/react';
 import { DelegateButton } from '@/components/DelegateButton';
 import { getStoredSession } from '@/lib/supabaseAuth';
 import type { AlignmentScores } from '@/lib/drepIdentity';
+import { getDominantDimension, getIdentityColor, getPersonalityLabel } from '@/lib/drepIdentity';
+import { buildAlignmentFromAnswers } from '@/lib/matching/answerVectors';
 import type { ConfidenceBreakdown } from '@/lib/matching/confidence';
 import { MatchConfidenceCTA } from '@/components/matching/MatchConfidenceCTA';
 import { saveMatchProfile, loadMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
@@ -167,6 +168,13 @@ export function QuickMatchFlow() {
   const abortRef = useRef<AbortController | null>(null);
   const posthog = usePostHog();
 
+  const partialIdentityColor = useMemo(() => {
+    if (Object.keys(answers).length === 0) return 'hsl(var(--primary))';
+    const partial = buildAlignmentFromAnswers(answers);
+    const dominant = getDominantDimension(partial);
+    return getIdentityColor(dominant).hex;
+  }, [answers]);
+
   // Load stored match profile on mount
   useEffect(() => {
     setStoredProfile(loadMatchProfile());
@@ -290,9 +298,10 @@ export function QuickMatchFlow() {
                   <div key={i} className="h-1 flex-1 rounded-full overflow-hidden bg-muted">
                     <div
                       className={cn(
-                        'h-full rounded-full bg-primary transition-all duration-300',
+                        'h-full rounded-full transition-all duration-500',
                         i < step ? 'w-full' : i === step ? 'w-1/2' : 'w-0',
                       )}
+                      style={{ backgroundColor: partialIdentityColor }}
                     />
                   </div>
                 ))}
@@ -330,7 +339,7 @@ export function QuickMatchFlow() {
             onSelect={(value) => handleAnswer(QUESTIONS[step].id, value)}
           />
         )}
-        {step === 'loading' && <LoadingScreen />}
+        {step === 'loading' && <LoadingScreen answers={answers} />}
         {step === 'results' && drepResults && spoResults && (
           <ResultsScreen drepResults={drepResults} spoResults={spoResults} onRestart={restart} />
         )}
@@ -456,23 +465,40 @@ function QuestionScreen({
   );
 }
 
-function LoadingScreen() {
+function LoadingScreen({ answers }: { answers: Record<string, string> }) {
+  const { alignments, personalityLabel, identityColor } = useMemo(() => {
+    const partial = buildAlignmentFromAnswers(answers);
+    const dominant = getDominantDimension(partial);
+    return {
+      alignments: partial,
+      personalityLabel: getPersonalityLabel(partial),
+      identityColor: getIdentityColor(dominant),
+    };
+  }, [answers]);
+
   return (
     <div
-      className="text-center space-y-6 animate-in fade-in duration-300"
+      className="text-center space-y-6 animate-in fade-in duration-500"
       role="status"
       aria-live="polite"
     >
-      <div className="relative mx-auto w-24 h-24" aria-hidden="true">
-        <div className="absolute inset-0 rounded-full border-2 border-primary/20 animate-ping" />
-        <div className="absolute inset-2 rounded-full border-2 border-primary/40 animate-pulse" />
-        <div className="absolute inset-0 flex items-center justify-center">
-          <Loader2 className="h-8 w-8 text-primary animate-spin" />
-        </div>
+      <div className="flex justify-center">
+        <GovernanceRadar alignments={alignments} size="medium" animate />
       </div>
-      <div className="space-y-1">
-        <p className="font-display text-lg font-semibold">Analyzing your governance values...</p>
-        <p className="text-sm text-muted-foreground">Matching against DReps and SPOs</p>
+      <div className="space-y-2">
+        <p className="font-display text-lg font-semibold">
+          Discovering your governance identity...
+        </p>
+        <Badge
+          className="text-xs px-2.5 py-0.5 animate-in fade-in duration-700"
+          style={{
+            backgroundColor: identityColor.hex + '20',
+            color: identityColor.hex,
+            borderColor: identityColor.hex + '40',
+          }}
+        >
+          {personalityLabel}
+        </Badge>
       </div>
     </div>
   );

--- a/lib/matching/answerVectors.ts
+++ b/lib/matching/answerVectors.ts
@@ -1,0 +1,50 @@
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+/**
+ * Answer-to-alignment vector mappings for the Quick Match quiz.
+ * Shared between the API route (server) and client components
+ * (progress bar identity color, loading screen preview).
+ */
+export const ANSWER_VECTORS: Record<string, Record<string, Partial<AlignmentScores>>> = {
+  treasury: {
+    conservative: { treasuryConservative: 85, treasuryGrowth: 20 },
+    growth: { treasuryConservative: 20, treasuryGrowth: 85 },
+    balanced: { treasuryConservative: 55, treasuryGrowth: 55 },
+  },
+  protocol: {
+    caution: { security: 85, innovation: 25 },
+    innovation: { security: 25, innovation: 85 },
+    case_by_case: { security: 55, innovation: 55 },
+  },
+  transparency: {
+    essential: { transparency: 90, decentralization: 70 },
+    nice_to_have: { transparency: 55, decentralization: 50 },
+    doesnt_matter: { transparency: 20, decentralization: 35 },
+  },
+};
+
+/**
+ * Build a full AlignmentScores object from quiz answers.
+ * Dimensions not covered by answers default to 50 (neutral).
+ */
+export function buildAlignmentFromAnswers(answers: Record<string, string>): AlignmentScores {
+  const scores: AlignmentScores = {
+    treasuryConservative: 50,
+    treasuryGrowth: 50,
+    decentralization: 50,
+    security: 50,
+    innovation: 50,
+    transparency: 50,
+  };
+
+  for (const [qId, answer] of Object.entries(answers)) {
+    const dimScores = ANSWER_VECTORS[qId]?.[answer];
+    if (dimScores) {
+      for (const [dim, val] of Object.entries(dimScores)) {
+        scores[dim as keyof AlignmentScores] = val;
+      }
+    }
+  }
+
+  return scores;
+}


### PR DESCRIPTION
## Summary
- Identity-colored progress bar: bar color shifts as users answer questions, reflecting their emerging governance identity (red for treasury conservative, cyan for innovation, etc.)
- Purpose-built loading screen: replaces generic spinner with GovernanceRadar showing user's alignment shape + personality label preview — the "values crystallizing" moment
- Extract shared `ANSWER_VECTORS` and `buildAlignmentFromAnswers()` to `lib/matching/answerVectors.ts` — eliminates duplication between API route and client components
- Add 16 pure function tests covering all 27 answer combinations

## Impact
- **What changed**: Quiz experience has visual identity arc (color shift + radar preview) before full results reveal
- **User-facing**: Yes — progress bar shifts color per answer, loading shows governance radar + personality preview
- **Risk**: Low — no API logic changes, ANSWER_VECTORS extraction is a refactor with identical values
- **Scope**: `components/civica/match/QuickMatchFlow.tsx`, `lib/matching/answerVectors.ts` (new), `app/api/governance/quick-match/route.ts`, `__tests__/matching/quickMatchHelpers.test.ts` (new)

## Test plan
- [ ] Q1 answer → progress bar fills with identity color (not generic primary)
- [ ] Q2 answer → color may shift if dominant dimension changes
- [ ] Q3 answer → loading screen shows mini GovernanceRadar + personality badge
- [ ] Full quiz → results appear correctly after loading
- [ ] Retake quiz → progress bar resets to primary color
- [ ] SPO tab works identically
- [ ] `npm run test` — 16 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)