### PR TITLE
feat: GHI Explorer + live activity ticker on Pulse

### DIFF
--- a/app/api/governance/health-index/history/route.ts
+++ b/app/api/governance/health-index/history/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { createClient } from '@/lib/supabase';
 import { computeGHI, type GHIResult } from '@/lib/ghi';
+import { GHI_CALIBRATION } from '@/lib/scoring/calibration';
 
 export const GET = withRouteHandler(async (request) => {
   const epochs = Math.min(parseInt(request.nextUrl.searchParams.get('epochs') ?? '20', 10), 50);
@@ -21,6 +22,9 @@ export const GET = withRouteHandler(async (request) => {
     epoch: s.epoch_no,
     score: Number(s.score),
     band: s.band as string,
+    components:
+      (s.components as { name: string; value: number; weight: number; contribution: number }[]) ??
+      null,
   }));
 
   const trend: { direction: 'up' | 'down' | 'flat'; delta: number; streakEpochs: number } = {
@@ -70,6 +74,7 @@ export const GET = withRouteHandler(async (request) => {
       history,
       trend,
       componentTrends,
+      calibration: GHI_CALIBRATION,
     },
     { headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600' } },
   );

--- a/components/ActivityTicker.tsx
+++ b/components/ActivityTicker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Vote, FileText, Users, ScrollText } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface ActivityEvent {
   type: 'vote' | 'rationale' | 'proposal';
@@ -15,6 +16,7 @@ interface ActivityEvent {
 interface ActivityTickerProps {
   initialEvents?: ActivityEvent[];
   onEventVisible?: (drepId: string) => void;
+  variant?: 'overlay' | 'inline';
 }
 
 const EVENT_ICONS: Record<string, { icon: typeof Vote; color: string }> = {
@@ -49,7 +51,11 @@ function formatEventText(event: ActivityEvent): string {
   }
 }
 
-export function ActivityTicker({ initialEvents, onEventVisible }: ActivityTickerProps) {
+export function ActivityTicker({
+  initialEvents,
+  onEventVisible,
+  variant = 'overlay',
+}: ActivityTickerProps) {
   const [events, setEvents] = useState<ActivityEvent[]>(initialEvents || []);
   const tickerRef = useRef<HTMLUListElement>(null);
   const pollRef = useRef<ReturnType<typeof setInterval>>(undefined);
@@ -98,32 +104,62 @@ export function ActivityTicker({ initialEvents, onEventVisible }: ActivityTicker
   // Duplicate events for seamless scroll loop
   const displayEvents = [...events, ...events];
 
+  const tickerList = (
+    <ul
+      ref={tickerRef}
+      className={cn(
+        'flex items-center gap-8 whitespace-nowrap',
+        variant === 'overlay' ? 'px-4 py-2.5 animate-ticker' : 'px-3 py-2 animate-ticker',
+      )}
+      aria-live="polite"
+      aria-label="Recent governance activity"
+      style={{
+        animationDuration: `${Math.max(15, displayEvents.length * 2)}s`,
+      }}
+    >
+      {displayEvents.map((event, i) => {
+        const config = EVENT_ICONS[event.type] || EVENT_ICONS.vote;
+        const Icon = config.icon;
+        return (
+          <li key={`${event.timestamp}-${i}`} className="flex items-center gap-2 text-sm shrink-0">
+            <Icon className={`h-3.5 w-3.5 ${config.color} shrink-0`} />
+            <span className={variant === 'overlay' ? 'text-white/70' : 'text-foreground/70'}>
+              {formatEventText(event)}
+            </span>
+            <span
+              className={cn(
+                'text-xs',
+                variant === 'overlay' ? 'text-white/30' : 'text-muted-foreground',
+              )}
+            >
+              {formatRelativeTime(event.timestamp)}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  if (variant === 'inline') {
+    return (
+      <div className="rounded-xl border border-border bg-card overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-400" />
+          </span>
+          <span className="text-xs font-medium text-muted-foreground">
+            Live Governance Activity
+          </span>
+        </div>
+        <div className="overflow-hidden">{tickerList}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="absolute bottom-0 left-0 right-0 z-10 overflow-hidden bg-black/50 backdrop-blur-md border-t border-white/5">
-      <ul
-        ref={tickerRef}
-        className="flex items-center gap-8 px-4 py-2.5 animate-ticker whitespace-nowrap"
-        aria-live="polite"
-        aria-label="Recent governance activity"
-        style={{
-          animationDuration: `${Math.max(15, displayEvents.length * 2)}s`,
-        }}
-      >
-        {displayEvents.map((event, i) => {
-          const config = EVENT_ICONS[event.type] || EVENT_ICONS.vote;
-          const Icon = config.icon;
-          return (
-            <li
-              key={`${event.timestamp}-${i}`}
-              className="flex items-center gap-2 text-sm shrink-0"
-            >
-              <Icon className={`h-3.5 w-3.5 ${config.color} shrink-0`} />
-              <span className="text-white/70">{formatEventText(event)}</span>
-              <span className="text-white/30 text-xs">{formatRelativeTime(event.timestamp)}</span>
-            </li>
-          );
-        })}
-      </ul>
+      {tickerList}
     </div>
   );
 }

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -27,7 +27,10 @@ import { CivicaObservatory } from './CivicaObservatory';
 import { CivicaGovernanceCalendar } from './CivicaGovernanceCalendar';
 import { StateOfGovernance } from './StateOfGovernance';
 import { GHIHero } from './GHIHero';
+import { GHIExplorer } from './GHIExplorer';
 import { GovernanceImpactCard } from './GovernanceImpactCard';
+import { ActivityTicker } from '@/components/ActivityTicker';
+import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
 import type {
   TreasuryData,
@@ -214,6 +217,28 @@ export function CivicaPulseOverview() {
       })
     | undefined;
 
+  const { data: rawGhi } = useGovernanceHealthIndex(5);
+  const ghiData = rawGhi as
+    | {
+        current: {
+          score: number;
+          band: string;
+          components: { name: string; value: number; weight: number; contribution: number }[];
+        };
+        history: {
+          epoch: number;
+          components:
+            | { name: string; value: number; weight: number; contribution: number }[]
+            | null;
+        }[];
+        componentTrends: Record<string, { direction: string; delta: number }>;
+        calibration: Record<
+          string,
+          { floor: number; targetLow: number; targetHigh: number; ceiling: number }
+        >;
+      }
+    | undefined;
+
   const { data: rawLeaderboard } = useGovernanceLeaderboard();
   const leaderboard = rawLeaderboard as LeaderboardData | undefined;
 
@@ -284,6 +309,18 @@ export function CivicaPulseOverview() {
         <div role="tabpanel" id="pulse-tabpanel-now" aria-label="Now">
           {/* ── GHI Hero ─────────────────────────────────────────── */}
           <GHIHero />
+
+          {/* ── GHI Explorer (click-to-expand breakdown) ──────── */}
+          {ghiData?.current && (
+            <GHIExplorer
+              components={ghiData.current.components}
+              componentHistory={ghiData.history}
+              calibration={ghiData.calibration}
+              componentTrends={ghiData.componentTrends}
+              band={ghiData.current.band}
+              score={ghiData.current.score}
+            />
+          )}
 
           {/* ── State of Governance narrative ───────────────────── */}
           <StateOfGovernance />
@@ -681,6 +718,9 @@ export function CivicaPulseOverview() {
               </Link>
             </div>
           )}
+
+          {/* ── Live Activity Ticker (inline) ────────────────────── */}
+          <ActivityTicker variant="inline" />
         </div>
       )}
     </div>

--- a/components/civica/pulse/GHIExplorer.tsx
+++ b/components/civica/pulse/GHIExplorer.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { ChevronDown, Share2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { staggerContainerSlow, fadeInUp, spring } from '@/lib/animations';
+import { ShareModal } from '@/components/civica/shared/ShareModal';
+
+interface GHIComponentData {
+  name: string;
+  value: number;
+  weight: number;
+  contribution: number;
+}
+
+interface CalibrationCurve {
+  floor: number;
+  targetLow: number;
+  targetHigh: number;
+  ceiling: number;
+}
+
+interface HistoryEntry {
+  epoch: number;
+  components: GHIComponentData[] | null;
+}
+
+interface GHIExplorerProps {
+  components: GHIComponentData[];
+  componentHistory: HistoryEntry[];
+  calibration: Record<string, CalibrationCurve>;
+  componentTrends: Record<string, { direction: string; delta: number }>;
+  band: string;
+  score: number;
+}
+
+const BAND_COLORS: Record<string, string> = {
+  strong: 'bg-emerald-500',
+  good: 'bg-green-500',
+  fair: 'bg-amber-500',
+  critical: 'bg-rose-500',
+};
+
+const COMPONENT_LABELS: Record<string, string> = {
+  drepParticipation: 'DRep Participation',
+  citizenEngagement: 'Citizen Engagement',
+  deliberationQuality: 'Deliberation Quality',
+  governanceEffectiveness: 'Governance Effectiveness',
+  powerDistribution: 'Power Distribution',
+  systemStability: 'System Stability',
+};
+
+function getCalibrationKey(name: string): string {
+  return name.replace(/\s+/g, '').replace(/^./, (c) => c.toLowerCase());
+}
+
+function MiniSparkline({ data }: { data: (number | null)[] }) {
+  const valid = data.filter((d): d is number => d != null);
+  if (valid.length < 2) return null;
+
+  const min = Math.min(...valid);
+  const max = Math.max(...valid);
+  const range = max - min || 1;
+  const w = 60;
+  const h = 16;
+  const points = valid
+    .map((v, i) => `${(i / (valid.length - 1)) * w},${h - ((v - min) / range) * h}`)
+    .join(' ');
+
+  const isUp = valid[valid.length - 1] > valid[0];
+
+  return (
+    <svg
+      width={w}
+      height={h}
+      className={isUp ? 'text-emerald-500' : 'text-rose-400'}
+      aria-label={`Trend: ${valid.map((v) => v.toFixed(0)).join(', ')}`}
+    >
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.5" points={points} />
+    </svg>
+  );
+}
+
+function ZoneIndicator({ value, curve }: { value: number; curve: CalibrationCurve }) {
+  const position = Math.min(value / curve.ceiling, 1) * 100;
+  const zones = [
+    { pct: 0, color: 'bg-rose-500/30' },
+    { pct: (curve.floor / curve.ceiling) * 100, color: 'bg-amber-500/30' },
+    { pct: (curve.targetLow / curve.ceiling) * 100, color: 'bg-green-500/30' },
+    { pct: (curve.targetHigh / curve.ceiling) * 100, color: 'bg-emerald-500/30' },
+  ];
+
+  return (
+    <div className="relative h-1.5 rounded-full bg-muted overflow-hidden">
+      {zones.map((z, i) => {
+        const next = zones[i + 1]?.pct ?? 100;
+        return (
+          <div
+            key={i}
+            className={cn('absolute inset-y-0', z.color)}
+            style={{ left: `${z.pct}%`, width: `${next - z.pct}%` }}
+          />
+        );
+      })}
+      <div
+        className="absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-foreground border border-background"
+        style={{ left: `${position}%`, transform: `translate(-50%, -50%)` }}
+      />
+    </div>
+  );
+}
+
+export function GHIExplorer({
+  components,
+  componentHistory,
+  calibration,
+  componentTrends,
+  band,
+  score,
+}: GHIExplorerProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
+
+  const barColor = BAND_COLORS[band] ?? BAND_COLORS.fair;
+
+  return (
+    <>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls="ghi-explorer-panel"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {expanded ? 'Hide breakdown' : 'See what drives this score'}
+        <ChevronDown className={cn('h-3 w-3 transition-transform', expanded && 'rotate-180')} />
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            id="ghi-explorer-panel"
+            variants={staggerContainerSlow}
+            initial="hidden"
+            animate="visible"
+            exit="hidden"
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-3"
+          >
+            {components.map((comp) => {
+              const calKey = getCalibrationKey(comp.name);
+              const curve = calibration[calKey];
+              const trend = componentTrends[comp.name];
+              const label = COMPONENT_LABELS[calKey] ?? comp.name;
+
+              const sparkData = componentHistory
+                .filter((h) => h.components)
+                .map((h) => {
+                  const match = h.components!.find((c) => c.name === comp.name);
+                  return match?.value ?? null;
+                })
+                .slice(-5);
+
+              const scorePct = Math.min((comp.contribution / comp.weight) * 100, 100);
+
+              return (
+                <motion.div
+                  key={comp.name}
+                  variants={fadeInUp}
+                  className="rounded-lg border border-border bg-card p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">{label}</span>
+                    <span className="text-xs text-muted-foreground tabular-nums">
+                      {Math.round(comp.weight * 100)}%
+                    </span>
+                  </div>
+
+                  {/* Score bar */}
+                  <div className="relative h-2 rounded-full bg-muted overflow-hidden">
+                    <motion.div
+                      className={cn('absolute inset-y-0 left-0 rounded-full', barColor)}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${scorePct}%` }}
+                      transition={shouldReduceMotion ? { duration: 0 } : (spring.smooth as object)}
+                    />
+                  </div>
+
+                  {/* Zone indicator */}
+                  {curve && <ZoneIndicator value={comp.value} curve={curve} />}
+
+                  {/* Footer: sparkline + trend */}
+                  <div className="flex items-center justify-between">
+                    <MiniSparkline data={sparkData} />
+                    {trend && trend.delta !== 0 && (
+                      <span
+                        className={cn(
+                          'text-[10px] font-medium',
+                          trend.direction === 'up'
+                            ? 'text-emerald-500'
+                            : trend.direction === 'down'
+                              ? 'text-rose-500'
+                              : 'text-muted-foreground',
+                        )}
+                      >
+                        {trend.direction === 'up' ? '↑' : '↓'} {Math.abs(trend.delta).toFixed(1)}
+                      </span>
+                    )}
+                  </div>
+                </motion.div>
+              );
+            })}
+
+            {/* Share button */}
+            <motion.div variants={fadeInUp} className="col-span-full flex justify-end">
+              <button
+                onClick={() => setShareOpen(true)}
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Share2 className="h-3 w-3" />
+                Share GHI Report
+              </button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <ShareModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        title="Governance Health Report"
+        shareText={`Cardano Governance Health Index: ${Math.round(score)} (${band}). See the full breakdown on Governada.`}
+        shareUrl="https://governada.io/pulse"
+        ogImageUrl="/api/og/governance-health"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- **GHI Explorer**: Interactive click-to-expand component breakdown below the GHI Hero, showing all 6 governance health dimensions with animated cards, calibration zone indicators, mini sparklines (5-epoch), and trend deltas
- **ActivityTicker inline variant**: New `variant="inline"` mode renders as a contained card with green pulse dot header instead of the overlay positioning
- **API enhancement**: Health-index history endpoint now returns per-component data in history entries and calibration curves in the response
- Both components integrated into Pulse Now tab

## Impact
- **What changed**: Users can now drill into the GHI score to see exactly what drives each component, with visual calibration zones showing where each metric falls relative to targets. Live governance activity is shown inline at the bottom of the Now tab.
- **User-facing**: Yes — new interactive breakdown panel on Pulse page + live activity feed
- **Risk**: Low — additive UI components, no data mutations, existing behavior unchanged
- **Scope**: `GHIExplorer.tsx` (new), `ActivityTicker.tsx` (variant prop), `CivicaPulseOverview.tsx` (integration), `health-index/history/route.ts` (response shape)

## Test plan
- [ ] Verify GHI Explorer expands/collapses on click
- [ ] Verify 6 component cards show with correct labels, weights, sparklines
- [ ] Verify calibration zone indicators render correctly
- [ ] Verify ActivityTicker inline variant renders as card (not overlay)
- [ ] Verify existing overlay ActivityTicker on Observatory still works
- [ ] Mobile: verify responsive grid (1-col mobile, 2-col tablet, 3-col desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)