### PR TITLE
fix: profile page bugs — delegation trend, SPO data, activity links

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -780,7 +780,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       </div>
 
       {/* 5. Delegation Power Trend */}
-      {delegationTrend.length >= 2 && (
+      {delegationTrend.length >= 2 ? (
         <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
           <div className="flex items-center justify-between">
             <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
@@ -812,6 +812,15 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
             </span>
             <span>E{delegationTrend[delegationTrend.length - 1].epoch}</span>
           </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-card px-5 py-4">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
+            Delegation Trend
+          </span>
+          <p className="text-xs text-muted-foreground">
+            Delegation trend data will appear after 2+ epochs of delegation activity.
+          </p>
         </div>
       )}
 

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -630,24 +630,24 @@ export default async function PoolProfilePage({ params }: PageProps) {
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
-            {pledge != null && (
-              <div>
-                <p className="text-xs text-muted-foreground">Pledge</p>
-                <p className="text-sm font-mono tabular-nums font-medium">
-                  {formatAda(pledge)} \u20B3
-                </p>
-              </div>
-            )}
+            <div>
+              <p className="text-xs text-muted-foreground">Pledge</p>
+              <p className="text-sm font-mono tabular-nums font-medium">
+                {pledge != null && Number(pledge) > 0 ? `${formatAda(pledge)} \u20B3` : '\u2014'}
+              </p>
+            </div>
             <div>
               <p className="text-xs text-muted-foreground">Live Stake</p>
               <p className="text-sm font-mono tabular-nums font-medium">
-                {formatAda(liveStake)} \u20B3
+                {liveStake != null && Number(liveStake) > 0
+                  ? `${formatAda(liveStake)} \u20B3`
+                  : '\u2014'}
               </p>
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Delegators</p>
               <p className="text-sm font-mono tabular-nums font-medium">
-                {delegatorCount.toLocaleString()}
+                {delegatorCount > 0 ? delegatorCount.toLocaleString() : '\u2014'}
               </p>
             </div>
             <div>

--- a/components/ActivitySideWidget.tsx
+++ b/components/ActivitySideWidget.tsx
@@ -2,6 +2,7 @@
 
 /* eslint-disable react-hooks/set-state-in-effect -- async/external state sync in useEffect is standard React pattern */
 import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
 import { Vote, FileText, Users, ScrollText, TrendingUp, CheckCircle2 } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
 
@@ -12,6 +13,8 @@ interface ActivityEvent {
   detail: string | null;
   vote?: 'Yes' | 'No' | 'Abstain';
   timestamp: number;
+  proposalTxHash?: string;
+  proposalIndex?: number;
 }
 
 const EVENT_CONFIG: Record<string, { icon: typeof Vote; color: string; bg: string }> = {
@@ -108,7 +111,16 @@ export function ActivitySideWidget({ drepId, limit = 5, className = '' }: Activi
                 <Icon className={`h-3 w-3 ${config.color}`} />
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-xs leading-snug line-clamp-2">{formatEventText(event)}</p>
+                {event.proposalTxHash != null ? (
+                  <Link
+                    href={`/proposal/${event.proposalTxHash}/${event.proposalIndex ?? 0}`}
+                    className="text-xs leading-snug line-clamp-2 hover:text-primary transition-colors"
+                  >
+                    {formatEventText(event)}
+                  </Link>
+                ) : (
+                  <p className="text-xs leading-snug line-clamp-2">{formatEventText(event)}</p>
+                )}
                 <span className="text-[10px] text-muted-foreground">
                   {formatRelativeTime(event.timestamp)}
                 </span>


### PR DESCRIPTION
## Summary
- **DRep profile**: Add fallback card when delegation trend has fewer than 2 epochs of data, replacing empty space with an informative message
- **SPO pool page**: Display em-dash instead of "0" / "0 ADA" for pledge, live stake, and delegator count when values are null or zero (data sync gap)
- **Activity widget**: Wrap vote, proposal, and outcome events in links to the relevant proposal page using `proposalTxHash`/`proposalIndex` from the API
- **Verified (no changes needed)**: AlignmentTrajectory already has proper loading + empty state fallbacks; SPO cards already render names/tickers correctly from the pools API

## Impact
- **What changed**: 3 profile page UX fixes — empty state handling, zero-value display, and clickable activity links
- **User-facing**: Yes — DRep profiles show helpful delegation trend message instead of empty space; SPO profiles show dashes instead of misleading zeros; activity feed items link to proposals
- **Risk**: Low — display-only changes, no data mutations or API changes
- **Scope**: `app/drep/[drepId]/page.tsx`, `app/pool/[poolId]/page.tsx`, `components/ActivitySideWidget.tsx`