### PR TITLE
feat: surface alignment drift between citizen and delegated DRep

### DIFF
--- a/components/hub/DelegationPage.tsx
+++ b/components/hub/DelegationPage.tsx
@@ -15,7 +15,8 @@ import {
   Info,
 } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { useGovernanceHolder, useSPOSummary } from '@/hooks/queries';
+import { useGovernanceHolder, useSPOSummary, useAlignmentDrift } from '@/hooks/queries';
+import { FeatureGate } from '@/components/FeatureGate';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { computeTier } from '@/lib/scoring/tiers';
@@ -31,9 +32,19 @@ function TrendArrow({ value }: { value: number }) {
   return <Minus className="h-3.5 w-3.5 text-muted-foreground" />;
 }
 
+const DIMENSION_LABELS: Record<string, string> = {
+  treasury_conservative: 'Treasury (conservative)',
+  treasury_growth: 'Treasury (growth)',
+  decentralization: 'Decentralization',
+  security: 'Security',
+  innovation: 'Innovation',
+  transparency: 'Transparency',
+};
+
 function DRepSection() {
   const { stakeAddress, delegatedDrep } = useSegment();
   const { data: holderRaw, isLoading } = useGovernanceHolder(stakeAddress);
+  const { data: driftData } = useAlignmentDrift(delegatedDrep ? stakeAddress : null);
 
   if (isLoading) {
     return (
@@ -151,6 +162,57 @@ function DRepSection() {
           <p className="text-xs text-muted-foreground mt-0.5">Recent Votes</p>
         </div>
       </div>
+
+      {/* Alignment drift indicator */}
+      <FeatureGate flag="alignment_drift">
+        {driftData?.drift && driftData.drift.classification !== 'low' && (
+          <div
+            className={`rounded-xl p-3 space-y-2 ${
+              driftData.drift.classification === 'high'
+                ? 'border border-red-500/30 bg-red-500/5'
+                : 'border border-amber-500/30 bg-amber-500/5'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <ShieldAlert
+                  className={`h-4 w-4 ${
+                    driftData.drift.classification === 'high' ? 'text-red-500' : 'text-amber-500'
+                  }`}
+                />
+                <span
+                  className={`text-sm font-medium ${
+                    driftData.drift.classification === 'high'
+                      ? 'text-red-600 dark:text-red-400'
+                      : 'text-amber-600 dark:text-amber-400'
+                  }`}
+                >
+                  {driftData.drift.classification === 'high'
+                    ? 'Values misaligned'
+                    : 'Values drifting'}
+                </span>
+              </div>
+              <span className="text-xs text-muted-foreground tabular-nums">
+                Drift: {driftData.drift.score}
+              </span>
+            </div>
+            {driftData.drift.worstDimension && (
+              <p className="text-xs text-muted-foreground">
+                Biggest gap:{' '}
+                {DIMENSION_LABELS[driftData.drift.worstDimension] ?? driftData.drift.worstDimension}
+              </p>
+            )}
+            {driftData.drift.classification === 'high' && (
+              <Link
+                href="/match"
+                className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+              >
+                Find a better match <ArrowRight className="h-3 w-3" />
+              </Link>
+            )}
+          </div>
+        )}
+      </FeatureGate>
 
       {/* Link to full profile */}
       <Link

--- a/components/hub/cards/AlertCard.tsx
+++ b/components/hub/cards/AlertCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Bell, ShieldAlert, TrendingDown } from 'lucide-react';
+import { Bell, ShieldAlert, TrendingDown, GitCompareArrows } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { useGovernanceHolder } from '@/hooks/queries';
+import { useGovernanceHolder, useAlignmentDrift } from '@/hooks/queries';
+import { useFeatureFlag } from '@/components/FeatureGate';
 import { HubCard, type CardUrgency } from './HubCard';
 
 /**
@@ -21,6 +22,8 @@ import { HubCard, type CardUrgency } from './HubCard';
 export function AlertCard() {
   const { stakeAddress, delegatedDrep } = useSegment();
   const { data: holderRaw } = useGovernanceHolder(stakeAddress);
+  const { data: driftData } = useAlignmentDrift(delegatedDrep ? stakeAddress : null);
+  const driftFlagEnabled = useFeatureFlag('alignment_drift');
 
   // No DRep = no alert (RepresentationCard handles the undelegated state)
   if (!delegatedDrep) return null;
@@ -35,7 +38,7 @@ export function AlertCard() {
   const participationRate = (drep.participationRate as number) ?? 100;
   const scoreChange = (drep.scoreChange as number) ?? 0;
 
-  // Check for alert conditions
+  // Check for alert conditions (priority order: inactive > drift > participation > score drop)
   type AlertInfo = { message: string; detail: string; urgency: CardUrgency; icon: typeof Bell };
 
   let alert: AlertInfo | null = null;
@@ -46,6 +49,14 @@ export function AlertCard() {
       detail: 'Consider finding a new representative to keep your ADA voiced.',
       urgency: 'critical',
       icon: ShieldAlert,
+    };
+  } else if (driftFlagEnabled && driftData?.drift?.classification === 'high') {
+    alert = {
+      message: 'Your values are misaligned with your DRep',
+      detail:
+        'Based on your governance profile, your priorities have diverged. Consider reviewing your delegation.',
+      urgency: 'warning',
+      icon: GitCompareArrows,
     };
   } else if (participationRate < 30) {
     alert = {

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -566,6 +566,37 @@ export function useDRepOutcomeSummary(drepId: string | null | undefined) {
   });
 }
 
+export interface AlignmentDriftData {
+  hasDelegation: boolean;
+  drepId?: string;
+  drift: {
+    score: number;
+    classification: 'low' | 'moderate' | 'high';
+    dimensions: Array<{
+      dimension: string;
+      citizenValue: number;
+      drepValue: number;
+      delta: number;
+    }>;
+    worstDimension: string | null;
+  } | null;
+  alternatives: Array<{
+    drep_id: string;
+    match_score: number;
+    governance_score: number;
+  }>;
+  message?: string;
+}
+
+export function useAlignmentDrift(wallet: string | null | undefined) {
+  return useQuery<AlignmentDriftData>({
+    queryKey: ['alignment-drift', wallet],
+    queryFn: () => fetchJson(`/api/governance/drift?wallet=${encodeURIComponent(wallet!)}`),
+    enabled: !!wallet,
+    staleTime: 5 * 60_000,
+  });
+}
+
 export function useAccountInfo(stakeAddress: string | null | undefined) {
   return useQuery({
     queryKey: ['account-info', stakeAddress],


### PR DESCRIPTION
## Summary
- Wire up client-side alignment drift detection via `useAlignmentDrift` hook (TanStack Query)
- DelegationPage shows amber/red drift indicator with worst-dimension detail between stats grid and profile link
- AlertCard adds high-drift as a priority alert condition (inactive > drift > low participation > score drop)
- All gated behind `alignment_drift` feature flag (currently disabled in DB)

## Impact
- **What changed**: Citizens who have delegated to a DRep now see drift indicators when their governance profile diverges from their DRep's voting alignment
- **User-facing**: Yes — amber "Values drifting" and red "Values misaligned" indicators on delegation page + alert card
- **Risk**: Low — feature-flagged off, no backend changes (drift engine/API/Inngest already built), client-only wiring
- **Scope**: 3 files modified (hooks/queries.ts, DelegationPage.tsx, AlertCard.tsx)

## Test plan
- [x] Preflight passes (format + lint + types + 590 tests)
- [ ] Feature flag disabled: no drift UI visible
- [ ] Feature flag enabled: drift indicator shows for delegated citizens with governance profiles
- [ ] AlertCard priority ordering: inactive > high drift > low participation > score drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)