### PR TITLE
fix: citizen-undelegated audit fixes

### DIFF
--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -45,6 +45,21 @@ interface CivicaDRepCardProps {
   endorsementCount?: number;
 }
 
+/** Returns the top 1-2 pillar strengths (scores >= 65) as citizen-friendly labels. */
+function getPillarStrengths(drep: EnrichedDRep): string[] {
+  const pillars: [string, number][] = [
+    ['Strong rationale', drep.engagementQuality ?? 0],
+    ['Active voter', drep.effectiveParticipationV3 ?? 0],
+    ['Reliable', drep.reliabilityV3 ?? 0],
+    ['Clear identity', drep.governanceIdentity ?? 0],
+  ];
+  return pillars
+    .filter(([, v]) => v >= 65)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([label]) => label);
+}
+
 export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: CivicaDRepCardProps) {
   const score = drep.drepScore ?? 0;
   const tier = tierKey(computeTier(score));
@@ -57,6 +72,7 @@ export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: Civ
   const dominantDim = hasAlignment ? getDominantDimension(alignments) : null;
   const identityColor = dominantDim ? getIdentityColor(dominantDim) : null;
   const traitTags = getDRepTraitTags(drep);
+  const pillarStrengths = getPillarStrengths(drep);
 
   const recency = formatRecency(drep.lastVoteTime);
   const rationaleRate = Math.round(drep.rationaleRate ?? 0);
@@ -172,6 +188,20 @@ export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: Civ
               className="text-[9px] text-muted-foreground bg-muted/60 px-1.5 py-0.5 rounded-full"
             >
               {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* ── Pillar strengths ─────────────────────────────────── */}
+      {pillarStrengths.length > 0 && (
+        <div className="flex items-center gap-1.5 flex-wrap mb-2">
+          {pillarStrengths.map((label) => (
+            <span
+              key={label}
+              className="text-[9px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full"
+            >
+              {label}
             </span>
           ))}
         </div>

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useRef, useCallback } from 'react';
+import { useState, useMemo, useRef, useCallback, useDeferredValue } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -190,6 +190,7 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     return sortParam === 'match' && loadMatchProfile() ? 'match' : 'score';
   });
 
+  const deferredSearch = useDeferredValue(filters.search);
   const pageSize = viewMode === 'table' ? TABLE_PAGE_SIZE : CARD_PAGE_SIZE;
 
   const toggleViewMode = (mode: ViewMode) => {
@@ -219,8 +220,8 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
   const filtered = useMemo(() => {
     let result = dreps;
 
-    if (filters.search.trim()) {
-      const q = filters.search.toLowerCase();
+    if (deferredSearch.trim()) {
+      const q = deferredSearch.toLowerCase();
       result = result.filter(
         (d) =>
           d.name?.toLowerCase().includes(q) ||
@@ -286,7 +287,7 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     }
 
     return result;
-  }, [dreps, filters, sortMode, matchProfile]);
+  }, [dreps, deferredSearch, filters, sortMode, matchProfile]);
 
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -830,6 +830,27 @@ function ResultsScreen({
                         <Badge variant="secondary" className="text-xs">
                           {heroMatch.personalityLabel}
                         </Badge>
+                        {(heroMatch.agreeDimensions.length > 0 ||
+                          heroMatch.differDimensions.length > 0) && (
+                          <div className="flex items-center gap-1.5 flex-wrap justify-center">
+                            {heroMatch.agreeDimensions.slice(0, 3).map((dim) => (
+                              <span
+                                key={dim}
+                                className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded-full"
+                              >
+                                {dim}
+                              </span>
+                            ))}
+                            {heroMatch.differDimensions.slice(0, 2).map((dim) => (
+                              <span
+                                key={dim}
+                                className="text-[10px] font-medium text-rose-500 dark:text-rose-400 bg-rose-500/10 px-2 py-0.5 rounded-full"
+                              >
+                                {dim}
+                              </span>
+                            ))}
+                          </div>
+                        )}
                         <p className="text-sm text-muted-foreground">
                           {getMatchNarrative(heroMatch)}
                         </p>
@@ -1082,11 +1103,26 @@ function QuickMatchResultCard({
               )}
             </div>
 
-            {/* Match narrative */}
+            {/* Alignment dimension badges */}
             {(match.agreeDimensions.length > 0 || match.differDimensions.length > 0) && (
-              <p className="text-xs text-muted-foreground leading-relaxed">
-                {getMatchNarrative(match)}
-              </p>
+              <div className="flex items-center gap-1 flex-wrap">
+                {match.agreeDimensions.slice(0, 3).map((dim) => (
+                  <span
+                    key={dim}
+                    className="text-[9px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full"
+                  >
+                    {dim}
+                  </span>
+                ))}
+                {match.differDimensions.slice(0, 2).map((dim) => (
+                  <span
+                    key={dim}
+                    className="text-[9px] font-medium text-rose-500 dark:text-rose-400 bg-rose-500/10 px-1.5 py-0.5 rounded-full"
+                  >
+                    {dim}
+                  </span>
+                ))}
+              </div>
             )}
 
             <div className="flex gap-2 mt-1">

--- a/components/drep/DRepDetailedAnalysis.tsx
+++ b/components/drep/DRepDetailedAnalysis.tsx
@@ -16,28 +16,26 @@ interface DRepDetailedAnalysisProps {
  * - Citizens and anonymous users see a collapsed "Show detailed analysis" toggle.
  * - DReps, SPOs, CC members, and researchers see everything expanded by default.
  *
- * This keeps the citizen experience focused on summary intelligence while
- * preserving full depth for governance participants who need it.
+ * Defaults to collapsed to avoid CLS — expands only after segment confirms
+ * the user is a governance participant.
  */
 export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
   const { segment, isLoading } = useSegment();
 
-  // DReps, SPOs, and CC members see everything expanded
   const isDetailedSegment = segment === 'drep' || segment === 'spo' || segment === 'cc';
 
-  const [expanded, setExpanded] = useState(isDetailedSegment);
+  // User toggle: null = not yet toggled by user, use segment-derived default
+  const [userToggled, setUserToggled] = useState<boolean | null>(null);
 
-  // For detailed segments, always render expanded (no gate)
-  if (isDetailedSegment) {
+  // Derived expanded state: user toggle wins, else expand for confirmed detailed segments
+  const expanded = userToggled !== null ? userToggled : !isLoading && isDetailedSegment;
+
+  // For confirmed detailed segments, render children directly (no gate)
+  if (!isLoading && isDetailedSegment) {
     return <>{children}</>;
   }
 
-  // While loading segment, render nothing to avoid flash of collapsed → expanded
-  if (isLoading) {
-    return null;
-  }
-
-  // Citizens and anonymous users get the collapsible gate
+  // Citizens, anonymous, and loading state: show collapsed gate (stable layout)
   return (
     <div className="space-y-4">
       {!expanded && (
@@ -45,7 +43,7 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setExpanded(true)}
+            onClick={() => setUserToggled(true)}
             className="gap-2 text-muted-foreground hover:text-foreground"
           >
             <span>Show detailed analysis</span>
@@ -60,7 +58,6 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
           expanded ? 'opacity-100' : 'max-h-0 overflow-hidden opacity-0',
         )}
       >
-        {/* Only mount children when expanded to avoid unnecessary data fetching */}
         {expanded && <div className="space-y-6">{children}</div>}
       </div>
 
@@ -69,7 +66,7 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => setExpanded(false)}
+            onClick={() => setUserToggled(false)}
             className="gap-2 text-xs text-muted-foreground"
           >
             <span>Hide detailed analysis</span>

--- a/components/hub/cards/RepresentationCard.tsx
+++ b/components/hub/cards/RepresentationCard.tsx
@@ -20,13 +20,7 @@ export function RepresentationCard() {
   const { stakeAddress, delegatedDrep, delegatedPool } = useSegment();
   const { data: holderRaw, isLoading, isError, refetch } = useGovernanceHolder(stakeAddress);
 
-  if (isLoading) return <HubCardSkeleton />;
-  if (isError)
-    return <HubCardError message="Couldn't load delegation status" onRetry={() => refetch()} />;
-
-  const holder = holderRaw as Record<string, unknown> | undefined;
-
-  // Undelegated state
+  // Undelegated citizens don't need holder data — show CTA immediately
   if (!delegatedDrep) {
     return (
       <HubCard href="/match" urgency="warning" label="You have no DRep. Find a representative.">
@@ -48,7 +42,12 @@ export function RepresentationCard() {
     );
   }
 
+  if (isLoading) return <HubCardSkeleton />;
+  if (isError)
+    return <HubCardError message="Couldn't load delegation status" onRetry={() => refetch()} />;
+
   // Delegated state — build the summary
+  const holder = holderRaw as Record<string, unknown> | undefined;
   const drep = holder?.drep as Record<string, unknown> | undefined;
   const drepName = (drep?.name as string) || (drep?.ticker as string) || 'Your DRep';
   const drepScore = (drep?.score as number) ?? 0;

--- a/components/matching/MatchContextBadge.tsx
+++ b/components/matching/MatchContextBadge.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Sparkles } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { loadMatchProfile, alignmentDistance, distanceToMatchScore } from '@/lib/matchStore';
+import { computeDimensionAgreement } from '@/lib/matching/dimensionAgreement';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 
 interface MatchContextBadgeProps {
@@ -17,14 +19,14 @@ interface MatchContextBadgeProps {
  * Shows "Your match: X%" when the user has completed Quick Match and the
  * current DRep can be scored against their stored governance preferences.
  *
- * Reads from localStorage — renders nothing if no stored profile or if
- * an explicit matchScore is already being displayed.
+ * Hover/tap reveals which dimensions you agree/differ on.
  */
 export function MatchContextBadge({ drepAlignments, existingMatchScore }: MatchContextBadgeProps) {
   const [matchScore, setMatchScore] = useState<number | null>(null);
+  const [agreeDims, setAgreeDims] = useState<string[]>([]);
+  const [differDims, setDifferDims] = useState<string[]>([]);
 
   useEffect(() => {
-    // Don't compute if an explicit score is already shown
     if (existingMatchScore != null && existingMatchScore > 0) return;
 
     const profile = loadMatchProfile();
@@ -34,15 +36,48 @@ export function MatchContextBadge({ drepAlignments, existingMatchScore }: MatchC
     const score = distanceToMatchScore(distance);
     if (score > 0) {
       setMatchScore(score);
+      const { agreeDimensions, differDimensions } = computeDimensionAgreement(
+        profile.userAlignments,
+        drepAlignments,
+      );
+      setAgreeDims(agreeDimensions);
+      setDifferDims(differDimensions);
     }
   }, [drepAlignments, existingMatchScore]);
 
   if (matchScore === null) return null;
 
+  const hasExplanation = agreeDims.length > 0 || differDims.length > 0;
+
   return (
-    <Badge variant="outline" className="text-xs gap-1 border-primary/30 bg-primary/5 text-primary">
-      <Sparkles className="h-3 w-3" />
-      Your match: {matchScore}%
-    </Badge>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge
+            variant="outline"
+            className="text-xs gap-1 border-primary/30 bg-primary/5 text-primary cursor-help"
+          >
+            <Sparkles className="h-3 w-3" />
+            Your match: {matchScore}%
+          </Badge>
+        </TooltipTrigger>
+        {hasExplanation && (
+          <TooltipContent side="bottom" className="max-w-64 space-y-1.5">
+            {agreeDims.length > 0 && (
+              <p className="text-xs">
+                <span className="font-medium text-emerald-500">Aligned:</span>{' '}
+                {agreeDims.join(', ')}
+              </p>
+            )}
+            {differDims.length > 0 && (
+              <p className="text-xs">
+                <span className="font-medium text-rose-400">Differ:</span> {differDims.join(', ')}
+              </p>
+            )}
+            <p className="text-[10px] text-muted-foreground">Based on your Quick Match answers</p>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Fix Hub showing "Couldn't load delegation status" for undelegated citizens by checking delegation state before holder API result
- Add `useDeferredValue` to browse search for smoother filtering of 2000+ DReps
- Add pillar strength tags (Strong rationale, Active voter, Reliable, Clear identity) to DRep browse cards
- Fix DRepDetailedAnalysis CLS by defaulting collapsed during segment load instead of rendering null
- Add alignment dimension badges (green=agree, red=differ) to Quick Match result cards and hero match
- Add match explanation tooltip to MatchContextBadge on DRep profiles showing agree/differ dimensions

## Impact
- **What changed**: 6 targeted UX fixes for the citizen-undelegated persona experience
- **User-facing**: Yes — delegation error resolved, browse cards richer, match results more informative, DRep profile more stable
- **Risk**: Low — styling and rendering order changes, no data/API changes
- **Scope**: 6 components (RepresentationCard, CivicaDRepBrowse, CivicaDRepCard, DRepDetailedAnalysis, QuickMatchFlow, MatchContextBadge)

## Test plan
- [ ] Connect wallet with no DRep delegation — Hub shows "Unrepresented" card (no error)
- [ ] Browse /governance/representatives — search filtering is smooth, cards show green pillar tags
- [ ] Complete Quick Match — results show green/red dimension badges below personality label
- [ ] Visit DRep profile with stored match — badge shows "Your match: X%" with tooltip on hover
- [ ] Visit DRep profile as citizen — detailed analysis starts collapsed, no layout flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)