### PR TITLE
feat: personalized governance briefing + epoch report editorial

### DIFF
--- a/app/pulse/report/[epoch]/page.tsx
+++ b/app/pulse/report/[epoch]/page.tsx
@@ -7,9 +7,11 @@ import { getSupabaseAdmin } from '@/lib/supabase';
 import { ShareActions } from '@/components/ShareActions';
 import { GHI_BAND_COLORS, GHI_BAND_LABELS, type GHIBand } from '@/lib/ghi';
 import { StateOfGovernanceContent } from './report-content';
+import { FloatingShareFAB } from '@/components/civica/pulse/FloatingShareFAB';
 import type { ReportData } from '@/lib/stateOfGovernance';
 import { BASE_URL } from '@/lib/constants';
-import { ArrowLeft, Calendar, TrendingUp, TrendingDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ArrowLeft, Calendar, TrendingUp, TrendingDown, Bell } from 'lucide-react';
 
 export const dynamic = 'force-dynamic';
 
@@ -85,6 +87,11 @@ export default async function StateOfGovernancePage({ params }: Props) {
   const ghiDelta =
     data.ghiPrevScore != null ? Math.round((data.ghi.score - data.ghiPrevScore) * 10) / 10 : null;
 
+  // Fetch previous epoch report for inter-epoch comparison
+  const prevEpoch = data.epoch - 1;
+  const prevReport = await getReport(String(prevEpoch));
+  const prevData = prevReport ? (prevReport.report_data as unknown as ReportData) : null;
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-6 space-y-8">
       <Link
@@ -158,6 +165,66 @@ export default async function StateOfGovernancePage({ params }: Props) {
         </div>
       </header>
 
+      {/* Key Takeaways */}
+      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <h3 className="text-sm font-bold">Key Takeaways</h3>
+        <ul className="space-y-1.5 text-sm text-muted-foreground list-disc list-inside">
+          {data.stats.activeDReps > 0 && (
+            <li>
+              {data.stats.activeDReps} DReps voted this epoch
+              {ghiDelta != null && (
+                <>
+                  {' '}
+                  — participation is{' '}
+                  {ghiDelta > 0 ? 'trending up' : ghiDelta < 0 ? 'declining' : 'holding steady'}
+                </>
+              )}
+            </li>
+          )}
+          {data.proposals.length > 0 && (
+            <li>{data.proposals.length} proposals were submitted for governance review</li>
+          )}
+          <li>
+            Governance Health Index: {data.ghi.score} ({bandLabel})
+            {ghiDelta != null && ghiDelta !== 0 && (
+              <>
+                {' '}
+                — {ghiDelta > 0
+                  ? `up ${ghiDelta} points`
+                  : `down ${Math.abs(ghiDelta)} points`}{' '}
+                from last epoch
+              </>
+            )}
+          </li>
+          {data.stats.avgParticipation > 0 && (
+            <li>Average DRep participation rate: {data.stats.avgParticipation}%</li>
+          )}
+        </ul>
+      </div>
+
+      {/* Inter-epoch comparison */}
+      {prevData && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <DeltaCard label="GHI Score" current={data.ghi.score} previous={prevData.ghi.score} />
+          <DeltaCard
+            label="Active DReps"
+            current={data.stats.activeDReps}
+            previous={prevData.stats.activeDReps}
+          />
+          <DeltaCard
+            label="Votes Cast"
+            current={data.stats.totalVotes}
+            previous={prevData.stats.totalVotes}
+          />
+          <DeltaCard
+            label="Participation"
+            current={data.stats.avgParticipation}
+            previous={prevData.stats.avgParticipation}
+            suffix="%"
+          />
+        </div>
+      )}
+
       <StateOfGovernanceContent data={data} narrative={narrative} />
 
       {/* Share footer */}
@@ -169,12 +236,56 @@ export default async function StateOfGovernancePage({ params }: Props) {
           surface="governance_report"
         />
 
-        <div className="text-center">
-          <Link href="/my-gov/profile" className="text-sm text-primary hover:underline">
-            Subscribe to weekly governance updates
+        {/* Subscribe CTA */}
+        <div className="rounded-xl border border-dashed border-border p-5 text-center space-y-2">
+          <Bell className="h-5 w-5 text-primary mx-auto" />
+          <p className="text-sm font-medium">Get epoch reports in your inbox</p>
+          <p className="text-xs text-muted-foreground">
+            Be the first to read each epoch&apos;s governance analysis
+          </p>
+          <Link
+            href="/my-gov/profile"
+            className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+          >
+            Set up notifications &rarr;
           </Link>
         </div>
       </div>
+
+      {/* Floating share FAB */}
+      <FloatingShareFAB epoch={data.epoch} score={data.ghi.score} band={bandLabel} />
+    </div>
+  );
+}
+
+function DeltaCard({
+  label,
+  current,
+  previous,
+  suffix = '',
+}: {
+  label: string;
+  current: number;
+  previous: number;
+  suffix?: string;
+}) {
+  const delta = Math.round((current - previous) * 10) / 10;
+  return (
+    <div className="rounded-lg border border-border bg-card p-3 text-center">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold tabular-nums">
+        {current}
+        {suffix}
+      </p>
+      <p
+        className={cn(
+          'text-xs font-medium',
+          delta > 0 ? 'text-emerald-500' : delta < 0 ? 'text-rose-500' : 'text-muted-foreground',
+        )}
+      >
+        {delta > 0 ? '\u2191' : delta < 0 ? '\u2193' : '\u2192'} {Math.abs(delta)}
+        {suffix} from last epoch
+      </p>
     </div>
   );
 }

--- a/components/civica/pulse/FloatingShareFAB.tsx
+++ b/components/civica/pulse/FloatingShareFAB.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Share2 } from 'lucide-react';
+import { ShareModal } from '@/components/civica/shared/ShareModal';
+
+export function FloatingShareFAB({
+  epoch,
+  score,
+  band,
+}: {
+  epoch: number;
+  score: number;
+  band: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <button
+        onClick={() => setShareOpen(true)}
+        className="fixed bottom-6 right-6 z-50 rounded-full bg-primary text-primary-foreground p-3 shadow-lg hover:bg-primary/90 transition-colors"
+        aria-label="Share this report"
+      >
+        <Share2 className="h-5 w-5" />
+      </button>
+
+      <ShareModal
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        title={`Epoch ${epoch} Governance Report`}
+        shareText={`Cardano Epoch ${epoch} Governance Report — GHI: ${score} (${band}). Read the full analysis:`}
+        shareUrl={`https://governada.io/pulse/report/${epoch}`}
+        ogImageUrl={`/api/og/governance-report/${epoch}`}
+      />
+    </>
+  );
+}

--- a/components/civica/pulse/GovernanceImpactCard.tsx
+++ b/components/civica/pulse/GovernanceImpactCard.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useWallet } from '@/utils/wallet-context';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { useDRepReportCard, useAccountInfo } from '@/hooks/queries';
+import { useDRepReportCard, useAccountInfo, useEpochSummary } from '@/hooks/queries';
 import { computeTier } from '@/lib/scoring/tiers';
 
 interface GovernanceImpactCardProps {
@@ -56,33 +56,68 @@ export function GovernanceImpactCard({
 
   const { data: reportCard, isLoading: reportCardLoading } = useDRepReportCard(effectiveDrepId);
   const { data: accountInfo, isLoading: accountLoading } = useAccountInfo(stakeAddress);
+  const walletAddress = stakeAddress ?? undefined;
+  const { data: epochSummary } = useEpochSummary(walletAddress);
 
-  // Don't render if wallet not connected
-  if (!connected) return null;
-
-  // Connected but no delegation — show CTA
-  if (!effectiveDrepId) {
+  // No-wallet preview: blurred mock stats create FOMO
+  if (!connected) {
     return (
-      <Link
-        href="/match"
-        className={cn(
-          'block rounded-xl border border-border bg-card p-4 transition-colors',
-          'hover:border-primary/30 group',
-        )}
-      >
-        <div className="flex items-center gap-3">
-          <div className="flex items-center justify-center h-9 w-9 rounded-lg bg-primary/10">
-            <UserCheck className="h-4.5 w-4.5 text-primary" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-foreground">Delegate to personalize your view</p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Find a DRep who represents your governance values
-            </p>
-          </div>
-          <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
+      <div className="relative rounded-xl border border-border bg-card p-4 overflow-hidden">
+        <div className="absolute inset-0 backdrop-blur-sm bg-card/60 z-10 flex flex-col items-center justify-center gap-2">
+          <Shield className="h-5 w-5 text-primary" aria-hidden />
+          <p className="text-sm font-medium">Your Governance This Epoch</p>
+          <p className="text-xs text-muted-foreground text-center max-w-[200px]">
+            Connect your wallet to see how your DRep represents you
+          </p>
         </div>
-      </Link>
+        <div className="opacity-30 pointer-events-none select-none" aria-hidden="true">
+          <div className="grid grid-cols-3 gap-4 py-2">
+            <div className="space-y-1">
+              <span className="text-[10px] text-muted-foreground block">Voting Power</span>
+              <span className="text-lg font-semibold block">{'\u2588\u2588'} ADA</span>
+            </div>
+            <div className="space-y-1">
+              <span className="text-[10px] text-muted-foreground block">Your DRep</span>
+              <span className="text-lg font-semibold block">
+                {'\u2588\u2588\u2588\u2588\u2588\u2588'}
+              </span>
+            </div>
+            <div className="space-y-1">
+              <span className="text-[10px] text-muted-foreground block">Proposals Voted</span>
+              <span className="text-lg font-semibold block">{'\u2588\u2588'}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Connected but no delegation — show CTA with ADA balance
+  if (!effectiveDrepId) {
+    const balanceAda = accountInfo?.totalBalanceAda
+      ? Math.round(Number(accountInfo.totalBalanceAda))
+      : null;
+
+    return (
+      <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4 text-primary" aria-hidden />
+          <h3 className="text-xs font-semibold text-primary uppercase tracking-wider">
+            Your Governance Impact
+          </h3>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {balanceAda
+            ? `You hold ${balanceAda.toLocaleString()} ADA but aren't represented in governance.`
+            : `You're connected but not yet represented in governance.`}
+        </p>
+        <Link
+          href="/match"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          Find your DRep match <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
     );
   }
 
@@ -96,8 +131,26 @@ export function GovernanceImpactCard({
         tier?: string;
         participationRate?: number | null;
         drepId?: string;
+        scoreHistory?: { snapshot_date: string; score: number }[];
       }
     | undefined;
+
+  const es = epochSummary as
+    | {
+        drep_votes_cast: number;
+        proposals_voted_on: number;
+        drep_score_at_epoch: number | null;
+        drep_tier_at_epoch: string | null;
+      }
+    | undefined;
+
+  // Score trajectory from report card history
+  const scoreHistory = rc?.scoreHistory ?? [];
+  const currentScore =
+    scoreHistory.length > 0 ? scoreHistory[scoreHistory.length - 1]?.score : null;
+  const prevScore = scoreHistory.length > 1 ? scoreHistory[scoreHistory.length - 2]?.score : null;
+  const scoreDelta =
+    currentScore != null && prevScore != null ? Math.round(currentScore - prevScore) : null;
 
   const userAda = accountInfo?.totalBalanceAda ?? 0;
   const totalGovernedAda = totalAdaGovernedLovelace / 1_000_000;
@@ -214,6 +267,47 @@ export function GovernanceImpactCard({
           </p>
         </div>
       </div>
+
+      {/* DRep activity this epoch */}
+      {es && (
+        <div className="border-t border-border pt-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              This Epoch
+            </h4>
+            {scoreDelta != null && scoreDelta !== 0 && (
+              <span
+                className={cn(
+                  'text-xs font-medium',
+                  scoreDelta > 0
+                    ? 'text-emerald-500'
+                    : scoreDelta < 0
+                      ? 'text-rose-500'
+                      : 'text-muted-foreground',
+                )}
+              >
+                Score: {prevScore} {'\u2192'} {currentScore} ({scoreDelta > 0 ? '+' : ''}
+                {scoreDelta})
+              </span>
+            )}
+          </div>
+
+          <p className="text-sm text-muted-foreground">
+            Your DRep voted on <strong>{es.drep_votes_cast}</strong> of{' '}
+            <strong>{es.proposals_voted_on}</strong> proposals
+            {es.drep_votes_cast > 0 && es.proposals_voted_on > 0 && (
+              <>
+                {' '}
+                &mdash;{' '}
+                <strong>
+                  {Math.round((es.drep_votes_cast / es.proposals_voted_on) * 100)}%
+                </strong>{' '}
+                participation
+              </>
+            )}
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -60,6 +60,22 @@ export function useGovernanceHealthIndex(epochs = 20) {
   });
 }
 
+export function useEpochSummary(wallet: string | undefined, epoch?: number) {
+  return useQuery({
+    queryKey: ['epoch-summary', wallet, epoch],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (wallet) params.set('wallet', wallet);
+      if (epoch) params.set('epoch', String(epoch));
+      const res = await fetch(`/api/user/epoch-summary?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch epoch summary');
+      return res.json();
+    },
+    enabled: !!wallet,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
 export function useGovernanceTimeline() {
   return useQuery({
     queryKey: ['governance-timeline'],


### PR DESCRIPTION
## Summary
- **No-wallet preview**: Blurred mock governance stats with "Connect wallet" CTA creates FOMO for disconnected users
- **Enhanced delegation CTA**: Shows user's ADA balance when connected but undelegated
- **DRep vote detail**: Epoch summary showing vote count, participation %, score trajectory in the impact card
- **Key takeaways box**: Auto-generated bullet points on epoch report pages
- **Inter-epoch comparison**: Side-by-side delta cards for GHI, DReps, votes, participation
- **Floating share FAB**: Appears on scroll for easy sharing mid-read
- **Enhanced subscribe CTA**: Prominent dashed-border card with bell icon

## Impact
- **What changed**: Three distinct wallet states (disconnected/connected-undelegated/delegated) now each have tailored UI. Epoch reports transformed from data pages to editorial content with key takeaways and epoch comparisons.
- **User-facing**: Yes — new preview card for non-connected users, enhanced impact card for connected users, and editorial improvements on all epoch reports
- **Risk**: Low — additive UI, no data mutations, existing API endpoints unchanged
- **Scope**: `GovernanceImpactCard.tsx`, `FloatingShareFAB.tsx` (new), `hooks/queries.ts`, `report/[epoch]/page.tsx`

## Test plan
- [ ] `/pulse` with NO wallet: blurred preview card visible with "Connect wallet" CTA
- [ ] `/pulse` with wallet, no delegation: shows ADA balance + "Find your DRep match" link
- [ ] `/pulse` with wallet + delegation: shows 3 stats + DRep vote detail section
- [ ] `/pulse/report/[epoch]`: key takeaways box with 3-4 bullet points
- [ ] Inter-epoch comparison cards show deltas
- [ ] Scroll down on report: floating share FAB appears bottom-right
- [ ] Subscribe CTA visible at bottom of report
- [ ] All above work in dark mode and on mobile 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)