### PR TITLE
feat: Phase 1a — breadcrumb navigation for entity profiles

### DIFF
--- a/app/committee/[ccHotId]/page.tsx
+++ b/app/committee/[ccHotId]/page.tsx
@@ -5,11 +5,9 @@ import { createClient } from '@/lib/supabase';
 import { getCCTransparencyHistory, getCCMembersTransparency } from '@/lib/data';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { CCTransparencyTrend } from '@/components/cc/CCTransparencyTrend';
 import {
-  ArrowLeft,
   Scale,
   BookOpen,
   Sparkles,
@@ -19,6 +17,7 @@ import {
   Vote,
   MessageCircle,
 } from 'lucide-react';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
 
 export const dynamic = 'force-dynamic';
 
@@ -197,12 +196,13 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     <div className="container mx-auto px-4 py-8 space-y-6">
       <PageViewTracker event="cc_member_profile_viewed" properties={{ cc_hot_id: decodedId }} />
 
-      <Link href="/discover/committee">
-        <Button variant="ghost" className="gap-2 -ml-2">
-          <ArrowLeft className="h-4 w-4" />
-          All Committee Members
-        </Button>
-      </Link>
+      <Breadcrumb
+        items={[
+          { label: 'Governance', href: '/' },
+          { label: 'Committee', href: '/discover/committee' },
+          { label: authorName ?? `CC ${decodedId.slice(0, 12)}\u2026` },
+        ]}
+      />
 
       {/* Hero */}
       <div className="space-y-4">

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -6,7 +6,6 @@
 
 import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
-import Link from 'next/link';
 import nextDynamic from 'next/dynamic';
 import type { Metadata } from 'next';
 
@@ -34,9 +33,9 @@ const ScoreSimulator = nextDynamic(
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
 );
 import { ScoreCard } from '@/components/ScoreCard';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { ArrowLeft, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { ShieldCheck, ShieldAlert } from 'lucide-react';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DetailPageSkeleton } from '@/components/LoadingSkeleton';
 import { DRepDashboardWrapper } from '@/components/DRepDashboardWrapper';
@@ -499,12 +498,13 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         shareUrl={`https://governada.io/drep/${encodeURIComponent(drep.drepId)}`}
       />
 
-      <Link href="/">
-        <Button variant="ghost" className="gap-2 -ml-2">
-          <ArrowLeft className="h-4 w-4" />
-          Back to DReps
-        </Button>
-      </Link>
+      <Breadcrumb
+        items={[
+          { label: 'Governance', href: '/' },
+          { label: 'Representatives', href: '/' },
+          { label: drepName },
+        ]}
+      />
 
       {/* ════════════════════════════════════════════
           VP1 — "The Story" (above fold)

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 import { createClient } from '@/lib/supabase';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { PoolProfileClient } from '@/components/PoolProfileClient';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
-import { ArrowLeft, BarChart3, MessageSquare, ExternalLink } from 'lucide-react';
+import { BarChart3, MessageSquare, ExternalLink } from 'lucide-react';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import nextDynamic from 'next/dynamic';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
@@ -298,12 +298,13 @@ export default async function PoolProfilePage({ params }: PageProps) {
       <div className="container mx-auto px-4 py-8 space-y-8">
         <PageViewTracker event="pool_profile_viewed" properties={{ pool_id: poolId }} />
 
-        <Link href="/discover">
-          <Button variant="ghost" className="gap-2 -ml-2">
-            <ArrowLeft className="h-4 w-4" />
-            Back to Discover
-          </Button>
-        </Link>
+        <Breadcrumb
+          items={[
+            { label: 'Governance', href: '/' },
+            { label: 'Pools', href: '/discover' },
+            { label: poolId.slice(0, 16) + '\u2026' },
+          ]}
+        />
 
         <div className="space-y-2">
           <h1 className="text-2xl font-bold tracking-tight">SPO Governance Profile</h1>
@@ -786,12 +787,13 @@ export default async function PoolProfilePage({ params }: PageProps) {
           shareUrl={`https://governada.io/pool/${encodeURIComponent(poolId)}`}
         />
 
-        <Link href="/discover">
-          <Button variant="ghost" className="gap-2 -ml-2">
-            <ArrowLeft className="h-4 w-4" />
-            Back to Discover
-          </Button>
-        </Link>
+        <Breadcrumb
+          items={[
+            { label: 'Governance', href: '/' },
+            { label: 'Pools', href: '/discover' },
+            { label: ticker ? `${displayName} [${ticker}]` : displayName },
+          ]}
+        />
 
         {/* VP1: The Story */}
         <SpoProfileHero

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -1,15 +1,13 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
 import { getProposalByKey, getVotesByProposal } from '@/lib/data';
 import { blockTimeToEpoch } from '@/lib/koios';
 import { getTreasuryBalance } from '@/lib/treasury';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProposalDescription } from '@/components/ProposalDescription';
 import { ProposalAiSummary } from '@/components/ProposalAiSummary';
 import { ThresholdMeter } from '@/components/ThresholdMeter';
-import { ArrowLeft } from 'lucide-react';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { getProposalStatus } from '@/utils/proposalPriority';
 import { ProposalOutcomeSection } from '@/components/ProposalOutcomeSection';
 import { ProposalVoterTabs } from '@/components/ProposalVoterTabs';
@@ -106,12 +104,13 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         properties={{ tx_hash: txHash, index: proposalIndex }}
       />
 
-      <Link href="/discover">
-        <Button variant="ghost" className="gap-2 -ml-2">
-          <ArrowLeft className="h-4 w-4" />
-          All Proposals
-        </Button>
-      </Link>
+      <Breadcrumb
+        items={[
+          { label: 'Governance', href: '/' },
+          { label: 'Proposals', href: '/discover' },
+          { label: title },
+        ]}
+      />
 
       {/* 1. Hero */}
       <ProposalHeroV1

--- a/components/shared/Breadcrumb.tsx
+++ b/components/shared/Breadcrumb.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import { ChevronRight } from 'lucide-react';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+function truncateLabel(label: string, maxLength = 40): string {
+  if (label.length <= maxLength) return label;
+  return label.slice(0, maxLength - 1).trimEnd() + '\u2026';
+}
+
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="-ml-2">
+      <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li key={index} className="flex items-center gap-1">
+              {index > 0 && (
+                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+              )}
+              {item.href && !isLast ? (
+                <Link
+                  href={item.href}
+                  className="hover:text-foreground transition-colors whitespace-nowrap"
+                >
+                  {truncateLabel(item.label)}
+                </Link>
+              ) : (
+                <span
+                  className={
+                    isLast
+                      ? 'text-foreground font-medium truncate max-w-[280px]'
+                      : 'whitespace-nowrap'
+                  }
+                  title={item.label.length > 40 ? item.label : undefined}
+                >
+                  {truncateLabel(item.label)}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- Add reusable `Breadcrumb` component (`components/shared/Breadcrumb.tsx`) with accessible markup (`nav`/`ol`), chevron separators, and automatic label truncation at 40 chars
- Replace "Back to X" ghost buttons with structured breadcrumb trails on all 4 entity profile pages:
  - **DRep**: Governance > Representatives > [DRep Name]
  - **Pool**: Governance > Pools > [Pool Name/Ticker]
  - **Committee**: Governance > Committee > [CC Member Name]
  - **Proposal**: Governance > Proposals > [Proposal Title]
- Clean up unused imports (`Button`, `ArrowLeft`, `Link`) from modified pages

## Test plan
- [ ] Visit a DRep profile — breadcrumb shows "Governance > Representatives > [name]", clicking "Governance" or "Representatives" navigates to `/`
- [ ] Visit a Pool profile (scored and unscored) — breadcrumb shows "Governance > Pools > [name/ticker]", links go to `/discover`
- [ ] Visit a CC member profile — breadcrumb shows "Governance > Committee > [name]", "Committee" links to `/discover/committee`
- [ ] Visit a Proposal detail page — breadcrumb shows "Governance > Proposals > [title]", truncated if >40 chars with title tooltip
- [ ] Verify no "Back to" buttons remain on any entity page
- [ ] Screen reader: `nav` has `aria-label="Breadcrumb"`, items are in `ol > li`
- [ ] `npm run preflight` passes (format, lint, types, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)