### PR TITLE
feat: citizen-undelegated experience improvements

### DIFF
--- a/app/api/engagement/endorsements/batch/route.ts
+++ b/app/api/engagement/endorsements/batch/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/engagement/endorsements/batch?entityType=drep&entityIds=id1,id2,...
+ *
+ * Returns a map of entityId -> total endorsement count.
+ * Uses precomputed engagement_signal_aggregations for performance.
+ * Falls back to direct count from citizen_endorsements if aggregations are empty.
+ */
+export const GET = withRouteHandler(
+  async (request: NextRequest) => {
+    const { searchParams } = request.nextUrl;
+    const entityType = searchParams.get('entityType');
+    const entityIdsParam = searchParams.get('entityIds');
+
+    if (!entityType || !entityIdsParam) {
+      return NextResponse.json({ error: 'entityType and entityIds required' }, { status: 400 });
+    }
+
+    const entityIds = entityIdsParam.split(',').filter(Boolean).slice(0, 100); // Cap at 100
+    if (entityIds.length === 0) {
+      return NextResponse.json({ counts: {} });
+    }
+
+    const supabase = createClient();
+
+    // Try precomputed aggregations first (most efficient)
+    const { data: aggRows } = await supabase
+      .from('engagement_signal_aggregations')
+      .select('entity_id, data')
+      .eq('entity_type', entityType)
+      .eq('signal_type', 'endorsements')
+      .in('entity_id', entityIds);
+
+    const counts: Record<string, number> = {};
+
+    if (aggRows && aggRows.length > 0) {
+      for (const row of aggRows) {
+        const data = row.data as { total?: number } | null;
+        if (data && typeof data.total === 'number' && data.total > 0) {
+          counts[row.entity_id] = data.total;
+        }
+      }
+    }
+
+    // For any IDs not found in aggregations, fall back to direct count
+    const missingIds = entityIds.filter((id) => !(id in counts));
+    if (missingIds.length > 0) {
+      const { data: directRows } = await supabase
+        .from('citizen_endorsements')
+        .select('entity_id')
+        .eq('entity_type', entityType)
+        .in('entity_id', missingIds);
+
+      if (directRows) {
+        const directCounts: Record<string, number> = {};
+        for (const row of directRows) {
+          directCounts[row.entity_id] = (directCounts[row.entity_id] || 0) + 1;
+        }
+        for (const [id, count] of Object.entries(directCounts)) {
+          if (count > 0) counts[id] = count;
+        }
+      }
+    }
+
+    return NextResponse.json(
+      { counts },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=300',
+        },
+      },
+    );
+  },
+  { auth: 'none' },
+);

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -110,13 +110,14 @@ export const POST = withRouteHandler(async (request) => {
     if (!pools?.length) {
       return NextResponse.json({
         matches: [],
+        nearMisses: [],
         userAlignments,
         personalityLabel: null,
         matchType: 'spo',
       });
     }
 
-    const ranked = pools
+    const allRankedSPO = pools
       .map((p) => {
         const spoAlignments = extractAlignments(p);
         const distance = euclideanDistance(userAlignments, spoAlignments);
@@ -132,9 +133,15 @@ export const POST = withRouteHandler(async (request) => {
           differDimensions: dimAgreement.differDimensions,
         };
       })
-      .sort((a, b) => b.matchScore - a.matchScore || b.entityScore - a.entityScore)
+      .sort((a, b) => b.matchScore - a.matchScore || b.entityScore - a.entityScore);
+
+    const ranked = allRankedSPO
       .filter((r) => r.matchScore >= MIN_MATCH_SCORE && r.entityScore >= MIN_ENTITY_SCORE)
       .slice(0, 5);
+
+    // Near-misses: top results that didn't meet thresholds (for empty state guidance)
+    const spoNearMisses =
+      ranked.length === 0 ? allRankedSPO.filter((r) => !ranked.includes(r)).slice(0, 3) : [];
 
     const personalityLabel = getPersonalityLabel(userAlignments);
     const dominant = getDominantDimension(userAlignments);
@@ -159,18 +166,21 @@ export const POST = withRouteHandler(async (request) => {
       matches_count: ranked.length,
     });
 
+    const formatMatch = (r: (typeof allRankedSPO)[number]) => ({
+      drepId: r.entityId,
+      drepName: r.entityName,
+      drepScore: r.entityScore,
+      matchScore: r.matchScore,
+      alignments: r.alignments,
+      identityColor: getIdentityColor(r.dominantDimension).hex,
+      personalityLabel: getPersonalityLabel(r.alignments),
+      agreeDimensions: r.agreeDimensions,
+      differDimensions: r.differDimensions,
+    });
+
     return NextResponse.json({
-      matches: ranked.map((r) => ({
-        drepId: r.entityId,
-        drepName: r.entityName,
-        drepScore: r.entityScore,
-        matchScore: r.matchScore,
-        alignments: r.alignments,
-        identityColor: getIdentityColor(r.dominantDimension).hex,
-        personalityLabel: getPersonalityLabel(r.alignments),
-        agreeDimensions: r.agreeDimensions,
-        differDimensions: r.differDimensions,
-      })),
+      matches: ranked.map(formatMatch),
+      nearMisses: spoNearMisses.map(formatMatch),
       userAlignments,
       personalityLabel,
       identityColor: identityColor.hex,
@@ -190,13 +200,14 @@ export const POST = withRouteHandler(async (request) => {
   if (!dreps?.length) {
     return NextResponse.json({
       matches: [],
+      nearMisses: [],
       userAlignments,
       personalityLabel: null,
       matchType: 'drep',
     });
   }
 
-  const ranked = dreps
+  const allRanked = dreps
     .map((d) => {
       const drepAlignments = extractAlignments(d);
       const distance = euclideanDistance(userAlignments, drepAlignments);
@@ -215,12 +226,19 @@ export const POST = withRouteHandler(async (request) => {
     .sort((a, b) => b.matchScore - a.matchScore || b.drepScore - a.drepScore);
 
   // Apply quality thresholds before selecting top results
-  const qualified = ranked.filter(
+  const qualified = allRanked.filter(
     (r) => r.matchScore >= MIN_MATCH_SCORE && r.drepScore >= MIN_ENTITY_SCORE,
   );
   // Prefer named DReps in results; fall back to unnamed if fewer than 3 named
   const namedRanked = qualified.filter((r) => r.drepName);
   const topRanked = (namedRanked.length >= 3 ? namedRanked : qualified).slice(0, 5);
+
+  // Near-misses: top results that didn't meet thresholds (for empty state guidance)
+  const topRankedIds = new Set(topRanked.map((r) => r.drepId));
+  const nearMisses =
+    topRanked.length === 0
+      ? allRanked.filter((r) => !topRankedIds.has(r.drepId) && r.drepName).slice(0, 3)
+      : [];
 
   const personalityLabel = getPersonalityLabel(userAlignments);
   const dominant = getDominantDimension(userAlignments);
@@ -245,18 +263,21 @@ export const POST = withRouteHandler(async (request) => {
     matches_count: topRanked.length,
   });
 
+  const formatDrepMatch = (r: (typeof allRanked)[number]) => ({
+    drepId: r.drepId,
+    drepName: r.drepName,
+    drepScore: r.drepScore,
+    matchScore: r.matchScore,
+    alignments: r.alignments,
+    identityColor: getIdentityColor(r.dominantDimension).hex,
+    personalityLabel: getPersonalityLabel(r.alignments),
+    agreeDimensions: r.agreeDimensions,
+    differDimensions: r.differDimensions,
+  });
+
   return NextResponse.json({
-    matches: topRanked.map((r) => ({
-      drepId: r.drepId,
-      drepName: r.drepName,
-      drepScore: r.drepScore,
-      matchScore: r.matchScore,
-      alignments: r.alignments,
-      identityColor: getIdentityColor(r.dominantDimension).hex,
-      personalityLabel: getPersonalityLabel(r.alignments),
-      agreeDimensions: r.agreeDimensions,
-      differDimensions: r.differDimensions,
-    })),
+    matches: topRanked.map(formatDrepMatch),
+    nearMisses: nearMisses.map(formatDrepMatch),
     userAlignments,
     personalityLabel,
     identityColor: identityColor.hex,

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -58,6 +58,7 @@ const SimilarDReps = nextDynamic(
 import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
+import { DRepDetailedAnalysis } from '@/components/drep/DRepDetailedAnalysis';
 import { DRepCitizenSignals } from '@/components/DRepCitizenSignals';
 const CitizenEndorsements = nextDynamic(
   () => import('@/components/engagement/CitizenEndorsements').then((m) => m.CitizenEndorsements),
@@ -111,6 +112,7 @@ import {
   getSocialLinkChecks,
   isDRepClaimed,
   getOpenProposalsForDRep,
+  getEndorsementCount,
 } from '@/lib/data';
 import { createClient } from '@/lib/supabase';
 import { BASE_URL } from '@/lib/constants';
@@ -390,25 +392,41 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
 
   const matchScore = match ? parseInt(match, 10) : null;
 
-  const [
-    scoreHistory,
-    percentile,
-    rank,
-    delegationTrend,
-    linkChecks,
-    isClaimed,
-    spoAlignPct,
-    openProposals,
-  ] = await Promise.all([
-    getScoreHistory(drep.drepId),
-    getDRepPercentile(drep.drepScore),
-    getDRepRank(drep.drepId),
-    getDRepDelegationTrend(drep.drepId),
-    getSocialLinkChecks(drep.drepId),
-    isDRepClaimed(drep.drepId),
-    getSpoAlignment(drep.votes),
-    getOpenProposalsForDRep(drep.drepId),
-  ]);
+  let scoreHistory: Awaited<ReturnType<typeof getScoreHistory>> = [];
+  let percentile = 0;
+  let rank: number | null = 0;
+  let delegationTrend: Awaited<ReturnType<typeof getDRepDelegationTrend>> = [];
+  let linkChecks: Awaited<ReturnType<typeof getSocialLinkChecks>> = [];
+  let isClaimed = false;
+  let spoAlignPct: number | null = null;
+  let openProposals: Awaited<ReturnType<typeof getOpenProposalsForDRep>> = [];
+  let endorsementCount = 0;
+
+  try {
+    [
+      scoreHistory,
+      percentile,
+      rank,
+      delegationTrend,
+      linkChecks,
+      isClaimed,
+      spoAlignPct,
+      openProposals,
+      endorsementCount,
+    ] = await Promise.all([
+      getScoreHistory(drep.drepId),
+      getDRepPercentile(drep.drepScore),
+      getDRepRank(drep.drepId),
+      getDRepDelegationTrend(drep.drepId),
+      getSocialLinkChecks(drep.drepId),
+      isDRepClaimed(drep.drepId),
+      getSpoAlignment(drep.votes),
+      getOpenProposalsForDRep(drep.drepId),
+      getEndorsementCount('drep', drep.drepId),
+    ]);
+  } catch (err) {
+    console.error('[DRepProfile] Secondary data fetch failed, using defaults:', err);
+  }
 
   const pendingProposalCount = openProposals.length;
 
@@ -616,6 +634,13 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
             tooltip="How often this DRep votes the same way as the SPO majority"
           />
         )}
+        {endorsementCount > 0 && (
+          <KeyFact
+            label="Citizen Endorsements"
+            value={endorsementCount.toLocaleString()}
+            tooltip="Number of citizens who have endorsed this DRep across governance competencies like treasury oversight, technical expertise, and communication"
+          />
+        )}
         {drep.totalVotes > 0 && (
           <div className="flex flex-col items-center text-center min-w-[100px]">
             <span className="text-xs text-muted-foreground">Voting Pattern</span>
@@ -705,58 +730,10 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <SocialProofBadge drepId={drep.drepId} variant="views" />
       </div>
 
-      {/* 5. Delegation Power Trend */}
-      {delegationTrend.length >= 2 ? (
-        <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-              Delegation Trend
-            </span>
-            <span className="text-xs text-muted-foreground">{delegationTrend.length} epochs</span>
-          </div>
-          <div className="flex items-end gap-[2px] h-10">
-            {(() => {
-              const counts = delegationTrend.map((d) => d.delegatorCount);
-              const maxCount = Math.max(...counts, 1);
-              return delegationTrend.map((d) => (
-                <div
-                  key={d.epoch}
-                  className="flex-1 bg-primary/60 rounded-t-sm min-w-[3px]"
-                  style={{ height: `${Math.max(4, (d.delegatorCount / maxCount) * 100)}%` }}
-                  title={`Epoch ${d.epoch}: ${d.delegatorCount.toLocaleString()} delegators, ${d.votingPowerAda.toLocaleString()} ADA`}
-                />
-              ));
-            })()}
-          </div>
-          <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
-            <span>E{delegationTrend[0].epoch}</span>
-            <span>
-              {delegationTrend[delegationTrend.length - 1].delegatorCount.toLocaleString()}{' '}
-              delegators &middot;{' '}
-              {(delegationTrend[delegationTrend.length - 1].votingPowerAda / 1_000_000).toFixed(1)}M
-              ADA
-            </span>
-            <span>E{delegationTrend[delegationTrend.length - 1].epoch}</span>
-          </div>
-        </div>
-      ) : (
-        <div className="rounded-xl border border-border bg-card px-5 py-4">
-          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
-            Delegation Trend
-          </span>
-          <p className="text-xs text-muted-foreground">
-            Delegation trend data will appear after 2+ epochs of delegation activity.
-          </p>
-        </div>
-      )}
-
-      {/* 6. Treasury Stance (compact in VP1) */}
+      {/* 5. Treasury Stance (compact in VP1) */}
       <DRepTreasuryStance drepId={drep.drepId} compact />
 
-      {/* 7. Activity feed */}
-      <ActivitySideWidget drepId={drep.drepId} limit={5} />
-
-      {/* 8. About & Community (folded from former Community tab into Overview) */}
+      {/* 6. About & Governance Statements */}
       <AboutSection
         description={drep.description}
         bio={drep.metadata?.bio}
@@ -768,100 +745,157 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <DRepDashboardWrapper drepId={drep.drepId} drepName={drepName} isClaimed={isClaimed} />
       </Suspense>
 
-      {/* 9. Similar DReps */}
-      <SimilarDReps drepId={drep.drepId} />
-
       {/* ════════════════════════════════════════════
-          VP2 — "The Record" (below fold, tabbed)
+          Detailed Analysis — gated for citizens/anonymous.
+          DReps, SPOs, and CC members see everything expanded.
+          Citizens see a "Show detailed analysis" toggle.
           ════════════════════════════════════════════ */}
-
-      <DRepProfileTabsV2
-        drepId={drep.drepId}
-        statementsContent={statementsContent}
-        votingRecordContent={
-          <div className="space-y-6">
-            <DRepOutcomeSummary drepId={drep.drepId} />
-            <Suspense fallback={<DetailPageSkeleton />}>
-              <VotingHistoryWithPrefs votes={drep.votes} />
-            </Suspense>
-          </div>
-        }
-        scoreAnalysisContent={
-          <ScoreAnalysisGate
-            drepId={drep.drepId}
-            isClaimed={isClaimed}
-            ownerContent={
-              <>
-                {tierProgress.recommendedAction && (
-                  <div className="rounded-xl border border-primary/20 bg-primary/5 px-5 py-4 flex items-start gap-3">
-                    <div className="flex-1">
-                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
-                        Recommended Action
-                      </p>
-                      <p className="text-sm font-medium">{tierProgress.recommendedAction}</p>
-                    </div>
-                    {tierProgress.pointsToNext != null && (
-                      <div className="shrink-0 text-right">
-                        <p className="text-xl font-bold font-display tabular-nums text-primary">
-                          +{tierProgress.pointsToNext}
-                        </p>
-                        <p className="text-[10px] text-muted-foreground uppercase tracking-wider">
-                          pts to {tierProgress.nextTier}
-                        </p>
-                      </div>
-                    )}
-                  </div>
+      <DRepDetailedAnalysis>
+        {/* Delegation Power Trend */}
+        {delegationTrend.length >= 2 ? (
+          <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Delegation Trend
+              </span>
+              <span className="text-xs text-muted-foreground">{delegationTrend.length} epochs</span>
+            </div>
+            <div className="flex items-end gap-[2px] h-10">
+              {(() => {
+                const counts = delegationTrend.map((d) => d.delegatorCount);
+                const maxCount = Math.max(...counts, 1);
+                return delegationTrend.map((d) => (
+                  <div
+                    key={d.epoch}
+                    className="flex-1 bg-primary/60 rounded-t-sm min-w-[3px]"
+                    style={{ height: `${Math.max(4, (d.delegatorCount / maxCount) * 100)}%` }}
+                    title={`Epoch ${d.epoch}: ${d.delegatorCount.toLocaleString()} delegators, ${d.votingPowerAda.toLocaleString()} ADA`}
+                  />
+                ));
+              })()}
+            </div>
+            <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
+              <span>E{delegationTrend[0].epoch}</span>
+              <span>
+                {delegationTrend[delegationTrend.length - 1].delegatorCount.toLocaleString()}{' '}
+                delegators &middot;{' '}
+                {(delegationTrend[delegationTrend.length - 1].votingPowerAda / 1_000_000).toFixed(
+                  1,
                 )}
-                <ScoreSimulator drepId={drep.drepId} pendingCount={pendingProposalCount} />
-                <ScoreDeepDive
-                  score={drep.drepScore}
-                  engagementQuality={drep.engagementQuality}
-                  engagementQualityRaw={drep.engagementQualityRaw}
-                  effectiveParticipation={drep.effectiveParticipationV3}
-                  effectiveParticipationRaw={drep.effectiveParticipationV3Raw}
-                  reliability={drep.reliabilityV3}
-                  reliabilityRaw={drep.reliabilityV3Raw}
-                  governanceIdentity={drep.governanceIdentity}
-                  governanceIdentityRaw={drep.governanceIdentityRaw}
-                  scoreMomentum={drep.scoreMomentum}
-                  rationaleRate={drep.rationaleRate}
-                  deliberationModifier={drep.deliberationModifier}
-                  reliabilityStreak={drep.reliabilityStreak}
-                  reliabilityRecency={drep.reliabilityRecency}
-                  reliabilityLongestGap={drep.reliabilityLongestGap}
-                  reliabilityTenure={drep.reliabilityTenure}
-                  profileCompleteness={drep.profileCompleteness}
-                  delegatorCount={drep.delegatorCount}
-                />
-                <ScoreCard
-                  drep={drep}
-                  adjustedRationale={adjustedRationale}
-                  pillars={pillars}
-                  pillarStatuses={pillarStatuses}
-                  quickWin={quickWin}
-                  percentile={percentile}
-                  participationHint={participationHint}
-                  rationaleHint={rationaleHint}
-                  reliabilityHint={reliabilityHint}
-                  profileHint={profileHint}
-                />
-                <MilestoneBadges drepId={drep.drepId} compact />
-              </>
-            }
-            publicContent={
-              <>
-                <ScoreHistoryChart history={scoreHistory} />
-                <ActivityHeatmap drepId={drep.drepId} />
-              </>
-            }
-          />
-        }
-        trajectoryContent={
-          <div className="space-y-6">
-            <AlignmentTrajectory drepId={drep.drepId} />
+                M ADA
+              </span>
+              <span>E{delegationTrend[delegationTrend.length - 1].epoch}</span>
+            </div>
           </div>
-        }
-      />
+        ) : (
+          <div className="rounded-xl border border-border bg-card px-5 py-4">
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
+              Delegation Trend
+            </span>
+            <p className="text-xs text-muted-foreground">
+              Delegation trend data will appear after 2+ epochs of delegation activity.
+            </p>
+          </div>
+        )}
+
+        {/* Activity feed */}
+        <ActivitySideWidget drepId={drep.drepId} limit={5} />
+
+        {/* Similar DReps */}
+        <SimilarDReps drepId={drep.drepId} />
+
+        {/* ════════════════════════════════════════════
+            VP2 — "The Record" (below fold, tabbed)
+            ════════════════════════════════════════════ */}
+
+        <DRepProfileTabsV2
+          drepId={drep.drepId}
+          statementsContent={statementsContent}
+          votingRecordContent={
+            <div className="space-y-6">
+              <DRepOutcomeSummary drepId={drep.drepId} />
+              <Suspense fallback={<DetailPageSkeleton />}>
+                <VotingHistoryWithPrefs votes={drep.votes} />
+              </Suspense>
+            </div>
+          }
+          scoreAnalysisContent={
+            <ScoreAnalysisGate
+              drepId={drep.drepId}
+              isClaimed={isClaimed}
+              ownerContent={
+                <>
+                  {tierProgress.recommendedAction && (
+                    <div className="rounded-xl border border-primary/20 bg-primary/5 px-5 py-4 flex items-start gap-3">
+                      <div className="flex-1">
+                        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+                          Recommended Action
+                        </p>
+                        <p className="text-sm font-medium">{tierProgress.recommendedAction}</p>
+                      </div>
+                      {tierProgress.pointsToNext != null && (
+                        <div className="shrink-0 text-right">
+                          <p className="text-xl font-bold font-display tabular-nums text-primary">
+                            +{tierProgress.pointsToNext}
+                          </p>
+                          <p className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                            pts to {tierProgress.nextTier}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  <ScoreSimulator drepId={drep.drepId} pendingCount={pendingProposalCount} />
+                  <ScoreDeepDive
+                    score={drep.drepScore}
+                    engagementQuality={drep.engagementQuality}
+                    engagementQualityRaw={drep.engagementQualityRaw}
+                    effectiveParticipation={drep.effectiveParticipationV3}
+                    effectiveParticipationRaw={drep.effectiveParticipationV3Raw}
+                    reliability={drep.reliabilityV3}
+                    reliabilityRaw={drep.reliabilityV3Raw}
+                    governanceIdentity={drep.governanceIdentity}
+                    governanceIdentityRaw={drep.governanceIdentityRaw}
+                    scoreMomentum={drep.scoreMomentum}
+                    rationaleRate={drep.rationaleRate}
+                    deliberationModifier={drep.deliberationModifier}
+                    reliabilityStreak={drep.reliabilityStreak}
+                    reliabilityRecency={drep.reliabilityRecency}
+                    reliabilityLongestGap={drep.reliabilityLongestGap}
+                    reliabilityTenure={drep.reliabilityTenure}
+                    profileCompleteness={drep.profileCompleteness}
+                    delegatorCount={drep.delegatorCount}
+                  />
+                  <ScoreCard
+                    drep={drep}
+                    adjustedRationale={adjustedRationale}
+                    pillars={pillars}
+                    pillarStatuses={pillarStatuses}
+                    quickWin={quickWin}
+                    percentile={percentile}
+                    participationHint={participationHint}
+                    rationaleHint={rationaleHint}
+                    reliabilityHint={reliabilityHint}
+                    profileHint={profileHint}
+                  />
+                  <MilestoneBadges drepId={drep.drepId} compact />
+                </>
+              }
+              publicContent={
+                <>
+                  <ScoreHistoryChart history={scoreHistory} />
+                  <ActivityHeatmap drepId={drep.drepId} />
+                </>
+              }
+            />
+          }
+          trajectoryContent={
+            <div className="space-y-6">
+              <AlignmentTrajectory drepId={drep.drepId} />
+            </div>
+          }
+        />
+      </DRepDetailedAnalysis>
     </div>
   );
 

--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -15,6 +15,7 @@ import {
 import { fadeInUp, staggerContainer } from '@/lib/animations';
 import { cn } from '@/lib/utils';
 import { Users, TrendingUp, Award } from 'lucide-react';
+import { MatchContextBadge } from '@/components/matching/MatchContextBadge';
 
 interface DRepProfileHeroProps {
   name: string;
@@ -79,25 +80,24 @@ export function DRepProfileHero({
               )}
             </div>
 
-            {/* Trait tags */}
-            {traitTags.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {traitTags.map((tag) => (
-                  <Badge
-                    key={tag}
-                    variant="outline"
-                    className={cn('text-xs', 'dark:border-border/60 dark:bg-card/50')}
-                  >
-                    {tag}
-                  </Badge>
-                ))}
-                {!isActive && (
-                  <Badge variant="secondary" className="text-xs">
-                    Inactive
-                  </Badge>
-                )}
-              </div>
-            )}
+            {/* Trait tags + match context */}
+            <div className="flex flex-wrap gap-2">
+              {traitTags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className={cn('text-xs', 'dark:border-border/60 dark:bg-card/50')}
+                >
+                  {tag}
+                </Badge>
+              ))}
+              {!isActive && (
+                <Badge variant="secondary" className="text-xs">
+                  Inactive
+                </Badge>
+              )}
+              <MatchContextBadge drepAlignments={alignments} existingMatchScore={matchScore} />
+            </div>
 
             {/* Key stats */}
             <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-muted-foreground pt-2">

--- a/components/DelegateButton.tsx
+++ b/components/DelegateButton.tsx
@@ -170,6 +170,9 @@ export function DelegateButton({ drepId, drepName, size = 'sm', className }: Del
             Your ADA stays in your wallet.
           </p>
         </div>
+        <p className="text-[10px] text-muted-foreground">
+          You can change your DRep anytime — delegation is never permanent.
+        </p>
         <div className="flex gap-2">
           <Button variant="outline" size="sm" className="flex-1 h-7 text-xs" onClick={reset}>
             Cancel

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import { TrendingUp, TrendingDown, Minus, CheckCircle2, XCircle, ChevronRight } from 'lucide-react';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  CheckCircle2,
+  XCircle,
+  ChevronRight,
+  Heart,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { computeTier } from '@/lib/scoring/tiers';
 import { getScoreNarrative } from '@/lib/scoring/scoreNarratives';
@@ -34,9 +42,10 @@ interface CivicaDRepCardProps {
   drep: EnrichedDRep;
   rank?: number;
   matchScore?: number | null;
+  endorsementCount?: number;
 }
 
-export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) {
+export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: CivicaDRepCardProps) {
   const score = drep.drepScore ?? 0;
   const tier = tierKey(computeTier(score));
   const momentum = drep.scoreMomentum ?? null;
@@ -90,6 +99,12 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
             {drep.delegatorCount > 0 && (
               <span className="text-[10px] text-muted-foreground">
                 · {drep.delegatorCount.toLocaleString()} delegators
+              </span>
+            )}
+            {endorsementCount != null && endorsementCount > 0 && (
+              <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                · <Heart className="h-2.5 w-2.5" aria-hidden="true" />
+                <span className="tabular-nums">{endorsementCount}</span>
               </span>
             )}
             {recency && (

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import { CivicaDRepCard } from '@/components/civica/cards/CivicaDRepCard';
 import { computeTier } from '@/lib/scoring/tiers';
 import { TIER_SCORE_COLOR, TIER_BADGE_BG, tierKey } from '@/components/civica/cards/tierStyles';
+import { useBatchEndorsementCounts } from '@/hooks/useEngagement';
 import type { EnrichedDRep } from '@/lib/koios';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
@@ -292,6 +293,11 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
   const totalPages = Math.ceil(filtered.length / pageSize);
   const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);
 
+  // Fetch endorsement counts for visible DReps
+  const pageEntityIds = useMemo(() => pageItems.map((d) => d.drepId), [pageItems]);
+  const { data: endorsementData } = useBatchEndorsementCounts('drep', pageEntityIds);
+  const endorsementCounts = endorsementData?.counts ?? {};
+
   return (
     <div ref={contentRef} className="space-y-4 pt-4">
       <AnonymousNudge variant="representatives" />
@@ -428,6 +434,7 @@ export function CivicaDRepBrowse({ dreps }: CivicaDRepBrowseProps) {
                   drep={drep}
                   rank={sortMode === 'match' ? undefined : page * pageSize + i + 1}
                   matchScore={ms}
+                  endorsementCount={endorsementCounts[drep.drepId]}
                 />
               </div>
             );

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -61,6 +61,7 @@ interface MatchResult {
 
 interface QuickMatchResponse {
   matches: MatchResult[];
+  nearMisses?: MatchResult[];
   userAlignments: AlignmentScores;
   personalityLabel: string;
   identityColor: string;
@@ -858,31 +859,12 @@ function ResultsScreen({
             ))}
           </div>
         ) : (
-          <div className="text-center py-10 space-y-3">
-            <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-              {activeTab === 'spo' ? (
-                <Server className="h-6 w-6 text-muted-foreground" />
-              ) : (
-                <Users className="h-6 w-6 text-muted-foreground" />
-              )}
-            </div>
-            <p className="font-medium text-sm">
-              No {activeTab === 'spo' ? 'SPO' : 'DRep'} matches found
-            </p>
-            <p className="text-xs text-muted-foreground max-w-sm mx-auto">
-              No {activeTab === 'spo' ? 'SPOs' : 'DReps'} currently meet our quality threshold for
-              your preferences. As {activeTab === 'spo' ? 'SPOs' : 'DReps'} improve their governance
-              participation, more matches will appear.
-            </p>
-            <Button asChild variant="outline" size="sm">
-              <Link
-                href={activeTab === 'spo' ? '/governance/pools' : '/governance/representatives'}
-              >
-                Browse all active {activeTab === 'spo' ? 'SPOs' : 'DReps'}
-                <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
-              </Link>
-            </Button>
-          </div>
+          <EmptyMatchState
+            activeTab={activeTab}
+            nearMisses={activeResults.nearMisses ?? []}
+            userAlignments={drepResults.userAlignments}
+            onRetake={onRestart}
+          />
         )}
       </div>
 
@@ -908,6 +890,96 @@ function ResultsScreen({
   );
 }
 
+/* ─── Empty match state ────────────────────────────────── */
+
+function EmptyMatchState({
+  activeTab,
+  nearMisses,
+  userAlignments,
+  onRetake,
+}: {
+  activeTab: MatchType;
+  nearMisses: MatchResult[];
+  userAlignments: AlignmentScores;
+  onRetake: () => void;
+}) {
+  const entityLabelPlural = activeTab === 'spo' ? 'SPOs' : 'DReps';
+  const browsePath = activeTab === 'spo' ? '/governance/pools' : '/governance/representatives';
+  const hasNearMisses = nearMisses.length > 0;
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-300">
+      {/* Explanation */}
+      <div className="text-center py-6 space-y-3">
+        <div className="mx-auto w-12 h-12 rounded-full bg-amber-500/10 flex items-center justify-center">
+          {activeTab === 'spo' ? (
+            <Server className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+          ) : (
+            <Users className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+          )}
+        </div>
+        <p className="font-medium text-sm">Your governance values are quite specific</p>
+        <p className="text-xs text-muted-foreground max-w-sm mx-auto leading-relaxed">
+          {hasNearMisses
+            ? `No ${entityLabelPlural} closely align with your full set of preferences right now, but we found some partial matches below. As more ${entityLabelPlural} participate in governance, stronger matches will appear.`
+            : `No ${entityLabelPlural} currently have enough governance activity to match against your preferences. As ${entityLabelPlural} improve their governance participation, matches will appear.`}
+        </p>
+      </div>
+
+      {/* Near-miss results */}
+      {hasNearMisses && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 justify-center">
+            <div className="h-px flex-1 bg-border/50" />
+            <p className="text-xs font-medium text-amber-600 dark:text-amber-400 tracking-wide uppercase shrink-0">
+              Closest Matches — Lower Alignment
+            </p>
+            <div className="h-px flex-1 bg-border/50" />
+          </div>
+          <p className="text-[11px] text-muted-foreground text-center max-w-sm mx-auto">
+            These {entityLabelPlural} are the closest to your values but fall below our confidence
+            threshold. Review their profiles to decide for yourself.
+          </p>
+          <div className="space-y-3 opacity-90">
+            {nearMisses.map((match, i) => (
+              <div
+                key={match.drepId}
+                className="animate-in fade-in slide-in-from-bottom-3"
+                style={{
+                  animationDelay: `${i * 150}ms`,
+                  animationFillMode: 'backwards',
+                }}
+              >
+                <QuickMatchResultCard
+                  rank={i + 1}
+                  match={match}
+                  userAlignments={userAlignments}
+                  matchType={activeTab}
+                  isNearMiss
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col items-center gap-2 pt-2">
+        <Button variant="outline" size="sm" onClick={onRetake} className="gap-2">
+          <RotateCcw className="h-3.5 w-3.5" />
+          Try Different Answers
+        </Button>
+        <Button asChild variant="ghost" size="sm">
+          <Link href={browsePath}>
+            Browse all active {entityLabelPlural}
+            <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /* ─── Result card ───────────────────────────────────────── */
 
 function QuickMatchResultCard({
@@ -915,11 +987,13 @@ function QuickMatchResultCard({
   match,
   userAlignments,
   matchType = 'drep',
+  isNearMiss = false,
 }: {
   rank: number;
   match: MatchResult;
   userAlignments: AlignmentScores;
   matchType?: MatchType;
+  isNearMiss?: boolean;
 }) {
   const displayName = match.drepName || match.drepId.slice(0, 16) + '...';
   const isSPO = matchType === 'spo';
@@ -929,8 +1003,13 @@ function QuickMatchResultCard({
 
   return (
     <Card
-      className="overflow-hidden hover:border-primary/30 transition-colors"
-      aria-label={`Rank ${rank}: ${displayName}, ${match.matchScore}% match`}
+      className={cn(
+        'overflow-hidden transition-colors',
+        isNearMiss
+          ? 'border-amber-500/20 hover:border-amber-500/40 bg-amber-500/[0.02]'
+          : 'hover:border-primary/30',
+      )}
+      aria-label={`${isNearMiss ? 'Near miss ' : ''}Rank ${rank}: ${displayName}, ${match.matchScore}% match`}
     >
       <CardContent className="p-4">
         <div className="flex gap-4">
@@ -980,10 +1059,20 @@ function QuickMatchResultCard({
               </Badge>
             </div>
 
-            {/* Personality */}
-            <Badge variant="secondary" className="text-[10px]">
-              {match.personalityLabel}
-            </Badge>
+            {/* Personality + near-miss indicator */}
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <Badge variant="secondary" className="text-[10px]">
+                {match.personalityLabel}
+              </Badge>
+              {isNearMiss && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] text-amber-600 dark:text-amber-400 border-amber-500/30 bg-amber-500/5"
+                >
+                  Lower alignment
+                </Badge>
+              )}
+            </div>
 
             {/* Match narrative */}
             {(match.agreeDimensions.length > 0 || match.differDimensions.length > 0) && (
@@ -993,7 +1082,7 @@ function QuickMatchResultCard({
             )}
 
             <div className="flex gap-2 mt-1">
-              {!isSPO && (
+              {!isSPO && !isNearMiss && (
                 <DelegateButton
                   drepId={match.drepId}
                   drepName={displayName}

--- a/components/drep/DRepDetailedAnalysis.tsx
+++ b/components/drep/DRepDetailedAnalysis.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface DRepDetailedAnalysisProps {
+  children: ReactNode;
+}
+
+/**
+ * Progressive disclosure gate for DRep profile analytics sections.
+ *
+ * - Citizens and anonymous users see a collapsed "Show detailed analysis" toggle.
+ * - DReps, SPOs, CC members, and researchers see everything expanded by default.
+ *
+ * This keeps the citizen experience focused on summary intelligence while
+ * preserving full depth for governance participants who need it.
+ */
+export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
+  const { segment, isLoading } = useSegment();
+
+  // DReps, SPOs, and CC members see everything expanded
+  const isDetailedSegment = segment === 'drep' || segment === 'spo' || segment === 'cc';
+
+  const [expanded, setExpanded] = useState(isDetailedSegment);
+
+  // For detailed segments, always render expanded (no gate)
+  if (isDetailedSegment) {
+    return <>{children}</>;
+  }
+
+  // While loading segment, render nothing to avoid flash of collapsed → expanded
+  if (isLoading) {
+    return null;
+  }
+
+  // Citizens and anonymous users get the collapsible gate
+  return (
+    <div className="space-y-4">
+      {!expanded && (
+        <div className="flex justify-center py-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setExpanded(true)}
+            className="gap-2 text-muted-foreground hover:text-foreground"
+          >
+            <span>Show detailed analysis</span>
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'transition-all duration-300 ease-in-out',
+          expanded ? 'opacity-100' : 'max-h-0 overflow-hidden opacity-0',
+        )}
+      >
+        {/* Only mount children when expanded to avoid unnecessary data fetching */}
+        {expanded && <div className="space-y-6">{children}</div>}
+      </div>
+
+      {expanded && (
+        <div className="flex justify-center py-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded(false)}
+            className="gap-2 text-xs text-muted-foreground"
+          >
+            <span>Hide detailed analysis</span>
+            <ChevronDown className="h-4 w-4 rotate-180" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -32,7 +32,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
       href={href}
       aria-label={label}
       className={cn(
-        'group block rounded-2xl border p-4 sm:p-5 transition-colors hover:border-primary/40',
+        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5 transition-colors hover:border-primary/40',
         URGENCY_STYLES[urgency],
         className,
       )}
@@ -51,7 +51,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-border bg-card p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />

--- a/components/matching/MatchContextBadge.tsx
+++ b/components/matching/MatchContextBadge.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Sparkles } from 'lucide-react';
+import { loadMatchProfile, alignmentDistance, distanceToMatchScore } from '@/lib/matchStore';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+interface MatchContextBadgeProps {
+  /** The DRep's alignment scores — used to compute match against stored user profile. */
+  drepAlignments: AlignmentScores;
+  /** If an explicit match score is already provided (e.g. from URL param), skip localStorage. */
+  existingMatchScore?: number | null;
+}
+
+/**
+ * Shows "Your match: X%" when the user has completed Quick Match and the
+ * current DRep can be scored against their stored governance preferences.
+ *
+ * Reads from localStorage — renders nothing if no stored profile or if
+ * an explicit matchScore is already being displayed.
+ */
+export function MatchContextBadge({ drepAlignments, existingMatchScore }: MatchContextBadgeProps) {
+  const [matchScore, setMatchScore] = useState<number | null>(null);
+
+  useEffect(() => {
+    // Don't compute if an explicit score is already shown
+    if (existingMatchScore != null && existingMatchScore > 0) return;
+
+    const profile = loadMatchProfile();
+    if (!profile) return;
+
+    const distance = alignmentDistance(profile.userAlignments, drepAlignments);
+    const score = distanceToMatchScore(distance);
+    if (score > 0) {
+      setMatchScore(score);
+    }
+  }, [drepAlignments, existingMatchScore]);
+
+  if (matchScore === null) return null;
+
+  return (
+    <Badge variant="outline" className="text-xs gap-1 border-primary/30 bg-primary/5 text-primary">
+      <Sparkles className="h-3 w-3" />
+      Your match: {matchScore}%
+    </Badge>
+  );
+}

--- a/hooks/useEngagement.ts
+++ b/hooks/useEngagement.ts
@@ -211,6 +211,29 @@ export function useEndorsements(entityType: string, entityId: string) {
   });
 }
 
+// -- Batch Endorsement Counts --
+
+export interface BatchEndorsementCounts {
+  counts: Record<string, number>;
+}
+
+/**
+ * Fetch endorsement counts for multiple entities in a single request.
+ * Returns a map of entityId -> total endorsement count (only entries with count > 0).
+ */
+export function useBatchEndorsementCounts(entityType: string, entityIds: string[]) {
+  const key = entityIds.length > 0 ? entityIds.slice().sort().join(',') : '';
+  return useQuery<BatchEndorsementCounts>({
+    queryKey: ['endorsement-counts', entityType, key],
+    queryFn: () =>
+      fetchJsonWithAuth(
+        `/api/engagement/endorsements/batch?entityType=${encodeURIComponent(entityType)}&entityIds=${encodeURIComponent(entityIds.join(','))}`,
+      ),
+    staleTime: STALE_60S,
+    enabled: entityIds.length > 0,
+  });
+}
+
 // -- Citizen Credibility --
 
 export type { CredibilityResult as CitizenCredibility } from '@/lib/citizenCredibility';

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1356,6 +1356,51 @@ export async function getSocialLinkChecks(drepId: string): Promise<SocialLinkChe
 }
 
 // ============================================================================
+// ENDORSEMENT COUNTS
+// ============================================================================
+
+/**
+ * Fetch the total endorsement count for a DRep or SPO.
+ * Checks precomputed aggregations first, falls back to direct count.
+ */
+export async function getEndorsementCount(
+  entityType: 'drep' | 'spo',
+  entityId: string,
+): Promise<number> {
+  try {
+    const supabase = createClient();
+
+    // Try precomputed aggregation first
+    const { data: aggRow } = await supabase
+      .from('engagement_signal_aggregations')
+      .select('data')
+      .eq('entity_type', entityType)
+      .eq('entity_id', entityId)
+      .eq('signal_type', 'endorsements')
+      .order('epoch', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (aggRow?.data) {
+      const data = aggRow.data as { total?: number };
+      if (typeof data.total === 'number') return data.total;
+    }
+
+    // Fallback: direct count
+    const { count } = await supabase
+      .from('citizen_endorsements')
+      .select('id', { count: 'exact', head: true })
+      .eq('entity_type', entityType)
+      .eq('entity_id', entityId);
+
+    return count ?? 0;
+  } catch (err) {
+    logger.error('[Data] getEndorsementCount error', { error: err });
+    return 0;
+  }
+}
+
+// ============================================================================
 // CLAIM STATUS
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- **Progressive disclosure** on DRep profiles: detailed analytics (delegation trends, activity, similar DReps) collapsed behind toggle for citizen personas, expanded by default for DReps/SPOs
- **Match context badges**: "Your match: X%" pill on DRep profiles and cards when user has a Quick Match profile, reinforcing alignment
- **Social proof**: endorsement counts on DRep cards and profile key facts via new batch endorsement API
- **Warmer empty states**: Quick Match zero-results now shows near-miss DReps (amber-tinted) with "Try Different Answers" option
- **Delegation reassurance**: "You can change your DRep anytime" copy in delegation confirming state
- **Resilience**: DRep profile secondary queries wrapped in try-catch with safe fallbacks
- **CLS fix**: min-height on HubCard/skeleton to prevent layout shift

## Impact
- **What changed**: 8 UX improvements for citizen-undelegated persona across DRep discovery, matching, and delegation flows
- **User-facing**: Yes — citizens see cleaner DRep profiles, match context, social proof, and warmer empty states
- **Risk**: Low — additive UI changes, no data model changes, no migrations, secondary queries safely fallback
- **Scope**: 13 files (3 new, 10 modified) across components/, hooks/, lib/, app/api/, app/drep/

## Test plan
- [ ] Verify DRep profile loads correctly with progressive disclosure collapsed for anonymous/citizen
- [ ] Verify DRep profile shows expanded analytics for DRep/SPO personas
- [ ] Complete Quick Match flow and verify match badges appear on DRep cards/profiles
- [ ] Test Quick Match with answers that produce no matches — verify near-miss cards appear
- [ ] Verify endorsement counts render on DRep browse cards
- [ ] Verify delegation button shows reassurance copy in confirming state
- [ ] Verify HubCard skeleton doesn't cause layout shift
- [ ] Verify DRep profile loads gracefully when secondary queries fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)