### PR TITLE
feat: citizen-anonymous UX polish (audit fix)

### DIFF
--- a/app/api/embed/ghi/route.ts
+++ b/app/api/embed/ghi/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
       <path d="${sparkPath}" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <div style="color:#64748b;font-size:11px;margin-top:4px">Last 12 epochs</div>
-    <a href="https://governada.io/pulse" target="_blank" class="cta">View on Governada \u2197</a>
+    <a href="https://governada.io/governance/health" target="_blank" class="cta">View on Governada \u2197</a>
   </div>
 </body>
 </html>`;

--- a/app/api/og/governance-dna/route.tsx
+++ b/app/api/og/governance-dna/route.tsx
@@ -155,7 +155,7 @@ export async function GET(request: NextRequest) {
             Find your Governance DNA at governada.io
           </div>
 
-          <OGFooter left="$governada" right="governada.io/discover" />
+          <OGFooter left="$governada" right="governada.io/governance" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/governance-health/route.tsx
+++ b/app/api/og/governance-health/route.tsx
@@ -144,7 +144,7 @@ export async function GET() {
             </div>
           </div>
 
-          <OGFooter left="$governada" right="governada.io/pulse" />
+          <OGFooter left="$governada" right="governada.io/governance/health" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/leaderboard/route.tsx
+++ b/app/api/og/leaderboard/route.tsx
@@ -96,7 +96,7 @@ export async function GET() {
             })}
           </div>
 
-          <OGFooter left="$governada" right="governada.io/pulse#leaderboard" />
+          <OGFooter left="$governada" right="governada.io/governance/health#leaderboard" />
         </div>
       </OGBackground>,
       {

--- a/app/api/og/match/route.tsx
+++ b/app/api/og/match/route.tsx
@@ -1,0 +1,321 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { OGBackground, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+export const runtime = 'edge';
+
+interface ShareableProfile {
+  personality: string;
+  dimensions: AlignmentScores;
+  narrative: string;
+}
+
+const DIMENSION_ORDER: (keyof AlignmentScores)[] = [
+  'treasuryConservative',
+  'treasuryGrowth',
+  'decentralization',
+  'security',
+  'innovation',
+  'transparency',
+];
+
+const DIMENSION_LABELS: Record<keyof AlignmentScores, string> = {
+  treasuryConservative: 'Conservative',
+  treasuryGrowth: 'Growth',
+  decentralization: 'Decentral.',
+  security: 'Security',
+  innovation: 'Innovation',
+  transparency: 'Transparency',
+};
+
+const DIMENSION_COLORS: Record<keyof AlignmentScores, string> = {
+  treasuryConservative: '#dc2626',
+  treasuryGrowth: '#10b981',
+  decentralization: '#a855f7',
+  security: '#f59e0b',
+  innovation: '#06b6d4',
+  transparency: '#3b82f6',
+};
+
+function parseProfile(encoded: string | null): ShareableProfile | null {
+  if (!encoded) return null;
+  try {
+    const json = atob(encoded);
+    const data = JSON.parse(json);
+    if (!data.personality || !data.dimensions) return null;
+    return data as ShareableProfile;
+  } catch {
+    return null;
+  }
+}
+
+function getRadarPoints(dimensions: AlignmentScores, cx: number, cy: number, maxR: number): string {
+  return DIMENSION_ORDER.map((dim, i) => {
+    const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+    const score = (dimensions[dim] ?? 50) / 100;
+    const r = maxR * score;
+    return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+  }).join(' ');
+}
+
+function getGridPoints(cx: number, cy: number, maxR: number, scale: number): string {
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+    const r = maxR * scale;
+    return `${(cx + r * Math.cos(angle)).toFixed(1)},${(cy + r * Math.sin(angle)).toFixed(1)}`;
+  }).join(' ');
+}
+
+function getDominantColor(dimensions: AlignmentScores): string {
+  let bestDim: keyof AlignmentScores = 'transparency';
+  let bestDistance = -1;
+  for (const dim of DIMENSION_ORDER) {
+    const val = dimensions[dim] ?? 50;
+    const distance = Math.abs(val - 50);
+    if (distance > bestDistance) {
+      bestDistance = distance;
+      bestDim = dim;
+    }
+  }
+  return DIMENSION_COLORS[bestDim];
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const profile = parseProfile(request.nextUrl.searchParams.get('profile'));
+
+    if (!profile) {
+      return new ImageResponse(<OGFallback message="Find your governance match" />, {
+        width: 1200,
+        height: 630,
+      });
+    }
+
+    const accentColor = getDominantColor(profile.dimensions);
+    const cx = 200;
+    const cy = 200;
+    const maxR = 160;
+
+    return new ImageResponse(
+      <OGBackground glow={accentColor}>
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            padding: '48px 64px',
+          }}
+        >
+          {/* Left: Radar */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '420px',
+              marginRight: '48px',
+            }}
+          >
+            <svg width="400" height="400" viewBox="0 0 400 400">
+              {/* Grid rings */}
+              {[0.25, 0.5, 0.75, 1.0].map((scale) => (
+                <polygon
+                  key={scale}
+                  points={getGridPoints(cx, cy, maxR, scale)}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.08)"
+                  strokeWidth="1"
+                />
+              ))}
+              {/* Axis lines */}
+              {DIMENSION_ORDER.map((_, i) => {
+                const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                const ex = cx + maxR * Math.cos(angle);
+                const ey = cy + maxR * Math.sin(angle);
+                return (
+                  <line
+                    key={i}
+                    x1={cx}
+                    y1={cy}
+                    x2={ex}
+                    y2={ey}
+                    stroke="rgba(255,255,255,0.06)"
+                    strokeWidth="1"
+                  />
+                );
+              })}
+              {/* Data polygon glow */}
+              <polygon
+                points={getRadarPoints(profile.dimensions, cx, cy, maxR)}
+                fill={`${accentColor}10`}
+                stroke={accentColor}
+                strokeWidth="3"
+                opacity="0.3"
+              />
+              {/* Data polygon */}
+              <polygon
+                points={getRadarPoints(profile.dimensions, cx, cy, maxR)}
+                fill={`${accentColor}25`}
+                stroke={accentColor}
+                strokeWidth="2.5"
+              />
+              {/* Data points */}
+              {DIMENSION_ORDER.map((dim, i) => {
+                const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                const score = (profile.dimensions[dim] ?? 50) / 100;
+                const r = maxR * score;
+                const px = cx + r * Math.cos(angle);
+                const py = cy + r * Math.sin(angle);
+                return (
+                  <circle
+                    key={dim}
+                    cx={px}
+                    cy={py}
+                    r="4"
+                    fill={accentColor}
+                    stroke="#0c1222"
+                    strokeWidth="2"
+                  />
+                );
+              })}
+              {/* Axis labels */}
+              {DIMENSION_ORDER.map((dim, i) => {
+                const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+                const labelR = maxR + 28;
+                const lx = cx + labelR * Math.cos(angle);
+                const ly = cy + labelR * Math.sin(angle);
+                const cosA = Math.cos(angle);
+                const anchor: 'start' | 'middle' | 'end' =
+                  cosA > 0.3 ? 'start' : cosA < -0.3 ? 'end' : 'middle';
+                return (
+                  <text
+                    key={dim}
+                    x={lx}
+                    y={ly + 5}
+                    textAnchor={anchor}
+                    fill="#94a3b8"
+                    fontSize="13"
+                    fontFamily="sans-serif"
+                  >
+                    {DIMENSION_LABELS[dim]}
+                  </text>
+                );
+              })}
+            </svg>
+          </div>
+
+          {/* Right: Identity info */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              flex: 1,
+              justifyContent: 'center',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '16px',
+                fontWeight: 600,
+                color: accentColor,
+                textTransform: 'uppercase',
+                letterSpacing: '2px',
+                marginBottom: '12px',
+              }}
+            >
+              Governance Identity
+            </div>
+
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '48px',
+                fontWeight: 700,
+                color: OG.text,
+                lineHeight: 1.1,
+                marginBottom: '20px',
+              }}
+            >
+              {profile.personality}
+            </div>
+
+            {profile.narrative && (
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '20px',
+                  color: OG.textMuted,
+                  lineHeight: 1.5,
+                  marginBottom: '32px',
+                  maxWidth: '460px',
+                }}
+              >
+                {profile.narrative.length > 160
+                  ? profile.narrative.slice(0, 157) + '...'
+                  : profile.narrative}
+              </div>
+            )}
+
+            <div
+              style={{
+                display: 'flex',
+                gap: '12px',
+                flexWrap: 'wrap',
+              }}
+            >
+              {DIMENSION_ORDER.map((dim) => {
+                const score = profile.dimensions[dim] ?? 50;
+                return (
+                  <div
+                    key={dim}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '6px',
+                      padding: '4px 12px',
+                      borderRadius: '8px',
+                      backgroundColor: 'rgba(255,255,255,0.04)',
+                      border: '1px solid rgba(255,255,255,0.08)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: 'flex',
+                        width: '8px',
+                        height: '8px',
+                        borderRadius: '50%',
+                        backgroundColor: DIMENSION_COLORS[dim],
+                      }}
+                    />
+                    <span style={{ fontSize: '14px', color: OG.textMuted }}>
+                      {DIMENSION_LABELS[dim]}
+                    </span>
+                    <span style={{ fontSize: '14px', fontWeight: 600, color: OG.text }}>
+                      {score}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <OGFooter left="Find your match" right="governada.io/match" />
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG] Match image error:', error);
+    return new ImageResponse(<OGFallback message="Find your governance match" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/app/api/og/pulse/route.tsx
+++ b/app/api/og/pulse/route.tsx
@@ -101,7 +101,7 @@ export async function GET() {
             ))}
           </div>
 
-          <OGFooter left="$governada" right="governada.io/pulse" />
+          <OGFooter left="$governada" right="governada.io/governance/health" />
         </div>
       </OGBackground>,
       {
@@ -130,7 +130,7 @@ export async function GET() {
           <div
             style={{ display: 'flex', fontSize: '24px', color: OG.textMuted, marginTop: '16px' }}
           >
-            governada.io/pulse
+            governada.io/governance/health
           </div>
         </div>
       </OGBackground>,

--- a/app/api/push/send/route.ts
+++ b/app/api/push/send/route.ts
@@ -46,7 +46,7 @@ export const POST = withRouteHandler(
             body: proposalTitle
               ? `"${proposalTitle}" is open for voting. This is a high-impact proposal.`
               : 'A critical governance proposal is now open for voting.',
-            url: txHash ? `/proposal/${txHash}/${index || 0}` : '/discover',
+            url: txHash ? `/proposal/${txHash}/${index || 0}` : '/governance/proposals',
           },
         };
         break;

--- a/app/committee/[ccHotId]/page.tsx
+++ b/app/committee/[ccHotId]/page.tsx
@@ -199,7 +199,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
       <Breadcrumb
         items={[
           { label: 'Governance', href: '/' },
-          { label: 'Committee', href: '/discover/committee' },
+          { label: 'Committee', href: '/governance/committee' },
           { label: authorName ?? `CC ${decodedId.slice(0, 12)}\u2026` },
         ]}
       />

--- a/app/committee/page.tsx
+++ b/app/committee/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function CommitteeLegacyRedirect() {
-  redirect('/discover/committee');
+  redirect('/governance/committee');
 }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -51,7 +51,7 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
   const { dreps: drepsParam } = await searchParams;
 
   if (!drepsParam) {
-    redirect('/discover');
+    redirect('/governance');
   }
 
   const ids = drepsParam
@@ -61,7 +61,7 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
     .slice(0, 3);
 
   if (ids.length < 2) {
-    redirect('/discover');
+    redirect('/governance');
   }
 
   // Fetch all DReps in parallel

--- a/app/discover/committee/page.tsx
+++ b/app/discover/committee/page.tsx
@@ -192,11 +192,11 @@ export default async function CommitteeTransparencyPage() {
       <PageViewTracker event="civica_committee_page_viewed" />
 
       <Link
-        href="/discover"
+        href="/governance"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ArrowLeft className="h-3.5 w-3.5" />
-        Back to Discover
+        Back to Governance
       </Link>
 
       <div className="space-y-1">

--- a/app/engage/EngageClient.tsx
+++ b/app/engage/EngageClient.tsx
@@ -195,7 +195,7 @@ function EpochRecap({
 
       <div className="pt-1">
         <Link
-          href="/pulse"
+          href="/governance/health"
           className="text-xs text-primary hover:underline inline-flex items-center gap-1"
         >
           Full governance health

--- a/app/learn/LearnClient.tsx
+++ b/app/learn/LearnClient.tsx
@@ -2,18 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import {
-  BookOpen,
-  ChevronRight,
-  Users,
-  Vote,
-  Shield,
-  Landmark,
-  Scale,
-  Zap,
-  Search,
-  X,
-} from 'lucide-react';
+import { BookOpen, ChevronRight, Users, Vote, Shield, Scale, Search, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 import { GOV_TERMS, type GovTermDef } from '@/lib/microcopy';
@@ -26,7 +15,7 @@ const GETTING_STARTED = [
       'Cardano uses on-chain governance where ADA holders can vote on protocol changes, treasury spending, and constitutional amendments through elected representatives.',
     icon: Scale,
     color: 'text-violet-400 bg-violet-500/10',
-    link: '/discover',
+    link: '/governance',
     linkLabel: 'Explore representatives',
   },
   {
@@ -44,7 +33,7 @@ const GETTING_STARTED = [
       'Governance actions include treasury withdrawals, parameter changes, hard forks, and constitutional updates. Each requires approval from DReps, stake pools, and the Constitutional Committee.',
     icon: Vote,
     color: 'text-sky-400 bg-sky-500/10',
-    link: '/discover?tab=proposals',
+    link: '/governance/proposals',
     linkLabel: 'Browse proposals',
   },
   {
@@ -53,26 +42,8 @@ const GETTING_STARTED = [
       'Cardano governance has three pillars: DReps (citizen representatives), SPOs (stake pool operators), and the Constitutional Committee. Major decisions need approval from multiple bodies.',
     icon: Shield,
     color: 'text-amber-400 bg-amber-500/10',
-    link: '/discover?tab=committee',
+    link: '/governance/committee',
     linkLabel: 'View the Committee',
-  },
-  {
-    title: 'Treasury & funding',
-    description:
-      "The Cardano treasury is funded by transaction fees and monetary expansion. Governance proposals can request treasury withdrawals to fund ecosystem projects — your DRep's vote decides.",
-    icon: Landmark,
-    color: 'text-rose-400 bg-rose-500/10',
-    link: '/pulse',
-    linkLabel: 'See the Pulse',
-  },
-  {
-    title: 'Why your participation matters',
-    description:
-      'Governance quorum requirements mean your delegation matters. Without enough active participation, critical proposals can stall. Every delegated ADA strengthens the system.',
-    icon: Zap,
-    color: 'text-primary bg-primary/10',
-    link: '/match',
-    linkLabel: 'Get started',
   },
 ];
 
@@ -103,7 +74,7 @@ export function LearnClient() {
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <BookOpen className="h-5 w-5 text-primary" />
-          <h1 className="text-2xl font-bold tracking-tight">Learn</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Help</h1>
         </div>
         <p className="text-sm text-muted-foreground">
           Everything you need to understand Cardano governance — from delegation to treasury.

--- a/app/match/result/MatchResultClient.tsx
+++ b/app/match/result/MatchResultClient.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { ArrowRight, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import { getDominantDimension, getIdentityColor } from '@/lib/drepIdentity';
+
+interface ShareableProfile {
+  personality: string;
+  dimensions: AlignmentScores;
+  narrative: string;
+}
+
+function parseProfile(encoded: string | undefined): ShareableProfile | null {
+  if (!encoded) return null;
+  try {
+    const json = atob(encoded);
+    const data = JSON.parse(json);
+    if (!data.personality || !data.dimensions) return null;
+    return data as ShareableProfile;
+  } catch {
+    return null;
+  }
+}
+
+function getPersonalityDescription(label: string): string {
+  const descriptions: Record<string, string> = {
+    'The Guardian': 'Protects what matters — treasury discipline and institutional stability.',
+    'The Fiscal Hawk': 'Holds every ADA accountable. The treasury exists to be guarded.',
+    'The Prudent Steward': 'Balances caution with responsibility. Thoughtful governance.',
+    'The Builder': 'Invests in growth. The ecosystem thrives when we fund boldly.',
+    'The Growth Champion': 'Pushes for expansion. Nothing ventured, nothing gained.',
+    'The Catalyst': 'Sparks change. Strategic investment fuels the future.',
+    'The Federalist': 'Champions distributed governance. Power to the community.',
+    'The Power Distributor': 'Distributes power. No single entity should dominate.',
+    'The Decentralizer': 'Keeps decisions close to the people they affect.',
+    'The Sentinel': 'Guards the protocol. Security and stability come first.',
+    'The Cautious Architect': 'Stands watch over system integrity. Careful, deliberate.',
+    'The Shield': 'Smooths out volatility. Steady progress over disruption.',
+    'The Pioneer': 'Explores the frontier. Innovation is non-negotiable.',
+    'The Changemaker': "Pushes boundaries. Cardano leads by building what's next.",
+    'The Innovator': "Thinks in decades. Today's experiments are tomorrow's standards.",
+    'The Beacon': 'Demands accountability. Every vote explained, every decision justified.',
+    'The Transparent Champion': 'Makes governance visible. Sunlight is the best disinfectant.',
+    'The Open Book': "Holds feet to fire. Transparency isn't optional.",
+  };
+  return descriptions[label] || "A unique governance identity shaping Cardano's future.";
+}
+
+export function MatchResultClient({ encoded }: { encoded: string | undefined }) {
+  const profile = useMemo(() => parseProfile(encoded), [encoded]);
+
+  if (!profile) {
+    return (
+      <div className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center px-4">
+        <div className="text-center max-w-lg space-y-6 animate-in fade-in duration-500">
+          <div className="mx-auto w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center">
+            <Zap className="h-8 w-8 text-primary" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="font-display text-3xl sm:text-4xl font-bold tracking-tight">
+              Governance Match
+            </h1>
+            <p className="text-muted-foreground text-base sm:text-lg leading-relaxed">
+              This link doesn&apos;t contain a valid match profile. Take the quiz to discover your
+              governance identity.
+            </p>
+          </div>
+          <Button asChild size="lg" className="text-base px-8 py-6 rounded-xl font-semibold">
+            <Link href="/match">
+              Take the Quiz
+              <ArrowRight className="ml-2 h-5 w-5" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const dominant = getDominantDimension(profile.dimensions);
+  const identityColor = getIdentityColor(dominant);
+
+  return (
+    <div className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center px-4 py-8">
+      <div className="w-full max-w-2xl space-y-8 animate-in fade-in slide-in-from-bottom-6 duration-500">
+        <div className="text-center space-y-4">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-widest">
+            Governance Identity
+          </p>
+
+          <div className="flex justify-center">
+            <GovernanceRadar alignments={profile.dimensions} size="full" />
+          </div>
+
+          <div className="space-y-2">
+            <Badge
+              className="text-sm px-3 py-1"
+              style={{
+                backgroundColor: identityColor.hex + '20',
+                color: identityColor.hex,
+                borderColor: identityColor.hex + '40',
+              }}
+            >
+              {profile.personality}
+            </Badge>
+            <p className="text-sm text-muted-foreground max-w-sm mx-auto">
+              {getPersonalityDescription(profile.personality)}
+            </p>
+          </div>
+
+          {profile.narrative && (
+            <div className="text-center max-w-md mx-auto">
+              <p className="text-sm text-foreground/90 leading-relaxed">{profile.narrative}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-4 pb-8">
+          <Button asChild size="lg" className="text-base px-8 font-semibold">
+            <Link href="/match">
+              <Zap className="mr-2 h-5 w-5" />
+              Take the Quiz
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <Link href="/governance/representatives">
+              Browse DReps
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/match/result/page.tsx
+++ b/app/match/result/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import { BASE_URL } from '@/lib/constants';
+import { MatchResultClient } from './MatchResultClient';
+
+export const dynamic = 'force-dynamic';
+
+interface MatchResultPageProps {
+  searchParams: Promise<{ profile?: string }>;
+}
+
+function parseProfile(encoded: string | undefined) {
+  if (!encoded) return null;
+  try {
+    const json = Buffer.from(encoded, 'base64').toString('utf-8');
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({ searchParams }: MatchResultPageProps): Promise<Metadata> {
+  const { profile: encoded } = await searchParams;
+  const profile = parseProfile(encoded);
+
+  const title = profile?.personality
+    ? `I'm ${profile.personality} — Governada`
+    : 'Governance Match Result — Governada';
+  const description = profile?.narrative
+    ? profile.narrative
+    : 'Discover your governance identity on Cardano. Take the Quick Match quiz to find DReps and SPOs who share your values.';
+
+  const ogImageUrl = encoded
+    ? `${BASE_URL}/api/og/match?profile=${encodeURIComponent(encoded)}`
+    : `${BASE_URL}/api/og/match`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'website',
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: 'Governance Identity' }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function MatchResultPage({ searchParams }: MatchResultPageProps) {
+  const { profile: encoded } = await searchParams;
+  return <MatchResultClient encoded={encoded} />;
+}

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -684,7 +684,7 @@ export default function MethodologyPage() {
               <p className="text-xs font-semibold text-foreground">GHI reference</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded">
                 &ldquo;Cardano governance health stands at [X]/100 ([Band]) per the Governada
-                Governance Health Index, epoch [N]. Source: governada.io/pulse&rdquo;
+                Governance Health Index, epoch [N]. Source: governada.io/governance/health&rdquo;
               </code>
             </div>
             <div className="rounded-xl border border-border bg-card p-4 space-y-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,26 +29,26 @@ export const metadata: Metadata = {
 async function getGovernancePulse() {
   const supabase = createClient();
 
-  const [drepsResult, proposalsResult] = await Promise.all([
-    supabase.from('dreps').select('info', { count: 'exact' }).range(0, 9999),
+  const [activeDRepsResult, totalDRepsResult, openProposalsResult] = await Promise.all([
+    supabase
+      .from('dreps')
+      .select('id', { count: 'exact', head: true })
+      .eq('info->>isActive', 'true'),
+    supabase.from('dreps').select('id', { count: 'exact', head: true }),
     supabase
       .from('proposals')
-      .select('tx_hash, ratified_epoch, enacted_epoch, dropped_epoch, expired_epoch'),
+      .select('tx_hash', { count: 'exact', head: true })
+      .is('ratified_epoch', null)
+      .is('enacted_epoch', null)
+      .is('dropped_epoch', null)
+      .is('expired_epoch', null),
   ]);
-
-  const dreps = drepsResult.data || [];
-  const proposals = proposalsResult.data || [];
-  const activeDReps = dreps.filter((d) => (d.info as Record<string, unknown> | null)?.isActive);
-
-  const openProposals = proposals.filter(
-    (p) => !p.ratified_epoch && !p.enacted_epoch && !p.dropped_epoch && !p.expired_epoch,
-  );
 
   return {
     totalAdaGoverned: '',
-    activeProposals: openProposals.length,
-    activeDReps: activeDReps.length,
-    totalDReps: drepsResult.count ?? dreps.length,
+    activeProposals: openProposalsResult.count ?? 0,
+    activeDReps: activeDRepsResult.count ?? 0,
+    totalDReps: totalDRepsResult.count ?? 0,
     votesThisWeek: 0,
     claimedDReps: 0,
     activeSpOs: 0,

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -301,7 +301,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
         <Breadcrumb
           items={[
             { label: 'Governance', href: '/' },
-            { label: 'Pools', href: '/discover' },
+            { label: 'Pools', href: '/governance/pools' },
             { label: poolId.slice(0, 16) + '\u2026' },
           ]}
         />
@@ -790,7 +790,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
         <Breadcrumb
           items={[
             { label: 'Governance', href: '/' },
-            { label: 'Pools', href: '/discover' },
+            { label: 'Pools', href: '/governance/pools' },
             { label: ticker ? `${displayName} [${ticker}]` : displayName },
           ]}
         />

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -107,7 +107,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
       <Breadcrumb
         items={[
           { label: 'Governance', href: '/' },
-          { label: 'Proposals', href: '/discover' },
+          { label: 'Proposals', href: '/governance/proposals' },
           { label: title },
         ]}
       />

--- a/app/pulse/history/page.tsx
+++ b/app/pulse/history/page.tsx
@@ -22,10 +22,10 @@ export default async function PulseHistoryPage() {
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
       <Link
-        href="/pulse"
+        href="/governance/health"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
       >
-        <ArrowLeft className="h-4 w-4" /> Back to Pulse
+        <ArrowLeft className="h-4 w-4" /> Back to Governance Health
       </Link>
 
       <h1 className="text-2xl font-bold mb-2">Epoch Recaps</h1>

--- a/app/pulse/report/[epoch]/page.tsx
+++ b/app/pulse/report/[epoch]/page.tsx
@@ -95,10 +95,10 @@ export default async function StateOfGovernancePage({ params }: Props) {
   return (
     <div className="max-w-4xl mx-auto px-4 py-6 space-y-8">
       <Link
-        href="/pulse"
+        href="/governance/health"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
-        <ArrowLeft className="h-4 w-4" /> Back to Pulse
+        <ArrowLeft className="h-4 w-4" /> Back to Governance Health
       </Link>
 
       {/* Hero */}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,7 +20,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const staticPages: MetadataRoute.Sitemap = [
     { url: BASE_URL, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
     {
-      url: `${BASE_URL}/discover`,
+      url: `${BASE_URL}/governance`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 0.9,

--- a/components/BrandedLoader.tsx
+++ b/components/BrandedLoader.tsx
@@ -127,9 +127,9 @@ export function BrandedLoader() {
 
       {/* Brand text */}
       <div className="text-center animate-fade-in-up">
-        <p className="text-2xl font-bold text-primary tracking-tight font-sans">$governada</p>
+        <p className="text-2xl font-bold text-primary tracking-tight font-sans">Governada</p>
         <p className="text-sm text-muted-foreground mt-1 tracking-wide">
-          Observing Cardano Governance
+          Governance Intelligence for Cardano
         </p>
       </div>
     </div>

--- a/components/CommitteeDiscovery.tsx
+++ b/components/CommitteeDiscovery.tsx
@@ -137,7 +137,7 @@ export function CommitteeDiscovery() {
 
       {/* Link to full transparency page */}
       <div className="flex items-center justify-end">
-        <Link href="/discover/committee" className="text-xs text-primary hover:underline">
+        <Link href="/governance/committee" className="text-xs text-primary hover:underline">
           View full Transparency Index →
         </Link>
       </div>

--- a/components/DelegationIntelligence.tsx
+++ b/components/DelegationIntelligence.tsx
@@ -97,7 +97,7 @@ export function DelegationIntelligence({
             your views against DReps.
           </p>
           <Link
-            href="/discover"
+            href="/governance/proposals"
             className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
           >
             <Vote className="h-3.5 w-3.5" />

--- a/components/DeveloperPage.tsx
+++ b/components/DeveloperPage.tsx
@@ -342,7 +342,7 @@ export function DeveloperPage() {
               <a href="#explorer">API Explorer</a>
             </Button>
             <Button variant="outline" asChild>
-              <Link href="/pulse">View Governance Pulse</Link>
+              <Link href="/governance/health">View Governance Health</Link>
             </Button>
           </div>
         </div>

--- a/components/EmbedCrossChain.tsx
+++ b/components/EmbedCrossChain.tsx
@@ -110,7 +110,7 @@ export function EmbedCrossChain({ theme }: EmbedCrossChainProps) {
 
       <div className="mt-3 flex items-center justify-between">
         <a
-          href="https://governada.io/pulse"
+          href="https://governada.io/governance/health"
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-medium hover:underline"

--- a/components/EmbedGHI.tsx
+++ b/components/EmbedGHI.tsx
@@ -106,7 +106,7 @@ export function EmbedGHI({ theme }: EmbedGHIProps) {
 
       <div className="mt-2 flex justify-between items-center">
         <a
-          href="https://governada.io/pulse"
+          href="https://governada.io/governance/health"
           target="_blank"
           rel="noopener noreferrer"
           className="text-[10px] font-medium hover:underline"

--- a/components/FinancialImpactCard.tsx
+++ b/components/FinancialImpactCard.tsx
@@ -99,7 +99,7 @@ export function FinancialImpactCard({
         </div>
 
         <Link
-          href="/pulse"
+          href="/governance/health"
           className="flex items-center gap-1 text-xs text-primary hover:underline mt-1"
         >
           View full treasury dashboard <ArrowRight className="h-3 w-3" />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -54,10 +54,13 @@ export function Footer() {
 
           {/* Center: Nav links */}
           <div className="flex items-center gap-6 text-sm text-muted-foreground">
-            <Link href="/discover" className="hover:text-foreground transition-colors">
+            <Link
+              href="/governance/representatives"
+              className="hover:text-foreground transition-colors"
+            >
               Discover DReps
             </Link>
-            <Link href="/discover" className="hover:text-foreground transition-colors">
+            <Link href="/governance/proposals" className="hover:text-foreground transition-colors">
               Proposals
             </Link>
             <a

--- a/components/GovernanceDNAReveal.tsx
+++ b/components/GovernanceDNAReveal.tsx
@@ -196,7 +196,7 @@ export function GovernanceDNAReveal({ result, onRetake }: GovernanceDNARevealPro
                   <RefreshCw className="h-3.5 w-3.5" />
                   Retake Quiz
                 </Button>
-                <Link href="/discover">
+                <Link href="/governance/proposals">
                   <Button variant="ghost" size="sm" className="gap-1.5">
                     <Vote className="h-3.5 w-3.5" />
                     Vote on Proposals
@@ -227,7 +227,7 @@ export function GovernanceDNAReveal({ result, onRetake }: GovernanceDNARevealPro
                 {result.topMatches[0].matchScore}%)
               </p>
               <ShareActions
-                url="https://governada.io/discover"
+                url="https://governada.io/governance"
                 text={`I took the Governance DNA Quiz on @GovernadaIO! My top match: ${result.topMatches[0].name} (${result.topMatches[0].matchScore}%). Find your ideal DRep:`}
                 imageUrl={`/api/og/governance-dna?votes=${result.votesCount}${result.topMatches
                   .slice(0, 3)

--- a/components/GovernanceDashboard.tsx
+++ b/components/GovernanceDashboard.tsx
@@ -161,7 +161,7 @@ function PollHistorySection({ history }: { history: DashboardData['pollHistory']
             You haven&apos;t voted in any polls yet. Head to the proposals page to share your
             opinion.
           </p>
-          <Link href="/discover" className="mt-3 inline-block">
+          <Link href="/governance/proposals" className="mt-3 inline-block">
             <Button
               variant="outline"
               size="sm"

--- a/components/GovernanceHeartbeat.tsx
+++ b/components/GovernanceHeartbeat.tsx
@@ -49,7 +49,7 @@ export function GovernanceHeartbeat() {
       <Tooltip>
         <TooltipTrigger asChild>
           <Link
-            href="/pulse"
+            href="/governance/health"
             className="relative flex items-center justify-center w-5 h-5"
             aria-label={labels[level]}
           >

--- a/components/GovernanceObservatory.tsx
+++ b/components/GovernanceObservatory.tsx
@@ -125,7 +125,7 @@ export function GovernanceObservatory({
             Governance Observatory
           </CardTitle>
           <ShareActions
-            url={`${BASE_URL}/pulse`}
+            url={`${BASE_URL}/governance/health`}
             text="How does governance compare across Cardano, Ethereum, and Polkadot? Check the Observatory on @GovernadaIO:"
             imageUrl={`${BASE_URL}/api/og/cross-chain`}
             imageFilename="cross-chain-governance.png"

--- a/components/GovernanceWidget.tsx
+++ b/components/GovernanceWidget.tsx
@@ -37,7 +37,7 @@ export function GovernanceWidget() {
       : 'border-l-primary';
 
   return (
-    <Link href="/discover">
+    <Link href="/governance/proposals">
       <div
         className={`flex items-center gap-3 px-4 py-3 rounded-lg border border-border/50 bg-card hover:bg-muted/30 transition-colors cursor-pointer border-l-4 ${borderColor}`}
       >

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -205,13 +205,13 @@ export function Header() {
         </div>
 
         <nav className="flex items-center space-x-2 sm:space-x-4">
-          <Link href="/discover" className={navLinkClass('/discover')}>
+          <Link href="/governance" className={navLinkClass('/governance')}>
             <Compass className="h-4 w-4" />
-            <span>Discover</span>
+            <span>Governance</span>
           </Link>
-          <Link href="/pulse" className={navLinkClass('/pulse')}>
+          <Link href="/governance/health" className={navLinkClass('/governance/health')}>
             <Activity className="h-4 w-4" />
-            <span>Pulse</span>
+            <span>Health</span>
           </Link>
           {isAuthenticated && (
             <Link href="/my-gov" prefetch={false} className={navLinkClass('/my-gov')}>

--- a/components/KeyboardShortcuts.tsx
+++ b/components/KeyboardShortcuts.tsx
@@ -30,10 +30,10 @@ export function KeyboardShortcuts() {
           router.push('/');
           break;
         case 'd':
-          router.push('/discover');
+          router.push('/governance');
           break;
         case 'p':
-          router.push('/discover');
+          router.push('/governance/proposals');
           break;
         case 'g':
           router.push('/my-gov');

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -33,8 +33,8 @@ interface MobileNavProps {
 }
 
 const PRIMARY_NAV_ITEMS = [
-  { href: '/discover', label: 'Discover', icon: Compass },
-  { href: '/pulse', label: 'Pulse', icon: Activity },
+  { href: '/governance', label: 'Governance', icon: Compass },
+  { href: '/governance/health', label: 'Health', icon: Activity },
 ];
 
 const AUTH_NAV_ITEM = { href: '/my-gov', label: 'My Governance', icon: Vote };

--- a/components/NavDirectionProvider.tsx
+++ b/components/NavDirectionProvider.tsx
@@ -14,7 +14,7 @@ function pathDepth(p: string) {
   return p.split('/').filter(Boolean).length;
 }
 
-const GOVERNANCE_ROUTES = new Set(['/pulse', '/discover', '/my-gov']);
+const GOVERNANCE_ROUTES = new Set(['/governance/health', '/governance', '/my-gov']);
 
 function inferDirection(prev: string, next: string): NavDirection {
   if (!prev || prev === next) return 'neutral';

--- a/components/PersonalGovernanceCard.tsx
+++ b/components/PersonalGovernanceCard.tsx
@@ -127,7 +127,7 @@ function DelegatedCard({ data }: { data: DelegatedData }) {
             My Governance
           </Link>
           <Link
-            href="/discover"
+            href="/governance/proposals"
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-border text-sm font-medium hover:bg-accent transition-colors"
           >
             View Proposals <ArrowRight className="h-3.5 w-3.5" />
@@ -150,7 +150,7 @@ function UndelegatedCard({ data }: { data: UndelegatedData }) {
           Delegation is free, non-custodial, and takes 30 seconds.
         </p>
         <Link
-          href="/discover"
+          href="/governance/representatives"
           className="inline-flex items-center gap-2 px-6 py-2.5 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
         >
           Find Your Representative <ArrowRight className="h-4 w-4" />
@@ -217,7 +217,7 @@ function DRepCard({ data }: { data: DRepData }) {
             Open Dashboard
           </Link>
           <Link
-            href="/discover"
+            href="/governance/proposals"
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg border border-border text-sm font-medium hover:bg-accent transition-colors"
           >
             View Proposals <ArrowRight className="h-3.5 w-3.5" />

--- a/components/PoolGovernanceCard.tsx
+++ b/components/PoolGovernanceCard.tsx
@@ -19,7 +19,7 @@ export function PoolGovernanceCard({}: PoolGovernanceCardProps) {
       <CardContent>
         <p className="text-sm text-muted-foreground">
           Track your staking pool&apos;s governance participation.
-          <Link href="/discover?tab=spos" className="text-cyan-500 hover:underline ml-1">
+          <Link href="/governance/pools" className="text-cyan-500 hover:underline ml-1">
             Explore governance-active pools &rarr;
           </Link>
         </p>

--- a/components/QuickMatch.tsx
+++ b/components/QuickMatch.tsx
@@ -384,7 +384,7 @@ function QuickMatchResults({ result }: { result: QuickMatchResult }) {
             These matches are based on your values. The DNA Quiz votes on real proposals for higher
             accuracy.
           </p>
-          <Link href="/discover">
+          <Link href="/governance/representatives">
             <Button className="gap-2">
               Take the DNA Quiz <ArrowRight className="h-4 w-4" />
             </Button>
@@ -461,7 +461,7 @@ function QuickMatchPoolResults({ result }: { result: QuickMatchPoolResult }) {
           <p className="text-sm text-muted-foreground">
             Browse governance-active stake pools and compare their voting records.
           </p>
-          <Link href="/discover?tab=spos">
+          <Link href="/governance/pools">
             <Button
               variant="outline"
               className="gap-2 border-cyan-500/40 text-cyan-600 hover:bg-cyan-500/10"

--- a/components/TreasuryHealthWidget.tsx
+++ b/components/TreasuryHealthWidget.tsx
@@ -57,7 +57,7 @@ export function TreasuryHealthWidget() {
             <span className="text-sm font-medium">Treasury Health</span>
           </div>
           <Link
-            href="/pulse"
+            href="/governance/health"
             className="flex items-center gap-1 text-xs text-primary hover:underline"
           >
             Full dashboard <ArrowRight className="h-3 w-3" />

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { TrendingUp, TrendingDown, Minus, CheckCircle2, XCircle, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { computeTier } from '@/lib/scoring/tiers';
+import { getScoreNarrative } from '@/lib/scoring/scoreNarratives';
 import { TIER_SCORE_COLOR, TIER_BORDER, TIER_BG, TIER_GLOW, tierKey } from './tierStyles';
 import { TierBadge } from './TierBadge';
 import type { EnrichedDRep } from '@/lib/koios';
@@ -50,6 +51,7 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
 
   const recency = formatRecency(drep.lastVoteTime);
   const rationaleRate = Math.round(drep.rationaleRate ?? 0);
+  const scoreNarrative = getScoreNarrative({ score, percentile: 0 });
 
   return (
     <Link
@@ -126,6 +128,9 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
           )}
         </div>
       </div>
+
+      {/* ── Score narrative ──────────────────────────────────── */}
+      <p className="text-xs text-muted-foreground mb-2">{scoreNarrative}</p>
 
       {/* ── Governance identity ───────────────────────────────── */}
       {(personalityLabel || traitTags.length > 0) && (

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -10,6 +10,7 @@ import { CivicaDRepCard } from '@/components/civica/cards/CivicaDRepCard';
 import { computeTier } from '@/lib/scoring/tiers';
 import { TIER_SCORE_COLOR, TIER_BADGE_BG, tierKey } from '@/components/civica/cards/tierStyles';
 import type { EnrichedDRep } from '@/lib/koios';
+import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
 import {
@@ -293,6 +294,7 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
 
   return (
     <div ref={contentRef} className="space-y-4 pt-4">
+      <AnonymousNudge variant="representatives" />
       <DiscoverFilterBar
         search={filters.search}
         onSearchChange={(v) => setFilter('search', v)}

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -40,6 +40,7 @@ interface BrowseProposal {
 }
 import { ProposalDeliveryBadge } from '@/components/civica/proposals/ProposalDeliveryBadge';
 import type { DeliveryStatus } from '@/lib/proposalOutcomes';
+import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
 
@@ -277,6 +278,8 @@ export function ProposalsBrowse() {
             : 'Active governance proposals in Cardano'}
         </p>
       </div>
+
+      <AnonymousNudge variant="proposals" />
 
       {/* Status pipeline overview */}
       {statusCounts.length > 1 && (

--- a/components/civica/home/EpochBriefing.tsx
+++ b/components/civica/home/EpochBriefing.tsx
@@ -679,7 +679,7 @@ function EpochBriefingContent({
           Where your money goes
         </p>
         <Link
-          href="/pulse"
+          href="/governance/health"
           className="text-xs text-primary hover:underline inline-flex items-center gap-1 min-h-[44px] sm:min-h-0"
         >
           Full details
@@ -759,7 +759,7 @@ function EpochBriefingContent({
             )}
           </div>
           <Link
-            href="/discover"
+            href="/governance/proposals"
             className="shrink-0 text-sm font-medium text-primary hover:underline inline-flex items-center gap-1 min-h-[44px]"
           >
             View

--- a/components/civica/home/HomeAnonymous.tsx
+++ b/components/civica/home/HomeAnonymous.tsx
@@ -211,7 +211,7 @@ export function HomeAnonymous({ pulseData }: HomeAnonymousProps) {
 
           {/* Path 2: Stake — Pool Discovery */}
           <Link
-            href="/discover?tab=pools"
+            href="/governance/pools"
             onClick={() => posthog?.capture('citizen_path_clicked', { path: 'stake' })}
             className={cn(
               'group relative rounded-xl border border-border bg-card/80 backdrop-blur-sm p-6',

--- a/components/civica/home/HomeCitizen.tsx
+++ b/components/civica/home/HomeCitizen.tsx
@@ -108,7 +108,7 @@ function UndelegatedHome({ pulseData }: { pulseData: PulseData }) {
               </Link>
             </Button>
             <Button asChild variant="outline" size="lg" className="flex-1">
-              <Link href="/discover">Browse all DReps</Link>
+              <Link href="/governance/representatives">Browse all DReps</Link>
             </Button>
           </div>
         </div>

--- a/components/civica/home/TreasuryCitizenView.tsx
+++ b/components/civica/home/TreasuryCitizenView.tsx
@@ -92,7 +92,7 @@ export function TreasuryCitizenView({ className }: { className?: string }) {
             <p className="text-sm font-semibold text-foreground">Where Your Money Goes</p>
           </div>
           <Link
-            href="/pulse"
+            href="/governance/health"
             className="text-xs text-primary hover:underline inline-flex items-center gap-1"
           >
             Full details

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -19,6 +19,8 @@ import {
   History,
   Server,
   Users,
+  Share2,
+  Check,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -35,6 +37,13 @@ import { buildAlignmentFromAnswers } from '@/lib/matching/answerVectors';
 import type { ConfidenceBreakdown } from '@/lib/matching/confidence';
 import { MatchConfidenceCTA } from '@/components/matching/MatchConfidenceCTA';
 import { saveMatchProfile, loadMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
+import {
+  webShare,
+  canWebShare,
+  copyToClipboard,
+  trackShare,
+  buildMatchResultUrl,
+} from '@/lib/share';
 
 /* ─── Types ─────────────────────────────────────────────── */
 
@@ -596,6 +605,69 @@ function getMatchNarrative(match: MatchResult): string {
   return `${strength} alignment across your governance values.`;
 }
 
+function buildShareableUrl(results: QuickMatchResponse): string {
+  const profile = {
+    personality: results.personalityLabel,
+    dimensions: results.userAlignments,
+    narrative: getValuesNarrative(results.userAlignments),
+  };
+  const encoded = btoa(JSON.stringify(profile));
+  return buildMatchResultUrl(encoded);
+}
+
+function ShareButton({ results }: { results: QuickMatchResponse }) {
+  const [copied, setCopied] = useState(false);
+  const posthog = usePostHog();
+
+  const handleShare = useCallback(async () => {
+    const url = buildShareableUrl(results);
+    const shareText = `I'm "${results.personalityLabel}" on Cardano governance. Find your governance identity:`;
+
+    trackShare('quick_match', 'share_button', { personality: results.personalityLabel });
+    posthog?.capture('match_shared', { personality: results.personalityLabel });
+
+    if (canWebShare()) {
+      const shared = await webShare({
+        title: `I'm ${results.personalityLabel} — Governada`,
+        text: shareText,
+        url,
+      });
+      if (shared) {
+        trackShare(
+          'quick_match',
+          'native_share',
+          { personality: results.personalityLabel },
+          'success',
+        );
+        return;
+      }
+    }
+
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      setCopied(true);
+      trackShare('quick_match', 'clipboard', { personality: results.personalityLabel }, 'success');
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [results, posthog]);
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleShare} className="gap-2">
+      {copied ? (
+        <>
+          <Check className="h-4 w-4" />
+          Link Copied
+        </>
+      ) : (
+        <>
+          <Share2 className="h-4 w-4" />
+          Share Your Identity
+        </>
+      )}
+    </Button>
+  );
+}
+
 function ResultsScreen({
   drepResults,
   spoResults,
@@ -641,6 +713,8 @@ function ResultsScreen({
             {getValuesNarrative(drepResults.userAlignments)}
           </p>
         </div>
+
+        <ShareButton results={drepResults} />
       </div>
 
       {/* Tab toggle */}
@@ -801,7 +875,9 @@ function ResultsScreen({
               participation, more matches will appear.
             </p>
             <Button asChild variant="outline" size="sm">
-              <Link href={activeTab === 'spo' ? '/discover?tab=spos' : '/discover'}>
+              <Link
+                href={activeTab === 'spo' ? '/governance/pools' : '/governance/representatives'}
+              >
                 Browse all active {activeTab === 'spo' ? 'SPOs' : 'DReps'}
                 <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
               </Link>
@@ -818,7 +894,7 @@ function ResultsScreen({
       {/* CTAs */}
       <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2 pb-8">
         <Button asChild size="lg">
-          <Link href={activeTab === 'spo' ? '/discover?tab=spos' : '/discover?sort=match'}>
+          <Link href={activeTab === 'spo' ? '/governance/pools' : '/governance/representatives'}>
             Browse All {activeTab === 'spo' ? 'SPOs' : 'DReps'}
             <ArrowRight className="ml-2 h-4 w-4" />
           </Link>

--- a/components/civica/mygov/CitizenCommandCenter.tsx
+++ b/components/civica/mygov/CitizenCommandCenter.tsx
@@ -497,7 +497,7 @@ export function CitizenCommandCenter({
           </Link>
           <p className="text-xs text-muted-foreground">
             Or{' '}
-            <Link href="/discover" className="text-primary hover:underline">
+            <Link href="/governance/representatives" className="text-primary hover:underline">
               browse all DReps
             </Link>
           </p>
@@ -564,7 +564,7 @@ export function CitizenCommandCenter({
 
       {/* Open proposals callout */}
       {!pulseLoading && activeProposals > 0 && (
-        <Link href="/discover" className="block group">
+        <Link href="/governance/proposals" className="block group">
           <div className="rounded-xl border border-border bg-card p-4 flex items-center justify-between hover:border-primary/30 transition-colors">
             <div className="flex items-center gap-3">
               <Vote className="h-4 w-4 text-muted-foreground" />
@@ -590,7 +590,7 @@ export function CitizenCommandCenter({
               Recent DRep Votes
             </p>
             <Link
-              href={delegatedDrep ? `/drep/${delegatedDrep}` : '/discover'}
+              href={delegatedDrep ? `/drep/${delegatedDrep}` : '/governance/representatives'}
               className="text-xs text-muted-foreground hover:text-primary transition-colors"
             >
               See all

--- a/components/civica/mygov/CivicaInbox.tsx
+++ b/components/civica/mygov/CivicaInbox.tsx
@@ -354,7 +354,7 @@ function buildSystemNotifications(pulse: Record<string, unknown> | undefined): N
       bgColor: 'bg-card',
       title: `Governance health: ${ghiScore.toFixed(0)}${ghiDelta != null ? ` (${ghiDelta > 0 ? '+' : ''}${ghiDelta.toFixed(1)} this epoch)` : ''}`,
       description: 'The Governance Health Index reflects current ecosystem health.',
-      href: '/pulse',
+      href: '/governance/health',
       cta: 'See Pulse',
       priority: 3,
     });

--- a/components/civica/mygov/CivicaProfile.tsx
+++ b/components/civica/mygov/CivicaProfile.tsx
@@ -334,7 +334,7 @@ export function CivicaProfile() {
             <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
           </Link>
           <Link
-            href="/discover"
+            href="/governance/representatives"
             className="flex items-center justify-between rounded-lg border border-border bg-muted/20 px-4 py-3 hover:border-primary/30 transition-colors group"
           >
             <div>

--- a/components/civica/mygov/DRepCommandCenter.tsx
+++ b/components/civica/mygov/DRepCommandCenter.tsx
@@ -473,7 +473,7 @@ export function DRepCommandCenter({ drepId }: { drepId: string }) {
             </div>
             {pendingCount > 5 && (
               <Link
-                href="/discover"
+                href="/governance/proposals"
                 className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
               >
                 View all

--- a/components/civica/mygov/SPOCommandCenter.tsx
+++ b/components/civica/mygov/SPOCommandCenter.tsx
@@ -637,7 +637,7 @@ export function SPOCommandCenter({ poolId }: { poolId: string }) {
             </div>
             {pendingCount > 5 && (
               <Link
-                href="/discover"
+                href="/governance/proposals"
                 className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
               >
                 View all

--- a/components/civica/mygov/SPOInbox.tsx
+++ b/components/civica/mygov/SPOInbox.tsx
@@ -327,7 +327,7 @@ function buildSystemNotifications(
       bgColor: 'bg-sky-950/10',
       title: `${activeProposals} governance proposal${activeProposals > 1 ? 's' : ''} in progress`,
       description: 'Some proposals may require SPO votes. Check for pending actions.',
-      href: '/discover?tab=proposals',
+      href: '/governance/proposals',
       cta: 'View',
       priority: 3,
     });
@@ -349,7 +349,7 @@ function buildSystemNotifications(
       bgColor: 'bg-card',
       title: `Governance health: ${ghiScore.toFixed(0)}${ghiDelta != null ? ` (${ghiDelta > 0 ? '+' : ''}${ghiDelta.toFixed(1)} this epoch)` : ''}`,
       description: 'The Governance Health Index reflects current ecosystem health.',
-      href: '/pulse',
+      href: '/governance/health',
       cta: 'See Pulse',
       priority: 3,
     });
@@ -452,7 +452,7 @@ export function SPOInbox() {
       bgColor: 'bg-rose-950/10',
       title: `${inbox.criticalCount} critical proposal${inbox.criticalCount > 1 ? 's' : ''} need your vote`,
       description: 'These proposals affect core protocol parameters or governance structure.',
-      href: '/discover?tab=proposals',
+      href: '/governance/proposals',
       cta: 'Review',
       priority: 1,
     });
@@ -472,7 +472,7 @@ export function SPOInbox() {
       bgColor: 'bg-amber-950/10',
       title: `${inbox.urgentCount} proposal${inbox.urgentCount > 1 ? 's' : ''} expiring soon`,
       description: 'Vote before these proposals expire to maintain your participation score.',
-      href: '/discover?tab=proposals',
+      href: '/governance/proposals',
       cta: 'Vote Now',
       priority: 2,
     });
@@ -720,7 +720,7 @@ export function SPOInbox() {
           </div>
           {inbox.pendingProposals.length > 5 && (
             <Link
-              href="/discover?tab=proposals"
+              href="/governance/proposals"
               className="block text-center text-xs text-muted-foreground hover:text-primary transition-colors py-1"
             >
               View all {inbox.pendingCount ?? 0} pending proposals

--- a/components/civica/pulse/CivicaEpochReport.tsx
+++ b/components/civica/pulse/CivicaEpochReport.tsx
@@ -169,14 +169,14 @@ export function CivicaEpochReport() {
               count={activeProposals}
               color={criticalProposals > 0 ? 'text-amber-400' : 'text-primary'}
               icon={Vote}
-              href="/discover"
+              href="/governance/proposals"
             />
             <PipelineStep
               label="Critical"
               count={criticalProposals}
               color={criticalProposals > 0 ? 'text-rose-400' : 'text-muted-foreground'}
               icon={AlertCircle}
-              href={criticalProposals > 0 ? '/discover' : undefined}
+              href={criticalProposals > 0 ? '/governance/proposals' : undefined}
             />
             <PipelineStep
               label="Votes/week"

--- a/components/civica/pulse/CivicaGovernanceCalendar.tsx
+++ b/components/civica/pulse/CivicaGovernanceCalendar.tsx
@@ -322,7 +322,7 @@ export function CivicaGovernanceCalendar() {
       {/* Active proposals context */}
       {((pulse?.activeProposals as number | undefined) ?? 0) > 0 && (
         <Link
-          href="/discover"
+          href="/governance/proposals"
           className="flex items-center justify-between rounded-xl border border-border bg-card p-4 hover:border-primary/30 transition-colors group"
         >
           <div>

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -33,6 +33,7 @@ import { ActivityTicker } from '@/components/ActivityTicker';
 import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { EmptyState } from './EmptyState';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
+import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type {
   TreasuryData,
@@ -265,6 +266,7 @@ export function CivicaPulseOverview() {
         pageKey="pulse"
         message="The big picture. How healthy is Cardano governance right now? Track participation, treasury, and trends over time."
       />
+      <AnonymousNudge variant="health" />
       {/* ── Tab bar ─────────────────────────────────────────── */}
       <div
         className="flex gap-1 border-b border-border -mb-2 overflow-x-auto"
@@ -383,7 +385,7 @@ export function CivicaPulseOverview() {
                 }
                 icon={Vote}
                 accent={(pulse?.criticalProposals ?? 0) > 0 ? 'warning' : 'success'}
-                href="/discover"
+                href="/governance/proposals"
               />
               <StatCard
                 label="Active DReps"
@@ -391,7 +393,7 @@ export function CivicaPulseOverview() {
                 sub={pulse?.totalDReps ? `of ${pulse.totalDReps} total` : undefined}
                 icon={Users}
                 accent="default"
-                href="/discover"
+                href="/governance/representatives"
                 trend={
                   pulse?.deltas?.activeDRepsDelta != null
                     ? pulse.deltas.activeDRepsDelta > 0
@@ -776,7 +778,7 @@ export function CivicaPulseOverview() {
                 </p>
               </div>
               <Link
-                href="/discover"
+                href="/governance/representatives"
                 className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-0.5"
               >
                 Browse DReps <ChevronRight className="h-3.5 w-3.5" />

--- a/components/civica/shared/AnonymousNudge.tsx
+++ b/components/civica/shared/AnonymousNudge.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { X } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+type NudgeVariant = 'proposals' | 'representatives' | 'health';
+
+const MESSAGES: Record<NudgeVariant, { text: string; cta: string; href: string }> = {
+  proposals: {
+    text: 'Want representation on these decisions?',
+    cta: 'Find your DRep in 60 seconds',
+    href: '/match',
+  },
+  representatives: {
+    text: 'Not sure who to pick?',
+    cta: 'Take the 60-second match quiz',
+    href: '/match',
+  },
+  health: {
+    text: 'This is your governance.',
+    cta: 'Connect your wallet to see how you\u2019re represented',
+    href: '/match',
+  },
+};
+
+const STORAGE_KEY = 'governada_nudge_dismissed';
+
+export function AnonymousNudge({ variant }: { variant: NudgeVariant }) {
+  const { segment } = useSegment();
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const map: Record<string, boolean> = raw ? JSON.parse(raw) : {};
+      setDismissed(!!map[variant]);
+    } catch {
+      setDismissed(false);
+    }
+  }, [variant]);
+
+  if (segment !== 'anonymous' || dismissed) return null;
+
+  const { text, cta, href } = MESSAGES[variant];
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      const map: Record<string, boolean> = raw ? JSON.parse(raw) : {};
+      map[variant] = true;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    } catch {}
+  };
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 px-4 py-3">
+      <p className="flex-1 text-sm text-muted-foreground">
+        {text}{' '}
+        <Link href={href} className="font-medium text-primary hover:underline">
+          {cta} &rarr;
+        </Link>
+      </p>
+      <button
+        onClick={dismiss}
+        className="shrink-0 rounded p-1 text-muted-foreground/60 hover:text-foreground transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/components/civica/shared/CivicaErrorState.tsx
+++ b/components/civica/shared/CivicaErrorState.tsx
@@ -16,7 +16,7 @@ export function CivicaErrorState({
   variant,
   entityType = 'DRep',
   lastKnownEpoch,
-  backHref = '/discover',
+  backHref = '/governance',
 }: CivicaErrorStateProps) {
   if (variant === 'data-lag') {
     return (

--- a/components/engagement/CitizenVoiceSection.tsx
+++ b/components/engagement/CitizenVoiceSection.tsx
@@ -76,7 +76,7 @@ export function CitizenVoiceSection({ data }: CitizenVoiceSectionProps) {
         <p className="text-xs text-muted-foreground">
           Your DRep voted differently on {summary.drepDiverged} proposal
           {summary.drepDiverged !== 1 ? 's' : ''}.{' '}
-          <Link href="/discover?tab=dreps" className="text-primary hover:underline">
+          <Link href="/governance/representatives" className="text-primary hover:underline">
             Explore other DReps
           </Link>
         </p>

--- a/components/governance-cards.tsx
+++ b/components/governance-cards.tsx
@@ -212,7 +212,7 @@ export function DelegationHealthCard({
             You haven&apos;t delegated to a DRep yet. Find one aligned with your values to
             participate in governance.
           </p>
-          <Link href="/discover">
+          <Link href="/governance/representatives">
             <Button size="sm" className="gap-2">
               Find a DRep
               <ArrowRight className="h-3.5 w-3.5" />
@@ -325,7 +325,7 @@ export function RepresentationScoreCard({ rep }: { rep: RepresentationData }) {
             Vote on proposals to see how well your DRep represents your views. Each poll vote you
             cast builds this score.
           </p>
-          <Link href="/discover">
+          <Link href="/governance/proposals">
             <Button
               variant="outline"
               size="sm"
@@ -428,7 +428,7 @@ export function ActiveProposalsSection({ proposals }: { proposals: ActiveProposa
             icon={ScrollText}
             title="All Quiet on the Governance Front"
             message="No proposals are open right now. Check back next epoch, or review recent outcomes."
-            action={{ label: 'View Past Proposals', href: '/discover' }}
+            action={{ label: 'View Past Proposals', href: '/governance/proposals' }}
             compact
             component="ActiveProposals"
           />
@@ -544,7 +544,7 @@ export function ActiveProposalsSection({ proposals }: { proposals: ActiveProposa
         </TooltipProvider>
 
         <div className="mt-3 pt-3 border-t">
-          <Link href="/discover">
+          <Link href="/governance/proposals">
             <Button
               variant="outline"
               size="sm"

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -65,7 +65,7 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
             </Link>
           </Button>
           <Button asChild variant="outline" size="lg" className="flex-1 gap-2">
-            <Link href="/discover">
+            <Link href="/governance">
               Explore Governance
               <ArrowRight className="h-4 w-4" />
             </Link>

--- a/components/hub/HubCardConfig.ts
+++ b/components/hub/HubCardConfig.ts
@@ -128,7 +128,7 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
     type: 'discovery',
     priority: 2,
     conditional: false,
-    href: '/discover',
+    href: '/governance',
   },
 };
 

--- a/components/hub/cards/DiscoveryCard.tsx
+++ b/components/hub/cards/DiscoveryCard.tsx
@@ -31,7 +31,7 @@ export function DiscoveryMatchCard() {
 
 export function DiscoveryExploreCard() {
   return (
-    <HubCard href="/discover" urgency="default" label="Explore Cardano governance">
+    <HubCard href="/governance" urgency="default" label="Explore Cardano governance">
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <Search className="h-4 w-4 text-muted-foreground" />

--- a/docs/strategy/context/build-manifest.md
+++ b/docs/strategy/context/build-manifest.md
@@ -149,6 +149,18 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 - [x] 5-second test heading on proposals browse | PR #257
 - [x] CDN cache headers on proposals API | PR #257
 
+### 1f: Citizen-Anonymous UX Polish
+
+- [x] Stale `/discover` route references purged (46 files) — all internal links now point to `/governance/*` routes directly
+- [x] Match results "Browse All DReps/SPOs" links fixed → `/governance/representatives` and `/governance/pools`
+- [x] Help page: heading "Learn" → "Help", stale links fixed, cards reduced from 6 to 4 (per UX constraints)
+- [x] Score narratives surfaced on DRep browse cards — `getScoreNarrative()` rendered as subtitle on `CivicaDRepCard`
+- [x] Landing page SSR optimized — heavy `info` JSONB fetch replaced with count-only queries (`head: true`)
+- [x] BrandedLoader "$governada" → "Governada", tagline → "Governance Intelligence for Cardano"
+- [x] `/governance` anonymous redirect moved to middleware (server-side, no client-side skeleton flash)
+- [x] AnonymousNudge conversion CTAs on proposals, representatives, and health pages — dismissible, localStorage-persisted
+- [x] Shareable match results — `/match/result?profile=<base64>` page, OG image generation with radar chart, share button with `navigator.share()` + clipboard fallback
+
 ### Remaining
 
 - [ ] `/you/inbox` notifications — page exists but notification pipeline not wired to real events
@@ -285,3 +297,4 @@ Tracked in `docs/strategy/world-class-packages.md`. 13 QPs targeting 84->95+ sco
 | Date       | Persona-State     | E1 JTBD | E2 Friction | E3 Intel | E4 Emotion | E5 Craft | E6 Vision | Total | PR   |
 | ---------- | ----------------- | ------- | ----------- | -------- | ---------- | -------- | --------- | ----- | ---- |
 | 2026-03-10 | citizen-delegated | 7/10    | 6/10        | 6/10     | 6/10       | 7/10     | 6/10      | 38/60 | #257 |
+| 2026-03-10 | citizen-anonymous | 6/10    | 5/10        | 7/10     | 6/10       | 7/10     | 5/10      | 36/60 | —    |

--- a/hooks/useAlignmentAlerts.ts
+++ b/hooks/useAlignmentAlerts.ts
@@ -405,7 +405,7 @@ export function useAlignmentAlerts() {
         type: 'new-proposals',
         title: `${newProposalCount} new proposal${newProposalCount !== 1 ? 's' : ''}`,
         description: `${newProposalCount} new governance proposal${newProposalCount !== 1 ? 's' : ''} since your last visit.`,
-        link: '/discover',
+        link: '/governance/proposals',
         timestamp: now,
         read: false,
       });
@@ -508,7 +508,7 @@ export function useAlignmentAlerts() {
           title: `${govSummary.criticalOpenCount} critical proposal${govSummary.criticalOpenCount !== 1 ? 's' : ''} open`,
           description:
             'A high-impact governance proposal (Hard Fork, No Confidence, or Constitution change) is currently open for voting.',
-          link: '/discover',
+          link: '/governance/proposals',
           timestamp: now,
           read: false,
           metadata: { criticalCount: govSummary.criticalOpenCount },

--- a/lib/actionFeed.ts
+++ b/lib/actionFeed.ts
@@ -73,7 +73,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'vote_required',
         title: `${pendingVotesCount} proposal${pendingVotesCount > 1 ? 's' : ''} await your vote`,
         description: 'Voting on open proposals improves your participation score.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 1,
         cta: 'View Proposals',
       });
@@ -97,7 +97,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'delegation_stale',
         title: 'Your DRep status is inactive',
         description: 'Vote on open proposals to restore your active status.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 1,
         cta: 'View Proposals',
       });
@@ -127,7 +127,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'proposal_expiring',
         title: `${criticalProposals} critical proposal${criticalProposals > 1 ? 's' : ''} active`,
         description: 'High-importance proposals may expire soon.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 2,
         cta: 'View Now',
       });
@@ -141,7 +141,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'delegation_stale',
         title: 'You have no active delegation',
         description: 'Delegate to a DRep to participate in governance.',
-        href: '/discover',
+        href: '/governance/representatives',
         priority: 1,
         cta: 'Find a DRep',
       });
@@ -151,7 +151,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'delegation_stale',
         title: 'Your delegated DRep is inactive',
         description: "Your DRep hasn't voted recently. Consider re-delegating.",
-        href: '/discover',
+        href: '/governance/representatives',
         priority: 1,
         cta: 'Find Another DRep',
       });
@@ -161,7 +161,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'score_dropped',
         title: "Your DRep's score is low",
         description: `Score: ${delegatedDrepScore.toFixed(0)}. Consider reviewing their performance.`,
-        href: delegatedDrep ? `/drep/${delegatedDrep}` : '/discover',
+        href: delegatedDrep ? `/drep/${delegatedDrep}` : '/governance/representatives',
         priority: 2,
         cta: 'Review DRep',
       });
@@ -173,7 +173,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'proposal_expiring',
         title: `${criticalProposals} critical proposal${criticalProposals > 1 ? 's' : ''} in progress`,
         description: 'Important governance decisions are being made.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 2,
         cta: 'View Proposals',
       });
@@ -185,7 +185,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'vote_required',
         title: `${activeProposals} open proposal${activeProposals > 1 ? 's' : ''} being voted on`,
         description: 'Your DRep is representing your vote on these proposals.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 3,
         cta: 'See Proposals',
       });
@@ -199,7 +199,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'vote_required',
         title: `${pendingVotesCount} proposal${pendingVotesCount > 1 ? 's' : ''} await your pool\u2019s vote`,
         description: 'Voting on governance proposals builds your governance reputation.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 1,
         cta: 'View Proposals',
       });
@@ -236,7 +236,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'vote_required',
         title: 'Cast your first governance vote',
         description: 'Start building your governance score by voting on an open proposal.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 2,
         cta: 'View Proposals',
       });
@@ -248,7 +248,7 @@ export function generateActions(input: ActionFeedInput): Action[] {
         type: 'proposal_expiring',
         title: `${criticalProposals} critical proposal${criticalProposals > 1 ? 's' : ''} active`,
         description: 'High-importance proposals may expire soon.',
-        href: '/discover',
+        href: '/governance/proposals',
         priority: 2,
         cta: 'View Now',
       });

--- a/lib/commandIndex.ts
+++ b/lib/commandIndex.ts
@@ -37,7 +37,7 @@ export const PAGE_COMMANDS: CommandItem[] = [
     sublabel: 'Browse governance representatives',
     group: 'pages',
     icon: Compass,
-    href: '/discover',
+    href: '/governance',
     shortcut: 'D',
   },
   {
@@ -46,7 +46,7 @@ export const PAGE_COMMANDS: CommandItem[] = [
     sublabel: 'Browse active governance proposals',
     group: 'pages',
     icon: ScrollText,
-    href: '/discover',
+    href: '/governance/proposals',
     shortcut: 'P',
   },
   {
@@ -80,7 +80,7 @@ export const PAGE_COMMANDS: CommandItem[] = [
     sublabel: 'State of Cardano governance',
     group: 'pages',
     icon: BarChart3,
-    href: '/pulse',
+    href: '/governance/health',
   },
   {
     id: 'page-dashboard-drep',
@@ -96,7 +96,7 @@ export const PAGE_COMMANDS: CommandItem[] = [
     sublabel: 'CC member transparency scores and voting records',
     group: 'pages',
     icon: Landmark,
-    href: '/discover/committee',
+    href: '/governance/committee',
   },
   {
     id: 'page-developers',

--- a/lib/governanceBrief.ts
+++ b/lib/governanceBrief.ts
@@ -319,7 +319,7 @@ function generateHolderBriefTemplate(ctx: HolderBriefContext): GeneratedBrief {
     greeting: "Here's your weekly governance roundup from Governada.",
     sections,
     ctaText: 'Explore DReps',
-    ctaUrl: '/discover',
+    ctaUrl: '/governance/representatives',
   };
 }
 

--- a/lib/matching/confidence.ts
+++ b/lib/matching/confidence.ts
@@ -193,7 +193,7 @@ function getNextAction(
           type: 'vote_proposals',
           label: 'Vote on governance proposals',
           description: `Vote on ${TARGETS.pollVotes - inputs.pollVoteCount} more real proposals to strengthen your governance profile.`,
-          href: '/discover?tab=proposals',
+          href: '/governance/proposals',
           potentialGain: gap,
         });
         break;
@@ -203,7 +203,7 @@ function getNextAction(
           label: 'Vote on different proposal types',
           description:
             'Broaden your profile by voting on treasury, protocol, and governance proposals.',
-          href: '/discover',
+          href: '/governance/proposals',
           potentialGain: gap,
         });
         break;
@@ -222,7 +222,7 @@ function getNextAction(
           type: 'delegate',
           label: 'Delegate to a DRep',
           description: 'Confirm your governance values by delegating to a DRep who represents you.',
-          href: '/discover?sort=match',
+          href: '/governance/representatives',
           potentialGain: gap,
         });
         break;

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -68,7 +68,11 @@ export function buildCompareUrl(drepIds: string[]): string {
 }
 
 export function buildPulseUrl(): string {
-  return `${SITE_URL}/pulse`;
+  return `${SITE_URL}/governance/health`;
+}
+
+export function buildMatchResultUrl(encodedProfile: string): string {
+  return `${SITE_URL}/match/result?profile=${encodeURIComponent(encodedProfile)}`;
 }
 
 export function trackShare(

--- a/middleware.ts
+++ b/middleware.ts
@@ -49,6 +49,14 @@ export function middleware(request: NextRequest) {
     }
   }
 
+  // ── Anonymous /governance redirect (server-side for faster nav) ──
+  if (pathname === '/governance') {
+    const session = request.cookies.get('drepscore_session');
+    if (!session?.value) {
+      return NextResponse.redirect(new URL('/governance/proposals', request.url));
+    }
+  }
+
   // ── Auth gate ─────────────────────────────────────────────────────
   if (AUTH_REQUIRED_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'))) {
     const session = request.cookies.get('drepscore_session');
@@ -85,6 +93,7 @@ export const config = {
   matcher: [
     '/api/v1/:path*',
     '/discover',
+    '/governance',
     '/pulse',
     '/workspace/:path*',
     '/you/:path*',


### PR DESCRIPTION
## Summary
- **Stale route purge**: All 46 files referencing deprecated `/discover` routes updated to `/governance/*` architecture
- **Anonymous conversion nudges**: Dismissible CTAs on proposals, representatives, and health pages guiding anonymous users to Quick Match
- **Score narratives on DRep cards**: `getScoreNarrative()` rendered on browse cards so anonymous users understand scores at a glance
- **Landing page SSR optimization**: Replaced heavy JSONB fetch with 3 count-only queries (`head: true`) for faster cold starts
- **BrandedLoader + middleware**: Fixed copy, added server-side `/governance` → `/governance/proposals` redirect for anonymous users
- **Shareable match results**: New `/match/result` page with OG image generation (radar chart), share button with `navigator.share()` + clipboard fallback

## Impact
- **What changed**: 6 audit fix chunks from `/audit-experience citizen-anonymous` (scored 36/60). Fixes broken routes, adds conversion funnel, improves intelligence surfacing, optimizes SSR, adds viral sharing feature.
- **User-facing**: Yes — anonymous visitors see correct nav links, conversion nudges, score explanations on DRep cards, faster landing page, and can share match results with OG previews.
- **Risk**: Low — no data model changes, no migrations, no env vars. All changes are frontend/middleware. 590/590 tests pass.
- **Scope**: 75 files across `app/`, `components/`, `lib/`, `middleware.ts`, `docs/`. 3 new files created, 1 new API route.

## Test plan
- [ ] Visit `/` without wallet — verify landing page loads with correct stats
- [ ] Click "Explore Governance" — verify redirect to `/governance/proposals` (not `/discover`)
- [ ] Browse DRep cards — verify score narrative subtitle appears below score
- [ ] Check proposals, representatives, health pages — verify AnonymousNudge appears, can be dismissed, stays dismissed on reload
- [ ] Complete Quick Match flow — verify share button appears, clicking copies link or opens share sheet
- [ ] Visit shared match URL (`/match/result?profile=...`) — verify page renders with radar chart and OG metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)