### PR TITLE
feat: homepage audit fixes — card redesigns, bug fixes, background exploration

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -88,6 +88,11 @@ export function CivicaHeader() {
   const { resolvedTheme, setTheme } = useTheme();
   const [walletModalOpen, setWalletModalOpen] = useState(false);
   const [pickerPreset, setPickerPreset] = useState<SegmentPreset | null>(null);
+  // For dual-role 2-step picker: stash the first pick while the second picker is open
+  const [pendingDualOverride, setPendingDualOverride] = useState<{
+    preset: SegmentPreset;
+    firstId: string;
+  } | null>(null);
 
   const isHome = pathname === '/';
 
@@ -360,7 +365,8 @@ export function CivicaHeader() {
           )}
         </div>
       </div>
-      {isAdmin && pickerPreset?.requiresPicker && (
+      {/* Primary picker (or first step of dual-role picker) */}
+      {isAdmin && pickerPreset?.requiresPicker && !pendingDualOverride && (
         <AdminViewAsPicker
           mode={pickerPreset.requiresPicker}
           open={!!pickerPreset}
@@ -370,6 +376,14 @@ export function CivicaHeader() {
           onSelect={(id) => {
             const p = pickerPreset;
             if (!p) return;
+
+            // If this preset has a secondary picker, stash the first pick and proceed to step 2
+            if (p.secondaryPicker) {
+              setPendingDualOverride({ preset: p, firstId: id });
+              return;
+            }
+
+            // Single-step picker — apply immediately
             if (p.segment === 'citizen' && p.requiresPicker === 'drep') {
               setOverride({ segment: 'citizen', delegatedDrep: id });
             } else if (p.segment === 'drep') {
@@ -382,6 +396,46 @@ export function CivicaHeader() {
           }}
           titleOverride={pickerPreset.pickerTitle}
           descriptionOverride={pickerPreset.pickerDescription}
+        />
+      )}
+      {/* Secondary picker (step 2 of dual-role picker) */}
+      {isAdmin && pendingDualOverride && (
+        <AdminViewAsPicker
+          mode={pendingDualOverride.preset.secondaryPicker!}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) {
+              // User cancelled step 2 — discard both picks
+              setPendingDualOverride(null);
+              setPickerPreset(null);
+            }
+          }}
+          onSelect={(secondaryId) => {
+            const { preset, firstId } = pendingDualOverride;
+
+            // Build the override with both IDs based on picker types
+            const overridePayload: Parameters<typeof setOverride>[0] = {
+              segment: preset.segment,
+            };
+            // Map first picker result
+            if (preset.requiresPicker === 'drep') {
+              overridePayload.drepId = firstId;
+            } else if (preset.requiresPicker === 'spo') {
+              overridePayload.poolId = firstId;
+            }
+            // Map second picker result
+            if (preset.secondaryPicker === 'spo') {
+              overridePayload.poolId = secondaryId;
+            } else if (preset.secondaryPicker === 'drep') {
+              overridePayload.drepId = secondaryId;
+            }
+
+            setOverride(overridePayload);
+            setPendingDualOverride(null);
+            setPickerPreset(null);
+          }}
+          titleOverride={pendingDualOverride.preset.secondaryPickerTitle}
+          descriptionOverride={pendingDualOverride.preset.secondaryPickerDescription}
         />
       )}
     </header>

--- a/components/civica/match/QuickMatchFlow.tsx
+++ b/components/civica/match/QuickMatchFlow.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import {
   Shield,
   Rocket,
@@ -686,7 +687,10 @@ function ResultsScreen({
   spoResults: QuickMatchResponse;
   onRestart: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState<MatchType>('drep');
+  const searchParams = useSearchParams();
+  const [activeTab, setActiveTab] = useState<MatchType>(() =>
+    searchParams.get('tab') === 'spo' ? 'spo' : 'drep',
+  );
   const activeResults = activeTab === 'drep' ? drepResults : spoResults;
   const hasMatches = activeResults.matches.length > 0;
 

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Users, Server } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ConstellationScene } from '@/components/ConstellationScene';
 
@@ -20,8 +20,8 @@ interface AnonymousLandingProps {
  * Radical simplicity. One value prop, one visual, two CTAs.
  * Passes the 5-second test: "This helps me participate in Cardano governance."
  *
- * No governance jargon. No multi-tab navigation. No data visualizations.
- * Social proof via live stats framed as liveness, not raw metrics.
+ * Two-path entry: Find your DRep OR Find your Stake Pool.
+ * Both go to Quick Match with the appropriate tab pre-selected.
  */
 export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
   return (
@@ -38,35 +38,36 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
         {/* Hero content */}
         <div className="relative z-10 text-center max-w-lg px-6 sm:pt-14">
           <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-white leading-tight hero-text-shadow">
-            Cardano has a government.
+            Your ADA gives you
             <br />
-            <span className="text-primary">Know who represents you.</span>
+            <span className="text-primary">a voice.</span>
           </h1>
           <p
-            className="mt-4 text-sm sm:text-base text-white/80 max-w-md mx-auto leading-relaxed"
+            className="mt-4 text-lg sm:text-xl text-white/90 font-medium"
             style={{
               textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)',
             }}
           >
-            Your ADA gives you a voice in how Cardano evolves. Find someone who represents your
-            values, or explore governance yourself.
+            It takes 60 seconds to use it.
           </p>
         </div>
       </section>
 
       {/* CTAs + social proof */}
       <section className="relative z-10 mx-auto w-full max-w-lg px-6 -mt-8 pb-12 space-y-6">
-        {/* Two CTAs */}
+        {/* Two CTAs — DRep and Stake Pool paths */}
         <div className="flex flex-col sm:flex-row gap-3">
           <Button asChild size="lg" className="flex-1 gap-2">
-            <Link href="/match">
+            <Link href="/match?tab=drep">
+              <Users className="h-4 w-4" />
               Find Your Representative
               <ArrowRight className="h-4 w-4" />
             </Link>
           </Button>
           <Button asChild variant="outline" size="lg" className="flex-1 gap-2">
-            <Link href="/governance">
-              Explore Governance
+            <Link href="/match?tab=spo">
+              <Server className="h-4 w-4" />
+              Find Your Stake Pool
               <ArrowRight className="h-4 w-4" />
             </Link>
           </Button>

--- a/components/hub/HubCardConfig.ts
+++ b/components/hub/HubCardConfig.ts
@@ -144,21 +144,8 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
 export const PERSONA_CARDS: Record<UserSegment, CardId[]> = {
   anonymous: ['discovery-match', 'discovery-explore'],
   citizen: ['alert', 'representation', 'coverage', 'governance-health', 'briefing', 'engagement'],
-  drep: [
-    'drep-action-queue',
-    'drep-delegators',
-    'drep-score',
-    'coverage',
-    'representation',
-    'governance-health',
-  ],
-  spo: [
-    'spo-governance-score',
-    'spo-delegators',
-    'coverage',
-    'representation',
-    'governance-health',
-  ],
+  drep: ['drep-action-queue', 'drep-delegators', 'drep-score', 'governance-health'],
+  spo: ['spo-governance-score', 'spo-delegators', 'governance-health'],
   cc: ['representation', 'coverage', 'governance-health', 'engagement'],
 };
 

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { HubCardRenderer } from './HubCardRenderer';
 import { AnonymousLanding } from './AnonymousLanding';
 import { HubCardSkeleton } from './cards/HubCard';
+import { ConstellationScene } from '@/components/ConstellationScene';
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -26,11 +28,13 @@ interface HubHomePageProps {
  * Anonymous: Clean conversion landing page.
  * Authenticated: Hub card renderer based on persona.
  *
- * The citizen Hub should feel like opening Apple Health —
- * one glance tells you everything is fine (or what needs attention).
+ * Background exploration: use ?bg=globe or ?bg=gradient to compare styles.
+ * Remove the exploration code once a decision is made.
  */
 export function HubHomePage({ pulseData }: HubHomePageProps) {
   const { segment, isLoading } = useSegment();
+  const searchParams = useSearchParams();
+  const bgMode = searchParams.get('bg');
 
   // While detecting segment, show skeleton cards to prevent CLS flash
   if (isLoading) {
@@ -48,5 +52,39 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     return <AnonymousLanding pulseData={pulseData} />;
   }
 
+  // Authenticated homepage — optional background exploration
+  if (bgMode === 'globe') {
+    return (
+      <div className="relative min-h-[calc(100vh-4rem)]">
+        {/* Subtle globe behind cards */}
+        <div className="fixed inset-0 top-14 pointer-events-none opacity-15">
+          <ConstellationScene className="w-full h-full" interactive={false} />
+        </div>
+        <div className="relative z-10">
+          <HubCardRenderer persona={segment} />
+        </div>
+      </div>
+    );
+  }
+
+  if (bgMode === 'gradient') {
+    return (
+      <div className="relative min-h-[calc(100vh-4rem)]">
+        {/* Ambient aurora gradient */}
+        <div className="fixed inset-0 top-14 pointer-events-none overflow-hidden">
+          <div className="absolute -top-1/2 -left-1/2 w-[200%] h-[200%] animate-[spin_120s_linear_infinite]">
+            <div className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-primary/8 blur-[120px]" />
+            <div className="absolute top-1/3 right-1/4 w-80 h-80 rounded-full bg-emerald-500/6 blur-[100px]" />
+            <div className="absolute bottom-1/4 left-1/3 w-72 h-72 rounded-full bg-violet-500/5 blur-[100px]" />
+          </div>
+        </div>
+        <div className="relative z-10">
+          <HubCardRenderer persona={segment} />
+        </div>
+      </div>
+    );
+  }
+
+  // Default — no background (current behavior)
   return <HubCardRenderer persona={segment} />;
 }

--- a/components/hub/cards/BriefingCard.tsx
+++ b/components/hub/cards/BriefingCard.tsx
@@ -75,7 +75,8 @@ export function BriefingCard() {
   return (
     <div
       className={cn(
-        'group block rounded-2xl border p-4 sm:p-5 transition-colors',
+        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5 transition-colors hover:border-primary/40',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         'border-border bg-card',
       )}
     >

--- a/components/hub/cards/CoverageCard.tsx
+++ b/components/hub/cards/CoverageCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Shield } from 'lucide-react';
+import { Shield, CheckCircle2, XCircle } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { HubCard, HubCardSkeleton, HubCardError, type CardUrgency } from './HubCard';
@@ -18,10 +18,11 @@ interface CoverageData {
 }
 
 /**
- * CoverageCard — One-liner governance coverage summary for the Hub.
+ * CoverageCard — Governance coverage as a two-item checklist.
  *
  * JTBD: "How complete is my governance representation?"
- * Shows coverage percentage with color-coded bar + one-line gap summary.
+ * Two checkmarks: DRep delegation + Pool delegation.
+ * Much clearer than a percentage (which only has 4 possible values).
  * Links to /delegation for the full breakdown.
  */
 export function CoverageCard() {
@@ -47,78 +48,86 @@ export function CoverageCard() {
   if (isError) return <HubCardError message="Couldn't load coverage" onRetry={() => refetch()} />;
   if (!data) return null;
 
-  const { coveragePct, gaps } = data;
+  const { hasDrep, hasPool, drepIsActive, poolIsGovActive } = data;
 
-  // Determine urgency and verdict
-  let verdict: string;
+  const drepOk = hasDrep && drepIsActive;
+  const poolOk = hasPool && poolIsGovActive;
+  const bothCovered = drepOk && poolOk;
+  const noneCovered = !drepOk && !poolOk;
+
   let urgency: CardUrgency;
-  if (coveragePct === 100) {
+  let verdict: string;
+  if (bothCovered) {
+    urgency = 'default';
     verdict = 'Full coverage';
-    urgency = 'success';
-  } else if (coveragePct >= 50) {
-    verdict = 'Partial coverage';
-    urgency = 'warning';
-  } else {
-    verdict = 'Low coverage';
+  } else if (noneCovered) {
     urgency = 'critical';
+    verdict = 'No coverage';
+  } else {
+    urgency = 'warning';
+    verdict = 'Partial coverage';
   }
-
-  const bandColor =
-    urgency === 'success'
-      ? 'text-emerald-600 dark:text-emerald-400'
-      : urgency === 'warning'
-        ? 'text-amber-600 dark:text-amber-400'
-        : 'text-red-600 dark:text-red-400';
-
-  const barColor =
-    urgency === 'success'
-      ? 'bg-emerald-500'
-      : urgency === 'warning'
-        ? 'bg-amber-500'
-        : 'bg-red-500';
-
-  // Build one-line gap summary
-  const gapSummary = gaps.length > 0 ? `Missing: ${gaps.join(', ').toLowerCase()}` : null;
 
   return (
     <HubCard
       href="/delegation"
-      urgency={urgency === 'success' ? 'default' : urgency}
-      label={`Governance coverage: ${verdict}, ${coveragePct}%`}
+      urgency={urgency === 'default' ? 'default' : urgency}
+      label={`Governance coverage: ${verdict}`}
     >
-      <div className="space-y-2">
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-1">
-            <div className="flex items-center gap-2">
-              <Shield className="h-4 w-4 text-muted-foreground" />
-              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Governance Coverage
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              How much of governance your delegates can vote on
-            </p>
-            <p className="text-base font-semibold text-foreground">
-              <span className={bandColor}>{verdict}</span>
-            </p>
-          </div>
-          <div className="text-right">
-            <span className={`text-2xl font-bold tabular-nums ${bandColor}`}>{coveragePct}</span>
-            <p className="text-xs text-muted-foreground">%</p>
-          </div>
+      <div className="space-y-2.5">
+        <div className="flex items-center gap-2">
+          <Shield className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Governance Coverage
+          </span>
         </div>
 
-        {/* Mini progress bar */}
-        <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all ${barColor}`}
-            style={{ width: `${coveragePct}%` }}
+        {/* Two-item checklist */}
+        <div className="space-y-1.5">
+          <CoverageCheckItem
+            label="DRep Delegation"
+            sublabel={
+              drepOk
+                ? 'Covers 5 of 7 action types'
+                : 'No active DRep — 5 action types unrepresented'
+            }
+            checked={drepOk}
+          />
+          <CoverageCheckItem
+            label="Pool Delegation"
+            sublabel={
+              poolOk
+                ? 'Covers 2 of 7 action types'
+                : 'No governance-active pool — 2 action types unrepresented'
+            }
+            checked={poolOk}
           />
         </div>
-
-        {/* One-line gap summary */}
-        {gapSummary && <p className="text-xs text-muted-foreground truncate">{gapSummary}</p>}
       </div>
     </HubCard>
+  );
+}
+
+function CoverageCheckItem({
+  label,
+  sublabel,
+  checked,
+}: {
+  label: string;
+  sublabel: string;
+  checked: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      {checked ? (
+        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+      ) : (
+        <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500/70" />
+      )}
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{label}</p>
+        <p className="text-xs text-muted-foreground truncate">{sublabel}</p>
+      </div>
+    </div>
   );
 }

--- a/components/hub/cards/GovernanceHealthCard.tsx
+++ b/components/hub/cards/GovernanceHealthCard.tsx
@@ -1,15 +1,22 @@
 'use client';
 
-import { Activity } from 'lucide-react';
+import { Activity, TrendingUp, TrendingDown, AlertTriangle } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { HubCard, HubCardSkeleton, HubCardError, type CardUrgency } from './HubCard';
 
+interface GHIComponent {
+  name: string;
+  value: number;
+  weight: number;
+  contribution: number;
+}
+
 /**
- * GovernanceHealthCard — GHI one-liner with health band.
+ * GovernanceHealthCard — GHI with component breakdown.
  *
  * JTBD: "Is Cardano governance healthy right now?"
- * One number, one word verdict, one link to /pulse for details.
- * Like a credit score — not a dashboard.
+ * Score + verdict + top components + weakest area callout.
+ * World-class: shows WHY the score is what it is, not just a number.
  */
 export function GovernanceHealthCard() {
   const {
@@ -34,8 +41,9 @@ export function GovernanceHealthCard() {
   const ghi = ghiRaw as Record<string, unknown> | undefined;
   const score = (ghi?.score as number) ?? (ghi?.compositeScore as number) ?? 0;
   const rounded = Math.round(score);
+  const components = (ghi?.components as GHIComponent[]) ?? [];
 
-  // Health band — like a credit score
+  // Health band
   let band: string;
   let urgency: CardUrgency;
   if (rounded >= 70) {
@@ -56,28 +64,72 @@ export function GovernanceHealthCard() {
         ? 'text-amber-600 dark:text-amber-400'
         : 'text-red-600 dark:text-red-400';
 
+  // Find weakest and strongest active components (skip disabled ones with value 0 and weight 0)
+  const activeComponents = components.filter((c) => c.weight > 0);
+  const sorted = [...activeComponents].sort((a, b) => a.value - b.value);
+  const weakest = sorted[0];
+  const strongest = sorted.at(-1);
+
+  // Short component name for display
+  const shortName = (name: string) =>
+    name
+      .replace('DRep ', '')
+      .replace('Governance ', '')
+      .replace('Citizen ', '')
+      .replace('System ', '');
+
   return (
     <HubCard
       href="/governance/health"
       urgency="default"
       label={`Governance health: ${band}, score ${rounded}`}
     >
-      <div className="flex items-center justify-between gap-4">
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <Activity className="h-4 w-4 text-muted-foreground" />
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Governance Health
-            </span>
+      <div className="space-y-2.5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-muted-foreground" />
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Governance Health
+              </span>
+            </div>
+            <p className="text-base font-semibold text-foreground">
+              <span className={bandColor}>{band}</span>
+            </p>
           </div>
-          <p className="text-base font-semibold text-foreground">
-            <span className={bandColor}>{band}</span>
-          </p>
+          <div className="text-right">
+            <span className={`text-2xl font-bold tabular-nums ${bandColor}`}>{rounded}</span>
+            <p className="text-xs text-muted-foreground">/ 100</p>
+          </div>
         </div>
-        <div className="text-right">
-          <span className={`text-2xl font-bold tabular-nums ${bandColor}`}>{rounded}</span>
-          <p className="text-xs text-muted-foreground">GHI</p>
-        </div>
+
+        {/* Component insights — strongest + weakest */}
+        {activeComponents.length > 0 && (
+          <div className="space-y-1 border-t border-border pt-2">
+            {strongest && strongest.value >= 60 && (
+              <div className="flex items-center gap-1.5 text-xs">
+                <TrendingUp className="h-3 w-3 text-emerald-500 shrink-0" />
+                <span className="text-muted-foreground">
+                  <span className="font-medium text-foreground">{shortName(strongest.name)}</span>{' '}
+                  leading at {strongest.value}
+                </span>
+              </div>
+            )}
+            {weakest && weakest !== strongest && (
+              <div className="flex items-center gap-1.5 text-xs">
+                {weakest.value < 50 ? (
+                  <AlertTriangle className="h-3 w-3 text-amber-500 shrink-0" />
+                ) : (
+                  <TrendingDown className="h-3 w-3 text-muted-foreground shrink-0" />
+                )}
+                <span className="text-muted-foreground">
+                  <span className="font-medium text-foreground">{shortName(weakest.name)}</span>{' '}
+                  lowest at {weakest.value}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </HubCard>
   );

--- a/components/hub/cards/RepresentationCard.tsx
+++ b/components/hub/cards/RepresentationCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ShieldCheck, ShieldAlert, ShieldX, User } from 'lucide-react';
+import { ShieldCheck, ShieldAlert, ShieldX, User, Ban, ThumbsDown } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useGovernanceHolder } from '@/hooks/queries';
 import { HubCard, HubCardSkeleton, HubCardError, type CardUrgency } from './HubCard';
@@ -13,14 +13,15 @@ import { getScoreNarrative } from '@/lib/scoring/scoreNarratives';
  * Shows at a glance: Do I have a DRep? Are they active? Are they voting?
  * Also shows pool governance status if they have a staking pool.
  *
+ * Handles special delegation states: abstain and no-confidence.
+ *
  * JTBD: "Is my ADA represented in governance?"
  * One conclusion + one link to /delegation for details.
  */
 export function RepresentationCard() {
   const { stakeAddress, delegatedDrep, delegatedPool } = useSegment();
-  const { data: holderRaw, isLoading, isError, refetch } = useGovernanceHolder(stakeAddress);
 
-  // Undelegated citizens don't need holder data — show CTA immediately
+  // Undelegated citizens — show CTA immediately
   if (!delegatedDrep) {
     return (
       <HubCard href="/match" urgency="warning" label="You have no DRep. Find a representative.">
@@ -42,18 +43,82 @@ export function RepresentationCard() {
     );
   }
 
+  // Always-abstain delegation — valid choice, no data fetch needed
+  if (delegatedDrep === 'drep_always_abstain') {
+    return (
+      <HubCard href="/delegation" urgency="default" label="Delegation: Always Abstain">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Ban className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Always Abstain
+            </span>
+          </div>
+          <p className="text-base font-semibold text-foreground">
+            Your ADA abstains on all governance actions
+          </p>
+          <p className="text-sm text-muted-foreground">
+            You&apos;ve chosen to abstain rather than delegate. Your ADA still counts toward quorum.
+          </p>
+        </div>
+      </HubCard>
+    );
+  }
+
+  // No-confidence delegation — valid choice, no data fetch needed
+  if (delegatedDrep === 'drep_always_no_confidence') {
+    return (
+      <HubCard href="/delegation" urgency="warning" label="Delegation: No Confidence">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <ThumbsDown className="h-4 w-4 text-amber-500" />
+            <span className="text-xs font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400">
+              No Confidence
+            </span>
+          </div>
+          <p className="text-base font-semibold text-foreground">
+            Your ADA signals no confidence in governance
+          </p>
+          <p className="text-sm text-muted-foreground">
+            This is an active signal. Your vote weight counts against all proposals.
+          </p>
+        </div>
+      </HubCard>
+    );
+  }
+
+  // Normal delegation — fetch holder data
+  return (
+    <DelegatedRepresentationCard
+      stakeAddress={stakeAddress}
+      delegatedDrep={delegatedDrep}
+      delegatedPool={delegatedPool}
+    />
+  );
+}
+
+function DelegatedRepresentationCard({
+  stakeAddress,
+
+  delegatedPool,
+}: {
+  stakeAddress: string | null;
+  delegatedDrep: string;
+  delegatedPool: string | null;
+}) {
+  const { data: holderRaw, isLoading, isError, refetch } = useGovernanceHolder(stakeAddress);
+
   if (isLoading) return <HubCardSkeleton />;
   if (isError)
     return <HubCardError message="Couldn't load delegation status" onRetry={() => refetch()} />;
 
-  // Delegated state — build the summary
   const holder = holderRaw as Record<string, unknown> | undefined;
   const drep = holder?.drep as Record<string, unknown> | undefined;
   const drepName = (drep?.name as string) || (drep?.ticker as string) || 'Your DRep';
   const drepScore = (drep?.score as number) ?? 0;
   const isActive = (drep?.isActive as boolean) ?? true;
   const participationRate = (drep?.participationRate as number) ?? 0;
-  // Determine urgency
+
   let urgency: CardUrgency = 'success';
   let statusLabel = 'Represented';
   let statusMessage = `${drepName} is active`;

--- a/components/hub/cards/StatusCard.tsx
+++ b/components/hub/cards/StatusCard.tsx
@@ -26,13 +26,38 @@ export function DRepDelegatorsCard() {
   const { drepId } = useSegment();
   const { data: trendsRaw, isLoading, isError, refetch } = useDashboardDelegatorTrends(drepId);
 
+  // Unclaimed DRep — no drepId to query
+  if (!drepId) {
+    return (
+      <HubCard href="/workspace" urgency="default" label="Claim your profile to see delegator data">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Delegators
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Claim your DRep profile to see who delegates to you
+          </p>
+        </div>
+      </HubCard>
+    );
+  }
+
   if (isLoading) return <HubCardSkeleton />;
   if (isError)
     return <HubCardError message="Couldn't load delegator data" onRetry={() => refetch()} />;
 
   const trends = trendsRaw as Record<string, unknown> | undefined;
-  const currentCount = (trends?.currentCount as number) ?? 0;
-  const change = (trends?.change as number) ?? 0;
+  const snapshots = (trends?.snapshots as { delegatorCount?: number }[]) ?? [];
+  const currentCount =
+    (trends?.currentDelegators as number) ?? snapshots.at(-1)?.delegatorCount ?? 0;
+  // Compute epoch-over-epoch change from the last two snapshots
+  const change =
+    snapshots.length >= 2
+      ? (snapshots.at(-1)?.delegatorCount ?? 0) - (snapshots.at(-2)?.delegatorCount ?? 0)
+      : 0;
 
   return (
     <HubCard
@@ -73,6 +98,25 @@ export function DRepDelegatorsCard() {
 export function DRepScoreCard() {
   const { drepId } = useSegment();
   const { data: reportRaw, isLoading, isError, refetch } = useDRepReportCard(drepId);
+
+  // Unclaimed DRep — no drepId to query
+  if (!drepId) {
+    return (
+      <HubCard href="/workspace" urgency="default" label="Claim your profile to see your score">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Trophy className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Your Score
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Claim your DRep profile to see your governance score
+          </p>
+        </div>
+      </HubCard>
+    );
+  }
 
   if (isLoading) return <HubCardSkeleton />;
   if (isError) return <HubCardError message="Couldn't load your score" onRetry={() => refetch()} />;

--- a/lib/admin/viewAsRegistry.ts
+++ b/lib/admin/viewAsRegistry.ts
@@ -32,9 +32,14 @@ export interface SegmentPreset {
   };
   /** If true, opens a picker dialog instead of applying immediately */
   requiresPicker?: 'drep' | 'spo' | 'cc';
+  /** After the first picker completes, open a second picker for this type */
+  secondaryPicker?: 'drep' | 'spo' | 'cc';
   /** Picker title/description overrides */
   pickerTitle?: string;
   pickerDescription?: string;
+  /** Secondary picker title/description overrides */
+  secondaryPickerTitle?: string;
+  secondaryPickerDescription?: string;
 }
 
 export const SEGMENT_PRESETS: SegmentPreset[] = [
@@ -112,13 +117,16 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
   // -- DRep + SPO (dual role) --
   {
     id: 'drep-spo-dual',
-    label: 'DRep + SPO (dual role)',
+    label: 'DRep + SPO (dual role)...',
     description: 'User is both a DRep and an SPO — shows combined workspace',
     segment: 'drep',
-    overrides: {
-      drepId: 'drep1_placeholder_dual',
-      poolId: 'pool1_placeholder_dual',
-    },
+    overrides: {},
+    requiresPicker: 'drep',
+    secondaryPicker: 'spo',
+    pickerTitle: 'Step 1: Pick a DRep',
+    pickerDescription: 'Select the DRep identity for the dual-role simulation.',
+    secondaryPickerTitle: 'Step 2: Pick a Stake Pool',
+    secondaryPickerDescription: 'Select the SPO identity for the dual-role simulation.',
   },
 
   // -- CC Member --


### PR DESCRIPTION
## Summary
- Fix DRep delegators showing 0 (data contract mismatch), abstain/no-confidence delegation crashes, unclaimed DRep errors
- Rewrite anonymous landing with new hero text and dual CTA to /match (DRep + SPO tabs)
- Replace coverage percentage bar with two-item checklist; enrich governance health card with component insights
- Remove citizen-facing cards (coverage, representation) from DRep and SPO personas
- Add 2-step picker for DRep+SPO dual-role in View As admin registry
- Add ?bg=globe and ?bg=gradient background variants for authenticated homepage (URL-param gated for user testing)

## Impact
- **What changed**: 11 files across hub cards, anonymous landing, match flow, View As registry, homepage dispatcher
- **User-facing**: Yes — anonymous landing redesign, card content changes for all personas, bug fixes for delegation/delegators/score cards
- **Risk**: Low — all changes are frontend/UI, no data or API changes, preflight passes clean
- **Scope**: Hub cards, AnonymousLanding, QuickMatchFlow, HubCardConfig, HubHomePage, CivicaHeader, viewAsRegistry

## Test plan
- [ ] Verify anonymous landing shows new hero text and both CTAs
- [ ] Click "Find Your Representative" → lands on /match with DRep tab active
- [ ] Click "Find Your Stake Pool" → lands on /match with SPO tab active
- [ ] View as citizen-delegated: RepresentationCard shows DRep status correctly
- [ ] View as citizen-abstainer: shows "Always Abstain" card (not crash)
- [ ] View as citizen-no-confidence: shows "No Confidence" card (not crash)
- [ ] View as DRep: no coverage or representation cards shown
- [ ] View as unclaimed DRep: delegators and score cards show "Claim your profile" CTA
- [ ] View as DRep+SPO: 2-step picker works (DRep first, then SPO)
- [ ] CoverageCard shows two-item checklist instead of percentage
- [ ] GovernanceHealthCard shows strongest/weakest component insights
- [ ] BriefingCard has hover state on mouseover
- [ ] Test ?bg=globe — subtle constellation behind cards
- [ ] Test ?bg=gradient — animated aurora gradient behind cards
- [ ] Default (no ?bg param) — plain background, no decoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)