### PR TITLE
fix: Pulse page UX — GHI context, tooltips, mover details, heatmap tuning

### DIFF
--- a/components/civica/charts/ActivityHeatmap.tsx
+++ b/components/civica/charts/ActivityHeatmap.tsx
@@ -17,14 +17,15 @@ interface ActivityHeatmapProps {
 
 const CELL_SIZE = 18;
 const CELL_GAP = 2;
-const COLS = 10;
 
 function getHeatColor(value: number): string {
-  if (value >= 80) return 'bg-emerald-500/80';
-  if (value >= 60) return 'bg-emerald-500/50';
-  if (value >= 40) return 'bg-emerald-500/30';
-  if (value >= 20) return 'bg-emerald-500/15';
-  if (value > 0) return 'bg-emerald-500/8';
+  // Adjusted thresholds: most participation rates cluster 30-60%, so spread
+  // the color range to better differentiate mid-range values
+  if (value >= 70) return 'bg-emerald-500/80';
+  if (value >= 55) return 'bg-emerald-500/60';
+  if (value >= 40) return 'bg-emerald-500/40';
+  if (value >= 25) return 'bg-emerald-500/25';
+  if (value > 0) return 'bg-emerald-500/10';
   return 'bg-muted/30';
 }
 
@@ -35,17 +36,19 @@ export function ActivityHeatmap({
 }: ActivityHeatmapProps) {
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
 
+  // Responsive column count: use fewer columns for small datasets
+  const cols = data.length < 20 ? 5 : 10;
+
   const cells = useMemo(() => {
-    // Take most recent N epochs, arrange in rows of COLS
     const sorted = [...data].sort((a, b) => a.epoch - b.epoch);
     return sorted.map((cell, i) => ({
       ...cell,
-      row: Math.floor(i / COLS),
-      col: i % COLS,
+      row: Math.floor(i / cols),
+      col: i % cols,
     }));
-  }, [data]);
+  }, [data, cols]);
 
-  const gridWidth = COLS * (CELL_SIZE + CELL_GAP);
+  const gridWidth = cols * (CELL_SIZE + CELL_GAP);
 
   const avgValue = cells.length > 0 ? cells.reduce((s, c) => s + c.value, 0) / cells.length : 0;
   const recentAvg =
@@ -61,10 +64,10 @@ export function ActivityHeatmap({
           <div className="flex gap-0.5">
             {[
               'bg-muted/30',
-              'bg-emerald-500/8',
-              'bg-emerald-500/15',
-              'bg-emerald-500/30',
-              'bg-emerald-500/50',
+              'bg-emerald-500/10',
+              'bg-emerald-500/25',
+              'bg-emerald-500/40',
+              'bg-emerald-500/60',
               'bg-emerald-500/80',
             ].map((c, i) => (
               <div key={i} className={cn('h-3 w-3 rounded-sm', c)} />
@@ -87,7 +90,7 @@ export function ActivityHeatmap({
         <div
           className="inline-grid"
           style={{
-            gridTemplateColumns: `repeat(${COLS}, ${CELL_SIZE}px)`,
+            gridTemplateColumns: `repeat(${cols}, ${CELL_SIZE}px)`,
             gap: CELL_GAP,
           }}
         >
@@ -125,11 +128,11 @@ export function ActivityHeatmap({
         )}
       </div>
 
-      {/* Epoch range */}
+      {/* Epoch range + count label */}
       {cells.length > 0 && (
         <div className="flex justify-between text-[10px] text-muted-foreground">
           <span>Epoch {cells[0].epoch}</span>
-          <span>{cells.length} epochs</span>
+          <span>Last {cells.length} epochs</span>
           <span>Epoch {cells[cells.length - 1].epoch}</span>
         </div>
       )}

--- a/components/civica/pulse/CivicaGovernanceTrends.tsx
+++ b/components/civica/pulse/CivicaGovernanceTrends.tsx
@@ -153,7 +153,7 @@ export function CivicaGovernanceTrends() {
     isError: ghiError,
     refetch: refetchGhi,
   } = useGovernanceHealthIndex(20);
-  const { data: rawLeaderboard } = useGovernanceLeaderboard();
+  const { data: rawLeaderboard, isLoading: leaderboardLoading } = useGovernanceLeaderboard();
 
   const sparklines = rawSparklines as Record<string, unknown> | undefined;
   const ghi = rawGhi as
@@ -312,7 +312,7 @@ export function CivicaGovernanceTrends() {
         <p className="text-sm font-semibold">DRep Tier Distribution</p>
         {dreps.length > 0 ? (
           <TierDistribution dreps={dreps} />
-        ) : (
+        ) : leaderboardLoading ? (
           <div className="space-y-2">
             {[1, 2, 3, 4, 5, 6].map((i) => (
               <div key={i} className="flex items-center gap-2">
@@ -322,6 +322,10 @@ export function CivicaGovernanceTrends() {
               </div>
             ))}
           </div>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            DRep tier distribution data is being compiled.
+          </p>
         )}
       </div>
 

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -33,6 +33,7 @@ import { ActivityTicker } from '@/components/ActivityTicker';
 import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { EmptyState } from './EmptyState';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type {
   TreasuryData,
   LeaderboardData,
@@ -595,25 +596,42 @@ export function CivicaPulseOverview() {
                     </p>
                   </div>
                   <div className="space-y-2">
-                    {gainers.map((m) => (
-                      <Link
-                        key={m.drepId}
-                        href={`/drep/${m.drepId}`}
-                        className="flex items-center justify-between group"
-                      >
-                        <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
-                          {m.name}
-                        </span>
-                        <div className="flex items-center gap-1 shrink-0">
-                          <span className="text-xs font-bold text-emerald-400 tabular-nums">
-                            +{m.delta}
-                          </span>
-                          <span className="text-[10px] text-muted-foreground">
-                            → {m.currentScore}
-                          </span>
-                        </div>
-                      </Link>
-                    ))}
+                    {gainers.map((m) => {
+                      const prevScore =
+                        m.currentScore != null && m.delta != null
+                          ? (m.currentScore as number) - (m.delta as number)
+                          : null;
+                      return (
+                        <TooltipProvider key={m.drepId}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Link
+                                href={`/drep/${m.drepId}`}
+                                className="flex items-center justify-between group"
+                              >
+                                <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
+                                  {m.name}
+                                </span>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  <span className="text-xs font-bold text-emerald-400 tabular-nums">
+                                    +{m.delta}
+                                  </span>
+                                  <span className="text-[10px] text-muted-foreground">
+                                    → {m.currentScore}
+                                  </span>
+                                </div>
+                              </Link>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-64">
+                              <p>
+                                Score changed from {prevScore ?? '?'} to {m.currentScore} this week.
+                                Visit their profile for detailed breakdown.
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      );
+                    })}
                   </div>
                 </div>
               )}
@@ -626,25 +644,42 @@ export function CivicaPulseOverview() {
                     </p>
                   </div>
                   <div className="space-y-2">
-                    {losers.map((m) => (
-                      <Link
-                        key={m.drepId}
-                        href={`/drep/${m.drepId}`}
-                        className="flex items-center justify-between group"
-                      >
-                        <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
-                          {m.name}
-                        </span>
-                        <div className="flex items-center gap-1 shrink-0">
-                          <span className="text-xs font-bold text-rose-400 tabular-nums">
-                            {m.delta}
-                          </span>
-                          <span className="text-[10px] text-muted-foreground">
-                            → {m.currentScore}
-                          </span>
-                        </div>
-                      </Link>
-                    ))}
+                    {losers.map((m) => {
+                      const prevScore =
+                        m.currentScore != null && m.delta != null
+                          ? (m.currentScore as number) - (m.delta as number)
+                          : null;
+                      return (
+                        <TooltipProvider key={m.drepId}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Link
+                                href={`/drep/${m.drepId}`}
+                                className="flex items-center justify-between group"
+                              >
+                                <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
+                                  {m.name}
+                                </span>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  <span className="text-xs font-bold text-rose-400 tabular-nums">
+                                    {m.delta}
+                                  </span>
+                                  <span className="text-[10px] text-muted-foreground">
+                                    → {m.currentScore}
+                                  </span>
+                                </div>
+                              </Link>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-64">
+                              <p>
+                                Score changed from {prevScore ?? '?'} to {m.currentScore} this week.
+                                Visit their profile for detailed breakdown.
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/components/civica/pulse/GHIExplorer.tsx
+++ b/components/civica/pulse/GHIExplorer.tsx
@@ -6,6 +6,7 @@ import { ChevronDown, Share2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { staggerContainerSlow, fadeInUp, spring } from '@/lib/animations';
 import { ShareModal } from '@/components/civica/shared/ShareModal';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface GHIComponentData {
   name: string;
@@ -49,6 +50,15 @@ const COMPONENT_LABELS: Record<string, string> = {
   governanceEffectiveness: 'Governance Effectiveness',
   powerDistribution: 'Power Distribution',
   systemStability: 'System Stability',
+};
+
+const COMPONENT_TOOLTIPS: Record<string, string> = {
+  drepParticipation: 'Percentage of active DReps who voted on proposals this epoch',
+  citizenEngagement: 'Delegation activity, endorsements, and community sentiment participation',
+  deliberationQuality: 'Rationale provision rate and depth of governance deliberation',
+  governanceEffectiveness: 'Proposal throughput, vote decisiveness, and outcome delivery',
+  powerDistribution: 'Distribution of voting power and delegation diversity across DReps',
+  systemStability: 'Protocol parameter stability and governance process consistency',
 };
 
 function getCalibrationKey(name: string): string {
@@ -156,6 +166,7 @@ export function GHIExplorer({
               const curve = calibration[calKey];
               const trend = componentTrends[comp.name];
               const label = COMPONENT_LABELS[calKey] ?? comp.name;
+              const tooltipText = COMPONENT_TOOLTIPS[calKey];
 
               const sparkData = componentHistory
                 .filter((h) => h.components)
@@ -174,7 +185,22 @@ export function GHIExplorer({
                   className="rounded-lg border border-border bg-card p-3 space-y-2"
                 >
                   <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">{label}</span>
+                    {tooltipText ? (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="text-sm font-medium cursor-help border-b border-dashed border-muted-foreground/40">
+                              {label}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-60">
+                            <p>{tooltipText}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <span className="text-sm font-medium">{label}</span>
+                    )}
                     <span className="text-xs text-muted-foreground tabular-nums">
                       {Math.round(comp.weight * 100)}%
                     </span>

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -24,30 +24,37 @@ interface GHIData {
   trend: GHITrend;
 }
 
-const BAND_STYLES: Record<string, { text: string; ring: string; bg: string; label: string }> = {
+const BAND_STYLES: Record<
+  string,
+  { text: string; ring: string; bg: string; label: string; description: string }
+> = {
   strong: {
     text: 'text-emerald-500',
     ring: 'var(--color-emerald-500)',
     bg: 'bg-emerald-500/10',
     label: 'Strong',
+    description: 'Cardano governance is highly active with broad participation.',
   },
   good: {
     text: 'text-green-500',
     ring: 'var(--color-green-500)',
     bg: 'bg-green-500/10',
     label: 'Good',
+    description: 'Governance is healthy with solid participation across most areas.',
   },
   fair: {
     text: 'text-amber-500',
     ring: 'var(--color-amber-500)',
     bg: 'bg-amber-500/10',
     label: 'Fair',
+    description: 'Governance participation is moderate, with room for improvement.',
   },
   critical: {
     text: 'text-rose-500',
     ring: 'var(--color-rose-500)',
     bg: 'bg-rose-500/10',
     label: 'Critical',
+    description: 'Governance participation is low. Key areas need attention.',
   },
 };
 
@@ -145,7 +152,10 @@ export function GHIHero() {
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">
-          <span className="text-2xl font-bold tabular-nums">{Math.round(score)}</span>
+          <div className="text-center leading-none">
+            <span className="text-2xl font-bold tabular-nums">{Math.round(score)}</span>
+            <span className="text-[9px] text-muted-foreground font-medium">/100</span>
+          </div>
         </div>
       </div>
 
@@ -170,6 +180,7 @@ export function GHIHero() {
           )}
         </div>
         {streakLabel && <p className="text-xs text-muted-foreground">{streakLabel}</p>}
+        <p className="text-sm text-muted-foreground">{style.description}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add one-sentence band descriptions to GHI Hero so users understand what their governance health score means at a glance
- Add hover tooltips to all 6 GHI Explorer component cards explaining what each metric measures
- Add score-change tooltips to Rising/Falling DReps in the weekly movers section
- Fix permanent skeleton state in DRep Tier Distribution by properly tracking loading state
- Tune Activity Heatmap with dynamic column count and adjusted color thresholds for better mid-range differentiation

## Impact
- **What changed**: 5 Pulse page UX improvements — contextual text, tooltips, loading states, and heatmap visual tuning
- **User-facing**: Yes — users see clearer explanations of governance health scores, can hover component cards and weekly movers for details, and see a more readable heatmap
- **Risk**: Low — styling and tooltip additions only, no data/API changes
- **Scope**: 5 component files in `components/civica/pulse/` and `components/civica/charts/`

## Test plan
- [ ] Verify GHI Hero shows band description text below the score ring
- [ ] Verify GHI Explorer component cards show tooltip on hover with dashed underline
- [ ] Verify Rising/Falling DReps show score-change tooltip on hover
- [ ] Verify Tier Distribution shows skeleton during load, proper content when loaded, and graceful message when empty
- [ ] Verify Activity Heatmap renders with appropriate column count and color distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)