### PR TITLE
fix: replace remaining Civica and DRepScore brand references

### DIFF
--- a/.claude/commands/launch-readiness.md
+++ b/.claude/commands/launch-readiness.md
@@ -155,7 +155,7 @@ Instructions:
 1. Check `app/layout.tsx` for site title, description, metadata, OG defaults
 2. Check `public/` for logo files, favicon (all sizes), apple-touch-icon, OG images
 3. Check `app/api/og/` for dynamic OG image generation — are all entity types covered?
-4. Verify brand consistency: is it "Governada" everywhere or does "DRepScore" still appear in user-facing text?
+4. Verify brand consistency: is it "Governada" everywhere or does "DRepScore" or "Civica" still appear in user-facing text?
 5. Check footer component for social links, branding, copyright
 6. Check for a custom 404 page and error pages
 7. Search for any placeholder text ("Lorem ipsum", "TODO", "Coming soon", "TBD") in user-facing components
@@ -168,7 +168,7 @@ IDENTITY:
 - Meta description: [what it says]
 - Favicon: [present/missing, all sizes?]
 - OG images: [default + dynamic coverage]
-- Brand name consistency: [Governada everywhere? / lingering "DRepScore" references]
+- Brand name consistency: [Governada everywhere? / lingering "DRepScore" or "Civica" references]
 
 POLISH:
 - Custom 404: [yes/no]
@@ -464,7 +464,7 @@ Regardless of verdict, outline the first week after launch:
 
 ## Rules
 
-- **Business ops are NOT optional.** A technically perfect app that has no privacy policy, broken OG images, or "DRepScore" in the title will damage credibility at launch. These are real blockers.
+- **Business ops are NOT optional.** A technically perfect app that has no privacy policy, broken OG images, or "DRepScore"/"Civica" in the title will damage credibility at launch. These are real blockers.
 - **Monetization is NOT a launch blocker.** You can launch pre-revenue. But the readiness assessment should be honest about what's ready vs not.
 - **Legal items ARE potential blockers.** No privacy policy = potential legal liability on day one. Flag these as blockers.
 - **The founder action items are key output.** Some launch readiness items can't be fixed by agents (social accounts, legal review, community setup). Surface these clearly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Governada (formerly DRepScore)
+# Governada
 
 Governance intelligence for the Cardano Nation.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Governance Intelligence for Cardano**
 
-Governada (formerly DRepScore) is the governance intelligence platform for Cardano. It serves every participant in the ecosystem — citizens (ADA holders), DReps, SPOs, Constitutional Committee, treasury proposal teams, and governance researchers — through one interconnected data engine.
+Governada is the governance intelligence platform for Cardano. It serves every participant in the ecosystem — citizens (ADA holders), DReps, SPOs, Constitutional Committee, treasury proposal teams, and governance researchers — through one interconnected data engine.
 
 ## What It Does
 

--- a/app/api/og/governance-identity/[drepId]/route.tsx
+++ b/app/api/og/governance-identity/[drepId]/route.tsx
@@ -258,7 +258,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ drep
             </div>
           </div>
         </div>
-        <OGFooter left="$drepscore" right={shortenDRepId(drepId)} />
+        <OGFooter left="$governada" right={shortenDRepId(drepId)} />
       </OGBackground>,
       {
         width: 1200,

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,8 +9,8 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-display: var(--font-civica-display);
-  --font-body: var(--font-civica-body);
+  --font-display: var(--font-governada-display);
+  --font-body: var(--font-governada-body);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -239,14 +239,14 @@
    ============================================================ */
 
 :root {
-  --font-civica-display: var(--font-geist-sans);
-  --font-civica-body: var(--font-geist-sans);
+  --font-governada-display: var(--font-geist-sans);
+  --font-governada-body: var(--font-geist-sans);
 }
 
 /* Governance font — feature-flagged via data-font attribute on body.
    Toggle via /admin/flags → governance_font or FF_GOVERNANCE_FONT env var. */
 body[data-font='governance'] {
-  --font-civica-display: var(--font-space-grotesk), var(--font-geist-sans);
+  --font-governada-display: var(--font-space-grotesk), var(--font-geist-sans);
 }
 
 /* ============================================================

--- a/components/BrandedLoader.tsx
+++ b/components/BrandedLoader.tsx
@@ -15,11 +15,11 @@ export function BrandedLoader() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const seen = sessionStorage.getItem('drepscore-intro-seen');
+    const seen = sessionStorage.getItem('governada-intro-seen');
     if (seen) return;
 
     setVisible(true);
-    sessionStorage.setItem('drepscore-intro-seen', '1');
+    sessionStorage.setItem('governada-intro-seen', '1');
 
     const fadeTimer = setTimeout(() => setFading(true), 1400);
     const hideTimer = setTimeout(() => setVisible(false), 2000);
@@ -127,7 +127,7 @@ export function BrandedLoader() {
 
       {/* Brand text */}
       <div className="text-center animate-fade-in-up">
-        <p className="text-2xl font-bold text-primary tracking-tight font-sans">$drepscore</p>
+        <p className="text-2xl font-bold text-primary tracking-tight font-sans">$governada</p>
         <p className="text-sm text-muted-foreground mt-1 tracking-wide">
           Observing Cardano Governance
         </p>

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -242,7 +242,7 @@ export function CommandPalette() {
               <kbd className="font-mono">↑↓</kbd> navigate <kbd className="font-mono">↵</kbd> select{' '}
               <kbd className="font-mono">esc</kbd> close
             </span>
-            <span className="font-mono text-primary/60">$drepscore</span>
+            <span className="font-mono text-primary/60">$governada</span>
           </div>
         </div>
       </div>

--- a/components/DRepReportCard.tsx
+++ b/components/DRepReportCard.tsx
@@ -61,7 +61,7 @@ export function DRepReportCard({
           url={url}
           text={shareText}
           imageUrl={ogImageUrl}
-          imageFilename={`drepscore-${name.replace(/\s+/g, '-').toLowerCase()}.png`}
+          imageFilename={`governada-${name.replace(/\s+/g, '-').toLowerCase()}.png`}
           surface="report_card"
           metadata={{ drep_id: drepId, score }}
         />

--- a/components/DeveloperPage.tsx
+++ b/components/DeveloperPage.tsx
@@ -54,7 +54,7 @@ const EMBED_CODE = {
   style="border-radius: 12px; overflow: hidden;"
 ></iframe>`,
   javascript: `<!-- Or use the script loader -->
-<div id="drepscore-widget"></div>
+<div id="governada-widget"></div>
 <script
   src="https://governada.io/embed.js"
   data-type="drep"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,21 +5,21 @@ import Link from 'next/link';
 import { Heart, Copy, Check, ExternalLink } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
-const DREPSCORE_HANDLE = '$drepscore';
-const DREPSCORE_STAKE_ADDRESS = 'stake1u88sq2fanqmq0nuu7l4fjx353k99ngwmus67qr9g5jks2jgznfqnh';
-const CARDANOSCAN_URL = `https://cardanoscan.io/stakekey/${DREPSCORE_STAKE_ADDRESS}`;
+const GOVERNADA_HANDLE = '$governada';
+const GOVERNADA_STAKE_ADDRESS = 'stake1u88sq2fanqmq0nuu7l4fjx353k99ngwmus67qr9g5jks2jgznfqnh';
+const CARDANOSCAN_URL = `https://cardanoscan.io/stakekey/${GOVERNADA_STAKE_ADDRESS}`;
 
 export function Footer() {
   const [copied, setCopied] = useState(false);
 
   const copyAddress = async () => {
-    await navigator.clipboard.writeText(DREPSCORE_STAKE_ADDRESS);
+    await navigator.clipboard.writeText(GOVERNADA_STAKE_ADDRESS);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
     import('@/lib/posthog')
       .then(({ posthog }) => {
         posthog.capture('donation_address_copied', {
-          handle: DREPSCORE_HANDLE,
+          handle: GOVERNADA_HANDLE,
           source: 'footer',
         });
       })
@@ -32,7 +32,7 @@ export function Footer() {
         posthog.capture('footer_link_clicked', {
           destination: 'cardanoscan',
           url: CARDANOSCAN_URL,
-          label: DREPSCORE_HANDLE,
+          label: GOVERNADA_HANDLE,
         });
       })
       .catch(() => {});
@@ -45,7 +45,7 @@ export function Footer() {
           {/* Left: Brand identity */}
           <div className="flex flex-col items-center md:items-start gap-2">
             <Link href="/" className="text-lg font-bold text-primary">
-              $drepscore
+              $governada
             </Link>
             <p className="text-xs text-muted-foreground">
               Cardano governance accountability, scored.
@@ -67,7 +67,7 @@ export function Footer() {
               onClick={handleCardanoScanClick}
               className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
             >
-              {DREPSCORE_HANDLE}
+              {GOVERNADA_HANDLE}
               <ExternalLink className="h-3 w-3" />
             </a>
           </div>
@@ -84,7 +84,7 @@ export function Footer() {
                       onClick={copyAddress}
                       className="inline-flex items-center gap-1 font-mono text-xs bg-muted px-2 py-0.5 rounded hover:bg-muted-foreground/20 transition-colors"
                     >
-                      {DREPSCORE_HANDLE}
+                      {GOVERNADA_HANDLE}
                       {copied ? (
                         <Check className="h-3 w-3 text-green-500" />
                       ) : (

--- a/components/GovernanceFontProvider.tsx
+++ b/components/GovernanceFontProvider.tsx
@@ -8,7 +8,7 @@ import { useFeatureFlag } from '@/components/FeatureGate';
  *
  * When the `governance_font` flag is enabled, sets a `data-font="governance"`
  * attribute on <body>. CSS in globals.css uses this to swap
- * --font-civica-display from Geist Sans to Space Grotesk.
+ * --font-governada-display from Geist Sans to Space Grotesk.
  *
  * Toggle via /admin/flags or env var FF_GOVERNANCE_FONT=true.
  */

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -198,7 +198,7 @@ export function Header() {
         <div className="flex items-center gap-2">
           <Link href="/" className="flex items-center space-x-2">
             <span className="text-2xl font-bold text-primary dark:drop-shadow-[0_0_12px_rgba(var(--primary-rgb),0.3)]">
-              $drepscore
+              $governada
             </span>
           </Link>
           <GovernanceHeartbeat />

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -90,7 +90,7 @@ export function MobileNav({
           className="w-72 overflow-y-auto !bg-[#0a0b14]/85 backdrop-blur-xl border-l-white/5"
         >
           <SheetHeader className="pb-2">
-            <SheetTitle className="text-left text-lg font-bold text-primary">$drepscore</SheetTitle>
+            <SheetTitle className="text-left text-lg font-bold text-primary">$governada</SheetTitle>
           </SheetHeader>
 
           <nav className="flex flex-col gap-1 px-2">

--- a/components/ScoreChangeMoment.tsx
+++ b/components/ScoreChangeMoment.tsx
@@ -70,7 +70,7 @@ export function ScoreChangeMoment({ drepId, drepName, currentScore }: ScoreChang
           url={shareUrl}
           text={shareText}
           imageUrl={imageUrl}
-          imageFilename={`drepscore-change-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
+          imageFilename={`governada-change-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
           surface="score_change_moment"
           metadata={{ drep_id: drepId, delta: change.delta }}
           variant="compact"

--- a/components/WrappedShareCard.tsx
+++ b/components/WrappedShareCard.tsx
@@ -93,7 +93,7 @@ export function WrappedShareCard({
           url={profileUrl}
           text={shareText}
           imageUrl={imageUrl}
-          imageFilename={`drepscore-${variant}-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
+          imageFilename={`governada-${variant}-${drepName.replace(/\s+/g, '-').toLowerCase()}.png`}
           surface={`wrapped_${variant}`}
           metadata={{ drep_id: drepId, score }}
         />

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -111,7 +111,7 @@ payload = {
     'embeds': [{
         'title': '$EMOJI $TITLE',
         'color': $COLOR,
-        'footer': {'text': 'Civica Agent \u2022 $TIMESTAMP'},
+        'footer': {'text': 'Governada Agent \u2022 $TIMESTAMP'},
         'fields': json.loads('''$FIELDS''')
     }]
 }
@@ -147,7 +147,7 @@ $DETAILS"
 
 _Next: $ACTION_
 
-_Civica Agent \u2022 $TIMESTAMP_"
+_Governada Agent \u2022 $TIMESTAMP_"
 
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
     -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \


### PR DESCRIPTION
## Summary
- Replace all remaining user-facing `$drepscore` Ada Handle references with `$governada` (Header, Footer, MobileNav, BrandedLoader, CommandPalette, OG images)
- Rename CSS variables `--font-civica-*` → `--font-governada-*`
- Update image filename prefixes from `drepscore-` to `governada-` in share/OG card components
- Update notification script footers from "Civica Agent" to "Governada Agent"
- Clean up `(formerly DRepScore)` from README and CLAUDE.md
- Update widget ID `drepscore-widget` → `governada-widget`

## Impact
- **What changed**: All remaining old-brand references in user-facing text, CSS variables, image filenames, and agent notifications updated to Governada
- **User-facing**: Yes — header, footer, mobile nav, loader, command palette, and share cards now display `$governada` instead of `$drepscore`
- **Risk**: Low — purely cosmetic/text changes, no logic or data flow modifications. 650 tests pass.
- **Scope**: 16 files (components, CSS, scripts, docs). No migrations, no API changes.

## Test plan
- [x] `npm run preflight` passes (format + lint + types + 650 tests)
- [ ] Verify header/footer show `$governada` on governada.io
- [ ] Verify OG share cards generate with `governada-` prefix
- [ ] Verify notification scripts send "Governada Agent" footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)