### PR TITLE
fix: prevent wallet connected-but-not-authenticated half-state

### DIFF
--- a/app/api/admin/debug/route.ts
+++ b/app/api/admin/debug/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST: Debug admin check — returns detailed diagnostics.
+ * Requires a valid session token via Authorization header.
+ * TEMPORARY — remove after debugging.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireAuth(request);
+    if (auth instanceof NextResponse) {
+      return NextResponse.json({
+        step: 'auth',
+        error: 'Session token invalid or missing',
+        hasAuthHeader: !!request.headers.get('authorization'),
+      });
+    }
+
+    const adminWalletsRaw = process.env.ADMIN_WALLETS || '';
+    const adminWallets = adminWalletsRaw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const result = isAdminWallet(auth.wallet);
+
+    return NextResponse.json({
+      step: 'complete',
+      walletFromSession: auth.wallet.slice(0, 15) + '...' + auth.wallet.slice(-6),
+      walletPrefix: auth.wallet.slice(0, 5),
+      adminWalletsCount: adminWallets.length,
+      adminWalletPrefixes: adminWallets.map((w) => w.slice(0, 10) + '...'),
+      adminWalletLengths: adminWallets.map((w) => w.length),
+      envVarLength: adminWalletsRaw.length,
+      envVarHasQuotes: adminWalletsRaw.startsWith('"') || adminWalletsRaw.startsWith("'"),
+      isAdmin: result,
+    });
+  } catch (e) {
+    return NextResponse.json({ step: 'error', error: String(e) });
+  }
+}

--- a/components/WalletConnectModal.tsx
+++ b/components/WalletConnectModal.tsx
@@ -85,11 +85,24 @@ export function WalletConnectModal({
     await connect(walletName);
   };
 
-  // Move to sign step when connected successfully
+  // Auto-authenticate once wallet connects — skip the manual sign step.
+  // The wallet extension will prompt the user to sign immediately after connection.
   useEffect(() => {
     if (connected && address && !error && step === 'connect') {
       setStep('sign');
+      // Auto-trigger authentication so user doesn't land in connected-but-not-authenticated state
+      (async () => {
+        clearError();
+        setAuthenticating(true);
+        const success = await authenticate();
+        setAuthenticating(false);
+        if (success) {
+          posthog.capture('wallet_authenticated', { wallet_name: selectedWallet });
+          setStep(skipPushPrompt ? 'success' : 'push');
+        }
+      })();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally fire only on connection state changes
   }, [connected, address, error, step]);
 
   const handleTryAgain = async () => {
@@ -136,6 +149,11 @@ export function WalletConnectModal({
     onOpenChange(false);
     if (step === 'success') {
       onSuccess?.();
+    }
+    // If user closes before authenticating, disconnect to prevent half-state
+    // (connected to wallet extension but no session token)
+    if (step === 'sign' || step === 'connect') {
+      disconnect();
     }
     setTimeout(() => setStep('connect'), 300);
   };

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -78,7 +78,7 @@ export function CivicaHeader() {
   const router = useRouter();
   const { connected, disconnect, logout, isAuthenticated } = useWallet();
   const { segment, realSegment, stakeAddress, delegatedDrep, tier, setOverride } = useSegment();
-  const { data: adminData } = useAdminCheck(isAuthenticated || connected);
+  const { data: adminData } = useAdminCheck(isAuthenticated);
   const isAdmin = adminData?.isAdmin === true;
   const hasOverride = segment !== realSegment;
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
@@ -110,7 +110,7 @@ export function CivicaHeader() {
           </Link>
 
           <nav className="flex items-center gap-1" aria-label="Main navigation">
-            {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || connected).map(
+            {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || isAuthenticated).map(
               ({ href, label, icon: Icon }) => {
                 const active = isActive(href);
                 return (
@@ -172,7 +172,7 @@ export function CivicaHeader() {
             <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
           </Button>
 
-          {connected ? (
+          {connected && isAuthenticated ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button


### PR DESCRIPTION
## Summary
- Auto-trigger wallet authentication immediately after CIP-30 connection — eliminates the gap where users could close the modal between connect and sign steps
- Disconnect wallet if user closes modal before completing auth flow
- Gate CivicaHeader dropdown and My Gov nav on `isAuthenticated` instead of just `connected`
- Add `force-dynamic` to admin check route and temporary debug endpoint

## Impact
- **What changed**: Users can no longer land in a connected-but-not-authenticated state where they see "Citizen" badge but have no session token
- **User-facing**: Yes — wallet connect flow now goes straight to signing prompt after CIP-30 connection. Admin link appears for admin wallets. All auth-gated features work.
- **Risk**: Low — the signing prompt was always part of the flow, it just auto-triggers now instead of requiring a manual click
- **Scope**: `WalletConnectModal.tsx`, `CivicaHeader.tsx`, temp `admin/debug` route

## Test plan
- [ ] Connect wallet on governada.io — verify signing prompt appears immediately after wallet connection
- [ ] Close modal during signing → verify user shows as disconnected (not half-connected)
- [ ] Complete full auth flow → verify green shield + address in header dropdown
- [ ] Admin wallet → verify Admin link appears in dropdown
- [ ] Navigate to /admin directly → verify access granted for admin wallet
- [ ] Refresh page → verify auto-reconnect + session restore works

🤖 Generated with [Claude Code](https://claude.com/claude-code)