### PR TITLE
fix: DRep workspace audit fixes — action queue, V3 pillars, intelligence, a11y

### DIFF
--- a/app/governance/loading.tsx
+++ b/app/governance/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function GovernanceLoading() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      <Skeleton className="h-8 w-48" />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <Skeleton key={i} className="h-32 w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/workspace/loading.tsx
+++ b/app/workspace/loading.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function WorkspaceLoading() {
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
+      <Skeleton className="h-7 w-32" />
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-xl" />
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-28 rounded-md" />
+        <Skeleton className="h-9 w-28 rounded-md" />
+        <Skeleton className="h-9 w-28 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/app/you/public-profile/page.tsx
+++ b/app/you/public-profile/page.tsx
@@ -1,21 +1,22 @@
 export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
+import { PublicProfileView } from '@/components/hub/PublicProfileView';
 
 export const metadata: Metadata = {
   title: 'Governada — Public Profile',
-  description: 'Edit how delegators see your governance profile.',
+  description: 'See how delegators view your governance profile and find ways to improve it.',
 };
 
 /**
  * /you/public-profile — DRep/SPO only.
- * Edit your public-facing governance profile.
+ * Shows how your public governance profile appears to delegators,
+ * with actionable tips to improve profile completeness.
  */
 export default function PublicProfilePage() {
   return (
     <div className="container mx-auto px-4 sm:px-6 py-6">
-      <h1 className="text-2xl font-bold mb-4">Public Profile</h1>
-      <p className="text-muted-foreground">Public profile editor will appear here.</p>
+      <PublicProfileView />
     </div>
   );
 }

--- a/components/civica/SectionPillBar.tsx
+++ b/components/civica/SectionPillBar.tsx
@@ -39,7 +39,7 @@ export function SectionPillBar({ section: _section }: SectionPillBarProps) {
               key={item.href}
               href={item.href}
               className={cn(
-                'shrink-0 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors whitespace-nowrap',
+                'shrink-0 rounded-full px-4 py-2.5 min-h-[44px] text-xs font-medium transition-colors whitespace-nowrap inline-flex items-center',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
                 active
                   ? 'bg-primary text-primary-foreground'

--- a/components/hub/PublicProfileView.tsx
+++ b/components/hub/PublicProfileView.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft, ExternalLink, CheckCircle2, AlertCircle, User, Trophy } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useDRepReportCard, useDashboardCompetitive } from '@/hooks/queries';
+import { computeTierProgress, type PillarBreakdown } from '@/lib/scoring/tiers';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface ProfileCheckItem {
+  label: string;
+  complete: boolean;
+  tip: string;
+}
+
+/**
+ * PublicProfileView — Shows DReps how their profile appears to delegators,
+ * with a profile completeness checklist and link to their public profile.
+ */
+export function PublicProfileView() {
+  const { segment, drepId, poolId } = useSegment();
+  const isDRep = segment === 'drep';
+  const isSPO = segment === 'spo';
+  const { data: reportRaw, isLoading } = useDRepReportCard(isDRep ? drepId : null);
+  const { data: compRaw } = useDashboardCompetitive(isDRep ? drepId : null);
+
+  if (!isDRep && !isSPO) {
+    return (
+      <div className="mx-auto w-full max-w-2xl py-12 text-center space-y-4">
+        <p className="text-muted-foreground">
+          Public profile management is available for DReps and SPOs.
+        </p>
+        <Button asChild>
+          <Link href="/">Back to Hub</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto w-full max-w-2xl space-y-6">
+        <div className="flex items-center gap-3">
+          <ArrowLeft className="h-5 w-5 text-muted-foreground" />
+          <Skeleton className="h-7 w-40" />
+        </div>
+        <Skeleton className="h-40 w-full rounded-xl" />
+        <Skeleton className="h-32 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  const report = reportRaw as Record<string, unknown> | undefined;
+  const competitive = compRaw as Record<string, unknown> | undefined;
+  const score = Math.round((report?.score as number) ?? 0);
+  const percentile = Math.round((competitive?.percentile as number) ?? 0);
+  const rationaleRate = (report?.rationaleRate as number) ?? 0;
+  const participation = (report?.participationRate as number) ?? 0;
+  const reliability = (report?.reliabilityScore as number) ?? (report?.reliability as number) ?? 0;
+  const profileCompleteness = (report?.profileCompleteness as number) ?? 0;
+
+  const pillarBreakdown: PillarBreakdown = {
+    engagementQuality: rationaleRate,
+    effectiveParticipation: participation,
+    reliability: reliability * 100,
+    governanceIdentity: profileCompleteness * 100,
+  };
+  const tierProgress = computeTierProgress(score, pillarBreakdown);
+
+  const profileId = isDRep ? drepId : poolId;
+  const profileUrl = isDRep
+    ? `/drep/${encodeURIComponent(profileId ?? '')}`
+    : `/pool/${encodeURIComponent(profileId ?? '')}`;
+
+  // Profile checklist based on what we can infer from the report card
+  const checks: ProfileCheckItem[] = [
+    {
+      label: 'Governance profile registered on-chain',
+      complete: !!profileId,
+      tip: 'Register as a DRep through your wallet to create your on-chain profile.',
+    },
+    {
+      label: 'Has voting activity',
+      complete: participation > 0,
+      tip: 'Cast votes on governance proposals to show delegators you are active.',
+    },
+    {
+      label: 'Provides vote rationales',
+      complete: rationaleRate > 25,
+      tip: 'Submit CIP-100 rationales when voting to explain your reasoning to delegators.',
+    },
+    {
+      label: 'Consistent voting record',
+      complete: reliability > 0.5,
+      tip: 'Vote regularly across epochs to build a reliable track record.',
+    },
+    {
+      label: 'Profile metadata complete',
+      complete: profileCompleteness > 0.5,
+      tip: 'Update your on-chain metadata with a governance statement, social links, and profile image.',
+    },
+  ];
+
+  const completedCount = checks.filter((c) => c.complete).length;
+  const completionPct = Math.round((completedCount / checks.length) * 100);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-6">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/workspace"
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <h1 className="text-xl font-bold text-foreground">Public Profile</h1>
+      </div>
+
+      {/* Profile preview card */}
+      <div className="rounded-2xl border border-border bg-card p-5 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-muted p-3">
+              <User className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium text-foreground truncate max-w-[200px]">
+                {profileId ? `${profileId.slice(0, 16)}...` : 'Not registered'}
+              </p>
+              <div className="flex items-center gap-2">
+                <Trophy className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-xs text-muted-foreground">
+                  {tierProgress.currentTier} &middot; Score {score}
+                </span>
+              </div>
+            </div>
+          </div>
+          {profileId && (
+            <Button asChild variant="outline" size="sm">
+              <Link href={profileUrl}>
+                <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                View as delegator
+              </Link>
+            </Button>
+          )}
+        </div>
+
+        {/* What delegators see — score and percentile */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{score}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Score</p>
+          </div>
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">
+              {percentile > 0 ? `${percentile}%` : '—'}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">Percentile</p>
+          </div>
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{completionPct}%</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Profile</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Profile completeness checklist */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+          Profile Completeness
+        </h3>
+        <div className="rounded-xl border border-border bg-card divide-y divide-border">
+          {checks.map((check) => (
+            <div key={check.label} className="flex items-start gap-3 p-3">
+              {check.complete ? (
+                <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-500 mt-0.5" />
+              ) : (
+                <AlertCircle className="h-5 w-5 shrink-0 text-amber-500 mt-0.5" />
+              )}
+              <div className="space-y-0.5">
+                <p
+                  className={`text-sm font-medium ${check.complete ? 'text-foreground' : 'text-muted-foreground'}`}
+                >
+                  {check.label}
+                </p>
+                {!check.complete && <p className="text-xs text-muted-foreground">{check.tip}</p>}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Info about on-chain profiles */}
+      <div className="rounded-xl border border-border bg-muted/30 p-4">
+        <p className="text-sm text-muted-foreground">
+          Your governance profile is stored on the Cardano blockchain. To update your display name,
+          governance statement, or social links, use your wallet&apos;s DRep metadata update
+          feature. Changes will appear on Governada after the next sync.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/hub/WorkspaceDelegatorsPage.tsx
+++ b/components/hub/WorkspaceDelegatorsPage.tsx
@@ -110,6 +110,34 @@ export function WorkspaceDelegatorsPage() {
             )}
           </div>
 
+          {/* Empty state guidance */}
+          {currentCount === 0 && (
+            <div className="rounded-xl border border-border bg-muted/30 p-5 space-y-3">
+              <p className="text-sm font-medium text-foreground">
+                No delegators yet? Here&apos;s how to grow:
+              </p>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex items-start gap-2">
+                  <span className="text-primary font-bold">1.</span>
+                  Complete your governance profile with a clear statement of principles
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-primary font-bold">2.</span>
+                  Vote consistently and add rationales explaining your reasoning
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="text-primary font-bold">3.</span>
+                  Share your DRep profile link on social media and community channels
+                </li>
+              </ul>
+              {isDRep && drepId && (
+                <Button asChild variant="outline" size="sm" className="mt-2">
+                  <Link href={`/drep/${encodeURIComponent(drepId)}`}>View Your Public Profile</Link>
+                </Button>
+              )}
+            </div>
+          )}
+
           {/* Recent changes */}
           {recentChanges.length > 0 && (
             <div className="space-y-2">

--- a/components/hub/WorkspacePage.tsx
+++ b/components/hub/WorkspacePage.tsx
@@ -98,7 +98,9 @@ function DRepWorkspace() {
 
   const urgentData = urgentRaw as Record<string, unknown> | undefined;
   const pendingProposals =
-    (urgentData?.pending as PendingProposal[]) ?? (urgentData?.urgent as PendingProposal[]) ?? [];
+    (urgentData?.pendingProposals as PendingProposal[]) ??
+    (urgentData?.proposals as PendingProposal[]) ??
+    [];
   const unexplainedVotes =
     (urgentData?.unexplainedVotes as { txHash: string; index: number; title: string }[]) ?? [];
 
@@ -160,6 +162,9 @@ function DRepWorkspace() {
 
       {/* Quick links */}
       <div className="flex flex-wrap gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/governance/proposals">View All Proposals</Link>
+        </Button>
         <Button asChild variant="outline" size="sm">
           <Link href="/workspace/votes">Voting Record</Link>
         </Button>

--- a/components/hub/WorkspacePerformancePage.tsx
+++ b/components/hub/WorkspacePerformancePage.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowLeft, Trophy, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { ArrowLeft, Trophy, TrendingUp, TrendingDown, Minus, Lightbulb } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useDRepReportCard, useDashboardCompetitive } from '@/hooks/queries';
-import { computeTier } from '@/lib/scoring/tiers';
+import { computeTierProgress, type PillarBreakdown } from '@/lib/scoring/tiers';
+import { getScoreNarrative } from '@/lib/scoring/scoreNarratives';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -24,7 +25,7 @@ interface ScorePillar {
  * WorkspacePerformancePage — DRep score breakdown + competitive position.
  *
  * JTBD: "How can I improve my score and ranking?"
- * Score with pillar breakdown, competitive context.
+ * Score with pillar breakdown, tier progress, recommended action, competitive context.
  */
 export function WorkspacePerformancePage() {
   const { segment, drepId } = useSegment();
@@ -61,23 +62,35 @@ export function WorkspacePerformancePage() {
   const competitive = compRaw as Record<string, unknown> | undefined;
 
   const score = Math.round((report?.score as number) ?? 0);
-  const tier = (report?.tier as string) ?? computeTier(score);
   const trend = (report?.trend as number) ?? 0;
   const rank = (competitive?.rank as number) ?? 0;
   const totalDReps = (competitive?.totalDReps as number) ?? 0;
   const percentile = Math.round((competitive?.percentile as number) ?? 0);
 
-  // Build pillar breakdown from report card
-  const pillars: ScorePillar[] = [];
+  // Build pillar breakdown with V3 names
   const participation = (report?.participationRate as number) ?? 0;
   const rationaleRate = (report?.rationaleRate as number) ?? 0;
   const reliability = (report?.reliabilityScore as number) ?? (report?.reliability as number) ?? 0;
   const profileCompleteness = (report?.profileCompleteness as number) ?? 0;
 
-  pillars.push({ label: 'Participation', value: Math.round(participation), max: 100 });
-  pillars.push({ label: 'Rationale Rate', value: Math.round(rationaleRate), max: 100 });
-  pillars.push({ label: 'Reliability', value: Math.round(reliability * 100), max: 100 });
-  pillars.push({ label: 'Profile', value: Math.round(profileCompleteness * 100), max: 100 });
+  const pillars: ScorePillar[] = [
+    { label: 'Engagement Quality', value: Math.round(rationaleRate), max: 100 },
+    { label: 'Effective Participation', value: Math.round(participation), max: 100 },
+    { label: 'Reliability', value: Math.round(reliability * 100), max: 100 },
+    { label: 'Governance Identity', value: Math.round(profileCompleteness * 100), max: 100 },
+  ];
+
+  // Compute tier progress + recommended action
+  const pillarBreakdown: PillarBreakdown = {
+    engagementQuality: rationaleRate,
+    effectiveParticipation: participation,
+    reliability: reliability * 100,
+    governanceIdentity: profileCompleteness * 100,
+  };
+  const tierProgress = computeTierProgress(score, pillarBreakdown);
+
+  // Score narrative
+  const narrative = getScoreNarrative({ score, percentile });
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
@@ -98,7 +111,7 @@ export function WorkspacePerformancePage() {
             <div className="flex items-center gap-2">
               <Trophy className="h-4 w-4 text-muted-foreground" />
               <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                {tier} Tier
+                {tierProgress.currentTier} Tier
               </span>
             </div>
             <p className="text-sm text-muted-foreground">
@@ -116,7 +129,39 @@ export function WorkspacePerformancePage() {
             </div>
           </div>
         </div>
+
+        {/* Score narrative */}
+        <p className="text-sm text-muted-foreground">{narrative}</p>
+
+        {/* Tier progress bar */}
+        {tierProgress.nextTier && tierProgress.pointsToNext !== null && (
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{tierProgress.currentTier}</span>
+              <span>
+                {tierProgress.pointsToNext} pts to {tierProgress.nextTier}
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${tierProgress.percentWithinTier}%` }}
+              />
+            </div>
+          </div>
+        )}
       </div>
+
+      {/* Recommended action */}
+      {tierProgress.recommendedAction && (
+        <div className="flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 p-4">
+          <Lightbulb className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium text-foreground">Recommended Next Step</p>
+            <p className="text-sm text-muted-foreground">{tierProgress.recommendedAction}</p>
+          </div>
+        </div>
+      )}
 
       {/* Pillar breakdown */}
       <div className="space-y-3">

--- a/components/hub/WorkspaceVotesPage.tsx
+++ b/components/hub/WorkspaceVotesPage.tsx
@@ -95,9 +95,12 @@ function VotesList({ votes }: { votes: VoteRecord[] }) {
             {v.proposalTitle || `Proposal ${v.proposalTxHash.slice(0, 8)}...`}
           </span>
           {v.hasRationale ? (
-            <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+            <CheckCircle2
+              className="h-4 w-4 shrink-0 text-emerald-500"
+              aria-label="Rationale provided"
+            />
           ) : (
-            <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" />
+            <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" aria-label="No rationale" />
           )}
         </Link>
       ))}

--- a/components/hub/cards/ActionCard.tsx
+++ b/components/hub/cards/ActionCard.tsx
@@ -31,7 +31,7 @@ export function ActionCard() {
     return <HubCardError message="Couldn't load pending votes" onRetry={() => refetch()} />;
 
   const urgentData = urgentRaw as Record<string, unknown> | undefined;
-  const urgentProposals = (urgentData?.urgent as UrgentProposal[]) ?? [];
+  const urgentProposals = (urgentData?.proposals as UrgentProposal[]) ?? [];
   const pendingCount = (urgentData?.pendingCount as number) ?? urgentProposals.length;
   const unexplainedVotes = (urgentData?.unexplainedVotes as unknown[]) ?? [];
 


### PR DESCRIPTION
## Summary
- **Critical P0 fix**: DRep action queue was always empty — `WorkspacePage` and `ActionCard` read wrong API field names (`pending`/`urgent` instead of `pendingProposals`/`proposals`)
- **Intelligence surfacing**: Performance page now uses V3 pillar names, shows tier progress bar, recommended action from scoring engine, and human-readable score narrative
- **Public profile**: Replaced stub with profile completeness checklist, score preview, and on-chain metadata guidance
- **Polish**: Delegator empty state with growth tips, workspace/governance loading skeletons, aria-labels on rationale icons, 44px mobile touch targets on pill bar

## Impact
- **What changed**: Fixed data mapping bug that prevented DRep workspace action queue from displaying proposals. Enhanced performance page with scoring intelligence. Added public profile view and accessibility improvements.
- **User-facing**: Yes — DReps will now see their pending proposals in the workspace (previously always showed "All caught up"). Performance page shows actionable tier progress and recommendations.
- **Risk**: Low — field name fixes match existing API contract, scoring functions already tested (590/590 pass), no data changes
- **Scope**: 7 modified files + 3 new files (loading skeletons + PublicProfileView component)

## Test plan
- [ ] Verify workspace action queue shows pending proposals for a DRep with unvoted proposals
- [ ] Verify performance page shows V3 pillar names and tier progress bar
- [ ] Verify `/you/public-profile` shows profile completeness checklist
- [ ] Verify delegator page shows growth tips when delegator count is 0
- [ ] Verify pill bar touch targets are at least 44px on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)