### PR TITLE
feat: guided empty states + accessibility pass for Pulse

### DIFF
--- a/components/ActivityTicker.tsx
+++ b/components/ActivityTicker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { Vote, FileText, Users, ScrollText } from 'lucide-react';
+import { Vote, FileText, Users, ScrollText, Activity } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ActivityEvent {
@@ -99,7 +99,18 @@ export function ActivityTicker({
     return () => clearInterval(interval);
   }, [events, onEventVisible]);
 
-  if (events.length === 0) return null;
+  if (events.length === 0) {
+    if (variant === 'inline') {
+      return (
+        <div className="rounded-xl border border-dashed border-border p-6 text-center space-y-2">
+          <Activity className="h-8 w-8 text-muted-foreground mx-auto" />
+          <p className="text-sm font-medium">No recent governance activity</p>
+          <p className="text-xs text-muted-foreground">The chain is quiet</p>
+        </div>
+      );
+    }
+    return null;
+  }
 
   // Duplicate events for seamless scroll loop
   const displayEvents = [...events, ...events];

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -322,6 +322,13 @@ export function CivicaPulseOverview() {
               score={ghiData.current.score}
             />
           )}
+          {!ghiData?.current && !loading && (
+            <EmptyState
+              icon={<Activity className="h-8 w-8" />}
+              title="Governance Health is being computed"
+              description="Check back after the current epoch"
+            />
+          )}
 
           {/* ── State of Governance narrative ───────────────────── */}
           <StateOfGovernance />
@@ -568,6 +575,13 @@ export function CivicaPulseOverview() {
               </div>
             </div>
           )}
+          {(pulse?.communityGap?.length ?? 0) === 0 && !loading && (
+            <EmptyState
+              icon={<Users className="h-8 w-8" />}
+              title="Community sentiment polls coming soon"
+              description="Be the first to participate"
+            />
+          )}
 
           {/* ── Weekly movers ───────────────────────────────────── */}
           {(gainers.length > 0 || losers.length > 0) && (
@@ -636,6 +650,13 @@ export function CivicaPulseOverview() {
               )}
             </div>
           )}
+          {gainers.length === 0 && losers.length === 0 && !loading && (
+            <EmptyState
+              icon={<TrendingUp className="h-8 w-8" />}
+              title="No significant DRep score changes this week"
+              description="Score changes are tracked weekly across all active DReps"
+            />
+          )}
 
           {/* ── Treasury Health Components ─────────────────────── */}
           {treasury?.healthComponents &&
@@ -680,7 +701,14 @@ export function CivicaPulseOverview() {
                             {Math.round(c.score ?? c.value ?? 0)}
                           </span>
                         </div>
-                        <div className="w-full h-1.5 bg-border rounded-full overflow-hidden">
+                        <div
+                          className="w-full h-1.5 bg-border rounded-full overflow-hidden"
+                          role="meter"
+                          aria-valuenow={Math.round(c.score ?? c.value ?? 0)}
+                          aria-valuemin={0}
+                          aria-valuemax={100}
+                          aria-label={`${c.name ?? c.label}: ${Math.round(c.score ?? c.value ?? 0)} out of 100`}
+                        >
                           <div
                             className={cn(
                               'h-full rounded-full',
@@ -691,6 +719,7 @@ export function CivicaPulseOverview() {
                                   : 'bg-rose-500',
                             )}
                             style={{ width: `${Math.min(100, c.score ?? c.value ?? 0)}%` }}
+                            aria-hidden="true"
                           />
                         </div>
                       </div>

--- a/components/civica/pulse/EmptyState.tsx
+++ b/components/civica/pulse/EmptyState.tsx
@@ -1,0 +1,27 @@
+interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="rounded-xl border border-dashed border-border p-6 text-center space-y-2">
+      {icon && <div className="text-muted-foreground mx-auto w-8 h-8">{icon}</div>}
+      <p className="text-sm font-medium">{title}</p>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/civica/pulse/GHIExplorer.tsx
+++ b/components/civica/pulse/GHIExplorer.tsx
@@ -92,7 +92,11 @@ function ZoneIndicator({ value, curve }: { value: number; curve: CalibrationCurv
   ];
 
   return (
-    <div className="relative h-1.5 rounded-full bg-muted overflow-hidden">
+    <div
+      className="relative h-1.5 rounded-full bg-muted overflow-hidden"
+      role="img"
+      aria-label={`Calibration zone: value ${Math.round(value)} of ${Math.round(curve.ceiling)} (target range ${Math.round(curve.targetLow)}–${Math.round(curve.targetHigh)})`}
+    >
       {zones.map((z, i) => {
         const next = zones[i + 1]?.pct ?? 100;
         return (
@@ -177,12 +181,20 @@ export function GHIExplorer({
                   </div>
 
                   {/* Score bar */}
-                  <div className="relative h-2 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="relative h-2 rounded-full bg-muted overflow-hidden"
+                    role="meter"
+                    aria-valuenow={Math.round(comp.value)}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label={`${label}: ${Math.round(comp.value)} out of 100`}
+                  >
                     <motion.div
                       className={cn('absolute inset-y-0 left-0 rounded-full', barColor)}
                       initial={{ width: 0 }}
                       animate={{ width: `${scorePct}%` }}
                       transition={shouldReduceMotion ? { duration: 0 } : (spring.smooth as object)}
+                      aria-hidden="true"
                     />
                   </div>
 

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -91,8 +91,15 @@ export function GHIHero() {
   return (
     <div className="flex items-center gap-5 p-5 rounded-xl border border-border bg-card">
       {/* Score ring */}
-      <div className="relative h-20 w-20 shrink-0">
-        <svg viewBox="0 0 36 36" className="h-20 w-20 -rotate-90">
+      <div
+        className="relative h-20 w-20 shrink-0"
+        role="meter"
+        aria-valuenow={Math.round(score)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Governance Health Index: ${Math.round(score)} out of 100`}
+      >
+        <svg viewBox="0 0 36 36" className="h-20 w-20 -rotate-90" aria-hidden="true">
           <circle
             cx="18"
             cy="18"
@@ -114,7 +121,7 @@ export function GHIHero() {
             className="transition-all duration-1000"
           />
         </svg>
-        <div className="absolute inset-0 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">
           <span className="text-2xl font-bold tabular-nums">{Math.round(score)}</span>
         </div>
       </div>
@@ -131,8 +138,9 @@ export function GHIHero() {
           {delta !== 0 && (
             <span
               className={cn('inline-flex items-center gap-0.5 text-xs font-medium', trendColor)}
+              aria-label={`Score ${delta > 0 ? 'increased' : 'decreased'} by ${Math.abs(Math.round(delta * 10) / 10)} points`}
             >
-              <TrendIcon className="h-3 w-3" />
+              <TrendIcon className="h-3 w-3" aria-hidden="true" />
               {delta > 0 ? '+' : ''}
               {Math.round(delta * 10) / 10}
             </span>


### PR DESCRIPTION
## Summary
- Add `EmptyState` component and integrate into 4 Pulse sections (GHI Explorer, Community Gap, Weekly Movers, Activity Ticker) — users see helpful guidance instead of blank space when data is unavailable
- Add ARIA `role="meter"` and labels to GHI score ring, Explorer component bars, calibration zone indicators, and treasury health bars for screen reader support
- Add `aria-label` to trend indicators and `aria-hidden` to decorative SVG elements

## Impact
- **What changed**: Empty states for data-absent Pulse sections + ARIA attributes on all progress/meter visualizations
- **User-facing**: Yes — users without data see descriptive messages instead of blank gaps; screen reader users get full context on scores
- **Risk**: Low — additive only, no data/logic changes
- **Scope**: 5 files (CivicaPulseOverview, EmptyState, GHIExplorer, GHIHero, ActivityTicker)

## Test plan
- [x] Preflight passes (format, lint, types, 631 tests)
- [ ] Verify empty states render when data is absent (mock empty API responses)
- [ ] Verify screen reader announces GHI score, component scores, and treasury health bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)