### PR TITLE
feat: GHI hero on Now tab, stat card deltas, elevate sentiment gap

### DIFF
--- a/app/api/governance/pulse/route.ts
+++ b/app/api/governance/pulse/route.ts
@@ -132,6 +132,23 @@ export const GET = withRouteHandler(async () => {
     }
   }
 
+  // Fetch previous epoch snapshot for epoch-over-epoch deltas
+  const { data: prevSnapshot } = await supabase
+    .from('governance_participation_snapshots')
+    .select('participation_rate, rationale_rate, active_drep_count')
+    .eq('epoch', currentEpoch - 1)
+    .single();
+
+  const deltas = {
+    participationDelta: prevSnapshot
+      ? Math.round((avgParticipation - prevSnapshot.participation_rate) * 10) / 10
+      : null,
+    rationaleDelta: prevSnapshot
+      ? Math.round((avgRationale - (prevSnapshot.rationale_rate ?? avgRationale)) * 10) / 10
+      : null,
+    activeDRepsDelta: prevSnapshot ? activeDReps.length - prevSnapshot.active_drep_count : null,
+  };
+
   const communityGap = topOpenForGap
     .map((p) => {
       const key = `${p.tx_hash}:${p.proposal_index}`;
@@ -176,6 +193,7 @@ export const GET = withRouteHandler(async () => {
         : null,
       currentEpoch,
       communityGap,
+      deltas,
     },
     {
       headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=60' },

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -26,6 +26,7 @@ import { CivicaGovernanceTrends } from './CivicaGovernanceTrends';
 import { CivicaObservatory } from './CivicaObservatory';
 import { CivicaGovernanceCalendar } from './CivicaGovernanceCalendar';
 import { StateOfGovernance } from './StateOfGovernance';
+import { GHIHero } from './GHIHero';
 import { GovernanceImpactCard } from './GovernanceImpactCard';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
 import type {
@@ -46,6 +47,11 @@ interface PulseDataLocal {
   avgParticipationRate?: number;
   avgRationaleRate?: number;
   totalAdaGoverned?: string;
+  deltas?: {
+    participationDelta?: number | null;
+    rationaleDelta?: number | null;
+    activeDRepsDelta?: number | null;
+  };
   communityGap?: CommunityGapItem[];
   spotlightProposal?: {
     txHash: string;
@@ -91,6 +97,8 @@ function StatCard({
   icon: Icon,
   accent,
   href,
+  trend,
+  delta,
 }: {
   label: string;
   value: React.ReactNode;
@@ -98,6 +106,8 @@ function StatCard({
   icon: React.FC<{ className?: string }>;
   accent?: 'default' | 'warning' | 'success' | 'danger';
   href?: string;
+  trend?: 'up' | 'down' | 'flat' | null;
+  delta?: string | null;
 }) {
   const accentClass = {
     default: 'text-primary',
@@ -123,8 +133,22 @@ function StatCard({
         </p>
         <Icon className={cn('h-4 w-4', accentClass)} aria-hidden="true" />
       </div>
-      <div className={cn('font-display text-3xl font-bold leading-none tabular-nums', accentClass)}>
-        {value}
+      <div className="flex items-baseline gap-2">
+        <div
+          className={cn('font-display text-3xl font-bold leading-none tabular-nums', accentClass)}
+        >
+          {value}
+        </div>
+        {delta && trend && trend !== 'flat' && (
+          <span
+            className={cn(
+              'text-[10px] font-medium whitespace-nowrap',
+              trend === 'up' ? 'text-emerald-500' : 'text-rose-500',
+            )}
+          >
+            {trend === 'up' ? '↑' : '↓'} {delta}
+          </span>
+        )}
       </div>
       {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
       {href && (
@@ -258,6 +282,9 @@ export function CivicaPulseOverview() {
       {/* ── Now tab ─────────────────────────────────────────── */}
       {activeTab === 'now' && (
         <div role="tabpanel" id="pulse-tabpanel-now" aria-label="Now">
+          {/* ── GHI Hero ─────────────────────────────────────────── */}
+          <GHIHero />
+
           {/* ── State of Governance narrative ───────────────────── */}
           <StateOfGovernance />
 
@@ -269,16 +296,13 @@ export function CivicaPulseOverview() {
             treasuryBalanceAda={treasury?.balance ?? treasury?.balanceAda ?? 0}
           />
 
-          {/* ── Header ──────────────────────────────────────────── */}
-          <div className="flex items-start justify-between">
-            <div>
-              <h2 className="text-lg font-bold">State of Governance</h2>
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {pulse?.currentEpoch
-                  ? `Epoch ${pulse.currentEpoch} · live data`
-                  : 'Live Cardano governance data'}
-              </p>
-            </div>
+          {/* ── Epoch context ────────────────────────────────────── */}
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              {pulse?.currentEpoch
+                ? `Epoch ${pulse.currentEpoch} · live data`
+                : 'Live Cardano governance data'}
+            </p>
             <div className="flex items-center gap-1.5">
               <span className="relative flex h-2 w-2">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
@@ -322,6 +346,20 @@ export function CivicaPulseOverview() {
                 icon={Users}
                 accent="default"
                 href="/discover"
+                trend={
+                  pulse?.deltas?.activeDRepsDelta != null
+                    ? pulse.deltas.activeDRepsDelta > 0
+                      ? 'up'
+                      : pulse.deltas.activeDRepsDelta < 0
+                        ? 'down'
+                        : 'flat'
+                    : null
+                }
+                delta={
+                  pulse?.deltas?.activeDRepsDelta != null && pulse.deltas.activeDRepsDelta !== 0
+                    ? `${Math.abs(pulse.deltas.activeDRepsDelta)} from last epoch`
+                    : null
+                }
               />
               <StatCard
                 label="Votes This Week"
@@ -342,6 +380,20 @@ export function CivicaPulseOverview() {
                       ? 'warning'
                       : 'danger'
                 }
+                trend={
+                  pulse?.deltas?.participationDelta != null
+                    ? pulse.deltas.participationDelta > 0
+                      ? 'up'
+                      : pulse.deltas.participationDelta < 0
+                        ? 'down'
+                        : 'flat'
+                    : null
+                }
+                delta={
+                  pulse?.deltas?.participationDelta != null && pulse.deltas.participationDelta !== 0
+                    ? `${Math.abs(pulse.deltas.participationDelta)}% from last epoch`
+                    : null
+                }
               />
               <StatCard
                 label="Avg Rationale Rate"
@@ -354,6 +406,20 @@ export function CivicaPulseOverview() {
                     : ((pulse?.avgRationaleRate as number | undefined) ?? 0) >= 30
                       ? 'warning'
                       : 'danger'
+                }
+                trend={
+                  pulse?.deltas?.rationaleDelta != null
+                    ? pulse.deltas.rationaleDelta > 0
+                      ? 'up'
+                      : pulse.deltas.rationaleDelta < 0
+                        ? 'down'
+                        : 'flat'
+                    : null
+                }
+                delta={
+                  pulse?.deltas?.rationaleDelta != null && pulse.deltas.rationaleDelta !== 0
+                    ? `${Math.abs(pulse.deltas.rationaleDelta)}% from last epoch`
+                    : null
                 }
               />
               {treasury && (
@@ -426,6 +492,45 @@ export function CivicaPulseOverview() {
             </div>
           )}
 
+          {/* ── Community vs DRep Sentiment Gap ─────────────────── */}
+          {(pulse?.communityGap?.length ?? 0) > 0 && (
+            <div className="rounded-xl border-l-2 border-l-primary border border-border bg-card p-4 space-y-3">
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-semibold">Where Citizens & DReps Diverge</h3>
+                <span className="text-[10px] text-muted-foreground px-1.5 py-0.5 rounded bg-muted">
+                  Unique to Governada
+                </span>
+              </div>
+              <div className="divide-y divide-border">
+                {(pulse!.communityGap as CommunityGapItem[]).slice(0, 3).map((g) => {
+                  const pollTotal = g.pollTotal || 1;
+                  const yesPct = Math.round(((g.pollYes ?? 0) / pollTotal) * 100);
+                  const noPct = Math.round(((g.pollNo ?? 0) / pollTotal) * 100);
+                  return (
+                    <Link
+                      key={`${g.txHash}-${g.index}`}
+                      href={`/proposal/${g.txHash}/${g.index}`}
+                      className="block py-3 first:pt-0 last:pb-0 hover:bg-muted/20 transition-colors"
+                    >
+                      <p className="text-sm truncate mb-1.5">{g.title}</p>
+                      <div className="flex items-center gap-3 text-[11px]">
+                        <span className="text-muted-foreground">
+                          Community: <strong className="text-emerald-400">{yesPct}% Yes</strong>
+                          {' / '}
+                          <strong className="text-rose-400">{noPct}% No</strong>
+                          <span className="text-muted-foreground/60"> ({pollTotal} votes)</span>
+                        </span>
+                        <span className="text-muted-foreground">
+                          DReps: <strong className="text-foreground">{g.drepVotePct}%</strong> voted
+                        </span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
           {/* ── Weekly movers ───────────────────────────────────── */}
           {(gainers.length > 0 || losers.length > 0) && (
             <div className="grid gap-3 sm:grid-cols-2">
@@ -491,42 +596,6 @@ export function CivicaPulseOverview() {
                   </div>
                 </div>
               )}
-            </div>
-          )}
-
-          {/* ── Community vs DRep Sentiment Gap ─────────────────── */}
-          {(pulse?.communityGap?.length ?? 0) > 0 && (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                Community vs DRep Sentiment
-              </p>
-              <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
-                {(pulse!.communityGap as CommunityGapItem[]).slice(0, 3).map((g) => {
-                  const pollTotal = g.pollTotal || 1;
-                  const yesPct = Math.round(((g.pollYes ?? 0) / pollTotal) * 100);
-                  const noPct = Math.round(((g.pollNo ?? 0) / pollTotal) * 100);
-                  return (
-                    <Link
-                      key={`${g.txHash}-${g.index}`}
-                      href={`/proposal/${g.txHash}/${g.index}`}
-                      className="block px-4 py-3 hover:bg-muted/20 transition-colors"
-                    >
-                      <p className="text-sm truncate mb-1.5">{g.title}</p>
-                      <div className="flex items-center gap-3 text-[11px]">
-                        <span className="text-muted-foreground">
-                          Community: <strong className="text-emerald-400">{yesPct}% Yes</strong>
-                          {' / '}
-                          <strong className="text-rose-400">{noPct}% No</strong>
-                          <span className="text-muted-foreground/60"> ({pollTotal} votes)</span>
-                        </span>
-                        <span className="text-muted-foreground">
-                          DReps: <strong className="text-foreground">{g.drepVotePct}%</strong> voted
-                        </span>
-                      </div>
-                    </Link>
-                  );
-                })}
-              </div>
             </div>
           )}
 

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useGovernanceHealthIndex } from '@/hooks/queries';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface GHICurrent {
+  score: number;
+  band: string;
+}
+
+interface GHITrend {
+  direction: 'up' | 'down' | 'flat';
+  delta: number;
+  streakEpochs: number;
+}
+
+interface GHIData {
+  current: GHICurrent;
+  trend: GHITrend;
+}
+
+const BAND_STYLES: Record<string, { text: string; ring: string; bg: string; label: string }> = {
+  strong: {
+    text: 'text-emerald-500',
+    ring: 'var(--color-emerald-500)',
+    bg: 'bg-emerald-500/10',
+    label: 'Strong',
+  },
+  good: {
+    text: 'text-green-500',
+    ring: 'var(--color-green-500)',
+    bg: 'bg-green-500/10',
+    label: 'Good',
+  },
+  fair: {
+    text: 'text-amber-500',
+    ring: 'var(--color-amber-500)',
+    bg: 'bg-amber-500/10',
+    label: 'Fair',
+  },
+  critical: {
+    text: 'text-rose-500',
+    ring: 'var(--color-rose-500)',
+    bg: 'bg-rose-500/10',
+    label: 'Critical',
+  },
+};
+
+export function GHIHero() {
+  const { data: rawGhi, isLoading, isError } = useGovernanceHealthIndex(1);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-5 p-5 rounded-xl border border-border bg-card">
+        <Skeleton className="h-20 w-20 rounded-full shrink-0" />
+        <div className="space-y-2 flex-1">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-3 w-64" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !rawGhi) return null;
+
+  const ghi = rawGhi as GHIData;
+  const score = ghi.current?.score ?? 0;
+  const band = ghi.current?.band ?? 'fair';
+  const delta = ghi.trend?.delta ?? 0;
+  const direction = ghi.trend?.direction ?? 'flat';
+  const streakEpochs = ghi.trend?.streakEpochs ?? 0;
+
+  const style = BAND_STYLES[band] ?? BAND_STYLES.fair;
+  const scorePct = Math.min(100, Math.max(0, score));
+
+  const TrendIcon = direction === 'up' ? TrendingUp : direction === 'down' ? TrendingDown : Minus;
+  const trendColor =
+    direction === 'up'
+      ? 'text-emerald-500'
+      : direction === 'down'
+        ? 'text-rose-500'
+        : 'text-muted-foreground';
+
+  const streakLabel =
+    streakEpochs > 1
+      ? `${streakEpochs}-epoch ${direction === 'up' ? 'climb' : direction === 'down' ? 'slide' : 'streak'}`
+      : null;
+
+  return (
+    <div className="flex items-center gap-5 p-5 rounded-xl border border-border bg-card">
+      {/* Score ring */}
+      <div className="relative h-20 w-20 shrink-0">
+        <svg viewBox="0 0 36 36" className="h-20 w-20 -rotate-90">
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            className="text-muted/30"
+          />
+          <circle
+            cx="18"
+            cy="18"
+            r="15.5"
+            fill="none"
+            stroke={style.ring}
+            strokeWidth="2.5"
+            strokeDasharray={`${scorePct} ${100 - scorePct}`}
+            strokeLinecap="round"
+            className="transition-all duration-1000"
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-2xl font-bold tabular-nums">{Math.round(score)}</span>
+        </div>
+      </div>
+
+      {/* Score context */}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h2 className="text-lg font-semibold">Governance Health</h2>
+          <span
+            className={cn('text-xs font-semibold px-2 py-0.5 rounded-full', style.bg, style.text)}
+          >
+            {style.label}
+          </span>
+          {delta !== 0 && (
+            <span
+              className={cn('inline-flex items-center gap-0.5 text-xs font-medium', trendColor)}
+            >
+              <TrendIcon className="h-3 w-3" />
+              {delta > 0 ? '+' : ''}
+              {Math.round(delta * 10) / 10}
+            </span>
+          )}
+        </div>
+        {streakLabel && <p className="text-xs text-muted-foreground">{streakLabel}</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `GHIHero` component with SVG score ring, color-coded band badge, and epoch-over-epoch trend delta — renders as the first element on the Now tab
- Extend pulse API with epoch-over-epoch deltas for participation, rationale, and active DReps from `governance_participation_snapshots`
- Wire deltas to stat cards with directional arrows (↑/↓) and "from last epoch" context
- Move community-vs-DRep sentiment gap above weekly movers, add left border accent and "Unique to Governada" badge
- Remove duplicate "State of Governance" h2 header — GHI Hero + narrative replace it

## Impact
- **What changed**: GHI score is now the first thing visible on the Pulse Now tab; stat cards show temporal context; sentiment gap is prominent
- **User-facing**: Yes — completely new visual hierarchy on the Now tab
- **Risk**: Low — new component + UI restructuring, no data model changes
- **Scope**: 3 files (1 new component, 1 modified overview, 1 API route extended)

## Test plan
- [ ] `/pulse` — GHI score ring visible as first element on Now tab
- [ ] Ring color matches the band (green for strong/good, amber for fair, rose for critical)
- [ ] Delta badge shows directional change from previous epoch
- [ ] StateOfGovernance narrative appears directly below the GHI hero
- [ ] Stat cards show epoch-over-epoch deltas (where data exists)
- [ ] Community sentiment gap section is ABOVE weekly movers
- [ ] Community gap has left border accent and "Unique to Governada" badge
- [ ] Dark mode: all new elements render correctly
- [ ] Mobile: GHI hero is readable, ring + text side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)