### PR TITLE
feat: navigation architecture overhaul (Phase 1-2)

### DIFF
--- a/app/delegation/page.tsx
+++ b/app/delegation/page.tsx
@@ -1,0 +1,24 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Delegation',
+  description:
+    'Monitor both governance relationships — DRep and stake pool — with governance coverage analysis.',
+};
+
+/**
+ * /delegation — Governance representation health.
+ * Shows DRep + Pool with coverage indicators, conflict detection, gap alerts.
+ */
+export default function DelegationPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Delegation</h1>
+      <p className="text-muted-foreground">
+        Governance coverage and representation health will appear here.
+      </p>
+    </div>
+  );
+}

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Constitutional Committee',
+  description: 'Constitutional Committee members, transparency index, and accountability records.',
+};
+
+/**
+ * /governance/committee — placeholder.
+ * Will be populated with content migrated from /discover/committee.
+ */
+export default function CommitteePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Constitutional Committee</h1>
+      <p className="text-muted-foreground">CC member directory will appear here.</p>
+    </div>
+  );
+}

--- a/app/governance/health/epoch/[epoch]/page.tsx
+++ b/app/governance/health/epoch/[epoch]/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Epoch Report',
+  description: 'Detailed governance report for a specific epoch.',
+};
+
+/**
+ * /governance/health/epoch/[epoch] — placeholder.
+ * Will be populated with content migrated from /pulse/report/[epoch].
+ */
+export default function EpochReportPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Epoch Report</h1>
+      <p className="text-muted-foreground">Epoch-specific governance report will appear here.</p>
+    </div>
+  );
+}

--- a/app/governance/health/page.tsx
+++ b/app/governance/health/page.tsx
@@ -1,0 +1,22 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Governance Health',
+  description:
+    "Governance Health Index — is Cardano's governance healthy? GHI score, participation trends, and epoch history.",
+};
+
+/**
+ * /governance/health — placeholder.
+ * Will be populated with content migrated from /pulse.
+ */
+export default function HealthPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Governance Health</h1>
+      <p className="text-muted-foreground">Governance Health Index will appear here.</p>
+    </div>
+  );
+}

--- a/app/governance/layout.tsx
+++ b/app/governance/layout.tsx
@@ -1,0 +1,10 @@
+import { SectionPillBar } from '@/components/civica/SectionPillBar';
+
+export default function GovernanceLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SectionPillBar section="governance" />
+      {children}
+    </>
+  );
+}

--- a/app/governance/page.tsx
+++ b/app/governance/page.tsx
@@ -1,0 +1,12 @@
+export const dynamic = 'force-dynamic';
+
+import { redirect } from 'next/navigation';
+
+/**
+ * /governance — redirects to persona-default sub-page.
+ * For now, defaults to /governance/proposals (the most universal entry point).
+ * TODO: make persona-aware (citizens → representatives if undelegated).
+ */
+export default function GovernancePage() {
+  redirect('/governance/proposals');
+}

--- a/app/governance/pools/page.tsx
+++ b/app/governance/pools/page.tsx
@@ -1,0 +1,24 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Pools',
+  description:
+    'Find governance-active Cardano stake pools. Sort by governance score and participation.',
+};
+
+/**
+ * /governance/pools — placeholder.
+ * Will be populated with content migrated from /discover?tab=spos.
+ */
+export default function PoolsPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Pools</h1>
+      <p className="text-muted-foreground">
+        Governance-active stake pool directory will appear here.
+      </p>
+    </div>
+  );
+}

--- a/app/governance/proposals/page.tsx
+++ b/app/governance/proposals/page.tsx
@@ -1,0 +1,22 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Proposals',
+  description:
+    'Active governance proposals in Cardano. See what is being decided, voting deadlines, and stake impact.',
+};
+
+/**
+ * /governance/proposals — placeholder.
+ * Will be populated with content migrated from /discover?tab=proposals.
+ */
+export default function ProposalsPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Proposals</h1>
+      <p className="text-muted-foreground">Active governance proposals will appear here.</p>
+    </div>
+  );
+}

--- a/app/governance/representatives/page.tsx
+++ b/app/governance/representatives/page.tsx
@@ -1,0 +1,22 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Representatives',
+  description:
+    'Find and evaluate Cardano DReps. Search, filter, and compare governance representatives.',
+};
+
+/**
+ * /governance/representatives — placeholder.
+ * Will be populated with content migrated from /discover?tab=dreps.
+ */
+export default function RepresentativesPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Representatives</h1>
+      <p className="text-muted-foreground">DRep directory will appear here.</p>
+    </div>
+  );
+}

--- a/app/governance/treasury/page.tsx
+++ b/app/governance/treasury/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Treasury',
+  description: 'Cardano treasury activity, spending transparency, and funding proposals.',
+};
+
+/**
+ * /governance/treasury — placeholder.
+ * New page: treasury activity and spending transparency.
+ */
+export default function TreasuryPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Treasury</h1>
+      <p className="text-muted-foreground">
+        Treasury activity and spending transparency will appear here.
+      </p>
+    </div>
+  );
+}

--- a/app/help/glossary/page.tsx
+++ b/app/help/glossary/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Glossary',
+  description: 'Governance terminology and definitions for Cardano governance.',
+};
+
+export default function GlossaryPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Glossary</h1>
+      <p className="text-muted-foreground">Governance terminology will appear here.</p>
+    </div>
+  );
+}

--- a/app/help/layout.tsx
+++ b/app/help/layout.tsx
@@ -1,0 +1,10 @@
+import { SectionPillBar } from '@/components/civica/SectionPillBar';
+
+export default function HelpLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SectionPillBar section="help" />
+      {children}
+    </>
+  );
+}

--- a/app/help/methodology/page.tsx
+++ b/app/help/methodology/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Methodology',
+  description: 'How governance scores are calculated. Scoring methodology and transparency.',
+};
+
+/**
+ * /help/methodology — placeholder.
+ * Will be populated with content migrated from /methodology.
+ */
+export default function MethodologyPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Methodology</h1>
+      <p className="text-muted-foreground">Scoring methodology will appear here.</p>
+    </div>
+  );
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Help',
+  description: 'Find answers to governance questions. FAQ, glossary, methodology, and support.',
+};
+
+/**
+ * /help — Help center.
+ * Will be populated with FAQ + search + quick links.
+ */
+export default function HelpPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Help</h1>
+      <p className="text-muted-foreground">FAQ and help center will appear here.</p>
+    </div>
+  );
+}

--- a/app/help/support/page.tsx
+++ b/app/help/support/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Support',
+  description: 'Contact, feedback, and status for Governada.',
+};
+
+export default function SupportPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Support</h1>
+      <p className="text-muted-foreground">Contact and feedback options will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/delegators/page.tsx
+++ b/app/workspace/delegators/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Delegators',
+  description: 'Who trusts you and how to engage them. Delegator management and communication.',
+};
+
+export default function DelegatorsPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Delegators</h1>
+      <p className="text-muted-foreground">Delegator management will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/layout.tsx
+++ b/app/workspace/layout.tsx
@@ -1,0 +1,10 @@
+import { SectionPillBar } from '@/components/civica/SectionPillBar';
+
+export default function WorkspaceLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SectionPillBar section="workspace" />
+      {children}
+    </>
+  );
+}

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Workspace',
+  description: 'Your governance workspace. Action queue for DReps, governance score for SPOs.',
+};
+
+/**
+ * /workspace — DRep default: Action Queue. SPO default: Gov Score.
+ * Placeholder — will render persona-appropriate workspace content.
+ */
+export default function WorkspacePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Workspace</h1>
+      <p className="text-muted-foreground">Your governance workspace will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/performance/page.tsx
+++ b/app/workspace/performance/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Performance',
+  description: 'Your score breakdown, competitive position, and improvement suggestions.',
+};
+
+export default function PerformancePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Performance</h1>
+      <p className="text-muted-foreground">Performance analytics will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/pool-profile/page.tsx
+++ b/app/workspace/pool-profile/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Pool Profile',
+  description: "Your pool's public governance identity.",
+};
+
+export default function PoolProfilePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Pool Profile</h1>
+      <p className="text-muted-foreground">Pool profile editor will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/position/page.tsx
+++ b/app/workspace/position/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Competitive Position',
+  description: 'Your competitive landscape, peer comparison, and governance rankings.',
+};
+
+export default function PositionPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Competitive Position</h1>
+      <p className="text-muted-foreground">Competitive analysis will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/rationales/page.tsx
+++ b/app/workspace/rationales/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Rationales',
+  description: 'Your published governance rationales and their reception.',
+};
+
+export default function RationalesPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Rationales</h1>
+      <p className="text-muted-foreground">Your published rationales will appear here.</p>
+    </div>
+  );
+}

--- a/app/workspace/votes/page.tsx
+++ b/app/workspace/votes/page.tsx
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Voting Record',
+  description: 'Your governance voting history with rationale status.',
+};
+
+export default function VotesPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Voting Record</h1>
+      <p className="text-muted-foreground">Your voting history will appear here.</p>
+    </div>
+  );
+}

--- a/app/you/identity/page.tsx
+++ b/app/you/identity/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Identity',
+  description: 'Connected wallets, credentials, and verification status.',
+};
+
+/**
+ * /you/identity — placeholder.
+ * Will be populated with content migrated from /my-gov/identity.
+ */
+export default function IdentityPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Identity</h1>
+      <p className="text-muted-foreground">Wallet and credential management will appear here.</p>
+    </div>
+  );
+}

--- a/app/you/inbox/page.tsx
+++ b/app/you/inbox/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Inbox',
+  description: 'Your governance notifications and alerts.',
+};
+
+/**
+ * /you/inbox — placeholder.
+ * Will be populated with content migrated from /my-gov/inbox.
+ */
+export default function InboxPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Inbox</h1>
+      <p className="text-muted-foreground">Notification history will appear here.</p>
+    </div>
+  );
+}

--- a/app/you/layout.tsx
+++ b/app/you/layout.tsx
@@ -1,0 +1,10 @@
+import { SectionPillBar } from '@/components/civica/SectionPillBar';
+
+export default function YouLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <SectionPillBar section="you" />
+      {children}
+    </>
+  );
+}

--- a/app/you/page.tsx
+++ b/app/you/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — You',
+  description: 'Your governance identity card. See and share your civic profile.',
+};
+
+/**
+ * /you — Governance ID summary.
+ * Will be populated with shareable governance identity card.
+ */
+export default function YouPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Governance Identity</h1>
+      <p className="text-muted-foreground">
+        Your shareable governance identity card will appear here.
+      </p>
+    </div>
+  );
+}

--- a/app/you/public-profile/page.tsx
+++ b/app/you/public-profile/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Public Profile',
+  description: 'Edit how delegators see your governance profile.',
+};
+
+/**
+ * /you/public-profile — DRep/SPO only.
+ * Edit your public-facing governance profile.
+ */
+export default function PublicProfilePage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Public Profile</h1>
+      <p className="text-muted-foreground">Public profile editor will appear here.</p>
+    </div>
+  );
+}

--- a/app/you/settings/page.tsx
+++ b/app/you/settings/page.tsx
@@ -1,0 +1,21 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Governada — Settings',
+  description: 'Preferences, display, and notification controls.',
+};
+
+/**
+ * /you/settings — placeholder.
+ * Will be populated with content migrated from /my-gov/profile.
+ */
+export default function SettingsPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <h1 className="text-2xl font-bold mb-4">Settings</h1>
+      <p className="text-muted-foreground">Preferences and settings will appear here.</p>
+    </div>
+  );
+}

--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -2,23 +2,18 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Compass, Activity, MessageCircle, Landmark } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
-
-const NAV_ITEMS = [
-  { href: '/', label: 'Home', icon: Home },
-  { href: '/discover', label: 'Discover', icon: Compass },
-  { href: '/engage', label: 'Engage', icon: MessageCircle },
-  { href: '/pulse', label: 'Pulse', icon: Activity },
-  { href: '/my-gov', label: 'My Gov', icon: Landmark, showBadge: true },
-] as const;
+import { getBottomBarItems } from '@/lib/nav/config';
 
 export function CivicaBottomNav() {
   const pathname = usePathname();
-  const { stakeAddress } = useSegment();
+  const { segment, stakeAddress, delegatedDrep, delegatedPool } = useSegment();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
+  const hasDelegation = !!(delegatedDrep || delegatedPool);
+
+  const navItems = getBottomBarItems(segment, hasDelegation);
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -27,42 +22,40 @@ export function CivicaBottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 z-40 sm:hidden bg-background/80 backdrop-blur-xl border-t border-border/50 pb-[env(safe-area-inset-bottom)]"
+      className="fixed bottom-0 inset-x-0 z-40 lg:hidden bg-background/80 backdrop-blur-xl border-t border-border/50 pb-[env(safe-area-inset-bottom)]"
       aria-label="Mobile navigation"
     >
       <div className="flex items-center justify-around h-14">
-        {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || !!stakeAddress).map(
-          ({ href, label, icon: Icon, ...rest }) => {
-            const active = isActive(href);
-            const showBadge = 'showBadge' in rest && rest.showBadge;
-            return (
-              <Link
-                key={href}
-                href={href}
-                className={cn(
-                  'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors [touch-action:manipulation]',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
-                  active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
+        {navItems.map(({ href, label, icon: Icon, badge }) => {
+          const active = isActive(href);
+          const badgeCount = badge === 'unread' ? unreadCount : 0;
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                'relative flex flex-col items-center justify-center gap-0.5 min-w-[64px] min-h-[44px] px-2 transition-colors [touch-action:manipulation]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
+                active ? 'text-primary' : 'text-muted-foreground active:text-foreground',
+              )}
+              aria-current={active ? 'page' : undefined}
+              aria-label={label}
+            >
+              <div className="relative inline-flex">
+                <Icon className="h-5 w-5" />
+                {badgeCount > 0 && (
+                  <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-500 text-[10px] text-white flex items-center justify-center font-bold">
+                    {badgeCount > 9 ? '9+' : badgeCount}
+                  </span>
                 )}
-                aria-current={active ? 'page' : undefined}
-                aria-label={label}
-              >
-                <div className="relative inline-flex">
-                  <Icon className="h-5 w-5" />
-                  {showBadge && unreadCount > 0 && (
-                    <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-red-500 text-[10px] text-white flex items-center justify-center font-bold">
-                      {unreadCount > 9 ? '9+' : unreadCount}
-                    </span>
-                  )}
-                </div>
-                <span className="text-[10px] font-medium leading-tight">{label}</span>
-                {active && (
-                  <span className="absolute bottom-[calc(env(safe-area-inset-bottom)+2px)] h-0.5 w-6 rounded-full bg-primary" />
-                )}
-              </Link>
-            );
-          },
-        )}
+              </div>
+              <span className="text-[10px] font-medium leading-tight">{label}</span>
+              {active && (
+                <span className="absolute bottom-[calc(env(safe-area-inset-bottom)+2px)] h-0.5 w-6 rounded-full bg-primary" />
+              )}
+            </Link>
+          );
+        })}
       </div>
     </nav>
   );

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -5,13 +5,8 @@ import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import {
-  Home,
-  Compass,
-  Activity,
-  Landmark,
-  MessageCircle,
-  BookOpen,
   Search,
+  Bell,
   User,
   Users,
   LogOut,
@@ -55,15 +50,6 @@ const WalletConnectModal = dynamic(
   { ssr: false },
 );
 
-const NAV_ITEMS = [
-  { href: '/', label: 'Home', icon: Home },
-  { href: '/discover', label: 'Discover', icon: Compass },
-  { href: '/pulse', label: 'Pulse', icon: Activity },
-  { href: '/engage', label: 'Engage', icon: MessageCircle },
-  { href: '/my-gov', label: 'My Gov', icon: Landmark },
-  { href: '/learn', label: 'Learn', icon: BookOpen },
-] as const;
-
 const SEGMENT_LABELS: Record<UserSegment, string> = {
   anonymous: '',
   citizen: 'Citizen',
@@ -103,11 +89,6 @@ export function CivicaHeader() {
   const [walletModalOpen, setWalletModalOpen] = useState(false);
   const [pickerPreset, setPickerPreset] = useState<SegmentPreset | null>(null);
 
-  const isActive = (href: string) => {
-    if (href === '/') return pathname === '/';
-    return pathname === href || pathname.startsWith(href + '/');
-  };
-
   const isHome = pathname === '/';
 
   const [scrolled, setScrolled] = useState(false);
@@ -130,52 +111,16 @@ export function CivicaHeader() {
       )}
     >
       <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">
-        <div className="flex items-center gap-1">
-          <Link
-            href="/"
-            className={cn(
-              'font-display text-lg font-bold tracking-tight mr-6 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
-              headerTransparent && 'nav-text-shadow',
-            )}
-          >
-            governada
-          </Link>
-
-          <nav className="flex items-center gap-1" aria-label="Main navigation">
-            {NAV_ITEMS.filter((item) => item.href !== '/my-gov' || isAuthenticated).map(
-              ({ href, label, icon: Icon }) => {
-                const active = isActive(href);
-                return (
-                  <Link
-                    key={href}
-                    href={href}
-                    className={cn(
-                      'relative flex items-center gap-2 px-3 py-2 min-h-[44px] text-sm font-medium rounded-md transition-colors',
-                      'hover:bg-accent hover:text-accent-foreground',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                      active ? 'text-foreground' : 'text-muted-foreground',
-                      headerTransparent && 'nav-text-shadow',
-                    )}
-                    aria-current={active ? 'page' : undefined}
-                  >
-                    <span className="relative inline-flex">
-                      <Icon className="h-4 w-4" />
-                      {href === '/my-gov' && unreadCount > 0 && (
-                        <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
-                          {unreadCount > 9 ? '9+' : unreadCount}
-                        </span>
-                      )}
-                    </span>
-                    {label}
-                    {active && (
-                      <span className="absolute bottom-0 left-3 right-3 h-0.5 rounded-full bg-primary" />
-                    )}
-                  </Link>
-                );
-              },
-            )}
-          </nav>
-        </div>
+        {/* Logo — sidebar handles navigation on desktop */}
+        <Link
+          href="/"
+          className={cn(
+            'font-display text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
+            headerTransparent && 'nav-text-shadow',
+          )}
+        >
+          governada
+        </Link>
 
         <div className="flex items-center gap-2">
           <Button
@@ -192,6 +137,24 @@ export function CivicaHeader() {
               ⌘K
             </kbd>
           </Button>
+
+          {/* Notification bell */}
+          {connected && isAuthenticated && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative h-8 w-8 text-muted-foreground hover:text-foreground"
+              onClick={() => router.push('/you/inbox')}
+              aria-label="Notifications"
+            >
+              <Bell className="h-4 w-4" />
+              {unreadCount > 0 && (
+                <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </span>
+              )}
+            </Button>
+          )}
 
           <Button
             variant="ghost"
@@ -234,7 +197,7 @@ export function CivicaHeader() {
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem onSelect={() => router.push('/my-gov/profile')}>
+                <DropdownMenuItem onSelect={() => router.push('/you/settings')}>
                   <User className="h-4 w-4" />
                   Profile & Settings
                 </DropdownMenuItem>

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useState, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { cn } from '@/lib/utils';
 import { SegmentProvider } from '@/components/providers/SegmentProvider';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { CivicaHeader } from './CivicaHeader';
 import { CivicaBottomNav } from './CivicaBottomNav';
+import { CivicaSidebar } from './CivicaSidebar';
+
+const SIDEBAR_STORAGE_KEY = 'governada_sidebar_collapsed';
 
 function DeepLinkHandler() {
   const router = useRouter();
@@ -31,7 +35,7 @@ function DeepLinkHandler() {
         if (drepId) router.push(`/drep/${encodeURIComponent(drepId)}`);
         break;
       case 'epoch-recap':
-        router.push(`/pulse`);
+        router.push('/governance/health');
         break;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally runs once on mount for deep link handling
@@ -41,9 +45,25 @@ function DeepLinkHandler() {
 }
 
 /**
- * Governada layout shell — wraps children with 4-tab nav + providers.
+ * Governada layout shell — sidebar on desktop, bottom bar on mobile.
+ * Sidebar is persona-adaptive via the nav config.
  */
 export function CivicaShell({ children }: { children: React.ReactNode }) {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    if (stored === 'true') setSidebarCollapsed(true);
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
   return (
     <SegmentProvider>
       <TierThemeProvider score={null}>
@@ -51,7 +71,15 @@ export function CivicaShell({ children }: { children: React.ReactNode }) {
           <DeepLinkHandler />
         </Suspense>
         <CivicaHeader />
-        <main id="main-content" className="relative z-0 min-h-screen pb-16 sm:pb-0" tabIndex={-1}>
+        <CivicaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+        <main
+          id="main-content"
+          className={cn(
+            'relative z-0 min-h-screen pb-16 lg:pb-0 transition-[padding-left] duration-200',
+            sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+          )}
+          tabIndex={-1}
+        >
           {children}
         </main>
         <CivicaBottomNav />

--- a/components/civica/CivicaSidebar.tsx
+++ b/components/civica/CivicaSidebar.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { PanelLeftClose, PanelLeft } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { getSidebarSections, type NavSection, type NavItem } from '@/lib/nav/config';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
+import { Button } from '@/components/ui/button';
+
+interface CivicaSidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
+  const pathname = usePathname();
+  const { segment, stakeAddress } = useSegment();
+  const unreadCount = useUnreadNotifications(stakeAddress ?? null);
+
+  const sections = getSidebarSections(segment);
+
+  const isActive = (href: string) => {
+    if (href === '/') return pathname === '/';
+    return pathname === href || pathname.startsWith(href + '/');
+  };
+
+  const isSectionActive = (section: NavSection) => {
+    if (section.href === '/') return pathname === '/';
+    return pathname.startsWith(section.href);
+  };
+
+  const getBadgeCount = (item: NavItem): number => {
+    if (item.badge === 'unread') return unreadCount;
+    // TODO: implement action badge count (pending votes)
+    return 0;
+  };
+
+  return (
+    <aside
+      className={cn(
+        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/50 bg-background transition-[width] duration-200',
+        collapsed ? 'w-16' : 'w-60',
+      )}
+    >
+      <nav className="flex-1 overflow-y-auto py-3 px-2" aria-label="Sidebar navigation">
+        {sections.map((section, sectionIdx) => (
+          <div key={section.id} className={cn(sectionIdx > 0 && 'mt-4')}>
+            {/* Section header / single link */}
+            {section.items ? (
+              <>
+                {/* Section label (not clickable) */}
+                {!collapsed && (
+                  <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                    {section.label}
+                  </div>
+                )}
+                {collapsed && (
+                  <div className="flex justify-center py-1.5">
+                    <section.icon className="h-4 w-4 text-muted-foreground/40" />
+                  </div>
+                )}
+                {/* Sub-items */}
+                <div className="space-y-0.5">
+                  {section.items.map((item) => {
+                    const active = isActive(item.href);
+                    const badge = getBadgeCount(item);
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        className={cn(
+                          'group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                          'hover:bg-accent hover:text-accent-foreground',
+                          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                          active ? 'bg-accent text-foreground' : 'text-muted-foreground',
+                          collapsed && 'justify-center px-0',
+                        )}
+                        aria-current={active ? 'page' : undefined}
+                        title={collapsed ? item.label : undefined}
+                      >
+                        {active && (
+                          <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-primary" />
+                        )}
+                        <span className="relative inline-flex shrink-0">
+                          <item.icon className="h-4 w-4" />
+                          {badge > 0 && (
+                            <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
+                              {badge > 9 ? '9+' : badge}
+                            </span>
+                          )}
+                        </span>
+                        {!collapsed && <span className="truncate">{item.label}</span>}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </>
+            ) : (
+              /* Single link section (Home, Delegation) */
+              <Link
+                href={section.href}
+                className={cn(
+                  'group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                  'hover:bg-accent hover:text-accent-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                  isSectionActive(section) ? 'bg-accent text-foreground' : 'text-muted-foreground',
+                  collapsed && 'justify-center px-0',
+                )}
+                aria-current={isSectionActive(section) ? 'page' : undefined}
+                title={collapsed ? section.label : undefined}
+              >
+                {isSectionActive(section) && (
+                  <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-primary" />
+                )}
+                <section.icon className="h-4 w-4 shrink-0" />
+                {!collapsed && <span>{section.label}</span>}
+              </Link>
+            )}
+          </div>
+        ))}
+      </nav>
+
+      {/* Collapse toggle */}
+      <div className="border-t border-border/50 p-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn('w-full', collapsed ? 'justify-center px-0' : 'justify-start')}
+          onClick={onToggle}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          {collapsed ? (
+            <PanelLeft className="h-4 w-4" />
+          ) : (
+            <>
+              <PanelLeftClose className="h-4 w-4 mr-2" />
+              <span className="text-xs text-muted-foreground">Collapse</span>
+            </>
+          )}
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/components/civica/SectionPillBar.tsx
+++ b/components/civica/SectionPillBar.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { getPillBarItems } from '@/lib/nav/config';
+
+interface SectionPillBarProps {
+  section: string;
+}
+
+/**
+ * Horizontal scrollable pill bar for section sub-pages.
+ * Renders below the page header on mobile, hidden on desktop (sidebar handles it).
+ */
+export function SectionPillBar({ section: _section }: SectionPillBarProps) {
+  const pathname = usePathname();
+  const { segment } = useSegment();
+  const items = getPillBarItems(pathname, segment);
+
+  if (!items || items.length < 2) return null;
+
+  return (
+    <div className="sticky top-14 z-20 lg:hidden border-b border-border/50 bg-background/80 backdrop-blur-xl">
+      <nav
+        className="flex items-center gap-1.5 px-4 py-2 overflow-x-auto scrollbar-none"
+        aria-label="Section navigation"
+      >
+        {items.map((item) => {
+          const active =
+            item.href === pathname ||
+            (item.href !== '/' && pathname.startsWith(item.href + '/')) ||
+            // Handle exact sub-page match (e.g., /governance/proposals is active for /governance/proposals)
+            pathname === item.href;
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'shrink-0 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors whitespace-nowrap',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                active
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground',
+              )}
+              aria-current={active ? 'page' : undefined}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/docs/strategy/context/navigation-architecture.md
+++ b/docs/strategy/context/navigation-architecture.md
@@ -1,0 +1,526 @@
+# Navigation Architecture Spec
+
+> **Purpose:** Definitive reference for all navigation, routing, and information architecture decisions. Every page, section, and nav element must conform to this spec. Agents MUST read this before building any page, layout, or navigation component.
+> **Status:** Approved architecture. Implementation pending.
+> **Companion docs:** `ux-constraints.md` (page-level JTBD), `persona-quick-ref.md` (persona JTBDs)
+
+---
+
+## Core Principles
+
+1. **JTBD-driven, not entity-driven.** Sections are organized around what users DO, not what data types exist. There is no "browse entities" section.
+2. **Hub-first.** The Home page (`/`) is every persona's control center. Most navigation starts from Hub cards that link deeper. The nav bar is a safety net, not the primary navigation surface.
+3. **Aggressive persona adaptation.** Different personas see different nav items, different Hub content, different defaults. This is not one product with conditional elements — it's different products sharing an engine.
+4. **Additive layers.** Personas stack. Everyone has the citizen layer. DReps add a workspace. SPOs add a workspace. DRep+SPO gets both. Nobody loses the citizen layer.
+5. **Three navigation tiers.** Global nav (top bar / bottom bar), section nav (sidebar / pill bar), and contextual nav (tabs within entity pages). Each tier uses the right pattern for its job.
+
+---
+
+## Sections
+
+### Hub (Home)
+
+| Attribute        | Value                                                       |
+| ---------------- | ----------------------------------------------------------- |
+| **Route**        | `/`                                                         |
+| **Purpose**      | Persona-adaptive control center. What needs your attention? |
+| **Who sees it**  | Everyone (content adapts per persona + state)               |
+| **Nav position** | Always first in global nav                                  |
+
+The Hub is NOT a landing page for authenticated users. It is an intelligent briefing surface that composites cards from all active persona layers, sorted by urgency.
+
+**Hub card types:**
+
+- **Action cards** — time-sensitive items requiring user response (DRep votes, delegation alerts)
+- **Status cards** — health indicators and summaries (delegation status, governance health, score trends)
+- **Engagement cards** — polls, sentiment votes, discussion prompts (the engagement layer)
+- **Discovery cards** — contextual suggestions (find a pool, explore a proposal)
+
+Cards are sorted by urgency: action > status > engagement > discovery. Within each tier, personalization determines order.
+
+**Anonymous Home** is a landing/conversion page — value prop, social proof, two CTAs ("Find Your Representative" + "Explore Governance").
+
+See `ux-constraints.md` for per-persona Hub constraints.
+
+### Workspace
+
+| Attribute        | Value                                    |
+| ---------------- | ---------------------------------------- |
+| **Route**        | `/workspace`                             |
+| **Purpose**      | Tools for doing your governance job      |
+| **Who sees it**  | DRep, SPO (not citizens, not anonymous)  |
+| **Nav position** | Second item in global nav (when visible) |
+
+Workspace is where governance actors DO WORK — vote, write rationales, manage delegators, improve scores. It is action-oriented, not informational.
+
+**Workspace adapts per persona:**
+
+DRep sub-pages:
+
+- `/workspace` — Action Queue (default: proposals needing votes, sorted by deadline)
+- `/workspace/votes` — Your voting record with rationales
+- `/workspace/rationales` — Your published rationales and their reception
+- `/workspace/delegators` — Who trusts you, delegator communication, growth trends
+- `/workspace/performance` — Your score breakdown, competitive position, improvement suggestions
+
+SPO sub-pages:
+
+- `/workspace` — Governance Score dashboard (default: score + trend + improvement tips)
+- `/workspace/pool-profile` — Your pool's public governance identity (edit)
+- `/workspace/delegators` — Who stakes with you, delegator communication
+- `/workspace/position` — Competitive landscape, peer comparison, governance rankings
+
+DRep+SPO: Both sets of sub-pages appear in the sidebar, grouped by role with clear headers ("DRep" / "Pool"). Action Queue remains the default landing.
+
+### Governance
+
+| Attribute        | Value                                                            |
+| ---------------- | ---------------------------------------------------------------- |
+| **Route**        | `/governance`                                                    |
+| **Purpose**      | Understand what's happening in Cardano governance                |
+| **Who sees it**  | Everyone                                                         |
+| **Nav position** | Third item in global nav (second for personas without Workspace) |
+
+Governance is the universal section where users explore governance activity. It is NOT an entity browser — it's organized around governance activity with entity directories as sub-pages.
+
+Sub-pages:
+
+- `/governance` — Overview (redirects to persona-default sub-page, or shows a governance summary)
+- `/governance/proposals` — What's being decided. Active proposals with status, voting deadlines, stake impact.
+- `/governance/representatives` — Who represents ADA holders. DRep directory with governance framing (delegation concentration, participation rates, then individual DReps).
+- `/governance/pools` — Infrastructure operators and their governance participation. Pool directory with governance scores.
+- `/governance/committee` — Constitutional Committee. CC member directory, transparency index, voting records.
+- `/governance/treasury` — How community funds are being spent. Treasury activity, fund tracking, spending transparency.
+- `/governance/health` — Governance Health Index. GHI score, participation trends, epoch history. (Absorbs the current `/pulse` section.)
+
+**Persona-aware default landing:**
+
+| Persona               | Default sub-page              | Why                                                    |
+| --------------------- | ----------------------------- | ------------------------------------------------------ |
+| Anonymous             | `/governance/proposals`       | "See what's being decided" — most tangible entry point |
+| Citizen (undelegated) | `/governance/representatives` | Finding a DRep is their primary need                   |
+| Citizen (delegated)   | `/governance/proposals`       | Understanding what's happening is their ongoing need   |
+| DRep                  | `/governance/proposals`       | Research beyond their action queue                     |
+| SPO                   | `/governance/pools`           | Competitive landscape                                  |
+
+### You (Account)
+
+| Attribute        | Value                                      |
+| ---------------- | ------------------------------------------ |
+| **Route**        | `/you`                                     |
+| **Purpose**      | Your identity, settings, and notifications |
+| **Who sees it**  | Authenticated users                        |
+| **Nav position** | Last item in global nav                    |
+
+"You" is account management — who you are, not what you do. Governance activity lives on the Hub and in the Workspace. "You" is for identity, settings, and notification history.
+
+Sub-pages:
+
+- `/you` — Governance ID summary (your shareable governance identity card)
+- `/you/identity` — Connected wallets, credentials, verification status
+- `/you/inbox` — Full notification history (also accessible via notification bell icon in top bar)
+- `/you/settings` — Preferences, display, notification controls
+
+DRep additions:
+
+- `/you/public-profile` — How delegators see you (edit your public-facing profile)
+
+SPO additions:
+
+- `/you/pool-profile` — Your pool's public governance page (view as others see it)
+
+### Match (Funnel Tool)
+
+| Attribute        | Value                                                                       |
+| ---------------- | --------------------------------------------------------------------------- |
+| **Route**        | `/match`                                                                    |
+| **Purpose**      | Find your governance team (DRep + governance-active pool)                   |
+| **Who sees it**  | Primarily anonymous and undelegated citizens                                |
+| **Nav position** | In bottom bar for anonymous/undelegated; accessible via Hub card for others |
+
+Match is a conversion funnel, not a permanent section. It is prominent for users who need to find representation and secondary for users who already have it.
+
+**Expanded scope:** Match covers both DRep matching (governance values alignment) and Pool matching (governance-active pool discovery). The flow guides users to assemble their "governance team."
+
+### Delegation
+
+| Attribute        | Value                                                         |
+| ---------------- | ------------------------------------------------------------- |
+| **Route**        | `/delegation`                                                 |
+| **Purpose**      | Monitor both governance relationships (DRep + Pool)           |
+| **Who sees it**  | Authenticated citizens with at least one delegation           |
+| **Nav position** | In bottom bar for delegated citizens; accessible via Hub card |
+
+The Delegation page shows both governance relationships — your DRep AND your stake pool operator — with health indicators, alignment scores, and governance coverage analysis.
+
+**Key concept: Governance Coverage.** Citizens need both a good DRep AND a governance-active pool to be fully represented. DReps vote on most governance actions (treasury, parameters, constitution). SPOs vote on hard forks and certain parameter changes. Together, they cover 100% of governance action types.
+
+Page content:
+
+- DRep card: status, voting record, alignment score, activity
+- Pool card: governance score, voting participation, governance activity
+- Coverage analysis: what percentage of governance action types your representatives cover
+- Conflict detection: alerts when your DRep and pool vote opposite ways
+- Gap detection: alerts when either representative stops participating
+- Improvement suggestions: better alternatives when gaps exist
+
+### Help
+
+| Attribute        | Value                                                                    |
+| ---------------- | ------------------------------------------------------------------------ |
+| **Route**        | `/help`                                                                  |
+| **Purpose**      | FAQ, glossary, methodology, support                                      |
+| **Who sees it**  | Everyone                                                                 |
+| **Nav position** | In bottom bar for anonymous; accessible from user menu for authenticated |
+
+Help absorbs `/methodology` and replaces `/learn`. Education is delivered inline (contextual tooltips, first-time banners, empty state guidance), with Help as the reference destination for users who want to go deeper.
+
+Sub-pages:
+
+- `/help` — FAQ + search
+- `/help/glossary` — Governance terminology
+- `/help/methodology` — Scoring methodology (absorbs current `/methodology`)
+- `/help/support` — Contact, feedback, status
+
+---
+
+## Entity Pages (Standalone Detail Views)
+
+Entity pages are accessed via Hub cards, Governance sub-pages, search, or direct links. They are NOT part of a section — they stand alone.
+
+| Route                | Purpose                                          | Breadcrumb                            |
+| -------------------- | ------------------------------------------------ | ------------------------------------- |
+| `/drep/[id]`         | DRep profile — decide if I should delegate       | Governance > Representatives > [Name] |
+| `/pool/[id]`         | Pool profile — evaluate governance participation | Governance > Pools > [Name]           |
+| `/committee/[id]`    | CC member profile — check accountability         | Governance > Committee > [Name]       |
+| `/proposal/[tx]/[i]` | Proposal detail — understand and decide          | Governance > Proposals > [Title]      |
+| `/compare`           | Side-by-side comparison                          | (contextual — depends on entry point) |
+
+**Entity page navigation rules:**
+
+1. Show breadcrumbs linking back to the parent Governance sub-page
+2. Use horizontal tabs for facets of the entity (voting record, score, community = tabs on a DRep profile)
+3. Include "Related" navigation: DRep profile links to proposals they voted on, proposal links to DReps who voted
+4. Include persona-aware CTAs: citizen sees "Delegate to this DRep", DRep sees "Compare to my record"
+
+---
+
+## Mobile Bottom Bar (4 items, persona-adaptive)
+
+The bottom bar is the primary navigation surface on mobile. It adapts per persona to show the 4 most important sections.
+
+| Persona                   | Item 1 | Item 2     | Item 3     | Item 4 |
+| ------------------------- | ------ | ---------- | ---------- | ------ |
+| **Anonymous**             | Home   | Governance | Match      | Help   |
+| **Citizen (undelegated)** | Home   | Governance | Match      | You    |
+| **Citizen (delegated)**   | Home   | Governance | Delegation | You    |
+| **DRep**                  | Home   | Workspace  | Governance | You    |
+| **SPO**                   | Home   | Workspace  | Governance | You    |
+| **DRep + SPO**            | Home   | Workspace  | Governance | You    |
+| **CC Member**             | Home   | Governance | Delegation | You    |
+
+**Bottom bar rules:**
+
+1. Always exactly 4 items
+2. Home is always first
+3. Items not in the bottom bar are accessible via the Hub, sidebar (desktop), or user menu
+4. Notification badge on You when unread inbox items exist
+5. Workspace shows a badge when action items are pending (DRep: votes due)
+6. Delegation shows a badge when governance health changes (DRep inactive, pool stopped voting)
+
+### Mobile Section Nav: Contextual Pill Bar
+
+When inside a section with sub-pages, a sticky horizontal pill bar appears below the page header. Pills are route links, not tabs.
+
+Example — entering Governance on mobile:
+
+```
+[Proposals] [Representatives] [Pools] [Committee] [Treasury] [Health]
+```
+
+**Pill bar rules:**
+
+1. Only appears in sections with 2+ sub-pages
+2. Scrollable horizontally if items exceed screen width
+3. Active pill is visually distinct (filled vs. outlined)
+4. Scroll-aware: hides on scroll-down, reappears on scroll-up (like Safari's address bar)
+5. Links to real routes, not client-side tab state
+6. Default selected pill matches persona-aware default sub-page
+
+---
+
+## Desktop Sidebar
+
+On desktop (≥1024px), the left sidebar provides persistent navigation for all sections. It is collapsible to icons only.
+
+```
+HOME                          ← Always visible
+
+WORKSPACE                     ← DRep/SPO only
+├── Action Queue              ← DRep
+├── Voting Record             ← DRep
+├── Rationales                ← DRep
+├── Gov Score                 ← SPO
+├── Pool Profile              ← SPO
+├── Delegators                ← DRep, SPO (grouped if both)
+└── Performance / Position    ← DRep, SPO
+
+GOVERNANCE                    ← Everyone
+├── Proposals
+├── Representatives
+├── Pools
+├── Committee
+├── Treasury
+└── Health
+
+──────────────────
+DELEGATION                    ← Authenticated w/ delegation
+YOU                           ← Authenticated
+HELP                          ← Everyone
+```
+
+**Sidebar rules:**
+
+1. Collapsible to icon-only mode (user preference, persisted)
+2. Sections without sub-pages (Home, Delegation) are single links, not expandable groups
+3. Workspace section only renders for DRep/SPO personas
+4. Sub-pages within each section are always visible (not collapsed by default) — the sidebar is the wayfinding surface, hiding items defeats its purpose
+5. Active page highlighted with distinct background + left border accent
+6. Width: 240px expanded, 64px collapsed
+7. On screens < 1024px, sidebar is hidden (mobile pill bar + bottom bar take over)
+
+---
+
+## Desktop Top Bar
+
+The top bar is minimal on desktop — the sidebar handles navigation.
+
+```
+[Logo/Home]                                    [Search ⌘K] [Notification Bell] [Theme] [User Menu]
+```
+
+**Top bar elements:**
+
+- Logo: links to `/` (Home)
+- Search: opens command palette (⌘K). Universal access to any page, entity, or action.
+- Notification bell: unread count badge, opens inbox dropdown or links to `/you/inbox`
+- Theme toggle: light/dark
+- User menu: profile pic → dropdown with: View Profile, Settings, Help, Admin (if admin), Disconnect Wallet
+
+**No navigation links in the top bar.** The sidebar handles all navigation on desktop.
+
+---
+
+## Engagement Layer (Not a Section)
+
+Engagement is a behavior layer, not a navigation destination. It surfaces across the product:
+
+1. **Hub action cards** — polls, sentiment votes, discussion prompts. Sorted by relevance and timeliness.
+2. **Entity page prompts** — "How do you feel about this proposal?" on proposal detail, "Rate your DRep" on DRep profiles.
+3. **Workspace feedback** — "Your rationale got 94% agreement" on DRep workspace.
+4. **Browsable feed** — All active engagement opportunities at `/governance/community` (optional sub-page, low priority). Most users encounter engagement through Hub cards, not by browsing.
+
+Every engagement action generates data (sentiment, satisfaction, governance temperature) that feeds back into intelligence (Pulse scores, DRep ratings, coverage analysis).
+
+---
+
+## Governance Coverage (New Concept)
+
+Governance Coverage is the idea that citizens need BOTH a good DRep AND a governance-active pool to be fully represented. This is a key differentiator for Governada.
+
+**How it works:**
+
+- DReps vote on: treasury withdrawals, parameter changes, hard forks, constitution changes, committee elections, info actions
+- SPOs vote on: hard fork initiation, certain parameter changes, no-confidence motions
+- Together, they cover all governance action types
+- Governance Coverage % = (action types where at least one representative voted) / (total action types with votes this epoch)
+
+**Where it surfaces:**
+
+- Hub status card: "Your governance coverage: 85%"
+- Delegation page: detailed breakdown by action type
+- Match flow: "Complete your governance team" when only DRep or only pool is delegated
+- Alerts: "Your pool hasn't voted on any governance action this epoch — your coverage dropped to 60%"
+
+**Intelligence opportunities:**
+
+- Conflict detection: DRep and pool voted opposite ways
+- Gap detection: one representative stopped participating
+- Trend analysis: coverage over time
+- Improvement suggestions: pools/DReps that would increase coverage
+
+---
+
+## Route Migration Map
+
+Current routes → new routes. Redirects must be maintained for SEO and existing links.
+
+| Current Route             | New Route                                   | Redirect                                       |
+| ------------------------- | ------------------------------------------- | ---------------------------------------------- |
+| `/`                       | `/`                                         | No change (content adapts per persona)         |
+| `/discover`               | `/governance`                               | 301 redirect                                   |
+| `/discover?tab=dreps`     | `/governance/representatives`               | 301 redirect                                   |
+| `/discover?tab=spos`      | `/governance/pools`                         | 301 redirect                                   |
+| `/discover?tab=proposals` | `/governance/proposals`                     | 301 redirect                                   |
+| `/discover?tab=committee` | `/governance/committee`                     | 301 redirect                                   |
+| `/discover?tab=rankings`  | `/governance/representatives?view=rankings` | 301 redirect                                   |
+| `/pulse`                  | `/governance/health`                        | 301 redirect                                   |
+| `/pulse/history`          | `/governance/health?period=history`         | 301 redirect                                   |
+| `/pulse/report/[epoch]`   | `/governance/health/epoch/[epoch]`          | 301 redirect                                   |
+| `/my-gov`                 | `/` (Hub)                                   | 301 redirect (authenticated users land on Hub) |
+| `/my-gov/identity`        | `/you/identity`                             | 301 redirect                                   |
+| `/my-gov/inbox`           | `/you/inbox`                                | 301 redirect                                   |
+| `/my-gov/profile`         | `/you/settings`                             | 301 redirect                                   |
+| `/engage`                 | `/` (Hub engagement cards)                  | 301 redirect                                   |
+| `/learn`                  | `/help`                                     | 301 redirect                                   |
+| `/methodology`            | `/help/methodology`                         | 301 redirect                                   |
+| `/match`                  | `/match`                                    | No change                                      |
+| `/drep/[id]`              | `/drep/[id]`                                | No change                                      |
+| `/pool/[id]`              | `/pool/[id]`                                | No change                                      |
+| `/proposal/[tx]/[i]`      | `/proposal/[tx]/[i]`                        | No change                                      |
+| `/committee/[id]`         | `/committee/[id]`                           | No change                                      |
+| `/compare`                | `/compare`                                  | No change                                      |
+| `/developers`             | `/developers`                               | No change (B2B, separate audience)             |
+
+**Redirect implementation:** Next.js `next.config.ts` redirects for simple routes. Middleware for query-param-based redirects (discover tabs, pulse tabs).
+
+---
+
+## Navigation State Management
+
+### URL Strategy
+
+- Section sub-pages use real routes (`/governance/proposals`), not query params or tabs
+- Entity page facets use hash (`/drep/[id]#voting`) for tab state within a profile
+- Filters and view options use query params (`/governance/representatives?sort=score&tier=rising`)
+- Persona-aware defaults are server-side redirects, not client-side
+
+### Sidebar State
+
+- Collapsed/expanded state persisted to `localStorage`
+- Active section auto-expands in sidebar
+- No "sticky last page" — entering a section always goes to the persona-default sub-page (unless user navigated directly via URL)
+
+### Bottom Bar State
+
+- Active item determined by current route prefix (`/workspace/*` → Workspace active)
+- Badge counts fetched via TanStack Query with polling interval
+- Persona detection via `useSegment()` hook — bottom bar items render from a config array, not hardcoded
+
+---
+
+## Admin Section (Unchanged)
+
+Admin (`/admin`) retains its existing sidebar layout. It is a separate product surface for operators, not subject to persona adaptation.
+
+---
+
+## Anti-Patterns
+
+Agents MUST NOT:
+
+1. **Use tabs for what should be separate routes.** Tabs are for facets of ONE entity (DRep profile tabs). Different pages that happen to share a section are separate routes with sidebar/pill navigation.
+2. **Put entity directories in the top-level nav.** DReps, Pools, Proposals are sub-pages of Governance, not top-level sections. The nav reflects user intent (understand governance), not data type (browse DReps).
+3. **Show the same nav to all personas.** The bottom bar, sidebar items, and Hub content MUST adapt. If a citizen and a DRep see identical navigation, the implementation is wrong.
+4. **Hide depth behind the command palette.** ⌘K is a power-user shortcut, not a substitute for visible navigation. Every important page must be reachable via the sidebar or bottom bar within 2 taps.
+5. **Create new top-level sections without updating this spec.** The section inventory (Hub, Workspace, Governance, You, Match, Delegation, Help) is closed. New features go inside existing sections or this spec is updated first.
+6. **Use query params for persistent navigation state.** `?tab=dreps` is a smell. If it deserves a tab, it deserves a route.
+7. **Build engagement as a destination.** Engagement is a layer that surfaces through Hub cards and contextual prompts. There is no `/engage` section.
+
+---
+
+## Implementation Notes
+
+### Component Architecture
+
+```
+app/
+├── layout.tsx              ← Root layout: providers + shell
+├── page.tsx                ← Hub (persona-adaptive)
+├── delegation/
+│   └── page.tsx            ← Delegation health (both reps)
+├── workspace/
+│   ├── layout.tsx          ← Workspace layout (sidebar aware)
+│   ├── page.tsx            ← Default: Action Queue (DRep) or Gov Score (SPO)
+│   ├── votes/page.tsx
+│   ├── rationales/page.tsx
+│   ├── delegators/page.tsx
+│   ├── performance/page.tsx
+│   ├── pool-profile/page.tsx    ← SPO only
+│   └── position/page.tsx        ← SPO only
+├── governance/
+│   ├── layout.tsx          ← Governance layout (sidebar/pill bar aware)
+│   ├── page.tsx            ← Redirects to persona-default sub-page
+│   ├── proposals/page.tsx
+│   ├── representatives/page.tsx
+│   ├── pools/page.tsx
+│   ├── committee/
+│   │   └── page.tsx
+│   ├── treasury/page.tsx
+│   └── health/
+│       ├── page.tsx        ← GHI + current epoch
+│       └── epoch/[epoch]/page.tsx
+├── you/
+│   ├── layout.tsx
+│   ├── page.tsx            ← Governance ID card
+│   ├── identity/page.tsx
+│   ├── inbox/page.tsx
+│   ├── settings/page.tsx
+│   └── public-profile/page.tsx  ← DRep/SPO only
+├── match/page.tsx
+├── help/
+│   ├── page.tsx
+│   ├── glossary/page.tsx
+│   ├── methodology/page.tsx
+│   └── support/page.tsx
+├── drep/[drepId]/page.tsx
+├── pool/[poolId]/page.tsx
+├── committee/[ccHotId]/page.tsx
+├── proposal/[txHash]/[index]/page.tsx
+├── compare/page.tsx
+├── developers/page.tsx
+└── admin/                  ← Unchanged
+```
+
+### Shell Component Update
+
+The `CivicaShell` (or its replacement) must:
+
+1. Render the sidebar on desktop (≥1024px) and bottom bar on mobile (<1024px)
+2. Read persona from `useSegment()` to determine which nav items to show
+3. Render the pill bar inside section layouts, not in the shell
+4. Handle sidebar collapse state via localStorage
+5. Show notification bell in top bar with unread count
+
+### View As Registry Update
+
+The admin View As system must be updated to:
+
+1. Preview each persona's bottom bar configuration
+2. Preview each persona's sidebar items
+3. Preview each persona's Hub card composition
+4. Test delegation states: undelegated, DRep only, pool only, both, neither active
+
+---
+
+## How Agents Use This Document
+
+### Before building ANY page:
+
+1. Check which section the page belongs to
+2. Verify the route matches this spec
+3. Confirm the page appears in the correct sidebar/pill bar position
+4. Check that persona adaptation is implemented (different personas may see different content on the same route)
+
+### Before modifying navigation:
+
+1. Re-read this spec
+2. Verify the change doesn't violate anti-patterns
+3. If adding a new page, specify which section it belongs to and what pill bar / sidebar position it gets
+4. If the change affects the bottom bar or sidebar structure, update this spec in the same PR
+
+### Before auditing navigation:
+
+1. Use this spec as the reference architecture
+2. Score against: does the implementation match the spec?
+3. Do NOT recommend adding new top-level sections without proposing an update to this spec first

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -1,0 +1,287 @@
+/**
+ * Navigation configuration — data-driven nav items per persona.
+ *
+ * This is the single source of truth for all navigation surfaces:
+ * - Desktop sidebar
+ * - Mobile bottom bar (4 items, persona-adaptive)
+ * - Mobile pill bar (section sub-pages)
+ *
+ * See docs/strategy/context/navigation-architecture.md for the full spec.
+ */
+
+import type { LucideIcon } from 'lucide-react';
+import {
+  Home,
+  Briefcase,
+  Globe,
+  User,
+  Handshake,
+  Compass,
+  HelpCircle,
+  FileText,
+  Users,
+  Building2,
+  Wallet,
+  Activity,
+  Vote,
+  ScrollText,
+  BarChart3,
+  Building,
+  Trophy,
+  UserCog,
+  Bell,
+  Settings,
+  BadgeCheck,
+  BookOpen,
+  MessageSquare,
+  Shield,
+} from 'lucide-react';
+import type { UserSegment } from '@/components/providers/SegmentProvider';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  /** Show notification badge when true */
+  badge?: 'unread' | 'actions';
+  /** Only show for these segments (undefined = all) */
+  segments?: UserSegment[];
+  /** Only show for authenticated users */
+  requiresAuth?: boolean;
+}
+
+export interface NavSection {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  href: string;
+  /** Sub-pages within this section (shown in sidebar + pill bar) */
+  items?: NavItem[];
+  /** Only show for these segments (undefined = all) */
+  segments?: UserSegment[];
+  /** Only show for authenticated users */
+  requiresAuth?: boolean;
+}
+
+export interface BottomBarConfig {
+  items: NavItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Section definitions (sidebar + pill bar source)
+// ---------------------------------------------------------------------------
+
+export const WORKSPACE_DREP_ITEMS: NavItem[] = [
+  { href: '/workspace', label: 'Action Queue', icon: Vote },
+  { href: '/workspace/votes', label: 'Voting Record', icon: ScrollText },
+  { href: '/workspace/rationales', label: 'Rationales', icon: FileText },
+  { href: '/workspace/delegators', label: 'Delegators', icon: Users },
+  { href: '/workspace/performance', label: 'Performance', icon: BarChart3 },
+];
+
+export const WORKSPACE_SPO_ITEMS: NavItem[] = [
+  { href: '/workspace', label: 'Gov Score', icon: BarChart3 },
+  { href: '/workspace/pool-profile', label: 'Pool Profile', icon: Building },
+  { href: '/workspace/delegators', label: 'Delegators', icon: Users },
+  { href: '/workspace/position', label: 'Position', icon: Trophy },
+];
+
+export const GOVERNANCE_ITEMS: NavItem[] = [
+  { href: '/governance/proposals', label: 'Proposals', icon: FileText },
+  { href: '/governance/representatives', label: 'Representatives', icon: Users },
+  { href: '/governance/pools', label: 'Pools', icon: Building2 },
+  { href: '/governance/committee', label: 'Committee', icon: Shield },
+  { href: '/governance/treasury', label: 'Treasury', icon: Wallet },
+  { href: '/governance/health', label: 'Health', icon: Activity },
+];
+
+export const YOU_ITEMS: NavItem[] = [
+  { href: '/you', label: 'Governance ID', icon: BadgeCheck },
+  { href: '/you/identity', label: 'Identity', icon: UserCog },
+  { href: '/you/inbox', label: 'Inbox', icon: Bell, badge: 'unread' },
+  { href: '/you/settings', label: 'Settings', icon: Settings },
+];
+
+export const HELP_ITEMS: NavItem[] = [
+  { href: '/help', label: 'FAQ', icon: HelpCircle },
+  { href: '/help/glossary', label: 'Glossary', icon: BookOpen },
+  { href: '/help/methodology', label: 'Methodology', icon: BarChart3 },
+  { href: '/help/support', label: 'Support', icon: MessageSquare },
+];
+
+// ---------------------------------------------------------------------------
+// Sidebar sections — ordered top to bottom
+// ---------------------------------------------------------------------------
+
+export function getSidebarSections(segment: UserSegment): NavSection[] {
+  const sections: NavSection[] = [
+    {
+      id: 'home',
+      label: 'Home',
+      icon: Home,
+      href: '/',
+    },
+  ];
+
+  // Workspace — DRep/SPO only
+  if (segment === 'drep' || segment === 'spo') {
+    const workspaceItems = segment === 'drep' ? WORKSPACE_DREP_ITEMS : WORKSPACE_SPO_ITEMS;
+    sections.push({
+      id: 'workspace',
+      label: 'Workspace',
+      icon: Briefcase,
+      href: '/workspace',
+      items: workspaceItems,
+      segments: ['drep', 'spo'],
+    });
+  }
+
+  // Governance — everyone
+  sections.push({
+    id: 'governance',
+    label: 'Governance',
+    icon: Globe,
+    href: '/governance',
+    items: GOVERNANCE_ITEMS,
+  });
+
+  // Delegation — authenticated with delegation
+  if (segment !== 'anonymous') {
+    sections.push({
+      id: 'delegation',
+      label: 'Delegation',
+      icon: Handshake,
+      href: '/delegation',
+      requiresAuth: true,
+    });
+  }
+
+  // You — authenticated
+  if (segment !== 'anonymous') {
+    sections.push({
+      id: 'you',
+      label: 'You',
+      icon: User,
+      href: '/you',
+      items: YOU_ITEMS,
+      requiresAuth: true,
+    });
+  }
+
+  // Help — everyone
+  sections.push({
+    id: 'help',
+    label: 'Help',
+    icon: HelpCircle,
+    href: '/help',
+    items: HELP_ITEMS,
+  });
+
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// Bottom bar — 4 items, persona-adaptive
+// ---------------------------------------------------------------------------
+
+const BOTTOM_BAR_ANONYMOUS: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/match', label: 'Match', icon: Compass },
+  { href: '/help', label: 'Help', icon: HelpCircle },
+];
+
+const BOTTOM_BAR_CITIZEN_UNDELEGATED: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/match', label: 'Match', icon: Compass },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+];
+
+const BOTTOM_BAR_CITIZEN_DELEGATED: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/delegation', label: 'Delegation', icon: Handshake },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+];
+
+const BOTTOM_BAR_DREP: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase, badge: 'actions' },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+];
+
+const BOTTOM_BAR_SPO: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+];
+
+const BOTTOM_BAR_CC: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/delegation', label: 'Delegation', icon: Handshake },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+];
+
+export function getBottomBarItems(segment: UserSegment, hasDelegation: boolean): NavItem[] {
+  switch (segment) {
+    case 'anonymous':
+      return BOTTOM_BAR_ANONYMOUS;
+    case 'citizen':
+      return hasDelegation ? BOTTOM_BAR_CITIZEN_DELEGATED : BOTTOM_BAR_CITIZEN_UNDELEGATED;
+    case 'drep':
+      return BOTTOM_BAR_DREP;
+    case 'spo':
+      return BOTTOM_BAR_SPO;
+    case 'cc':
+      return BOTTOM_BAR_CC;
+    default:
+      return BOTTOM_BAR_ANONYMOUS;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pill bar — derive from current route's section
+// ---------------------------------------------------------------------------
+
+export function getPillBarItems(pathname: string, segment: UserSegment): NavItem[] | null {
+  if (pathname.startsWith('/governance')) {
+    return GOVERNANCE_ITEMS;
+  }
+  if (pathname.startsWith('/workspace')) {
+    if (segment === 'drep') return WORKSPACE_DREP_ITEMS;
+    if (segment === 'spo') return WORKSPACE_SPO_ITEMS;
+    // DRep+SPO: show DRep items (action queue is default)
+    return WORKSPACE_DREP_ITEMS;
+  }
+  if (pathname.startsWith('/you')) {
+    return YOU_ITEMS;
+  }
+  if (pathname.startsWith('/help')) {
+    return HELP_ITEMS;
+  }
+  // No pill bar for single-page sections (Home, Delegation, Match)
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Section detection from pathname
+// ---------------------------------------------------------------------------
+
+export function getCurrentSection(pathname: string): string | null {
+  if (pathname === '/') return 'home';
+  if (pathname.startsWith('/workspace')) return 'workspace';
+  if (pathname.startsWith('/governance')) return 'governance';
+  if (pathname.startsWith('/delegation')) return 'delegation';
+  if (pathname.startsWith('/you')) return 'you';
+  if (pathname.startsWith('/match')) return 'match';
+  if (pathname.startsWith('/help')) return 'help';
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,8 @@
 /**
  * Next.js Middleware
+ * - Query-param redirects for old /discover?tab= routes
+ * - Auth gate for protected routes (workspace, you, delegation)
  * - CORS for /api/v1/* routes
- * - Auth gate for /dashboard (redirect to / if no session cookie)
  * Auth and rate limiting for API routes are handled in lib/api/handler.ts.
  */
 
@@ -16,12 +17,39 @@ const CORS_HEADERS = {
   'Access-Control-Max-Age': '86400',
 };
 
-const AUTH_REQUIRED_PATHS = ['/my-gov'];
+/** Old /discover?tab= → new /governance/* routes */
+const DISCOVER_TAB_MAP: Record<string, string> = {
+  dreps: '/governance/representatives',
+  spos: '/governance/pools',
+  proposals: '/governance/proposals',
+  committee: '/governance/committee',
+  rankings: '/governance/representatives?view=rankings',
+};
+
+const AUTH_REQUIRED_PATHS = ['/workspace', '/you', '/delegation'];
 
 export function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, searchParams } = request.nextUrl;
 
-  // Auth gate: redirect to home if no session cookie
+  // ── Query-param redirects ─────────────────────────────────────────
+  // /discover?tab=dreps → /governance/representatives etc.
+  if (pathname === '/discover') {
+    const tab = searchParams.get('tab');
+    if (tab && DISCOVER_TAB_MAP[tab]) {
+      return NextResponse.redirect(new URL(DISCOVER_TAB_MAP[tab], request.url), 301);
+    }
+    // No tab param → handled by next.config.ts redirect to /governance
+  }
+
+  // /pulse?tab=history → /governance/health (history merged into health page)
+  if (pathname === '/pulse') {
+    const tab = searchParams.get('tab');
+    if (tab === 'history') {
+      return NextResponse.redirect(new URL('/governance/health', request.url), 301);
+    }
+  }
+
+  // ── Auth gate ─────────────────────────────────────────────────────
   if (AUTH_REQUIRED_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
     const session = request.cookies.get('drepscore_session');
     const isPrefetch =
@@ -36,16 +64,15 @@ export function middleware(request: NextRequest) {
     }
   }
 
+  // ── CORS for public API ───────────────────────────────────────────
   if (!pathname.startsWith('/api/v1')) {
     return NextResponse.next();
   }
 
-  // Handle CORS preflight
   if (request.method === 'OPTIONS') {
     return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
   }
 
-  // Add CORS headers to the response
   const response = NextResponse.next();
   for (const [key, value] of Object.entries(CORS_HEADERS)) {
     response.headers.set(key, value);
@@ -55,5 +82,12 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/api/v1/:path*', '/my-gov/:path*'],
+  matcher: [
+    '/api/v1/:path*',
+    '/discover',
+    '/pulse',
+    '/workspace/:path*',
+    '/you/:path*',
+    '/delegation/:path*',
+  ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -48,23 +48,38 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
-      // Legacy route redirects (Phase A Task 1.5 — civica cutover)
-      { source: '/governance/calendar', destination: '/pulse', permanent: true },
-      { source: '/governance', destination: '/my-gov', permanent: true },
-      { source: '/dashboard', destination: '/my-gov', permanent: true },
-      { source: '/dashboard/spo', destination: '/my-gov', permanent: true },
-      { source: '/dashboard/inbox', destination: '/my-gov/inbox', permanent: true },
-      { source: '/profile', destination: '/my-gov/profile', permanent: true },
-      // /methodology now has its own page — no redirect needed
-      { source: '/treasury', destination: '/pulse', permanent: true },
-      { source: '/decentralization', destination: '/pulse', permanent: true },
+      // ── Navigation architecture v2 ────────────────────────────────────
+      // Old sections → new sections
+      { source: '/discover', destination: '/governance', permanent: true },
+      { source: '/pulse', destination: '/governance/health', permanent: true },
+      { source: '/pulse/history', destination: '/governance/health', permanent: true },
+      {
+        source: '/pulse/report/:epoch',
+        destination: '/governance/health/epoch/:epoch',
+        permanent: true,
+      },
+      { source: '/my-gov', destination: '/', permanent: true },
+      { source: '/my-gov/identity', destination: '/you/identity', permanent: true },
+      { source: '/my-gov/inbox', destination: '/you/inbox', permanent: true },
+      { source: '/my-gov/profile', destination: '/you/settings', permanent: true },
+      { source: '/engage', destination: '/', permanent: true },
+      { source: '/learn', destination: '/help', permanent: true },
+      { source: '/methodology', destination: '/help/methodology', permanent: true },
+
+      // Legacy routes (pre-civica)
+      { source: '/governance/calendar', destination: '/governance/health', permanent: true },
+      { source: '/dashboard', destination: '/', permanent: true },
+      { source: '/dashboard/spo', destination: '/', permanent: true },
+      { source: '/dashboard/inbox', destination: '/you/inbox', permanent: true },
+      { source: '/profile', destination: '/you/settings', permanent: true },
+      { source: '/treasury', destination: '/governance/treasury', permanent: true },
+      { source: '/decentralization', destination: '/governance/health', permanent: true },
       {
         source: '/proposals/:txHash/:index',
         destination: '/proposal/:txHash/:index',
         permanent: true,
       },
-      { source: '/proposals', destination: '/discover', permanent: true },
-      { source: '/committee', destination: '/discover/committee', permanent: true },
+      { source: '/proposals', destination: '/governance/proposals', permanent: true },
     ];
   },
   images: {


### PR DESCRIPTION
## Summary
- Scaffold new JTBD-driven route sections: `/governance`, `/workspace`, `/you`, `/delegation`, `/help` with placeholder pages and section layouts
- Add 301 redirects for all legacy routes (`/discover`, `/pulse`, `/my-gov`, `/engage`, `/learn`) in both `next.config.ts` and `middleware.ts` (query-param based)
- Create data-driven nav config (`lib/nav/config.ts`) as single source of truth for sidebar, bottom bar, and pill bar across all 6 personas
- Build collapsible desktop sidebar, mobile section pill bar, and persona-adaptive bottom bar (4 items per persona)
- Strip inline nav links from header, add notification bell

## Impact
- **What changed**: Full navigation infrastructure — new routes, new nav components, redirect rules, persona-adaptive config
- **User-facing**: Yes — desktop users get collapsible sidebar, mobile users get persona-adaptive bottom bar (4 items instead of 5), old URLs redirect correctly
- **Risk**: Medium — navigation is high-visibility but all old routes have 301 redirects. Pages are placeholder-only (Phase 3-4 will migrate content)
- **Scope**: 38 files (5 modified, 33 new). No migrations, no API changes, no scoring changes.

## Test plan
- [ ] Verify all old routes redirect: `/discover` → `/governance`, `/pulse` → `/governance/health`, `/my-gov` → `/`, `/engage` → `/`, `/learn` → `/help`
- [ ] Verify query-param redirects: `/discover?tab=dreps` → `/governance/representatives`, `/pulse?tab=history` → `/governance/health`
- [ ] Test sidebar collapse/expand on desktop, verify state persists across page loads
- [ ] Test bottom bar shows correct 4 items per persona using View As switcher
- [ ] Verify pill bar renders on mobile for governance/workspace/you/help sections
- [ ] Verify auth gate works on `/workspace`, `/you`, `/delegation` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)