### PR TITLE
feat(engage): extract shared labels, priority update path, staggered animation

### DIFF
--- a/components/engagement/ConcernFlagBanner.tsx
+++ b/components/engagement/ConcernFlagBanner.tsx
@@ -3,17 +3,7 @@
 import { AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useConcernFlags } from '@/hooks/useEngagement';
-
-const FLAG_LABELS: Record<string, string> = {
-  too_expensive: 'Too Expensive',
-  team_unproven: 'Team Unproven',
-  duplicates_existing: 'Duplicates Existing',
-  constitutional_concern: 'Constitutional Concern',
-  insufficient_detail: 'Insufficient Detail',
-  unrealistic_timeline: 'Unrealistic Timeline',
-  conflict_of_interest: 'Conflict of Interest',
-  scope_too_broad: 'Scope Too Broad',
-};
+import { CONCERN_LABEL_MAP } from '@/lib/engagement/labels';
 
 const THRESHOLD = 10;
 
@@ -40,7 +30,7 @@ export function ConcernFlagBanner({ txHash, proposalIndex, outcome }: ConcernFla
   if (significantFlags.length === 0) return null;
 
   const topFlag = significantFlags[0];
-  const topLabel = FLAG_LABELS[topFlag[0]] ?? topFlag[0];
+  const topLabel = CONCERN_LABEL_MAP[topFlag[0]] ?? topFlag[0];
   const topCount = topFlag[1];
 
   const isNegativeOutcome = outcome === 'dropped' || outcome === 'expired';

--- a/components/engagement/ConcernFlags.tsx
+++ b/components/engagement/ConcernFlags.tsx
@@ -12,18 +12,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { AlertTriangle, Info, Wallet } from 'lucide-react';
 import { hapticLight } from '@/lib/haptics';
 import { useConcernFlags } from '@/hooks/useEngagement';
+import { CONCERN_FLAG_LABELS } from '@/lib/engagement/labels';
 import type { ConcernFlagType } from '@/lib/api/schemas/engagement';
-
-const FLAG_LABELS: Record<ConcernFlagType, { label: string; emoji: string }> = {
-  too_expensive: { label: 'Too Expensive', emoji: '💰' },
-  team_unproven: { label: 'Team Unproven', emoji: '👤' },
-  duplicates_existing: { label: 'Duplicates Existing', emoji: '🔄' },
-  constitutional_concern: { label: 'Constitutional Concern', emoji: '📜' },
-  insufficient_detail: { label: 'Insufficient Detail', emoji: '📝' },
-  unrealistic_timeline: { label: 'Unrealistic Timeline', emoji: '⏰' },
-  conflict_of_interest: { label: 'Conflict of Interest', emoji: '⚖️' },
-  scope_too_broad: { label: 'Scope Too Broad', emoji: '🔭' },
-};
 
 interface ConcernFlagsProps {
   txHash: string;
@@ -134,7 +124,7 @@ export function ConcernFlags({ txHash, proposalIndex, isOpen }: ConcernFlagsProp
   const totalFlags = results?.total ?? 0;
 
   // Sort flags: user's flags first, then by count descending
-  const sortedFlags = (Object.keys(FLAG_LABELS) as ConcernFlagType[]).sort((a, b) => {
+  const sortedFlags = (Object.keys(CONCERN_FLAG_LABELS) as ConcernFlagType[]).sort((a, b) => {
     const aUser = userFlags.includes(a) ? 1 : 0;
     const bUser = userFlags.includes(b) ? 1 : 0;
     if (aUser !== bUser) return bUser - aUser;
@@ -196,7 +186,7 @@ export function ConcernFlags({ txHash, proposalIndex, isOpen }: ConcernFlagsProp
           {sortedFlags.map((flagType) => {
             const count = flags[flagType] || 0;
             const isUserFlag = userFlags.includes(flagType);
-            const { label, emoji } = FLAG_LABELS[flagType];
+            const { label, emoji } = CONCERN_FLAG_LABELS[flagType];
             const isSubmittingThis = submitting === flagType;
 
             return (

--- a/components/engagement/EngagementSummary.tsx
+++ b/components/engagement/EngagementSummary.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Users, AlertTriangle, Star, BarChart3 } from 'lucide-react';
+import { CONCERN_LABEL_MAP } from '@/lib/engagement/labels';
 
 interface EngagementSummaryProps {
   txHash: string;
@@ -40,17 +41,6 @@ export function EngagementSummary({ txHash, proposalIndex }: EngagementSummaryPr
   // Find top concern
   const topConcern = concerns ? Object.entries(concerns).sort(([, a], [, b]) => b - a)[0] : null;
 
-  const CONCERN_LABELS: Record<string, string> = {
-    too_expensive: 'Too Expensive',
-    team_unproven: 'Team Unproven',
-    duplicates_existing: 'Duplicates Existing',
-    constitutional_concern: 'Constitutional Concern',
-    insufficient_detail: 'Insufficient Detail',
-    unrealistic_timeline: 'Unrealistic Timeline',
-    conflict_of_interest: 'Conflict of Interest',
-    scope_too_broad: 'Scope Too Broad',
-  };
-
   return (
     <Card className="bg-muted/30" aria-label="Community engagement signals summary">
       <CardContent className="py-3">
@@ -75,7 +65,7 @@ export function EngagementSummary({ txHash, proposalIndex }: EngagementSummaryPr
             >
               <AlertTriangle className="h-3 w-3" />
               {totalConcerns} concern{totalConcerns !== 1 ? 's' : ''} &middot; Top:{' '}
-              {CONCERN_LABELS[topConcern[0]] ?? topConcern[0]}
+              {CONCERN_LABEL_MAP[topConcern[0]] ?? topConcern[0]}
             </Badge>
           )}
 

--- a/components/engagement/PriorityRecap.tsx
+++ b/components/engagement/PriorityRecap.tsx
@@ -3,21 +3,7 @@
 import { TrendingUp, TrendingDown, Minus, BarChart3 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { usePriorityRankings } from '@/hooks/useEngagement';
-
-const PRIORITY_LABELS: Record<string, string> = {
-  infrastructure: 'Infrastructure',
-  education: 'Education',
-  defi: 'DeFi',
-  marketing: 'Marketing',
-  developer_tooling: 'Developer Tooling',
-  governance_tooling: 'Governance Tooling',
-  identity_dids: 'Identity & DIDs',
-  interoperability: 'Interoperability',
-  security_auditing: 'Security & Auditing',
-  community_hubs: 'Community Hubs',
-  research: 'Research',
-  media_content: 'Media & Content',
-};
+import { PRIORITY_LABEL_MAP } from '@/lib/engagement/labels';
 
 interface PriorityRecapProps {
   currentEpoch: number;
@@ -64,7 +50,7 @@ export function PriorityRecap({ currentEpoch }: PriorityRecapProps) {
 
         <ol className="space-y-2">
           {top5.map((item) => {
-            const label = PRIORITY_LABELS[item.priority] ?? item.priority;
+            const label = PRIORITY_LABEL_MAP[item.priority] ?? item.priority;
             const priorRank = priorRanks.get(item.priority);
             const rankDelta = priorRank != null ? priorRank - item.rank : null;
 

--- a/components/engagement/PrioritySignals.tsx
+++ b/components/engagement/PrioritySignals.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useWallet } from '@/utils/wallet';
 import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,21 +11,7 @@ import { BarChart3, CheckCircle2, Wallet, ArrowUp } from 'lucide-react';
 import { hapticLight } from '@/lib/haptics';
 import { usePriorityRankings, useUserPrioritySignal } from '@/hooks/useEngagement';
 import { PRIORITY_AREAS, type PriorityArea } from '@/lib/api/schemas/engagement';
-
-const PRIORITY_LABELS: Record<PriorityArea, { label: string; icon: string }> = {
-  infrastructure: { label: 'Infrastructure', icon: '🏗️' },
-  education: { label: 'Education', icon: '📚' },
-  defi: { label: 'DeFi', icon: '💱' },
-  marketing: { label: 'Marketing', icon: '📣' },
-  developer_tooling: { label: 'Developer Tooling', icon: '🛠️' },
-  governance_tooling: { label: 'Governance Tooling', icon: '🏛️' },
-  identity_dids: { label: 'Identity & DIDs', icon: '🪪' },
-  interoperability: { label: 'Interoperability', icon: '🔗' },
-  security_auditing: { label: 'Security & Auditing', icon: '🔒' },
-  community_hubs: { label: 'Community Hubs', icon: '🤝' },
-  research: { label: 'Research', icon: '🔬' },
-  media_content: { label: 'Media & Content', icon: '📰' },
-};
+import { PRIORITY_LABELS } from '@/lib/engagement/labels';
 
 interface PrioritySignalsProps {
   epoch: number;
@@ -44,8 +30,18 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [animated, setAnimated] = useState(false);
 
   const hasSubmitted = !!userSignal || submitted;
+
+  // Staggered bar fill animation — must be before any early returns
+  const rankingData = rankings?.rankings ?? [];
+  useEffect(() => {
+    if (rankingData.length > 0) {
+      const timer = setTimeout(() => setAnimated(true), 50);
+      return () => clearTimeout(timer);
+    }
+  }, [rankingData.length]);
 
   const togglePriority = useCallback((area: PriorityArea) => {
     hapticLight();
@@ -133,7 +129,6 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
     );
   }
 
-  const rankingData = rankings?.rankings ?? [];
   const totalVoters = rankings?.totalVoters ?? 0;
 
   return (
@@ -162,7 +157,7 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
               {rankingData
                 .filter((r) => r.score > 0)
                 .slice(0, 10)
-                .map((item) => {
+                .map((item, index) => {
                   const maxScore = rankingData[0]?.score || 1;
                   const pct = Math.round((item.score / maxScore) * 100);
                   const info = PRIORITY_LABELS[item.priority as PriorityArea];
@@ -189,8 +184,11 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
                         aria-label={`${info?.label ?? item.priority}: ${pct}%`}
                       >
                         <div
-                          className="h-full rounded-full bg-primary transition-all duration-700"
-                          style={{ width: `${pct}%` }}
+                          className="h-full rounded-full bg-primary transition-all duration-700 ease-out"
+                          style={{
+                            width: animated ? `${pct}%` : '0%',
+                            transitionDelay: `${index * 80}ms`,
+                          }}
                         />
                       </div>
                     </div>
@@ -318,12 +316,27 @@ export function PrioritySignals({ epoch }: PrioritySignalsProps) {
       ) : (
         <Card>
           <CardContent className="py-6">
-            <div className="flex items-center gap-2 text-sm text-primary">
-              <CheckCircle2 className="h-5 w-5" />
-              <span className="font-medium">
-                Your priorities have been recorded for Epoch {epoch}. Thanks for making your voice
-                heard!
-              </span>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm text-primary">
+                <CheckCircle2 className="h-5 w-5" />
+                <span className="font-medium">
+                  Your priorities have been recorded for Epoch {epoch}. Thanks for making your voice
+                  heard!
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-xs text-muted-foreground shrink-0"
+                onClick={() => {
+                  if (userSignal?.rankedPriorities) {
+                    setSelected(userSignal.rankedPriorities as PriorityArea[]);
+                  }
+                  setSubmitted(false);
+                }}
+              >
+                Update
+              </Button>
             </div>
           </CardContent>
         </Card>

--- a/lib/engagement/labels.ts
+++ b/lib/engagement/labels.ts
@@ -1,0 +1,36 @@
+import type { ConcernFlagType, PriorityArea } from '@/lib/api/schemas/engagement';
+
+export const CONCERN_FLAG_LABELS: Record<ConcernFlagType, { label: string; emoji: string }> = {
+  too_expensive: { label: 'Too Expensive', emoji: '💰' },
+  team_unproven: { label: 'Team Unproven', emoji: '👤' },
+  duplicates_existing: { label: 'Duplicates Existing', emoji: '🔄' },
+  constitutional_concern: { label: 'Constitutional Concern', emoji: '📜' },
+  insufficient_detail: { label: 'Insufficient Detail', emoji: '📝' },
+  unrealistic_timeline: { label: 'Unrealistic Timeline', emoji: '⏰' },
+  conflict_of_interest: { label: 'Conflict of Interest', emoji: '⚖️' },
+  scope_too_broad: { label: 'Scope Too Broad', emoji: '🔭' },
+};
+
+export const PRIORITY_LABELS: Record<PriorityArea, { label: string; icon: string }> = {
+  infrastructure: { label: 'Infrastructure', icon: '🏗️' },
+  education: { label: 'Education', icon: '📚' },
+  defi: { label: 'DeFi', icon: '💱' },
+  marketing: { label: 'Marketing', icon: '📣' },
+  developer_tooling: { label: 'Developer Tooling', icon: '🛠️' },
+  governance_tooling: { label: 'Governance Tooling', icon: '🏛️' },
+  identity_dids: { label: 'Identity & DIDs', icon: '🪪' },
+  interoperability: { label: 'Interoperability', icon: '🔗' },
+  security_auditing: { label: 'Security & Auditing', icon: '🔒' },
+  community_hubs: { label: 'Community Hubs', icon: '🤝' },
+  research: { label: 'Research', icon: '🔬' },
+  media_content: { label: 'Media & Content', icon: '📰' },
+};
+
+// Simple string-only lookup for components that only need labels (not icons/emojis)
+export const CONCERN_LABEL_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(CONCERN_FLAG_LABELS).map(([k, v]) => [k, v.label]),
+);
+
+export const PRIORITY_LABEL_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(PRIORITY_LABELS).map(([k, v]) => [k, v.label]),
+);


### PR DESCRIPTION
## Summary
- Extract duplicate label constants (CONCERN_FLAG_LABELS, PRIORITY_LABELS) into shared `lib/engagement/labels.ts`
- Update 5 components to import from shared module instead of inline constants
- Add "Update" button to PrioritySignals confirmation card so users can change submitted priorities
- Add staggered bar fill animation on community priority rankings

## Impact
- **What changed**: Deduped label constants across 5 files, added priority update UX, added bar animation
- **User-facing**: Yes — users can now update their priorities after submission, and see animated bar fills
- **Risk**: Low — label extraction is a refactor, update button uses existing upsert API
- **Scope**: `lib/engagement/labels.ts` (new), 5 engagement components modified

## Test plan
- [ ] Priority rankings bars animate on page load with staggered fill
- [ ] After submitting priorities, "Update" button appears
- [ ] Clicking "Update" re-shows the form with current selections pre-filled
- [ ] All engagement components render correctly (concerns, sentiment, impact, priorities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)