### PR TITLE
fix: citizen-anonymous experience gaps v2 — accessibility, discovery, shareability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -662,7 +662,11 @@ button:not(:disabled):active,
   .animate-slide-up,
   .animate-cta-pulse,
   .animate-breathing-glow,
-  .animate-gradient-shift {
+  .animate-gradient-shift,
+  .animate-in,
+  .animate-grow,
+  .animate-scale-in,
+  .animate-check-pop {
     animation: none !important;
   }
 
@@ -670,7 +674,9 @@ button:not(:disabled):active,
     animation: none !important;
   }
 
-  [data-slot='card'] {
+  [data-slot='card'],
+  button:not(:disabled):active,
+  [role='button']:not(:disabled):active {
     transition: none !important;
   }
 }

--- a/app/match/result/MatchResultClient.tsx
+++ b/app/match/result/MatchResultClient.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import Link from 'next/link';
-import { ArrowRight, Zap } from 'lucide-react';
+import { ArrowRight, Zap, Share2, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import { getDominantDimension, getIdentityColor } from '@/lib/drepIdentity';
+import { webShare, canWebShare, copyToClipboard } from '@/lib/share';
 
 interface ShareableProfile {
   personality: string;
@@ -117,6 +118,8 @@ export function MatchResultClient({ encoded }: { encoded: string | undefined }) 
               <p className="text-sm text-foreground/90 leading-relaxed">{profile.narrative}</p>
             </div>
           )}
+
+          <ShareResultButton personality={profile.personality} encoded={encoded!} />
         </div>
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center pt-4 pb-8">
@@ -135,5 +138,45 @@ export function MatchResultClient({ encoded }: { encoded: string | undefined }) 
         </div>
       </div>
     </div>
+  );
+}
+
+function ShareResultButton({ personality, encoded }: { personality: string; encoded: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const url = `${window.location.origin}/match/result?profile=${encodeURIComponent(encoded)}`;
+    const text = `I'm "${personality}" on Cardano governance. Find your governance identity:`;
+
+    if (canWebShare()) {
+      const shared = await webShare({
+        title: `I'm ${personality} — Governada`,
+        text,
+        url,
+      });
+      if (shared) return;
+    }
+
+    const ok = await copyToClipboard(url);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [personality, encoded]);
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleShare} className="gap-2">
+      {copied ? (
+        <>
+          <Check className="h-4 w-4" />
+          Link Copied
+        </>
+      ) : (
+        <>
+          <Share2 className="h-4 w-4" />
+          Share This Identity
+        </>
+      )}
+    </Button>
   );
 }

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
 import { useProposals, useDRepVotes } from '@/hooks/queries';
 import { useWallet } from '@/utils/wallet-context';
 import { ProposalStatusFunnel } from '@/components/civica/charts/ProposalStatusFunnel';
@@ -319,8 +320,18 @@ export function ProposalsBrowse() {
 
       {/* List */}
       {pageItems.length === 0 ? (
-        <div className="py-16 text-center text-muted-foreground text-sm">
-          No proposals match your search.
+        <div className="py-16 text-center space-y-4">
+          <p className="text-muted-foreground text-sm">No proposals match your filters.</p>
+          <div className="flex gap-2 justify-center">
+            {!isDefault && (
+              <Button variant="outline" size="sm" onClick={resetFilters}>
+                Clear Filters
+              </Button>
+            )}
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/match">Try Quick Match &rarr;</Link>
+            </Button>
+          </div>
         </div>
       ) : (
         <div

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -25,9 +25,17 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { GovernanceRadar } from '@/components/GovernanceRadar';
-import { RadarOverlay } from '@/components/matching/RadarOverlay';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
+
+const GovernanceRadar = dynamic(
+  () => import('@/components/GovernanceRadar').then((m) => ({ default: m.GovernanceRadar })),
+  { ssr: false },
+);
+const RadarOverlay = dynamic(
+  () => import('@/components/matching/RadarOverlay').then((m) => ({ default: m.RadarOverlay })),
+  { ssr: false },
+);
 import { usePostHog } from 'posthog-js/react';
 import { DelegateButton } from '@/components/DelegateButton';
 import { getStoredSession } from '@/lib/supabaseAuth';

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -86,6 +86,16 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
             </span>
           </div>
         )}
+
+        {/* Secondary discovery link */}
+        <div className="flex justify-center">
+          <Link
+            href="/governance/health"
+            className="text-xs text-muted-foreground/70 hover:text-primary transition-colors"
+          >
+            Is Cardano governance healthy? &rarr;
+          </Link>
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- Extend `prefers-reduced-motion` CSS to cover `animate-in` (tw-animate-css) and other missing animation classes
- Add GHI discovery link on anonymous landing page for governance health discoverability
- Add forward CTAs to ProposalsBrowse empty state (clear filters + quick match fallback)
- Lazy-load GovernanceRadar/RadarOverlay in QuickMatchFlow via `next/dynamic` to reduce initial bundle
- Add share button to match result shared links enabling re-sharing of governance identity

## Impact
- **What changed**: 5 small UX improvements for the citizen-anonymous persona experience
- **User-facing**: Yes — anonymous visitors get better accessibility (reduced motion), a discovery path to GHI, helpful empty states, faster quiz loading, and re-shareable match results
- **Risk**: Low — styling additions, lazy-loading (existing pattern), and a new share button. No data changes, no API changes, no migrations
- **Scope**: `app/globals.css`, `components/hub/AnonymousLanding.tsx`, `components/civica/discover/ProposalsBrowse.tsx`, `components/civica/match/QuickMatchFlow.tsx`, `app/match/result/MatchResultClient.tsx`

## Context
Verify-audit follow-up to PR #258. Addresses remaining S-effort gaps from citizen-anonymous experience audit (41.5 → ~46/60).

## Test plan
- [ ] Verify `prefers-reduced-motion` suppresses all animations including `animate-in`
- [ ] Verify GHI link appears on anonymous landing below social proof
- [ ] Verify ProposalsBrowse empty state shows "Clear Filters" + "Try Quick Match" CTAs
- [ ] Verify QuickMatchFlow loads GovernanceRadar lazily (check network tab)
- [ ] Verify share button on `/match/result?profile=...` enables re-sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)