### PR TITLE
fix: add constellation hero to delegated citizen homepage

### DIFF
--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -188,9 +188,17 @@ export function HomeCitizen({ pulseData, ssrHolderData, ssrWalletAddress }: Home
   }
 
   return (
-    <div className="flex flex-col pb-16">
-      {/* Epoch Briefing — the citizen's entire home experience */}
-      <section className="mx-auto w-full max-w-2xl px-4 sm:px-6 pt-4 sm:pt-6">
+    <div className="relative flex flex-col">
+      {/* ── Constellation hero (25vh) — visual backdrop for briefing ── */}
+      <section className="relative h-[25vh] min-h-[180px] sm:-mt-14 overflow-hidden">
+        <div className="absolute inset-0">
+          <ConstellationScene className="w-full h-full" interactive={false} />
+        </div>
+        <div className="absolute inset-x-0 bottom-0 h-28 bg-gradient-to-t from-background to-transparent pointer-events-none" />
+      </section>
+
+      {/* Epoch Briefing — overlaps the hero for visual continuity */}
+      <section className="mx-auto w-full max-w-2xl px-4 sm:px-6 -mt-4 pb-16 relative z-10">
         <EpochBriefing wallet={wallet} />
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Delegated citizens and CC members were the only persona states without the constellation/globe hero on the homepage
- Adds the same 25vh ConstellationScene backdrop that DReps, SPOs, anonymous, and undelegated citizens already have
- EpochBriefing overlaps into the hero with `-mt-4 relative z-10` for visual continuity (same pattern as DRep/SPO content cards)

## Impact
- **What changed**: Delegated citizen homepage now shows the constellation hero instead of starting with a plain white/dark background
- **User-facing**: Yes — delegated citizens see the globe/constellation visualization when they load the homepage, matching every other persona state
- **Risk**: Low — styling only, no data/API/auth changes. ConstellationScene already imported and used in the same file for undelegated citizens
- **Scope**: `components/civica/home/HomeCitizen.tsx` only (11 insertions, 3 deletions)

## Test plan
- [x] Preflight passes (format + lint + types + 650 tests)
- [ ] Verify delegated citizen homepage shows constellation hero on governada.io
- [ ] Verify undelegated citizen, DRep, SPO, anonymous homepages unchanged
- [ ] Verify EpochBriefing content renders correctly below the hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>