### PR TITLE
fix: error states, skeleton fixes, mobile responsiveness, TanStack Query migration

### DIFF
--- a/app/pulse/loading.tsx
+++ b/app/pulse/loading.tsx
@@ -2,18 +2,25 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function PulseLoading() {
   return (
-    <div className="container mx-auto px-4 py-8 space-y-8 max-w-6xl">
-      <div className="text-center space-y-2">
-        <Skeleton className="h-10 w-64 mx-auto" />
-        <Skeleton className="h-5 w-96 mx-auto" />
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-28" />
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      {/* Tab bar — 3 tabs */}
+      <div className="flex gap-1 border-b border-border">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-24" />
         ))}
       </div>
-      <Skeleton className="h-64" />
-      <Skeleton className="h-96" />
+      {/* Stat cards — matches lg:grid-cols-4 */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-8 w-16" />
+            <Skeleton className="h-2.5 w-32" />
+          </div>
+        ))}
+      </div>
+      <Skeleton className="h-64 rounded-xl" />
+      <Skeleton className="h-48 rounded-xl" />
     </div>
   );
 }

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -26,7 +26,7 @@ function PulseFallback() {
   return (
     <div className="space-y-6 pt-4">
       <div className="flex gap-1 border-b border-border -mb-2">
-        {Array.from({ length: 6 }).map((_, i) => (
+        {Array.from({ length: 3 }).map((_, i) => (
           <Skeleton key={i} className="h-9 w-20" />
         ))}
       </div>

--- a/components/DelegatorPulse.tsx
+++ b/components/DelegatorPulse.tsx
@@ -50,15 +50,12 @@ export function DelegatorPulse({ txHash, proposalIndex, drepId }: DelegatorPulse
           <HeartPulse className="h-4 w-4" />
         </span>
         <h3 className="text-sm font-medium">Delegator Pulse</h3>
-        <Badge
-          variant="outline"
-          className="text-[10px] bg-primary/10 text-primary border-primary/30"
-        >
+        <Badge variant="outline" className="text-xs bg-primary/10 text-primary border-primary/30">
           Pro
         </Badge>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <PulseColumn
           label="Your Delegators"
           icon={<HeartPulse className="h-3 w-3" />}
@@ -73,7 +70,7 @@ export function DelegatorPulse({ txHash, proposalIndex, drepId }: DelegatorPulse
         />
       </div>
 
-      <p className="text-[10px] text-muted-foreground pt-1">
+      <p className="text-xs text-muted-foreground pt-1">
         Non-binding sentiment from ADA holders — distinct from on-chain DRep votes.
       </p>
     </div>
@@ -96,10 +93,10 @@ function PulseColumn({
   if (total === 0) {
     return (
       <div className="rounded-lg border p-2.5 space-y-1.5">
-        <div className="flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           {icon} {label}
         </div>
-        <p className="text-[10px] text-muted-foreground">{emptyText}</p>
+        <p className="text-xs text-muted-foreground">{emptyText}</p>
       </div>
     );
   }
@@ -111,10 +108,10 @@ function PulseColumn({
   return (
     <div className="rounded-lg border p-2.5 space-y-1.5">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
           {icon} {label}
         </div>
-        <span className="text-[10px] tabular-nums text-muted-foreground">{total}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">{total}</span>
       </div>
 
       {/* Stacked bar */}
@@ -124,7 +121,7 @@ function PulseColumn({
         {abstain > 0 && <div className="bg-amber-500 h-full" style={{ width: `${ap}%` }} />}
       </div>
 
-      <div className="flex justify-between text-[10px] tabular-nums text-muted-foreground">
+      <div className="flex justify-between text-xs tabular-nums text-muted-foreground">
         <span className="text-green-600 dark:text-green-400">{yp}% Y</span>
         <span className="text-red-600 dark:text-red-400">{np}% N</span>
         <span className="text-amber-600 dark:text-amber-400">{ap}% A</span>

--- a/components/InterBodyPulse.tsx
+++ b/components/InterBodyPulse.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useGovernanceInterBody } from '@/hooks/queries';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { Users } from 'lucide-react';
 
 interface SystemAlignment {
@@ -26,8 +27,12 @@ function AlignmentBar({ value, color }: { value: number; color: string }) {
 }
 
 export function InterBodyPulse() {
-  const { data: rawData, isLoading } = useGovernanceInterBody();
+  const { data: rawData, isLoading, isError, refetch } = useGovernanceInterBody();
   const data = (rawData as SystemAlignment) ?? null;
+
+  if (isError) {
+    return <ErrorCard message="Unable to load inter-body alignment." onRetry={refetch} />;
+  }
 
   if (isLoading) {
     return (
@@ -37,7 +42,7 @@ export function InterBodyPulse() {
         </CardHeader>
         <CardContent className="space-y-3">
           <Skeleton className="h-4 w-full" />
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             {[1, 2, 3].map((i) => (
               <Skeleton key={i} className="h-16 w-full" />
             ))}
@@ -64,7 +69,7 @@ export function InterBodyPulse() {
           alignment.
         </p>
 
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div className="space-y-2">
             <div className="text-center">
               <p className="text-2xl font-bold tabular-nums text-primary">

--- a/components/PulseLeaderboardClient.tsx
+++ b/components/PulseLeaderboardClient.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-/* eslint-disable react-hooks/set-state-in-effect -- async/external state sync in useEffect is standard React pattern */
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { Trophy } from 'lucide-react';
 
 interface LeaderboardEntry {
@@ -35,20 +37,31 @@ function tierColorClass(score: number) {
   return 'text-red-600 dark:text-red-400';
 }
 
+async function fetchLeaderboard(tier: string): Promise<{ leaderboard: LeaderboardEntry[] }> {
+  const res = await fetch(`/api/governance/leaderboard?tier=${tier}`);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
 export function PulseLeaderboardClient({ initialLeaderboard }: PulseLeaderboardClientProps) {
   const [tierFilter, setTierFilter] = useState('all');
-  const [leaderboard, setLeaderboard] = useState(initialLeaderboard);
 
-  useEffect(() => {
-    if (tierFilter === 'all') {
-      setLeaderboard(initialLeaderboard);
-      return;
-    }
-    fetch(`/api/governance/leaderboard?tier=${tierFilter}`)
-      .then((r) => r.json())
-      .then((d) => setLeaderboard(d.leaderboard))
-      .catch(() => {});
-  }, [tierFilter, initialLeaderboard]);
+  const {
+    data: queryData,
+    isLoading: tierLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['pulse-leaderboard', tierFilter],
+    queryFn: () =>
+      tierFilter === 'all'
+        ? Promise.resolve({ leaderboard: initialLeaderboard })
+        : fetchLeaderboard(tierFilter),
+    staleTime: 120_000,
+    initialData: tierFilter === 'all' ? { leaderboard: initialLeaderboard } : undefined,
+  });
+
+  const leaderboard = queryData?.leaderboard ?? initialLeaderboard;
 
   return (
     <Card>
@@ -74,36 +87,46 @@ export function PulseLeaderboardClient({ initialLeaderboard }: PulseLeaderboardC
         </div>
       </CardHeader>
       <CardContent>
-        <div className="space-y-2">
-          {leaderboard.map((d) => (
-            <Link key={d.drepId} href={`/drep/${encodeURIComponent(d.drepId)}`} className="block">
-              <div className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors">
-                <span
-                  className={`text-lg font-bold tabular-nums w-8 ${d.rank <= 3 ? 'text-amber-500' : 'text-muted-foreground'}`}
-                >
-                  #{d.rank}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{d.name}</p>
-                  <div className="flex items-center gap-2 mt-0.5">
-                    <Badge
-                      variant="outline"
-                      className={`text-[10px] ${SIZE_COLORS[d.sizeTier] || ''}`}
-                    >
-                      {d.sizeTier}
-                    </Badge>
-                    <span className="text-[10px] text-muted-foreground">
-                      P:{d.participation}% R:{d.rationale}%
-                    </span>
+        {isError ? (
+          <ErrorCard message="Unable to load leaderboard." onRetry={() => refetch()} />
+        ) : tierLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {leaderboard.map((d) => (
+              <Link key={d.drepId} href={`/drep/${encodeURIComponent(d.drepId)}`} className="block">
+                <div className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors">
+                  <span
+                    className={`text-lg font-bold tabular-nums w-8 ${d.rank <= 3 ? 'text-amber-500' : 'text-muted-foreground'}`}
+                  >
+                    #{d.rank}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{d.name}</p>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      <Badge
+                        variant="outline"
+                        className={`text-[10px] ${SIZE_COLORS[d.sizeTier] || ''}`}
+                      >
+                        {d.sizeTier}
+                      </Badge>
+                      <span className="text-[10px] text-muted-foreground">
+                        P:{d.participation}% R:{d.rationale}%
+                      </span>
+                    </div>
                   </div>
+                  <span className={`text-xl font-bold tabular-nums ${tierColorClass(d.score)}`}>
+                    {d.score}
+                  </span>
                 </div>
-                <span className={`text-xl font-bold tabular-nums ${tierColorClass(d.score)}`}>
-                  {d.score}
-                </span>
-              </div>
-            </Link>
-          ))}
-        </div>
+              </Link>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/civica/pulse/CivicaEpochReport.tsx
+++ b/components/civica/pulse/CivicaEpochReport.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { Vote, Users, CheckCircle2, Clock, AlertCircle } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { cn } from '@/lib/utils';
 import { useGovernancePulse } from '@/hooks/queries';
 
@@ -69,7 +70,7 @@ function PipelineStep({
 }
 
 export function CivicaEpochReport() {
-  const { data: rawPulse, isLoading } = useGovernancePulse();
+  const { data: rawPulse, isLoading, isError, refetch } = useGovernancePulse();
   const pulse = rawPulse as
     | {
         currentEpoch?: number;
@@ -100,6 +101,10 @@ export function CivicaEpochReport() {
   const activeDReps: number = pulse?.activeDReps ?? 0;
   const totalDReps: number = pulse?.totalDReps ?? 0;
   const votesThisWeek: number = pulse?.votesThisWeek ?? 0;
+
+  if (isError) {
+    return <ErrorCard message="Unable to load epoch report." onRetry={refetch} />;
+  }
 
   return (
     <div className="space-y-6">

--- a/components/civica/pulse/CivicaGovernanceCalendar.tsx
+++ b/components/civica/pulse/CivicaGovernanceCalendar.tsx
@@ -7,6 +7,7 @@ import { Calendar, Clock, AlertTriangle, ChevronRight, ChevronDown } from 'lucid
 import { cn } from '@/lib/utils';
 import { formatAda } from '@/lib/treasury';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import {
   useGovernancePulse,
   useGovernanceEpochRecap,
@@ -181,7 +182,12 @@ function EpochRecapCard({ recap }: { recap: Record<string, unknown> }) {
 }
 
 export function CivicaGovernanceCalendar() {
-  const { data: rawCalendar, isLoading: calendarLoading } = useGovernanceCalendar();
+  const {
+    data: rawCalendar,
+    isLoading: calendarLoading,
+    isError: calendarError,
+    refetch: refetchCalendar,
+  } = useGovernanceCalendar();
   const calendar = (rawCalendar as CalendarData) ?? null;
 
   const { data: rawPulse } = useGovernancePulse();
@@ -222,6 +228,10 @@ export function CivicaGovernanceCalendar() {
     : Array.isArray(recap)
       ? recap
       : [];
+
+  if (calendarError) {
+    return <ErrorCard message="Unable to load governance calendar." onRetry={refetchCalendar} />;
+  }
 
   return (
     <div className="space-y-6">

--- a/components/civica/pulse/CivicaGovernanceTrends.tsx
+++ b/components/civica/pulse/CivicaGovernanceTrends.tsx
@@ -2,6 +2,7 @@
 
 import { scaleLinear } from 'd3-scale';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { cn } from '@/lib/utils';
 import {
   useGovernanceSparklines,
@@ -133,8 +134,18 @@ function TierDistribution({ dreps }: { dreps: Record<string, unknown>[] }) {
 }
 
 export function CivicaGovernanceTrends() {
-  const { data: rawSparklines, isLoading: sparklinesLoading } = useGovernanceSparklines();
-  const { data: rawGhi, isLoading: ghiLoading } = useGovernanceHealthIndex(20);
+  const {
+    data: rawSparklines,
+    isLoading: sparklinesLoading,
+    isError: sparklinesError,
+    refetch: refetchSparklines,
+  } = useGovernanceSparklines();
+  const {
+    data: rawGhi,
+    isLoading: ghiLoading,
+    isError: ghiError,
+    refetch: refetchGhi,
+  } = useGovernanceHealthIndex(20);
   const { data: rawLeaderboard } = useGovernanceLeaderboard();
 
   const sparklines = rawSparklines as Record<string, unknown> | undefined;
@@ -167,6 +178,7 @@ export function CivicaGovernanceTrends() {
   const ghiValues = ghiHistory.map((h) => h.score);
 
   const isLoading = sparklinesLoading || ghiLoading;
+  const hasError = sparklinesError || ghiError;
 
   // Build a human-readable narrative for the GHI gauge
   const ghiNarrative = (() => {
@@ -185,6 +197,18 @@ export function CivicaGovernanceTrends() {
       : trend?.direction === 'down'
         ? 'text-rose-400'
         : 'text-muted-foreground';
+
+  if (hasError) {
+    return (
+      <ErrorCard
+        message="Unable to load governance trends."
+        onRetry={() => {
+          refetchSparklines();
+          refetchGhi();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/components/civica/pulse/CivicaObservatory.tsx
+++ b/components/civica/pulse/CivicaObservatory.tsx
@@ -4,6 +4,7 @@ import { Globe, TrendingUp, TrendingDown, Minus, Info, GitBranch } from 'lucide-
 import { scaleLinear } from 'd3-scale';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import {
   useGovernanceBenchmarks,
   useGovernanceHealthIndex,
@@ -357,8 +358,18 @@ function ChainComparisonBar({ chain, benchmark }: { chain: string; benchmark: Ch
 }
 
 export function CivicaObservatory() {
-  const { data: rawGHI, isLoading: ghiLoading } = useGovernanceHealthIndex(1);
-  const { data: rawBenchmarks, isLoading: benchLoading } = useGovernanceBenchmarks();
+  const {
+    data: rawGHI,
+    isLoading: ghiLoading,
+    isError: ghiError,
+    refetch: refetchGhi,
+  } = useGovernanceHealthIndex(1);
+  const {
+    data: rawBenchmarks,
+    isLoading: benchLoading,
+    isError: benchError,
+    refetch: refetchBench,
+  } = useGovernanceBenchmarks();
   const { data: rawDecentralization } = useGovernanceDecentralization();
   const { data: rawInterBody } = useGovernanceInterBody();
 
@@ -395,9 +406,22 @@ export function CivicaObservatory() {
     votingPower: number;
   }[];
   const loading = ghiLoading || benchLoading;
+  const hasError = ghiError || benchError;
 
   const cardanoBench = benchmarks.find((b) => b.chain === 'cardano');
   const otherBenchmarks = benchmarks.filter((b) => b.chain !== 'cardano');
+
+  if (hasError) {
+    return (
+      <ErrorCard
+        message="Unable to load observatory data."
+        onRetry={() => {
+          refetchGhi();
+          refetchBench();
+        }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from '@/lib/utils';
 import { formatAda } from '@/lib/treasury';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { useGovernancePulse } from '@/hooks/queries';
 import { useTreasuryCurrent } from '@/hooks/queries';
 import { useGovernanceLeaderboard } from '@/hooks/queries';
@@ -166,10 +167,20 @@ export function CivicaPulseOverview() {
     [searchParams, pathname],
   );
 
-  const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
+  const {
+    data: rawPulse,
+    isLoading: pulseLoading,
+    isError: pulseError,
+    refetch: refetchPulse,
+  } = useGovernancePulse();
   const pulse = rawPulse as PulseDataLocal | undefined;
 
-  const { data: rawTreasury, isLoading: treasuryLoading } = useTreasuryCurrent();
+  const {
+    data: rawTreasury,
+    isLoading: treasuryLoading,
+    isError: treasuryError,
+    refetch: refetchTreasury,
+  } = useTreasuryCurrent();
   const treasury = rawTreasury as
     | (TreasuryData & {
         balance?: number;
@@ -186,9 +197,19 @@ export function CivicaPulseOverview() {
   const losers: LeaderboardEntry[] = leaderboard?.weeklyMovers?.losers?.slice(0, 3) ?? [];
 
   const loading = pulseLoading || treasuryLoading;
+  const hasError = pulseError || treasuryError;
 
   return (
     <div className="space-y-6 pt-4">
+      {hasError && (
+        <ErrorCard
+          message="Unable to load governance data."
+          onRetry={() => {
+            refetchPulse();
+            refetchTreasury();
+          }}
+        />
+      )}
       <FirstVisitBanner
         pageKey="pulse"
         message="The big picture. How healthy is Cardano governance right now? Track participation, treasury, and trends over time."

--- a/components/civica/pulse/CivicaTreasury.tsx
+++ b/components/civica/pulse/CivicaTreasury.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { TrendingUp, TrendingDown, Minus, DollarSign, Clock, ExternalLink } from 'lucide-react';
 import { scaleLinear } from 'd3-scale';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import { cn } from '@/lib/utils';
 import { useTreasuryCurrent, useTreasuryHistory, useTreasuryPending } from '@/hooks/queries';
 import type { TreasuryData } from '@/types/api';
@@ -85,8 +86,18 @@ function BalanceSparkline({ snapshots }: { snapshots: { epoch: number; balanceAd
 }
 
 export function CivicaTreasury() {
-  const { data: rawCurrent, isLoading: currentLoading } = useTreasuryCurrent();
-  const { data: rawHistory, isLoading: historyLoading } = useTreasuryHistory(30);
+  const {
+    data: rawCurrent,
+    isLoading: currentLoading,
+    isError: currentError,
+    refetch: refetchCurrent,
+  } = useTreasuryCurrent();
+  const {
+    data: rawHistory,
+    isLoading: historyLoading,
+    isError: historyError,
+    refetch: refetchHistory,
+  } = useTreasuryHistory(30);
   const { data: rawPending, isLoading: pendingLoading } = useTreasuryPending();
 
   const treasury = rawCurrent as
@@ -116,6 +127,19 @@ export function CivicaTreasury() {
       : [];
 
   const isLoading = currentLoading || historyLoading;
+  const hasError = currentError || historyError;
+
+  if (hasError) {
+    return (
+      <ErrorCard
+        message="Unable to load treasury data."
+        onRetry={() => {
+          refetchCurrent();
+          refetchHistory();
+        }}
+      />
+    );
+  }
 
   const trendIcon =
     treasury?.trend === 'growing'

--- a/components/civica/pulse/StateOfGovernance.tsx
+++ b/components/civica/pulse/StateOfGovernance.tsx
@@ -2,6 +2,7 @@
 
 import { Sparkles } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
 import {
   useGovernanceHealthIndex,
   useGovernancePulse,
@@ -130,8 +131,18 @@ function buildPersonalAddendum(
 }
 
 export function StateOfGovernance() {
-  const { data: rawGHI, isLoading: ghiLoading } = useGovernanceHealthIndex(1);
-  const { data: rawPulse, isLoading: pulseLoading } = useGovernancePulse();
+  const {
+    data: rawGHI,
+    isLoading: ghiLoading,
+    isError: ghiError,
+    refetch: refetchGhi,
+  } = useGovernanceHealthIndex(1);
+  const {
+    data: rawPulse,
+    isLoading: pulseLoading,
+    isError: pulseError,
+    refetch: refetchPulse,
+  } = useGovernancePulse();
   const { data: rawTreasury } = useTreasuryCurrent();
 
   const { segment, delegatedDrep, drepId } = useSegment();
@@ -146,6 +157,19 @@ export function StateOfGovernance() {
   const narrative = buildNarrative(ghi, pulse, treasury);
   const personal = buildPersonalAddendum(pulse, summary, segment);
   const loading = ghiLoading || pulseLoading;
+  const hasError = ghiError || pulseError;
+
+  if (hasError) {
+    return (
+      <ErrorCard
+        message="Unable to load governance state."
+        onRetry={() => {
+          refetchGhi();
+          refetchPulse();
+        }}
+      />
+    );
+  }
 
   if (loading) {
     return (

--- a/components/ui/ErrorCard.tsx
+++ b/components/ui/ErrorCard.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { AlertCircle, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ErrorCardProps {
+  message?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorCard({
+  message = 'Failed to load data. Please try again.',
+  onRetry,
+  className,
+}: ErrorCardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-destructive/20 bg-destructive/5 p-6 text-center space-y-3',
+        className,
+      )}
+    >
+      <AlertCircle className="h-5 w-5 text-destructive mx-auto" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create reusable `ErrorCard` component with retry button for inline error display
- Add error states with retry to 8 Pulse components (Overview, EpochReport, Calendar, Trends, Observatory, StateOfGovernance, Treasury, InterBodyPulse)
- Migrate `PulseLeaderboardClient` from raw `fetch`/`useState`/`useEffect` to TanStack Query with loading skeletons and error handling
- Fix `loading.tsx` skeleton to match actual page layout (3 tabs, responsive grid, correct padding)
- Fix `PulseFallback` tab skeleton count from 6 to 3
- Fix InterBodyPulse mobile: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3`
- Fix DelegatorPulse mobile: `grid-cols-2` → `grid-cols-1 sm:grid-cols-2`, `text-[10px]` → `text-xs` for WCAG

## Impact
- **What changed**: All Pulse components now gracefully handle API failures with retry, leaderboard uses TanStack Query, skeletons match real layout, mobile is responsive
- **User-facing**: Yes — users see error cards with retry instead of blank sections on API failure; mobile users see stacking grids instead of cramped 3-column layouts
- **Risk**: Low — all changes are additive (error states) or pattern corrections (TanStack Query, responsive breakpoints). No data changes.
- **Scope**: 13 files — 1 new component, 8 Pulse components, 1 leaderboard client, 2 skeleton files, 1 sub-component

## Test plan
- [x] Preflight passes (631 tests, clean types, clean formatting)
- [ ] CI passes on GitHub
- [ ] `/pulse` renders normally with no regressions
- [ ] Kill network in DevTools → error cards appear with "Try again" buttons
- [ ] `/pulse` at 375px width — InterBodyPulse stacks, DelegatorPulse stacks, text is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)