### PR TITLE
feat: scroll-aware header backdrop for readability

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
@@ -110,18 +110,33 @@ export function CivicaHeader() {
 
   const isHome = pathname === '/';
 
+  const [scrolled, setScrolled] = useState(false);
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 32);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const headerTransparent = isHome && !scrolled;
+
   return (
     <header
       className={cn(
-        'sticky top-0 z-50 hidden sm:block transition-colors',
-        isHome ? 'bg-transparent' : 'border-b border-border/50 bg-background/80 backdrop-blur-xl',
+        'sticky top-0 z-50 hidden sm:block transition-[background-color,border-color,backdrop-filter] duration-300',
+        headerTransparent
+          ? 'bg-transparent'
+          : 'border-b border-border/50 bg-background/80 backdrop-blur-xl',
       )}
     >
       <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">
         <div className="flex items-center gap-1">
           <Link
             href="/"
-            className="font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded"
+            className={cn(
+              'font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
+              headerTransparent && 'nav-text-shadow',
+            )}
           >
             governada
           </Link>
@@ -139,6 +154,7 @@ export function CivicaHeader() {
                       'hover:bg-accent hover:text-accent-foreground',
                       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
                       active ? 'text-foreground' : 'text-muted-foreground',
+                      headerTransparent && 'nav-text-shadow',
                     )}
                     aria-current={active ? 'page' : undefined}
                   >


### PR DESCRIPTION
## Summary
- On the homepage, the CivicaHeader was always transparent, making nav links hard to read over hero content after scrolling
- Added scroll state detection (threshold: 32px) to transition the header from transparent to backdrop-blur background
- Applied `nav-text-shadow` CSS class to brand name and nav links while the header is transparent, for extra readability over dark hero sections
- Smooth 300ms transition on background-color, border-color, and backdrop-filter

## Impact
- **What changed**: Homepage header now transitions from transparent to frosted-glass background when user scrolls past 32px. Nav links get text-shadow while transparent.
- **User-facing**: Yes -- nav links are more readable over hero content on the homepage
- **Risk**: Low -- styling-only change, no data or API changes. Pattern mirrors the legacy Header.tsx scroll detection.
- **Scope**: `components/civica/CivicaHeader.tsx` only (1 file changed)

## Test plan
- [ ] Visit homepage at top -- header should be transparent with text shadows on nav
- [ ] Scroll down past the hero -- header should smoothly transition to backdrop-blur background
- [ ] Navigate to /discover or other pages -- header should always show backdrop-blur (non-homepage behavior unchanged)
- [ ] Verify mobile nav is unaffected (CivicaHeader is `hidden sm:block`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)