### PR TITLE
feat: match quality thresholds — min 40% match, 60 DRep score

### DIFF
--- a/app/api/governance/matches/route.ts
+++ b/app/api/governance/matches/route.ts
@@ -23,6 +23,10 @@ import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler'
 
 export const dynamic = 'force-dynamic';
 
+/** Minimum thresholds for match quality — below these, results are noise */
+const MIN_MATCH_SCORE = 40;
+const MIN_DREP_SCORE = 60;
+
 function normalizeVote(vote: string): string {
   return vote.charAt(0).toUpperCase() + vote.slice(1).toLowerCase();
 }
@@ -194,42 +198,45 @@ export const GET = withRouteHandler(
       userProposalTxHashes,
     );
 
-    const matches = filteredIds.map((drepId) => {
-      const info = drepInfoMap.get(drepId);
-      const overlap = overlapMap.get(drepId) || { agreed: 0, total: 0 };
-      const matchScore =
-        matchMethod === 'pca'
-          ? (pcaScoreMap.get(drepId) ??
-            (overlap.total > 0 ? Math.round((overlap.agreed / overlap.total) * 100) : 0))
-          : overlap.total > 0
-            ? Math.round((overlap.agreed / overlap.total) * 100)
-            : 0;
-      const confidence = calculateMatchConfidence(overlap.total);
+    const matches = filteredIds
+      .map((drepId) => {
+        const info = drepInfoMap.get(drepId);
+        const overlap = overlapMap.get(drepId) || { agreed: 0, total: 0 };
+        const matchScore =
+          matchMethod === 'pca'
+            ? (pcaScoreMap.get(drepId) ??
+              (overlap.total > 0 ? Math.round((overlap.agreed / overlap.total) * 100) : 0))
+            : overlap.total > 0
+              ? Math.round((overlap.agreed / overlap.total) * 100)
+              : 0;
+        const confidence = calculateMatchConfidence(overlap.total);
 
-      let dimensionAgreement = undefined;
-      let agreeDimensions = undefined;
-      let differDimensions = undefined;
-      if (userAlignments && info?.alignments) {
-        const dimResult = computeDimensionAgreement(userAlignments, info.alignments);
-        dimensionAgreement = dimResult.dimensionAgreement;
-        agreeDimensions = dimResult.agreeDimensions;
-        differDimensions = dimResult.differDimensions;
-      }
+        let dimensionAgreement = undefined;
+        let agreeDimensions = undefined;
+        let differDimensions = undefined;
+        if (userAlignments && info?.alignments) {
+          const dimResult = computeDimensionAgreement(userAlignments, info.alignments);
+          dimensionAgreement = dimResult.dimensionAgreement;
+          agreeDimensions = dimResult.agreeDimensions;
+          differDimensions = dimResult.differDimensions;
+        }
 
-      return {
-        drepId,
-        drepName: info?.name || null,
-        drepScore: info?.score || 0,
-        matchScore,
-        agreed: overlap.agreed,
-        overlapping: overlap.total,
-        confidence,
-        dimensionAgreement,
-        agreeDimensions,
-        differDimensions,
-        alignments: info?.alignments || null,
-      };
-    });
+        return {
+          drepId,
+          drepName: info?.name || null,
+          drepScore: info?.score || 0,
+          matchScore,
+          agreed: overlap.agreed,
+          overlapping: overlap.total,
+          confidence,
+          dimensionAgreement,
+          agreeDimensions,
+          differDimensions,
+          alignments: info?.alignments || null,
+        };
+      })
+      // Apply quality thresholds — below these, alignment is noise
+      .filter((m) => m.matchScore >= MIN_MATCH_SCORE && m.drepScore >= MIN_DREP_SCORE);
 
     captureServerEvent(
       'governance_matches_calculated',

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -21,6 +21,10 @@ import { captureServerEvent } from '@/lib/posthog-server';
 
 export const dynamic = 'force-dynamic';
 
+/** Minimum thresholds for match quality — below these, results are noise */
+const MIN_MATCH_SCORE = 40;
+const MIN_ENTITY_SCORE = 60;
+
 const DIMENSIONS: AlignmentDimension[] = [
   'treasuryConservative',
   'treasuryGrowth',
@@ -129,6 +133,7 @@ export const POST = withRouteHandler(async (request) => {
         };
       })
       .sort((a, b) => b.matchScore - a.matchScore || b.entityScore - a.entityScore)
+      .filter((r) => r.matchScore >= MIN_MATCH_SCORE && r.entityScore >= MIN_ENTITY_SCORE)
       .slice(0, 5);
 
     const personalityLabel = getPersonalityLabel(userAlignments);
@@ -209,9 +214,13 @@ export const POST = withRouteHandler(async (request) => {
     })
     .sort((a, b) => b.matchScore - a.matchScore || b.drepScore - a.drepScore);
 
+  // Apply quality thresholds before selecting top results
+  const qualified = ranked.filter(
+    (r) => r.matchScore >= MIN_MATCH_SCORE && r.drepScore >= MIN_ENTITY_SCORE,
+  );
   // Prefer named DReps in results; fall back to unnamed if fewer than 3 named
-  const namedRanked = ranked.filter((r) => r.drepName);
-  const topRanked = (namedRanked.length >= 3 ? namedRanked : ranked).slice(0, 5);
+  const namedRanked = qualified.filter((r) => r.drepName);
+  const topRanked = (namedRanked.length >= 3 ? namedRanked : qualified).slice(0, 5);
 
   const personalityLabel = getPersonalityLabel(userAlignments);
   const dominant = getDominantDimension(userAlignments);

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -796,13 +796,13 @@ function ResultsScreen({
               No {activeTab === 'spo' ? 'SPO' : 'DRep'} matches found
             </p>
             <p className="text-xs text-muted-foreground max-w-sm mx-auto">
-              Not enough {activeTab === 'spo' ? 'SPOs' : 'DReps'} have governance alignment data
-              yet. Browse all {activeTab === 'spo' ? 'SPOs' : 'DReps'} to find one manually, or
-              check back as more participate in governance.
+              No {activeTab === 'spo' ? 'SPOs' : 'DReps'} currently meet our quality threshold for
+              your preferences. As {activeTab === 'spo' ? 'SPOs' : 'DReps'} improve their governance
+              participation, more matches will appear.
             </p>
             <Button asChild variant="outline" size="sm">
               <Link href={activeTab === 'spo' ? '/discover?tab=spos' : '/discover'}>
-                Browse All {activeTab === 'spo' ? 'SPOs' : 'DReps'}
+                Browse all active {activeTab === 'spo' ? 'SPOs' : 'DReps'}
                 <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary
- Add minimum quality gates to match recommendations: **matchScore >= 40%** and **DRep/SPO score >= 60**
- Applied to both Quick Match (anonymous, `quick-match/route.ts`) and authenticated matches (`matches/route.ts`)
- Updated empty state messaging in `QuickMatchFlow.tsx` to explain quality thresholds
- "Browse all active DReps/SPOs" CTA links to Discover when no matches pass the threshold

## Impact
- **What changed**: Match APIs now filter out DReps/SPOs below quality thresholds before returning results. Users never see low-quality or weakly-aligned matches.
- **User-facing**: Yes — users may see fewer match results, but all results meet a quality bar. Empty state explains the threshold clearly with a fallback CTA to Discover.
- **Risk**: Low — additive filter on existing ranking logic. Existing delegations (My Gov, homepage) are unaffected since they use wallet data, not the matches API.
- **Scope**: 3 files modified: `app/api/governance/quick-match/route.ts`, `app/api/governance/matches/route.ts`, `components/civica/match/QuickMatchFlow.tsx`

## Edge cases handled
- If all results are filtered out, the API returns an empty array and the frontend shows a contextual empty state
- Existing delegation to a DRep with score < 60 remains visible — thresholds only apply to new match recommendations
- SPO matches use the same thresholds (governance_score >= 60, matchScore >= 40)

## Test plan
- [ ] Run Quick Match flow — verify results only show DReps with score >= 60 and match >= 40%
- [ ] Verify empty state appears if no matches pass threshold (may need specific answer combo)
- [ ] Check "Browse all active DReps" link works from empty state
- [ ] Verify authenticated matches page also filters correctly
- [ ] Confirm existing delegation display on My Gov is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)