### PR TITLE
feat: upgrade Committee tab with names, grades, search, TanStack Query

### DIFF
--- a/__tests__/components/discover-ux.test.tsx
+++ b/__tests__/components/discover-ux.test.tsx
@@ -139,6 +139,37 @@ describe('Proposal epochs-left logic', () => {
   });
 });
 
+// ── Committee VoteBar logic ─────────────────────────────────────
+
+describe('Committee VoteBar', () => {
+  it('computes correct proportions', () => {
+    const total = 10 + 3 + 2;
+    const yPct = (10 / total) * 100;
+    const nPct = (3 / total) * 100;
+    expect(yPct).toBeCloseTo(66.67, 1);
+    expect(nPct).toBeCloseTo(20, 1);
+  });
+
+  it('handles zero total gracefully', () => {
+    const total = 0 + 0 + 0;
+    expect(total).toBe(0);
+  });
+});
+
+describe('Committee member display name', () => {
+  it('shows author_name when available', () => {
+    const member = { name: 'Alice', ccHotId: 'cc_hot_1abc123def456' };
+    const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
+    expect(displayName).toBe('Alice');
+  });
+
+  it('falls back to truncated hex when name is null', () => {
+    const member = { name: null, ccHotId: 'cc_hot_1abc123def456789' };
+    const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
+    expect(displayName).toBe('cc_hot_1abc1…456789');
+  });
+});
+
 // ── Component tests ─────────────────────────────────────────────
 
 vi.mock('@/lib/utils', () => ({

--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -8,6 +8,7 @@ export const dynamic = 'force-dynamic';
 export const GET = withRouteHandler(async () => {
   const supabase = createClient();
 
+  // Fetch vote aggregation
   const { data: votes, error } = await supabase.from('cc_votes').select('cc_hot_id, vote');
 
   if (error) {
@@ -28,11 +29,34 @@ export const GET = withRouteHandler(async () => {
     memberMap.set(v.cc_hot_id, existing);
   }
 
+  // Fetch CC member metadata (names + transparency grades)
+  const ccIds = Array.from(memberMap.keys());
+  const { data: memberMeta } = await supabase
+    .from('cc_members')
+    .select('cc_hot_id, author_name, transparency_grade, transparency_index')
+    .in('cc_hot_id', ccIds);
+
+  const metaMap = new Map<
+    string,
+    { name: string | null; grade: string | null; index: number | null }
+  >();
+  for (const m of memberMeta || []) {
+    metaMap.set(m.cc_hot_id, {
+      name: m.author_name,
+      grade: m.transparency_grade,
+      index: m.transparency_index,
+    });
+  }
+
   const members = Array.from(memberMap.entries())
     .map(([ccHotId, counts]) => {
       const total = counts.yes + counts.no + counts.abstain;
+      const meta = metaMap.get(ccHotId);
       return {
         ccHotId,
+        name: meta?.name ?? null,
+        transparencyGrade: meta?.grade ?? null,
+        transparencyIndex: meta?.index ?? null,
         voteCount: total,
         yesCount: counts.yes,
         noCount: counts.no,
@@ -40,7 +64,13 @@ export const GET = withRouteHandler(async () => {
         approvalRate: total > 0 ? Math.round((counts.yes / total) * 100) : 0,
       };
     })
-    .sort((a, b) => b.voteCount - a.voteCount);
+    .sort((a, b) => {
+      // Sort by transparency index (descending) if available, then by vote count
+      if (a.transparencyIndex != null && b.transparencyIndex != null) {
+        return b.transparencyIndex - a.transparencyIndex;
+      }
+      return b.voteCount - a.voteCount;
+    });
 
   return NextResponse.json(
     { members },

--- a/components/CommitteeDiscovery.tsx
+++ b/components/CommitteeDiscovery.tsx
@@ -1,80 +1,159 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
+import { useState, useMemo } from 'react';
 import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useCommitteeMembers } from '@/hooks/queries';
+import type { CommitteeMemberQuickView } from '@/hooks/queries';
+import { DiscoverFilterBar } from '@/components/civica/discover/DiscoverFilterBar';
 
-interface MemberData {
-  ccHotId: string;
-  voteCount: number;
-  yesCount: number;
-  noCount: number;
-  abstainCount: number;
-  approvalRate: number;
+const GRADE_COLORS: Record<string, string> = {
+  A: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/30',
+  B: 'bg-sky-500/10 text-sky-500 border-sky-500/30',
+  C: 'bg-amber-500/10 text-amber-500 border-amber-500/30',
+  D: 'bg-orange-500/10 text-orange-500 border-orange-500/30',
+  F: 'bg-rose-500/10 text-rose-500 border-rose-500/30',
+};
+
+function VoteBar({ yes, no, abstain }: { yes: number; no: number; abstain: number }) {
+  const total = yes + no + abstain;
+  if (total === 0) return null;
+  const yPct = (yes / total) * 100;
+  const nPct = (no / total) * 100;
+  return (
+    <div
+      className="flex h-1.5 rounded-full overflow-hidden bg-muted"
+      title={`${yes} Yes / ${no} No / ${abstain} Abstain`}
+    >
+      {yPct > 0 && <div className="bg-emerald-500 transition-all" style={{ width: `${yPct}%` }} />}
+      {nPct > 0 && <div className="bg-rose-500 transition-all" style={{ width: `${nPct}%` }} />}
+    </div>
+  );
+}
+
+function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
+  const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
+  const gradeStyle = member.transparencyGrade ? GRADE_COLORS[member.transparencyGrade] || '' : '';
+
+  return (
+    <Link
+      href={`/committee#${member.ccHotId.slice(0, 12)}`}
+      className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors group"
+    >
+      {/* Transparency grade badge */}
+      {member.transparencyGrade ? (
+        <span
+          className={cn(
+            'text-[10px] font-bold w-6 h-6 rounded flex items-center justify-center border shrink-0',
+            gradeStyle,
+          )}
+        >
+          {member.transparencyGrade}
+        </span>
+      ) : (
+        <span className="w-6 h-6 rounded flex items-center justify-center bg-muted text-muted-foreground text-[10px] font-medium shrink-0">
+          —
+        </span>
+      )}
+
+      {/* Name */}
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium truncate block">{displayName}</span>
+        <span className="text-[10px] text-muted-foreground">
+          {member.voteCount} votes · {member.approvalRate}% approval
+        </span>
+      </div>
+
+      {/* Vote breakdown bar */}
+      <div className="w-24 shrink-0">
+        <VoteBar yes={member.yesCount} no={member.noCount} abstain={member.abstainCount} />
+      </div>
+    </Link>
+  );
 }
 
 function CommitteeSkeleton() {
   return (
     <div className="space-y-2">
       {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex items-center justify-between rounded-lg border p-4">
-          <Skeleton className="h-4 w-32" />
-          <div className="flex gap-2">
-            <Skeleton className="h-5 w-16" />
-            <Skeleton className="h-5 w-14" />
+        <div key={i} className="flex items-center gap-3 px-4 py-3">
+          <Skeleton className="h-6 w-6 rounded" />
+          <div className="flex-1 space-y-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-20" />
           </div>
+          <Skeleton className="h-1.5 w-24 rounded-full" />
         </div>
       ))}
     </div>
   );
 }
 
-function EmptyState() {
-  return (
-    <div className="text-center py-16 space-y-3">
-      <p className="text-muted-foreground text-sm">
-        No Constitutional Committee votes recorded yet.
-      </p>
-      <p className="text-xs text-muted-foreground/70">
-        CC members will appear here once they participate in on-chain governance.
-      </p>
-    </div>
-  );
-}
-
 export function CommitteeDiscovery() {
-  const [members, setMembers] = useState<MemberData[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data, isLoading } = useCommitteeMembers();
+  const members: CommitteeMemberQuickView[] = useMemo(() => data?.members ?? [], [data]);
 
-  useEffect(() => {
-    fetch('/api/governance/committee')
-      .then((r) => (r.ok ? r.json() : { members: [] }))
-      .then((data) => setMembers(data.members || []))
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
+  const [search, setSearch] = useState('');
 
-  if (loading) return <CommitteeSkeleton />;
-  if (members.length === 0) return <EmptyState />;
+  const filtered = useMemo(() => {
+    if (!search.trim()) return members;
+    const q = search.toLowerCase();
+    return members.filter(
+      (m) => m.name?.toLowerCase().includes(q) || m.ccHotId.toLowerCase().includes(q),
+    );
+  }, [members, search]);
+
+  const isFiltered = search !== '';
+  const resetFilters = () => setSearch('');
+
+  if (isLoading) return <CommitteeSkeleton />;
+
+  if (members.length === 0) {
+    return (
+      <div className="text-center py-16 space-y-3">
+        <p className="text-muted-foreground text-sm">
+          No Constitutional Committee votes recorded yet.
+        </p>
+        <p className="text-xs text-muted-foreground/70">
+          CC members will appear here once they participate in on-chain governance.
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="space-y-2">
-      {members.map((member) => (
-        <Link key={member.ccHotId} href={`/committee#${member.ccHotId.slice(0, 12)}`}>
-          <div className="flex items-center justify-between rounded-lg border p-4 hover:border-purple-500/40 transition-colors cursor-pointer">
-            <span className="font-mono text-sm truncate max-w-[200px]">
-              {member.ccHotId.slice(0, 20)}…
-            </span>
-            <div className="flex items-center gap-3">
-              <Badge variant="outline" className="text-purple-500 border-purple-500/40">
-                {member.voteCount} votes
-              </Badge>
-              <span className="text-xs text-muted-foreground">{member.approvalRate}% approval</span>
-            </div>
-          </div>
+    <div className="space-y-4">
+      <DiscoverFilterBar
+        search={search}
+        onSearchChange={(v) => setSearch(v)}
+        searchPlaceholder="Search CC member name or ID…"
+        resultCount={filtered.length}
+        totalCount={members.length}
+        entityLabel="CC members"
+        isFiltered={isFiltered}
+        onReset={resetFilters}
+      />
+
+      {/* Link to full transparency page */}
+      <div className="flex items-center justify-end">
+        <Link href="/discover/committee" className="text-xs text-primary hover:underline">
+          View full Transparency Index →
         </Link>
-      ))}
+      </div>
+
+      {/* Member list */}
+      {filtered.length === 0 ? (
+        <div className="py-16 text-center text-muted-foreground text-sm">
+          No CC members match your search.
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
+          {filtered.map((member) => (
+            <MemberRow key={member.ccHotId} member={member} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -8,6 +8,26 @@ async function fetchJson<T>(url: string): Promise<T> {
   return res.json();
 }
 
+export interface CommitteeMemberQuickView {
+  ccHotId: string;
+  name: string | null;
+  transparencyGrade: string | null;
+  transparencyIndex: number | null;
+  voteCount: number;
+  yesCount: number;
+  noCount: number;
+  abstainCount: number;
+  approvalRate: number;
+}
+
+export function useCommitteeMembers() {
+  return useQuery<{ members: CommitteeMemberQuickView[] }>({
+    queryKey: ['cc-members'],
+    queryFn: () => fetchJson('/api/governance/committee'),
+    staleTime: 120_000,
+  });
+}
+
 export function useGovernanceHolder(stakeAddress?: string | null) {
   return useQuery({
     queryKey: ['governance-holder', stakeAddress],


### PR DESCRIPTION
## Summary
- Enhance `/api/governance/committee` to fetch CC member metadata (author_name, transparency_grade, transparency_index) from `cc_members` table
- Add `useCommitteeMembers()` TanStack Query hook replacing raw `useEffect+fetch` pattern
- Rewrite `CommitteeDiscovery.tsx` with human names, A-F transparency grade badges, vote breakdown bars, and `DiscoverFilterBar` search
- Sort by transparency index (most transparent first), fallback to vote count

## Impact
- **What changed**: Committee tab transformed from bare-bones hex ID list to intelligence-enriched accountability view
- **User-facing**: Yes — CC members now show names, color-coded grade badges (A-F), vote breakdown bars, and searchable filter bar
- **Risk**: Low — backward-compatible API enhancement, existing fields preserved, no migrations needed
- **Scope**: `app/api/governance/committee/route.ts`, `components/CommitteeDiscovery.tsx`, `hooks/queries.ts`, `__tests__/components/discover-ux.test.tsx`

## Test plan
- [ ] `/discover?tab=committee` — CC members show names (where available)
- [ ] Transparency grade badges (A-F) visible with color coding
- [ ] Vote breakdown bars (green/red/grey) on each row
- [ ] Search by name and hex ID works
- [ ] Empty search results show "No CC members match your search"
- [ ] "View full Transparency Index" link navigates to `/discover/committee`
- [ ] Click a member navigates to `/committee#anchor`
- [ ] All 558 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)