### PR TITLE
feat: add DRep+SPO dual-role workspace grouping in sidebar

### DIFF
--- a/app/api/user/detect-segment/route.ts
+++ b/app/api/user/detect-segment/route.ts
@@ -36,9 +36,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   }
 
   // Enrich with tier data for header personalization
+  // For dual-role (DRep+SPO), use DRep tier since DRep is the primary segment
   let tier: string | null = null;
 
-  if (result.segment === 'drep' && result.drepId) {
+  if (result.drepId) {
     const { data: drep } = await supabase
       .from('dreps')
       .select('score')
@@ -47,7 +48,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     if (drep?.score != null) {
       tier = computeTier(drep.score);
     }
-  } else if (result.segment === 'spo' && result.poolId) {
+  } else if (result.poolId) {
     const { data: pool } = await supabase
       .from('pools')
       .select('governance_score')

--- a/components/civica/CivicaSidebar.tsx
+++ b/components/civica/CivicaSidebar.tsx
@@ -5,7 +5,12 @@ import { usePathname } from 'next/navigation';
 import { PanelLeftClose, PanelLeft } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { getSidebarSections, type NavSection, type NavItem } from '@/lib/nav/config';
+import {
+  getSidebarSections,
+  type NavSection,
+  type NavItem,
+  type NavItemGroup,
+} from '@/lib/nav/config';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 import { Button } from '@/components/ui/button';
 
@@ -16,10 +21,10 @@ interface CivicaSidebarProps {
 
 export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
   const pathname = usePathname();
-  const { segment, stakeAddress } = useSegment();
+  const { segment, stakeAddress, drepId, poolId } = useSegment();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
 
-  const sections = getSidebarSections(segment);
+  const sections = getSidebarSections({ segment, drepId, poolId });
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
@@ -37,6 +42,77 @@ export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
     return 0;
   };
 
+  /** Render a single nav item link */
+  const renderItem = (item: NavItem) => {
+    const active = isActive(item.href);
+    const badge = getBadgeCount(item);
+    return (
+      <Link
+        key={item.href}
+        href={item.href}
+        className={cn(
+          'group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+          active ? 'bg-accent text-foreground' : 'text-muted-foreground',
+          collapsed && 'justify-center px-0',
+        )}
+        aria-current={active ? 'page' : undefined}
+        title={collapsed ? item.label : undefined}
+      >
+        {active && (
+          <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-primary" />
+        )}
+        <span className="relative inline-flex shrink-0">
+          <item.icon className="h-4 w-4" />
+          {badge > 0 && (
+            <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
+              {badge > 9 ? '9+' : badge}
+            </span>
+          )}
+        </span>
+        {!collapsed && <span className="truncate">{item.label}</span>}
+      </Link>
+    );
+  };
+
+  /** Render items for a section — flat list or role-grouped */
+  const renderSectionItems = (section: NavSection) => {
+    // Dual-role grouped workspace
+    if (section.groups) {
+      return (
+        <div className="space-y-0.5">
+          {section.groups.map((group: NavItemGroup, groupIdx: number) => (
+            <div key={group.id}>
+              {/* Role sub-header — subtle, small text */}
+              {!collapsed && (
+                <div
+                  className={cn(
+                    'px-3 py-1 text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50',
+                    groupIdx > 0 && 'mt-2',
+                  )}
+                >
+                  {group.label}
+                </div>
+              )}
+              {collapsed && groupIdx > 0 && (
+                <div className="mx-3 my-1.5 border-t border-border/30" />
+              )}
+              {group.items.map(renderItem)}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    // Standard flat items
+    if (section.items) {
+      return <div className="space-y-0.5">{section.items.map(renderItem)}</div>;
+    }
+
+    return null;
+  };
+
   return (
     <aside
       className={cn(
@@ -48,7 +124,7 @@ export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
         {sections.map((section, sectionIdx) => (
           <div key={section.id} className={cn(sectionIdx > 0 && 'mt-4')}>
             {/* Section header / single link */}
-            {section.items ? (
+            {section.items || section.groups ? (
               <>
                 {/* Section label (not clickable) */}
                 {!collapsed && (
@@ -61,41 +137,8 @@ export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
                     <section.icon className="h-4 w-4 text-muted-foreground/40" />
                   </div>
                 )}
-                {/* Sub-items */}
-                <div className="space-y-0.5">
-                  {section.items.map((item) => {
-                    const active = isActive(item.href);
-                    const badge = getBadgeCount(item);
-                    return (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        className={cn(
-                          'group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                          'hover:bg-accent hover:text-accent-foreground',
-                          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                          active ? 'bg-accent text-foreground' : 'text-muted-foreground',
-                          collapsed && 'justify-center px-0',
-                        )}
-                        aria-current={active ? 'page' : undefined}
-                        title={collapsed ? item.label : undefined}
-                      >
-                        {active && (
-                          <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-full bg-primary" />
-                        )}
-                        <span className="relative inline-flex shrink-0">
-                          <item.icon className="h-4 w-4" />
-                          {badge > 0 && (
-                            <span className="absolute -top-1 -right-1 h-3.5 w-3.5 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
-                              {badge > 9 ? '9+' : badge}
-                            </span>
-                          )}
-                        </span>
-                        {!collapsed && <span className="truncate">{item.label}</span>}
-                      </Link>
-                    );
-                  })}
-                </div>
+                {/* Sub-items (flat or grouped) */}
+                {renderSectionItems(section)}
               </>
             ) : (
               /* Single link section (Home, Delegation) */

--- a/components/civica/SectionPillBar.tsx
+++ b/components/civica/SectionPillBar.tsx
@@ -16,8 +16,8 @@ interface SectionPillBarProps {
  */
 export function SectionPillBar({ section: _section }: SectionPillBarProps) {
   const pathname = usePathname();
-  const { segment } = useSegment();
-  const items = getPillBarItems(pathname, segment);
+  const { segment, drepId, poolId } = useSegment();
+  const items = getPillBarItems(pathname, segment, { drepId, poolId });
 
   if (!items || items.length < 2) return null;
 

--- a/lib/admin/viewAsRegistry.ts
+++ b/lib/admin/viewAsRegistry.ts
@@ -109,6 +109,18 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     pickerDescription: 'View the app as this pool operator.',
   },
 
+  // -- DRep + SPO (dual role) --
+  {
+    id: 'drep-spo-dual',
+    label: 'DRep + SPO (dual role)',
+    description: 'User is both a DRep and an SPO — shows combined workspace',
+    segment: 'drep',
+    overrides: {
+      drepId: 'drep1_placeholder_dual',
+      poolId: 'pool1_placeholder_dual',
+    },
+  },
+
   // -- CC Member --
   {
     id: 'cc-unclaimed',

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -54,6 +54,13 @@ export interface NavItem {
   requiresAuth?: boolean;
 }
 
+/** A labelled group of items within a section (for dual-role workspace) */
+export interface NavItemGroup {
+  id: string;
+  label: string;
+  items: NavItem[];
+}
+
 export interface NavSection {
   id: string;
   label: string;
@@ -61,6 +68,8 @@ export interface NavSection {
   href: string;
   /** Sub-pages within this section (shown in sidebar + pill bar) */
   items?: NavItem[];
+  /** Role-grouped items (used for dual-role workspace sections) */
+  groups?: NavItemGroup[];
   /** Only show for these segments (undefined = all) */
   segments?: UserSegment[];
   /** Only show for authenticated users */
@@ -117,7 +126,38 @@ export const HELP_ITEMS: NavItem[] = [
 // Sidebar sections — ordered top to bottom
 // ---------------------------------------------------------------------------
 
-export function getSidebarSections(segment: UserSegment): NavSection[] {
+/** Context for sidebar generation — supports dual-role detection */
+export interface SidebarContext {
+  segment: UserSegment;
+  /** Non-null when user is a registered DRep */
+  drepId?: string | null;
+  /** Non-null when user operates a stake pool */
+  poolId?: string | null;
+}
+
+/**
+ * Build deduplicated dual-role workspace groups.
+ * Items that appear in both lists (matched by href) are shown only in the
+ * DRep group to avoid visual clutter.
+ */
+function buildDualRoleGroups(): NavItemGroup[] {
+  const drepHrefs = new Set(WORKSPACE_DREP_ITEMS.map((i) => i.href));
+  const dedupedSpoItems = WORKSPACE_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href));
+
+  return [
+    { id: 'workspace-drep', label: 'DRep', items: WORKSPACE_DREP_ITEMS },
+    { id: 'workspace-pool', label: 'Pool', items: dedupedSpoItems },
+  ];
+}
+
+export function getSidebarSections(segmentOrContext: UserSegment | SidebarContext): NavSection[] {
+  // Support both the legacy single-segment call and the new context call
+  const ctx: SidebarContext =
+    typeof segmentOrContext === 'string' ? { segment: segmentOrContext } : segmentOrContext;
+  const { segment, drepId, poolId } = ctx;
+
+  const isDualRole = !!(drepId && poolId);
+
   const sections: NavSection[] = [
     {
       id: 'home',
@@ -127,8 +167,17 @@ export function getSidebarSections(segment: UserSegment): NavSection[] {
     },
   ];
 
-  // Workspace — DRep/SPO only
-  if (segment === 'drep' || segment === 'spo') {
+  // Workspace — DRep/SPO only (with dual-role grouping)
+  if (isDualRole) {
+    sections.push({
+      id: 'workspace',
+      label: 'Workspace',
+      icon: Briefcase,
+      href: '/workspace',
+      groups: buildDualRoleGroups(),
+      segments: ['drep', 'spo'],
+    });
+  } else if (segment === 'drep' || segment === 'spo') {
     const workspaceItems = segment === 'drep' ? WORKSPACE_DREP_ITEMS : WORKSPACE_SPO_ITEMS;
     sections.push({
       id: 'workspace',
@@ -251,14 +300,26 @@ export function getBottomBarItems(segment: UserSegment, hasDelegation: boolean):
 // Pill bar — derive from current route's section
 // ---------------------------------------------------------------------------
 
-export function getPillBarItems(pathname: string, segment: UserSegment): NavItem[] | null {
+export function getPillBarItems(
+  pathname: string,
+  segment: UserSegment,
+  context?: { drepId?: string | null; poolId?: string | null },
+): NavItem[] | null {
   if (pathname.startsWith('/governance')) {
     return GOVERNANCE_ITEMS;
   }
   if (pathname.startsWith('/workspace')) {
+    const isDualRole = !!(context?.drepId && context?.poolId);
+    if (isDualRole) {
+      // For dual-role users, combine both item sets (deduped) for pill bar
+      const drepHrefs = new Set(WORKSPACE_DREP_ITEMS.map((i) => i.href));
+      return [
+        ...WORKSPACE_DREP_ITEMS,
+        ...WORKSPACE_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href)),
+      ];
+    }
     if (segment === 'drep') return WORKSPACE_DREP_ITEMS;
     if (segment === 'spo') return WORKSPACE_SPO_ITEMS;
-    // DRep+SPO: show DRep items (action queue is default)
     return WORKSPACE_DREP_ITEMS;
   }
   if (pathname.startsWith('/you')) {

--- a/lib/walletDetection.ts
+++ b/lib/walletDetection.ts
@@ -34,6 +34,10 @@ interface KoiosPoolInfo {
 /**
  * Detect user segment from their wallet's stake address.
  * Checks: is SPO (pool operator), is DRep (registered), or citizen.
+ *
+ * When a user is both an SPO and a DRep, the primary segment is 'drep'
+ * (DRep action queue is the default workspace landing) but both poolId
+ * and drepId are populated so the UI can show both workspace groups.
  */
 export async function detectUserSegment(stakeAddress: string): Promise<SegmentDetectionResult> {
   const result: SegmentDetectionResult = {
@@ -66,16 +70,23 @@ export async function detectUserSegment(stakeAddress: string): Promise<SegmentDe
     result.delegatedPool = account.delegated_pool ?? null;
     result.delegatedDrep = account.delegated_drep ?? null;
 
+    // Check both roles — a user can be both an SPO and a DRep
     const poolId = await detectPoolOwnership(stakeAddress);
     if (poolId) {
-      result.segment = 'spo';
       result.poolId = poolId;
-      return result;
     }
 
-    if (account.delegated_drep && account.delegated_drep === stakeAddress) {
+    const isDrep = !!(account.delegated_drep && account.delegated_drep === stakeAddress);
+    if (isDrep) {
+      result.drepId = account.delegated_drep!;
+    }
+
+    // Determine primary segment. DRep takes priority for dual-role users
+    // because the DRep action queue is the default workspace landing.
+    if (isDrep) {
       result.segment = 'drep';
-      result.drepId = account.delegated_drep;
+    } else if (poolId) {
+      result.segment = 'spo';
     }
 
     return result;


### PR DESCRIPTION
## Summary
- When a user is both a DRep and an SPO, the sidebar workspace section now shows both sets of items under subtle role headers ("DRep" / "Pool")
- Shared items (e.g., Delegators) are deduplicated — shown only in the DRep group
- Wallet detection now checks both SPO and DRep roles instead of returning early on SPO match

## Impact
- **What changed**: Dual-role users (DRep+SPO) now see a combined workspace in the sidebar with role sub-headers. Detection no longer misses the DRep role when SPO is detected first.
- **User-facing**: Yes — DRep+SPO users will see both workspace item sets grouped by role. Single-role users are unaffected.
- **Risk**: Low — backwards-compatible changes. getSidebarSections still accepts a plain segment string. Existing single-role behavior is preserved by the isDualRole guard.
- **Scope**: 6 files: walletDetection.ts (detection fix), detect-segment/route.ts (tier enrichment), nav/config.ts (groups type + logic), CivicaSidebar.tsx (group rendering), SectionPillBar.tsx (pill bar context), viewAsRegistry.ts (admin preset)

## Changes
1. **`lib/walletDetection.ts`** — Detection no longer returns early when SPO is found; continues checking DRep. DRep is the primary segment for dual-role (action queue default).
2. **`lib/nav/config.ts`** — New `NavItemGroup` type, `groups` property on `NavSection`, `SidebarContext` interface. `getSidebarSections()` accepts either a segment string or context object. Deduplication of shared items between DRep and SPO lists.
3. **`components/civica/CivicaSidebar.tsx`** — Passes full context to getSidebarSections. Renders role sub-headers (9px uppercase muted text) when groups are present. Collapsed mode shows a thin divider between groups.
4. **`components/civica/SectionPillBar.tsx`** — Passes drepId/poolId context to getPillBarItems for dual-role pill bar support.
5. **`app/api/user/detect-segment/route.ts`** — Tier enrichment uses drepId-first logic (not segment-gated) to support dual-role.
6. **`lib/admin/viewAsRegistry.ts`** — New "DRep + SPO (dual role)" preset for admin View As testing.

## Test plan
- [ ] Preflight passes (format, lint, types, tests) — verified locally
- [ ] CI passes
- [ ] Admin "View As" > DRep > "DRep + SPO (dual role)" shows combined workspace with DRep and Pool sub-headers
- [ ] Single-role DRep sidebar unchanged
- [ ] Single-role SPO sidebar unchanged
- [ ] Anonymous/Citizen sidebar unchanged (no workspace section)
- [ ] Collapsed sidebar shows divider between groups, no text headers
- [ ] Pill bar on /workspace shows combined deduped items for dual-role

🤖 Generated with [Claude Code](https://claude.com/claude-code)