### PR TITLE
fix: Pulse polish — GHI ring animation, error recovery, a11y, query limits, tests

### DIFF
--- a/__tests__/components/pulse/ErrorCard.test.tsx
+++ b/__tests__/components/pulse/ErrorCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ErrorCard } from '@/components/ui/ErrorCard';
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('lucide-react', () => ({
+  AlertCircle: ({ className }: { className?: string }) => (
+    <span data-testid="icon-alert" className={className} />
+  ),
+  RefreshCw: ({ className }: { className?: string }) => (
+    <span data-testid="icon-refresh" className={className} />
+  ),
+}));
+
+afterEach(cleanup);
+
+describe('ErrorCard', () => {
+  it('renders default message when no message prop provided', () => {
+    render(<ErrorCard />);
+    expect(screen.getByText('Failed to load data. Please try again.')).toBeDefined();
+  });
+
+  it('renders custom message when provided', () => {
+    render(<ErrorCard message="Governance Health temporarily unavailable." />);
+    expect(screen.getByText('Governance Health temporarily unavailable.')).toBeDefined();
+  });
+
+  it('calls onRetry callback when retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ErrorCard onRetry={onRetry} />);
+    const retryButton = screen.getByText('Try again');
+    fireEvent.click(retryButton);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render retry button when onRetry is not provided', () => {
+    render(<ErrorCard />);
+    expect(screen.queryByText('Try again')).toBeNull();
+  });
+
+  it('has aria-live="assertive" and role="alert" on the container', () => {
+    render(<ErrorCard />);
+    const alertEl = screen.getByRole('alert');
+    expect(alertEl).toBeDefined();
+    expect(alertEl.getAttribute('aria-live')).toBe('assertive');
+  });
+});

--- a/__tests__/components/pulse/GHIExplorer.test.tsx
+++ b/__tests__/components/pulse/GHIExplorer.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: Record<string, unknown> & { children?: React.ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReducedMotion: () => false,
+}));
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: ({ className }: { className?: string }) => (
+    <span data-testid="icon-chevron" className={className} />
+  ),
+  Share2: ({ className }: { className?: string }) => (
+    <span data-testid="icon-share" className={className} />
+  ),
+}));
+
+vi.mock('@/lib/animations', () => ({
+  staggerContainerSlow: { hidden: {}, visible: {} },
+  fadeInUp: { hidden: {}, visible: {} },
+  spring: { smooth: {} },
+}));
+
+vi.mock('@/components/civica/shared/ShareModal', () => ({
+  ShareModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="share-modal">Share Modal</div> : null,
+}));
+
+import { GHIExplorer } from '@/components/civica/pulse/GHIExplorer';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const mockComponents = [
+  { name: 'DRep Participation', value: 75, weight: 0.2, contribution: 0.15 },
+  { name: 'Citizen Engagement', value: 60, weight: 0.15, contribution: 0.09 },
+  { name: 'Deliberation Quality', value: 80, weight: 0.2, contribution: 0.16 },
+  { name: 'Governance Effectiveness', value: 70, weight: 0.15, contribution: 0.105 },
+  { name: 'Power Distribution', value: 65, weight: 0.15, contribution: 0.0975 },
+  { name: 'System Stability', value: 85, weight: 0.15, contribution: 0.1275 },
+];
+
+const defaultProps = {
+  components: mockComponents,
+  componentHistory: [],
+  calibration: {},
+  componentTrends: {},
+  band: 'good',
+  score: 72,
+};
+
+describe('GHIExplorer', () => {
+  it('shows "See what drives this score" button when collapsed', () => {
+    render(<GHIExplorer {...defaultProps} />);
+    const button = screen.getByText('See what drives this score');
+    expect(button).toBeDefined();
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('sets aria-expanded=true after clicking the toggle button', () => {
+    render(<GHIExplorer {...defaultProps} />);
+    const button = screen.getByText('See what drives this score');
+    fireEvent.click(button);
+    // After expanding, button text changes to "Hide breakdown"
+    const expandedButton = screen.getByText('Hide breakdown');
+    expect(expandedButton.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders 6 component cards when expanded', () => {
+    render(<GHIExplorer {...defaultProps} />);
+    // Expand the explorer
+    fireEvent.click(screen.getByText('See what drives this score'));
+
+    // Each component should render with a meter role
+    const meters = screen.getAllByRole('meter');
+    expect(meters.length).toBe(6);
+
+    // Verify component labels are present
+    expect(screen.getByText('DRep Participation')).toBeDefined();
+    expect(screen.getByText('Citizen Engagement')).toBeDefined();
+    expect(screen.getByText('Deliberation Quality')).toBeDefined();
+    expect(screen.getByText('Governance Effectiveness')).toBeDefined();
+    expect(screen.getByText('Power Distribution')).toBeDefined();
+    expect(screen.getByText('System Stability')).toBeDefined();
+  });
+
+  it('renders share button in expanded state', () => {
+    render(<GHIExplorer {...defaultProps} />);
+    fireEvent.click(screen.getByText('See what drives this score'));
+
+    const shareButton = screen.getByText('Share GHI Report');
+    expect(shareButton).toBeDefined();
+  });
+
+  it('does not show component cards when collapsed', () => {
+    render(<GHIExplorer {...defaultProps} />);
+    expect(screen.queryByRole('meter')).toBeNull();
+    expect(screen.queryByText('Share GHI Report')).toBeNull();
+  });
+});

--- a/__tests__/components/pulse/GHIHero.test.tsx
+++ b/__tests__/components/pulse/GHIHero.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: Record<string, unknown>) => (
+      <div {...props}>{children as React.ReactNode}</div>
+    ),
+    circle: (props: Record<string, unknown>) => <circle {...(props as object)} />,
+  },
+  useReducedMotion: () => false,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('lucide-react', () => ({
+  TrendingUp: ({ className }: { className?: string }) => (
+    <span data-testid="icon-trending-up" className={className} />
+  ),
+  TrendingDown: ({ className }: { className?: string }) => (
+    <span data-testid="icon-trending-down" className={className} />
+  ),
+  Minus: ({ className }: { className?: string }) => (
+    <span data-testid="icon-minus" className={className} />
+  ),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+vi.mock('@/components/ui/ErrorCard', () => ({
+  ErrorCard: ({ message, onRetry }: { message?: string; onRetry?: () => void }) => (
+    <div data-testid="error-card" role="alert">
+      <p>{message}</p>
+      {onRetry && <button onClick={onRetry}>Try again</button>}
+    </div>
+  ),
+}));
+
+vi.mock('@/lib/animations', () => ({
+  spring: { smooth: {} },
+}));
+
+const mockUseGovernanceHealthIndex = vi.fn();
+
+vi.mock('@/hooks/queries', () => ({
+  useGovernanceHealthIndex: (...args: unknown[]) => mockUseGovernanceHealthIndex(...args),
+}));
+
+import { GHIHero } from '@/components/civica/pulse/GHIHero';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('GHIHero', () => {
+  it('shows skeleton loading state when data is loading', () => {
+    mockUseGovernanceHealthIndex.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    render(<GHIHero />);
+    const skeletons = screen.getAllByTestId('skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows ErrorCard with unavailable message on error', () => {
+    mockUseGovernanceHealthIndex.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
+
+    render(<GHIHero />);
+    const errorCard = screen.getByTestId('error-card');
+    expect(errorCard).toBeDefined();
+    expect(errorCard.textContent).toContain('Governance Health temporarily unavailable.');
+  });
+
+  it('renders score, band label, and trend for valid GHI data', () => {
+    mockUseGovernanceHealthIndex.mockReturnValue({
+      data: {
+        current: { score: 72, band: 'good' },
+        trend: { direction: 'up', delta: 3.5, streakEpochs: 2 },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<GHIHero />);
+
+    // Score
+    expect(container.textContent).toContain('72');
+    // Band label
+    expect(container.textContent).toContain('Good');
+    // Trend delta
+    expect(container.textContent).toContain('+3.5');
+    // Streak label
+    expect(container.textContent).toContain('2-epoch climb');
+    // Aria label on meter
+    const meter = screen.getByRole('meter');
+    expect(meter.getAttribute('aria-valuenow')).toBe('72');
+    expect(meter.getAttribute('aria-label')).toBe('Governance Health Index: 72 out of 100');
+  });
+
+  it('adds ring glow class when band is "strong"', () => {
+    mockUseGovernanceHealthIndex.mockReturnValue({
+      data: {
+        current: { score: 88, band: 'strong' },
+        trend: { direction: 'flat', delta: 0, streakEpochs: 1 },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<GHIHero />);
+    const outerDiv = container.firstElementChild as HTMLElement;
+    expect(outerDiv.className).toContain('ring-1');
+    expect(outerDiv.className).toContain('ring-emerald-500/20');
+    // Band label
+    expect(container.textContent).toContain('Strong');
+  });
+
+  it('does not add ring glow class for non-strong bands', () => {
+    mockUseGovernanceHealthIndex.mockReturnValue({
+      data: {
+        current: { score: 55, band: 'fair' },
+        trend: { direction: 'down', delta: -2, streakEpochs: 3 },
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<GHIHero />);
+    const outerDiv = container.firstElementChild as HTMLElement;
+    expect(outerDiv.className).not.toContain('ring-1');
+    expect(container.textContent).toContain('Fair');
+  });
+});

--- a/__tests__/components/pulse/GovernanceImpactCard.test.tsx
+++ b/__tests__/components/pulse/GovernanceImpactCard.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Shield: ({ className }: { className?: string }) => (
+    <span data-testid="icon-shield" className={className} />
+  ),
+  Vote: ({ className }: { className?: string }) => (
+    <span data-testid="icon-vote" className={className} />
+  ),
+  DollarSign: ({ className }: { className?: string }) => (
+    <span data-testid="icon-dollar" className={className} />
+  ),
+  ChevronRight: ({ className }: { className?: string }) => (
+    <span data-testid="icon-chevron-right" className={className} />
+  ),
+  UserCheck: ({ className }: { className?: string }) => (
+    <span data-testid="icon-user-check" className={className} />
+  ),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+vi.mock('@/lib/scoring/tiers', () => ({
+  computeTier: (score: number) => {
+    if (score >= 90) return 'Diamond';
+    if (score >= 75) return 'Gold';
+    if (score >= 60) return 'Silver';
+    return 'Bronze';
+  },
+}));
+
+const mockUseWallet = vi.fn();
+const mockUseSegment = vi.fn();
+const mockUseDRepReportCard = vi.fn();
+const mockUseAccountInfo = vi.fn();
+const mockUseEpochSummary = vi.fn();
+
+vi.mock('@/utils/wallet-context', () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+vi.mock('@/components/providers/SegmentProvider', () => ({
+  useSegment: () => mockUseSegment(),
+}));
+
+vi.mock('@/hooks/queries', () => ({
+  useDRepReportCard: (...args: unknown[]) => mockUseDRepReportCard(...args),
+  useAccountInfo: (...args: unknown[]) => mockUseAccountInfo(...args),
+  useEpochSummary: (...args: unknown[]) => mockUseEpochSummary(...args),
+}));
+
+import { GovernanceImpactCard } from '@/components/civica/pulse/GovernanceImpactCard';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const defaultProps = {
+  totalAdaGovernedLovelace: 25_000_000_000_000,
+  treasuryBalanceAda: 1_500_000_000,
+};
+
+describe('GovernanceImpactCard', () => {
+  it('shows blurred preview with "Connect your wallet" text when no wallet connected', () => {
+    mockUseWallet.mockReturnValue({
+      connected: false,
+      delegatedDrepId: null,
+    });
+    mockUseSegment.mockReturnValue({
+      stakeAddress: null,
+      delegatedDrep: null,
+    });
+    mockUseDRepReportCard.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseAccountInfo.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseEpochSummary.mockReturnValue({ data: undefined });
+
+    const { container } = render(<GovernanceImpactCard {...defaultProps} />);
+
+    // Should show the "Connect your wallet" message
+    expect(container.textContent).toContain('Connect your wallet');
+    expect(container.textContent).toContain('see how your DRep represents you');
+
+    // The blurred preview has pointer-events-none and backdrop-blur
+    const blurOverlay = container.querySelector('.backdrop-blur-sm');
+    expect(blurOverlay).not.toBeNull();
+  });
+
+  it('shows "Find your DRep match" link when connected but not delegated', () => {
+    mockUseWallet.mockReturnValue({
+      connected: true,
+      delegatedDrepId: null,
+    });
+    mockUseSegment.mockReturnValue({
+      stakeAddress: 'stake1abc123',
+      delegatedDrep: null,
+    });
+    mockUseDRepReportCard.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseAccountInfo.mockReturnValue({
+      data: { totalBalanceAda: 5000 },
+      isLoading: false,
+    });
+    mockUseEpochSummary.mockReturnValue({ data: undefined });
+
+    const { container } = render(<GovernanceImpactCard {...defaultProps} />);
+
+    expect(container.textContent).toContain('Your Governance Impact');
+    const matchLink = screen.getByText('Find your DRep match');
+    expect(matchLink).toBeDefined();
+    expect(matchLink.closest('a')?.getAttribute('href')).toBe('/match');
+    // Should mention their ADA balance
+    expect(container.textContent).toContain('5,000 ADA');
+    expect(container.textContent).toContain("aren't represented in governance");
+  });
+
+  it('shows voting power and DRep name when connected and delegated', () => {
+    mockUseWallet.mockReturnValue({
+      connected: true,
+      delegatedDrepId: 'drep1abc123def456',
+    });
+    mockUseSegment.mockReturnValue({
+      stakeAddress: 'stake1xyz789',
+      delegatedDrep: 'drep1abc123def456',
+    });
+    mockUseDRepReportCard.mockReturnValue({
+      data: {
+        name: 'CardanoMax',
+        score: 82,
+        tier: 'Gold',
+        participationRate: 95,
+        drepId: 'drep1abc123def456',
+        scoreHistory: [],
+      },
+      isLoading: false,
+    });
+    mockUseAccountInfo.mockReturnValue({
+      data: { totalBalanceAda: 250_000 },
+      isLoading: false,
+    });
+    mockUseEpochSummary.mockReturnValue({
+      data: {
+        drep_votes_cast: 8,
+        proposals_voted_on: 10,
+        drep_score_at_epoch: 82,
+        drep_tier_at_epoch: 'Gold',
+      },
+    });
+
+    const { container } = render(<GovernanceImpactCard {...defaultProps} />);
+
+    // DRep name visible
+    expect(container.textContent).toContain('CardanoMax');
+    // Voting power section header
+    expect(container.textContent).toContain('Your Voting Power');
+    // ADA amount formatted (250K)
+    expect(container.textContent).toContain('250K');
+    // Tier badge
+    expect(container.textContent).toContain('Gold');
+    // Participation rate
+    expect(container.textContent).toContain('95% participation');
+    // Epoch activity
+    expect(container.textContent).toContain('8');
+    expect(container.textContent).toContain('10');
+  });
+
+  it('shows loading skeletons while data is being fetched', () => {
+    mockUseWallet.mockReturnValue({
+      connected: true,
+      delegatedDrepId: 'drep1abc',
+    });
+    mockUseSegment.mockReturnValue({
+      stakeAddress: 'stake1xyz',
+      delegatedDrep: 'drep1abc',
+    });
+    mockUseDRepReportCard.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    mockUseAccountInfo.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    mockUseEpochSummary.mockReturnValue({ data: undefined });
+
+    render(<GovernanceImpactCard {...defaultProps} />);
+    const skeletons = screen.getAllByTestId('skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/app/api/governance/leaderboard/route.ts
+++ b/app/api/governance/leaderboard/route.ts
@@ -70,7 +70,8 @@ export const GET = withRouteHandler(
       .from('dreps')
       .select('id, score, info')
       .gt('score', 0)
-      .order('score', { ascending: false });
+      .order('score', { ascending: false })
+      .limit(2500);
 
     const movers = (currentDreps || [])
       .map((d) => {

--- a/components/civica/pulse/CivicaGovernanceTrends.tsx
+++ b/components/civica/pulse/CivicaGovernanceTrends.tsx
@@ -48,6 +48,8 @@ function TrendLine({
       preserveAspectRatio="none"
       className="w-full"
       style={{ height }}
+      role="img"
+      aria-label={`Trend over ${data.length} epochs: ${data[0]?.toFixed(1)} to ${data[data.length - 1]?.toFixed(1)}`}
     >
       <polygon points={areaPts} fill={color} opacity="0.12" />
       <polyline fill="none" stroke={color} strokeWidth="2" strokeLinejoin="round" points={pts} />
@@ -73,12 +75,17 @@ function DualLine({ rows, height = 80 }: { rows: SparkRow[]; height?: number }) 
     .map((r, i) => `${xScale(i).toFixed(1)},${yScale(r.rationale_rate).toFixed(1)}`)
     .join(' ');
 
+  const lastP = rows[rows.length - 1]?.participation_rate?.toFixed(1) ?? '?';
+  const lastR = rows[rows.length - 1]?.rationale_rate?.toFixed(1) ?? '?';
+
   return (
     <svg
       viewBox={`0 0 ${W} ${height}`}
       preserveAspectRatio="none"
       className="w-full"
       style={{ height }}
+      role="img"
+      aria-label={`Participation and rationale rates over ${rows.length} epochs. Latest: ${lastP}% participation, ${lastR}% rationale`}
     >
       <polyline fill="none" stroke="#60a5fa" strokeWidth="2" strokeLinejoin="round" points={pPts} />
       <polyline

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorCard } from '@/components/ui/ErrorCard';
+import { spring } from '@/lib/animations';
 
 interface GHICurrent {
   score: number;
@@ -48,8 +51,11 @@ const BAND_STYLES: Record<string, { text: string; ring: string; bg: string; labe
   },
 };
 
+const CIRCUMFERENCE = 2 * Math.PI * 15.5;
+
 export function GHIHero() {
-  const { data: rawGhi, isLoading, isError } = useGovernanceHealthIndex(1);
+  const { data: rawGhi, isLoading, isError, refetch } = useGovernanceHealthIndex(1);
+  const shouldReduceMotion = useReducedMotion();
 
   if (isLoading) {
     return (
@@ -63,7 +69,11 @@ export function GHIHero() {
     );
   }
 
-  if (isError || !rawGhi) return null;
+  if (isError || !rawGhi) {
+    return (
+      <ErrorCard message="Governance Health temporarily unavailable." onRetry={() => refetch()} />
+    );
+  }
 
   const ghi = rawGhi as GHIData;
   const score = ghi.current?.score ?? 0;
@@ -74,6 +84,7 @@ export function GHIHero() {
 
   const style = BAND_STYLES[band] ?? BAND_STYLES.fair;
   const scorePct = Math.min(100, Math.max(0, score));
+  const strokeOffset = CIRCUMFERENCE * (1 - scorePct / 100);
 
   const TrendIcon = direction === 'up' ? TrendingUp : direction === 'down' ? TrendingDown : Minus;
   const trendColor =
@@ -89,7 +100,13 @@ export function GHIHero() {
       : null;
 
   return (
-    <div className="flex items-center gap-5 p-5 rounded-xl border border-border bg-card">
+    <div
+      className={cn(
+        'flex items-center gap-5 p-5 rounded-xl border border-border bg-card',
+        band === 'strong' &&
+          'ring-1 ring-emerald-500/20 shadow-[0_0_15px_-3px] shadow-emerald-500/10',
+      )}
+    >
       {/* Score ring */}
       <div
         className="relative h-20 w-20 shrink-0"
@@ -109,16 +126,22 @@ export function GHIHero() {
             strokeWidth="2.5"
             className="text-muted/30"
           />
-          <circle
+          <motion.circle
             cx="18"
             cy="18"
             r="15.5"
             fill="none"
             stroke={style.ring}
             strokeWidth="2.5"
-            strokeDasharray={`${scorePct} ${100 - scorePct}`}
+            strokeDasharray={CIRCUMFERENCE}
             strokeLinecap="round"
-            className="transition-all duration-1000"
+            initial={{ strokeDashoffset: shouldReduceMotion ? strokeOffset : CIRCUMFERENCE }}
+            animate={{ strokeDashoffset: strokeOffset }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : { type: 'spring', ...(spring.smooth as object), delay: 0.2 }
+            }
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">

--- a/components/ui/ErrorCard.tsx
+++ b/components/ui/ErrorCard.tsx
@@ -16,19 +16,21 @@ export function ErrorCard({
 }: ErrorCardProps) {
   return (
     <div
+      role="alert"
+      aria-live="assertive"
       className={cn(
         'rounded-xl border border-destructive/20 bg-destructive/5 p-6 text-center space-y-3',
         className,
       )}
     >
-      <AlertCircle className="h-5 w-5 text-destructive mx-auto" />
+      <AlertCircle className="h-5 w-5 text-destructive mx-auto" aria-hidden />
       <p className="text-sm text-muted-foreground">{message}</p>
       {onRetry && (
         <button
           onClick={onRetry}
-          className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+          className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded"
         >
-          <RefreshCw className="h-3 w-3" />
+          <RefreshCw className="h-3 w-3" aria-hidden />
           Try again
         </button>
       )}


### PR DESCRIPTION
## Summary
- **GHI ring animation**: Framer Motion spring-physics draw on the health gauge ring, with `useReducedMotion` support
- **Strong band glow**: Subtle emerald ring + shadow when GHI band is "Strong" — creates a visual reward
- **Error recovery**: GHIHero now renders `ErrorCard` with retry instead of silently returning null
- **Accessibility hardening**: `role="alert"` + `aria-live` on ErrorCard, `role="img"` + `aria-label` on SVG charts, `focus-visible` rings on retry button
- **Query limits**: Added `.limit(2500)` on unbounded leaderboard dreps query
- **Test suite**: 19 new tests across GHIHero, GHIExplorer, GovernanceImpactCard, and ErrorCard

## Impact
- **What changed**: GHI gauge animates on load with spring physics, errors are recoverable, charts are screen-reader accessible, leaderboard query is bounded
- **User-facing**: Yes — ring animation is the first thing users see on Pulse; error states now offer retry instead of blank page
- **Risk**: Low — animation respects reduced-motion, ErrorCard is an existing pattern, query limit is generous (2500)
- **Scope**: 8 files changed (3 components, 1 API route, 4 test files)

## Test plan
- [ ] GHI gauge ring animates on page load (spring draw from 0 to score)
- [ ] Reduced-motion: ring appears instantly without animation
- [ ] Strong band: subtle emerald glow around the gauge card
- [ ] Network error on GHI: ErrorCard with "Try again" button appears
- [ ] Leaderboard loads correctly (query limit doesn't truncate visible data)
- [ ] Screen reader: SVG charts announce trend data
- [ ] All 19 new tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>