### PR TITLE
feat: Phase 1b — governance section completion

### DIFF
--- a/app/governance/GovernanceRedirect.tsx
+++ b/app/governance/GovernanceRedirect.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * Persona-aware redirect for /governance.
+ *
+ * Routes users to the most relevant governance sub-page based on their role:
+ * - Anonymous            -> /governance/proposals  (universal entry point)
+ * - Citizen (undelegated)-> /governance/representatives (help them find a DRep)
+ * - Citizen (delegated)  -> /governance/proposals  (track what matters)
+ * - DRep                 -> /governance/proposals  (their core workflow)
+ * - SPO                  -> /governance/pools       (their peer view)
+ * - CC                   -> /governance/proposals  (committee context)
+ */
+export function GovernanceRedirect() {
+  const router = useRouter();
+  const { segment, delegatedDrep, isLoading } = useSegment();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    let destination = '/governance/proposals';
+
+    if (segment === 'citizen' && !delegatedDrep) {
+      destination = '/governance/representatives';
+    } else if (segment === 'spo') {
+      destination = '/governance/pools';
+    }
+    // anonymous, drep, cc, and delegated citizen all go to /governance/proposals
+
+    router.replace(destination);
+  }, [segment, delegatedDrep, isLoading, router]);
+
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6">
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/governance/page.tsx
+++ b/app/governance/page.tsx
@@ -1,12 +1,19 @@
 export const dynamic = 'force-dynamic';
 
-import { redirect } from 'next/navigation';
+import { GovernanceRedirect } from './GovernanceRedirect';
 
 /**
- * /governance — redirects to persona-default sub-page.
- * For now, defaults to /governance/proposals (the most universal entry point).
- * TODO: make persona-aware (citizens → representatives if undelegated).
+ * /governance — persona-aware redirect to the most relevant sub-page.
+ *
+ * | Persona               | Destination                   |
+ * | --------------------- | ----------------------------- |
+ * | Anonymous             | /governance/proposals          |
+ * | Citizen (undelegated) | /governance/representatives    |
+ * | Citizen (delegated)   | /governance/proposals          |
+ * | DRep                  | /governance/proposals          |
+ * | SPO                   | /governance/pools              |
+ * | CC                    | /governance/proposals          |
  */
 export default function GovernancePage() {
-  redirect('/governance/proposals');
+  return <GovernanceRedirect />;
 }

--- a/app/governance/treasury/TreasuryOverview.tsx
+++ b/app/governance/treasury/TreasuryOverview.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { CivicaTreasury } from '@/components/civica/pulse/CivicaTreasury';
+import { TreasuryPendingProposals } from '@/components/TreasuryPendingProposals';
+import { TreasuryAccountabilitySection } from '@/components/TreasuryAccountabilitySection';
+import { TreasurySimulator } from '@/components/TreasurySimulator';
+import { useTreasuryCurrent } from '@/hooks/queries';
+
+/**
+ * Client-side treasury overview that composes existing treasury components
+ * into a cohesive spending transparency page.
+ *
+ * Data is fetched via TanStack Query hooks inside each child component.
+ * We also fetch treasury current here to pass required (but unused) props
+ * to components that have them in their interface.
+ */
+export function TreasuryOverview() {
+  const { data: rawCurrent } = useTreasuryCurrent();
+  const treasury = rawCurrent as
+    | {
+        balance?: number;
+        balanceAda?: number;
+        runwayMonths?: number;
+        burnRatePerEpoch?: number;
+        currentEpoch?: number;
+        [key: string]: unknown;
+      }
+    | undefined;
+
+  const balance = treasury?.balance ?? treasury?.balanceAda ?? 0;
+  const burnRate = treasury?.burnRatePerEpoch ?? 0;
+  const runway = treasury?.runwayMonths ?? 0;
+  const epoch = treasury?.currentEpoch ?? 0;
+
+  return (
+    <div className="space-y-8">
+      {/* Balance, sparkline, runway, and quick pending list */}
+      <section>
+        <CivicaTreasury />
+      </section>
+
+      {/* Detailed pending treasury proposals */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Pending Proposals</h2>
+        <TreasuryPendingProposals treasuryBalanceAda={balance} runwayMonths={runway} />
+      </section>
+
+      {/* Spending effectiveness and accountability ratings */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Spending Accountability</h2>
+        <TreasuryAccountabilitySection />
+      </section>
+
+      {/* Runway scenario projections */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Runway Projections</h2>
+        <TreasurySimulator currentBalance={balance} burnRate={burnRate} currentEpoch={epoch} />
+      </section>
+    </div>
+  );
+}

--- a/app/governance/treasury/page.tsx
+++ b/app/governance/treasury/page.tsx
@@ -1,23 +1,68 @@
 export const dynamic = 'force-dynamic';
 
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
+import { PageViewTracker } from '@/components/PageViewTracker';
+import { TreasuryOverview } from './TreasuryOverview';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export const metadata: Metadata = {
   title: 'Governada — Treasury',
-  description: 'Cardano treasury activity, spending transparency, and funding proposals.',
+  description:
+    'Cardano treasury balance, spending transparency, pending proposals, and runway projections.',
+  openGraph: {
+    title: 'Governada — Treasury',
+    description:
+      'Track Cardano treasury health — balance trends, pending withdrawals, spending effectiveness, and runway scenarios.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Governada — Treasury',
+    description: 'Cardano treasury spending transparency and health.',
+  },
 };
 
-/**
- * /governance/treasury — placeholder.
- * New page: treasury activity and spending transparency.
- */
+function TreasuryFallback() {
+  return (
+    <div className="space-y-6">
+      {/* Balance card skeleton */}
+      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-10 w-36" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+      {/* Stats row skeleton */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-8 w-20" />
+        </div>
+        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-8 w-12" />
+        </div>
+      </div>
+      {/* Pending proposals skeleton */}
+      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <Skeleton className="h-4 w-40" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function TreasuryPage() {
   return (
-    <div className="container mx-auto px-4 sm:px-6 py-6">
-      <h1 className="text-2xl font-bold mb-4">Treasury</h1>
-      <p className="text-muted-foreground">
-        Treasury activity and spending transparency will appear here.
-      </p>
-    </div>
+    <>
+      <PageViewTracker event="governance_treasury_viewed" />
+      <div className="container mx-auto px-4 sm:px-6 py-6">
+        <Suspense fallback={<TreasuryFallback />}>
+          <TreasuryOverview />
+        </Suspense>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- **Treasury page**: Replaced placeholder with full spending transparency page composed from existing components — `CivicaTreasury` (balance sparkline, runway, quick stats), `TreasuryPendingProposals` (detailed pending list with tier badges), `TreasuryAccountabilitySection` (effectiveness rate, donut chart, top/bottom rated), and `TreasurySimulator` (scenario projections with interactive controls). All data via existing TanStack Query hooks, no new API routes.
- **Persona-aware governance redirect**: `/governance` now routes users based on their segment — undelegated citizens to `/governance/representatives` (help find a DRep), SPOs to `/governance/pools` (peer view), all others to `/governance/proposals`. Uses `useSegment()` with `useRouter().replace()` and a skeleton loading state.

## Files changed
- `app/governance/page.tsx` — Server component renders client redirect
- `app/governance/GovernanceRedirect.tsx` — Client component with persona routing logic
- `app/governance/treasury/page.tsx` — Server page with metadata, Suspense boundary, skeleton fallback
- `app/governance/treasury/TreasuryOverview.tsx` — Client component composing 4 existing treasury components

## Test plan
- [ ] Visit `/governance` as anonymous user — should redirect to `/governance/proposals`
- [ ] Connect wallet as undelegated citizen — `/governance` redirects to `/governance/representatives`
- [ ] Connect wallet as delegated citizen — `/governance` redirects to `/governance/proposals`
- [ ] Connect wallet as SPO — `/governance` redirects to `/governance/pools`
- [ ] Visit `/governance/treasury` — see balance sparkline, runway stats, pending proposals, accountability section, and scenario projections
- [ ] Verify skeleton loading states appear before data loads on treasury page
- [ ] Verify other governance sub-pages are unchanged
- [ ] Preflight passes: format, lint, types, 590 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)