### PR TITLE
feat: proposal visual redesign — type-specific identities and zone layout

### DIFF
--- a/app/proposal/[txHash]/[index]/loading.tsx
+++ b/app/proposal/[txHash]/[index]/loading.tsx
@@ -3,71 +3,84 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export default function ProposalLoading() {
   return (
-    <div className="container mx-auto px-4 py-8 space-y-6">
-      {/* Back button */}
-      <Skeleton className="h-9 w-32" />
+    <div className="container mx-auto px-4 py-8 space-y-8">
+      {/* Breadcrumb */}
+      <Skeleton className="h-5 w-48" />
 
-      {/* Hero section */}
-      <div className="rounded-xl border bg-card p-6 space-y-4">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-6 w-24 rounded-full" />
-          <Skeleton className="h-6 w-20 rounded-full" />
+      {/* Zone 1: Hero */}
+      <div className="rounded-2xl border border-border/50 overflow-hidden">
+        <div className="px-6 pt-6 pb-4 space-y-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-6 w-28 rounded-full" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+          </div>
+          <Skeleton className="h-10 w-3/4" />
+          <div className="flex gap-4">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-5 w-28" />
+          </div>
         </div>
-        <Skeleton className="h-8 w-3/4" />
-        <div className="flex gap-4">
-          <Skeleton className="h-5 w-32" />
-          <Skeleton className="h-5 w-28" />
-          <Skeleton className="h-5 w-36" />
+        {/* Verdict strip */}
+        <div className="px-6 pb-5">
+          <Skeleton className="h-12 w-full rounded-lg" />
         </div>
       </div>
 
-      {/* Engagement summary */}
-      <div className="flex gap-3">
-        <Skeleton className="h-10 w-28 rounded-full" />
-        <Skeleton className="h-10 w-28 rounded-full" />
-        <Skeleton className="h-10 w-28 rounded-full" />
+      {/* Zone 2: Community Signals */}
+      <div className="space-y-4">
+        <div className="flex gap-3">
+          <Skeleton className="h-10 w-28 rounded-full" />
+          <Skeleton className="h-10 w-28 rounded-full" />
+          <Skeleton className="h-10 w-28 rounded-full" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-7 w-24 rounded-full" />
+          ))}
+        </div>
       </div>
 
-      {/* Dimension tags */}
-      <div className="flex gap-2 flex-wrap">
-        {[1, 2, 3, 4].map((i) => (
-          <Skeleton key={i} className="h-7 w-24 rounded-full" />
-        ))}
-      </div>
-
-      {/* Lifecycle timeline */}
-      <div className="rounded-xl border bg-card p-5 space-y-3">
-        <Skeleton className="h-5 w-40" />
-        <Skeleton className="h-16 w-full" />
-      </div>
-
-      {/* AI Summary */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-32" />
-        </CardHeader>
-        <CardContent className="space-y-2">
+      {/* Zone 3: Intelligence Briefing */}
+      <div className="rounded-2xl border border-border/50 bg-muted/20 p-6 space-y-4">
+        <Skeleton className="h-6 w-44" />
+        <div className="space-y-2">
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-5/6" />
           <Skeleton className="h-4 w-3/4" />
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
-      {/* Description */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-28" />
-        </CardHeader>
-        <CardContent className="space-y-2">
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-2/3" />
-        </CardContent>
-      </Card>
+      {/* Zone 4: Take Action */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-10 w-full rounded-lg" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-28" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </CardContent>
+        </Card>
+      </div>
 
-      {/* Threshold meter */}
+      {/* Zone 5: The Debate */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-24 w-full rounded-lg" />
+        ))}
+      </div>
+
+      {/* Zone 6: Deep Dive */}
       <Card>
         <CardHeader>
           <Skeleton className="h-6 w-40" />
@@ -78,17 +91,6 @@ export default function ProposalLoading() {
         </CardContent>
       </Card>
 
-      {/* Vote adoption curve */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-32" />
-        </CardHeader>
-        <CardContent>
-          <Skeleton className="h-48 w-full" />
-        </CardContent>
-      </Card>
-
-      {/* Voter tabs */}
       <div className="space-y-4">
         <div className="flex gap-2">
           <Skeleton className="h-9 w-20" />

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -5,7 +5,6 @@ import { blockTimeToEpoch } from '@/lib/koios';
 import { getTreasuryBalance } from '@/lib/treasury';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProposalDescription } from '@/components/ProposalDescription';
-import { ProposalAiSummary } from '@/components/ProposalAiSummary';
 import { ThresholdMeter } from '@/components/ThresholdMeter';
 import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { getProposalStatus } from '@/utils/proposalPriority';
@@ -13,19 +12,16 @@ import { ProposalOutcomeSection } from '@/components/ProposalOutcomeSection';
 import { ProposalVoterTabs } from '@/components/ProposalVoterTabs';
 import { SimilarProposals } from '@/components/SimilarProposals';
 import { PageViewTracker } from '@/components/PageViewTracker';
-import { ProposalHeroV1 } from '@/components/civica/proposals/ProposalHeroV1';
 import { VoteAdoptionCurve } from '@/components/civica/charts/VoteAdoptionCurve';
 import { ProposalDimensionTags } from '@/components/civica/proposals/ProposalDimensionTags';
-import { ProposalTopRationales } from '@/components/civica/proposals/ProposalTopRationales';
 import { ProposalLifecycleTimeline } from '@/components/civica/proposals/ProposalLifecycleTimeline';
-import { ParamChangesCard } from '@/components/civica/proposals/ParamChangesCard';
-import { VoteRationaleFlow } from '@/components/civica/proposals/VoteRationaleFlow';
-import { ConstitutionalAlignmentCard } from '@/components/ConstitutionalAlignmentCard';
-import { CitizenVoiceCard } from '@/components/engagement/CitizenVoiceCard';
 import { ImpactTags } from '@/components/engagement/ImpactTags';
-import { AskYourDRep } from '@/components/engagement/AskYourDRep';
 import { EngagementSummary } from '@/components/engagement/EngagementSummary';
 import { ConcernFlagBanner } from '@/components/engagement/ConcernFlagBanner';
+import { ProposalHeroV2 } from '@/components/civica/proposals/ProposalHeroV2';
+import { IntelligenceBriefing } from '@/components/civica/proposals/IntelligenceBriefing';
+import { DebateSection } from '@/components/civica/proposals/DebateSection';
+import { ActionPanel } from '@/components/civica/proposals/ActionPanel';
 
 export const dynamic = 'force-dynamic';
 
@@ -83,7 +79,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
       abstainCount: counts.abstain,
     }));
 
-  // Build rationale entries for the top-rationales card
+  // Build rationale entries for debate section
   const rationaleEntries = votes
     .filter((v) => v.rationaleAiSummary || v.rationaleText)
     .map((v) => ({
@@ -98,7 +94,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
   const title = proposal.title || `Proposal ${txHash.slice(0, 12)}...`;
 
   return (
-    <div className="container mx-auto px-4 py-8 space-y-6">
+    <div className="container mx-auto px-4 py-8 space-y-8">
       <PageViewTracker
         event="proposal_detail_viewed"
         properties={{ tx_hash: txHash, index: proposalIndex }}
@@ -112,8 +108,8 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         ]}
       />
 
-      {/* 1. Hero */}
-      <ProposalHeroV1
+      {/* Zone 1: Hero — type-specific gradient, verdict strip, prominent title */}
+      <ProposalHeroV2
         txHash={txHash}
         proposalIndex={proposalIndex}
         title={title}
@@ -133,26 +129,49 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         blockTime={proposal.blockTime}
       />
 
-      {/* 2. Engagement Summary + Concern Banner + Dimension Tags */}
-      <EngagementSummary txHash={txHash} proposalIndex={proposalIndex} />
+      {/* Zone 2: Community Signals — engagement, concerns, dimension tags */}
+      <div className="space-y-4">
+        <EngagementSummary txHash={txHash} proposalIndex={proposalIndex} />
+        <ConcernFlagBanner
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          outcome={
+            proposal.ratifiedEpoch != null
+              ? 'ratified'
+              : proposal.droppedEpoch != null
+                ? 'dropped'
+                : proposal.expiredEpoch != null
+                  ? 'expired'
+                  : null
+          }
+        />
+        <ProposalDimensionTags relevantPrefs={proposal.relevantPrefs} />
+      </div>
 
-      <ConcernFlagBanner
+      {/* Zone 3: Intelligence Briefing — AI summary + constitutional + params merged */}
+      <IntelligenceBriefing
         txHash={txHash}
         proposalIndex={proposalIndex}
-        outcome={
-          proposal.ratifiedEpoch != null
-            ? 'ratified'
-            : proposal.droppedEpoch != null
-              ? 'dropped'
-              : proposal.expiredEpoch != null
-                ? 'expired'
-                : null
-        }
+        aiSummary={proposal.aiSummary}
+        proposalType={proposal.proposalType}
+        paramChanges={proposal.paramChanges}
       />
 
-      <ProposalDimensionTags relevantPrefs={proposal.relevantPrefs} />
+      {/* Zone 4: Take Action — vote flow + citizen voice side by side */}
+      <ActionPanel
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+        title={title}
+        isOpen={isOpen}
+        proposalAbstract={proposal.abstract}
+        proposalType={proposal.proposalType}
+        aiSummary={proposal.aiSummary}
+      />
 
-      {/* 3. Lifecycle Timeline */}
+      {/* Zone 5: The Debate — structured pro/con rationales */}
+      <DebateSection rationales={rationaleEntries} />
+
+      {/* Zone 6: Deep Dive — timeline, thresholds, adoption, voters, description */}
       <ProposalLifecycleTimeline
         proposedEpoch={proposal.proposedEpoch}
         expirationEpoch={proposal.expirationEpoch}
@@ -163,40 +182,6 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         currentEpoch={currentEpoch}
       />
 
-      {/* 4. Constitutional Alignment (elevated position) */}
-      <ConstitutionalAlignmentCard txHash={txHash} proposalIndex={proposalIndex} />
-
-      {/* 5. Citizen Voice (combined sentiment + concerns) */}
-      <CitizenVoiceCard txHash={txHash} proposalIndex={proposalIndex} isOpen={isOpen} />
-
-      {/* 6. AI Summary */}
-      <ProposalAiSummary summary={proposal.aiSummary} />
-
-      {/* 7. Parameter Changes (ParameterChange proposals only) */}
-      {proposal.proposalType === 'ParameterChange' && proposal.paramChanges && (
-        <ParamChangesCard paramChanges={proposal.paramChanges} />
-      )}
-
-      {/* 8. Full Description */}
-      <ProposalDescription aiSummary={null} abstract={proposal.abstract} />
-
-      {/* Vote + Rationale Flow (DReps, SPOs, CC — open proposals only) */}
-      <VoteRationaleFlow
-        txHash={txHash}
-        proposalIndex={proposalIndex}
-        title={title}
-        isOpen={isOpen}
-        proposalAbstract={proposal.abstract}
-        proposalType={proposal.proposalType}
-        aiSummary={proposal.aiSummary}
-      />
-
-      {/* Ask Your DRep (open proposals only) */}
-      {isOpen && (
-        <AskYourDRep txHash={txHash} proposalIndex={proposalIndex} proposalTitle={title} />
-      )}
-
-      {/* 9. Voting Power */}
       <Card>
         <CardHeader>
           <CardTitle>DRep Voting Power</CardTitle>
@@ -219,7 +204,6 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         </CardContent>
       </Card>
 
-      {/* 10. Vote Adoption Curve */}
       {adoptionData.length > 1 && (
         <Card>
           <CardHeader>
@@ -231,7 +215,6 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         </Card>
       )}
 
-      {/* 11. Voter Tabs (DRep/SPO/CC) with status badge */}
       <ProposalVoterTabs
         votes={votes}
         txHash={txHash}
@@ -239,13 +222,10 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         status={status}
       />
 
-      {/* 12. Top Rationales */}
-      <ProposalTopRationales rationales={rationaleEntries} />
+      <ProposalDescription aiSummary={null} abstract={proposal.abstract} />
 
-      {/* 13. Similar Proposals */}
       <SimilarProposals txHash={txHash} proposalIndex={proposalIndex} />
 
-      {/* 14. Outcome (closed proposals only) */}
       {!isOpen && (
         <ProposalOutcomeSection
           proposal={{
@@ -267,7 +247,6 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         />
       )}
 
-      {/* Citizen Impact Feedback (enacted/ratified proposals) */}
       {(status === 'enacted' || status === 'ratified') && (
         <ImpactTags txHash={txHash} proposalIndex={proposalIndex} />
       )}

--- a/components/ProposalDrawer.tsx
+++ b/components/ProposalDrawer.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button';
 import { ExternalLink, TrendingUp, Clock, FileText, Users, Vote } from 'lucide-react';
 import { RationaleAssistant } from '@/components/RationaleAssistant';
 import { DelegatorPulse } from '@/components/DelegatorPulse';
+import { getProposalTheme } from '@/components/civica/proposals/proposal-theme';
 
 interface ProposalDrawerProps {
   open: boolean;
@@ -55,18 +56,6 @@ const PRIORITY_LABELS = {
   },
 };
 
-const TYPE_LABELS: Record<string, string> = {
-  TreasuryWithdrawals: 'Treasury Withdrawal',
-  ParameterChange: 'Parameter Change',
-  HardForkInitiation: 'Hard Fork',
-  InfoAction: 'Info Action',
-  NoConfidence: 'No Confidence',
-  NewCommittee: 'New Committee',
-  NewConstitutionalCommittee: 'New Constitutional Committee',
-  NewConstitution: 'New Constitution',
-  UpdateConstitution: 'Constitution Update',
-};
-
 export function ProposalDrawer({ open, onOpenChange, proposal, drepId }: ProposalDrawerProps) {
   useEffect(() => {
     if (open && proposal) {
@@ -101,7 +90,7 @@ export function ProposalDrawer({ open, onOpenChange, proposal, drepId }: Proposa
               {priorityConfig.label}
             </Badge>
             <Badge variant="outline" className="text-[10px]">
-              {TYPE_LABELS[proposal.proposalType] || proposal.proposalType}
+              {getProposalTheme(proposal.proposalType).label || proposal.proposalType}
             </Badge>
             {proposal.epochsRemaining != null && (
               <Badge

--- a/components/VoteDetailSheet.tsx
+++ b/components/VoteDetailSheet.tsx
@@ -10,21 +10,11 @@ import {
   SheetDescription,
 } from '@/components/ui/sheet';
 import { Badge } from '@/components/ui/badge';
-import {
-  ExternalLink,
-  Copy,
-  Check,
-  Shield,
-  Zap,
-  Landmark,
-  Eye,
-  Scale,
-  ArrowRight,
-  Sparkles,
-} from 'lucide-react';
+import { ExternalLink, Copy, Check, ArrowRight, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import Link from 'next/link';
 import { MarkdownContent } from '@/components/MarkdownContent';
+import { getProposalTheme } from '@/components/civica/proposals/proposal-theme';
 import { ProposalDeliveryBadge } from '@/components/civica/proposals/ProposalDeliveryBadge';
 
 interface VoteDetailSheetProps {
@@ -33,18 +23,6 @@ interface VoteDetailSheetProps {
   onOpenChange: (open: boolean) => void;
   userPrefs?: UserPrefKey[];
 }
-
-const PROPOSAL_TYPE_LABELS: Record<string, { label: string; icon: typeof Landmark }> = {
-  TreasuryWithdrawals: { label: 'Treasury', icon: Landmark },
-  ParameterChange: { label: 'Parameter Change', icon: Shield },
-  HardForkInitiation: { label: 'Hard Fork', icon: Zap },
-  InfoAction: { label: 'Info Action', icon: Eye },
-  NoConfidence: { label: 'No Confidence', icon: Scale },
-  NewCommittee: { label: 'Constitutional Committee', icon: Scale },
-  NewConstitutionalCommittee: { label: 'Constitutional Committee', icon: Scale },
-  NewConstitution: { label: 'Constitution', icon: Scale },
-  UpdateConstitution: { label: 'Constitution', icon: Scale },
-};
 
 const TREASURY_TIER_LABELS: Record<string, string> = {
   routine: '< 1M ADA',
@@ -106,7 +84,7 @@ export function VoteDetailSheet({
     userPrefs,
   );
 
-  const typeInfo = vote.proposalType ? PROPOSAL_TYPE_LABELS[vote.proposalType] : null;
+  const typeInfo = vote.proposalType ? getProposalTheme(vote.proposalType) : null;
   const TypeIcon = typeInfo?.icon;
 
   return (

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -42,18 +42,9 @@ interface BrowseProposal {
 import { ProposalDeliveryBadge } from '@/components/civica/proposals/ProposalDeliveryBadge';
 import type { DeliveryStatus } from '@/lib/proposalOutcomes';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
+import { getProposalTheme } from '@/components/civica/proposals/proposal-theme';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
-
-const TYPE_COLORS: Record<string, string> = {
-  ParameterChange: 'bg-blue-950/30 text-blue-400 border-blue-800/30',
-  HardForkInitiation: 'bg-orange-950/30 text-orange-400 border-orange-800/30',
-  TreasuryWithdrawals: 'bg-emerald-950/30 text-emerald-400 border-emerald-800/30',
-  NewConstitution: 'bg-purple-950/30 text-purple-400 border-purple-800/30',
-  NoConfidence: 'bg-rose-950/30 text-rose-400 border-rose-800/30',
-  UpdateCommittee: 'bg-violet-950/30 text-violet-400 border-violet-800/30',
-  InfoAction: 'bg-muted text-muted-foreground',
-};
 
 const STATUS_COLORS: Record<string, string> = {
   Open: 'text-emerald-400',
@@ -74,11 +65,6 @@ const TYPE_FILTERS = [
   { value: 'UpdateCommittee', label: 'Committee' },
   { value: 'InfoAction', label: 'Info' },
 ];
-
-function typeLabel(type: string): string {
-  const found = TYPE_FILTERS.find((t) => t.value === type);
-  return found?.label ?? type;
-}
 
 const VOTE_PILL: Record<string, { label: string; color: string }> = {
   Yes: { label: 'Yes', color: 'text-green-500 bg-green-500/10 border-green-500/20' },
@@ -351,8 +337,11 @@ export function ProposalsBrowse() {
               <Link
                 key={`${p.txHash}-${p.index}`}
                 href={`/proposal/${p.txHash}/${p.index}`}
-                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group animate-in fade-in duration-200 fill-mode-backwards"
-                style={{ animationDelay: `${Math.min(i, 14) * 20}ms` }}
+                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group animate-in fade-in duration-200 fill-mode-backwards border-l-2"
+                style={{
+                  animationDelay: `${Math.min(i, 14) * 20}ms`,
+                  borderLeftColor: p.type ? getProposalTheme(p.type).rowAccent : 'transparent',
+                }}
               >
                 {/* Row 1: Type + Title + Status */}
                 <div className="flex items-center gap-3">
@@ -360,10 +349,10 @@ export function ProposalsBrowse() {
                     <span
                       className={cn(
                         'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border shrink-0',
-                        TYPE_COLORS[p.type] ?? 'bg-muted text-muted-foreground',
+                        getProposalTheme(p.type).browseBadgeClass,
                       )}
                     >
-                      {typeLabel(p.type)}
+                      {getProposalTheme(p.type).label}
                     </span>
                   )}
                   <span className="flex-1 text-sm text-foreground truncate min-w-0">

--- a/components/civica/match/CuratedVoteFlow.tsx
+++ b/components/civica/match/CuratedVoteFlow.tsx
@@ -31,6 +31,7 @@ import {
   type ConfidenceBreakdown,
 } from '@/lib/matching/confidence';
 import { usePostHog } from 'posthog-js/react';
+import { getProposalTheme } from '@/components/civica/proposals/proposal-theme';
 
 /* ─── Types ────────────────────────────────────────────── */
 
@@ -83,16 +84,6 @@ const TYPE_COLORS: Record<string, string> = {
   NewConstitution: '#10b981',
   NoConfidence: '#f43f5e',
   UpdateCommittee: '#06b6d4',
-};
-
-const TYPE_LABELS: Record<string, string> = {
-  InfoAction: 'Info',
-  TreasuryWithdrawals: 'Treasury',
-  ParameterChange: 'Parameter',
-  HardForkInitiation: 'Hard Fork',
-  NewConstitution: 'Constitution',
-  NoConfidence: 'No Confidence',
-  UpdateCommittee: 'Committee',
 };
 
 const DIMENSION_LABELS: Record<keyof DimensionScores, string> = {
@@ -427,7 +418,7 @@ export function CuratedVoteFlow() {
     ? (TYPE_COLORS[currentProposal.type] ?? '#6b7280')
     : '#6b7280';
   const typeLabel = currentProposal?.type
-    ? (TYPE_LABELS[currentProposal.type] ?? currentProposal.type)
+    ? (getProposalTheme(currentProposal.type).label ?? currentProposal.type)
     : 'Proposal';
   const epochsLeft =
     currentProposal?.expirationEpoch && data.currentEpoch

--- a/components/civica/proposals/ActionPanel.tsx
+++ b/components/civica/proposals/ActionPanel.tsx
@@ -1,0 +1,44 @@
+import { VoteRationaleFlow } from '@/components/civica/proposals/VoteRationaleFlow';
+import { CitizenVoiceCard } from '@/components/engagement/CitizenVoiceCard';
+import { AskYourDRep } from '@/components/engagement/AskYourDRep';
+
+interface ActionPanelProps {
+  txHash: string;
+  proposalIndex: number;
+  title: string;
+  isOpen: boolean;
+  proposalAbstract?: string | null;
+  proposalType?: string | null;
+  aiSummary?: string | null;
+}
+
+export function ActionPanel({
+  txHash,
+  proposalIndex,
+  title,
+  isOpen,
+  proposalAbstract,
+  proposalType,
+  aiSummary,
+}: ActionPanelProps) {
+  return (
+    <section className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+        <VoteRationaleFlow
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          title={title}
+          isOpen={isOpen}
+          proposalAbstract={proposalAbstract}
+          proposalType={proposalType}
+          aiSummary={aiSummary}
+        />
+        <CitizenVoiceCard txHash={txHash} proposalIndex={proposalIndex} isOpen={isOpen} />
+      </div>
+
+      {isOpen && (
+        <AskYourDRep txHash={txHash} proposalIndex={proposalIndex} proposalTitle={title} />
+      )}
+    </section>
+  );
+}

--- a/components/civica/proposals/DebateSection.tsx
+++ b/components/civica/proposals/DebateSection.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { MessageSquare, ShieldCheck, ShieldAlert, ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { RationaleEntry } from './ProposalTopRationales';
+
+interface DebateSectionProps {
+  rationales: RationaleEntry[];
+}
+
+function RationaleCard({
+  entry,
+  expanded,
+  onToggle,
+}: {
+  entry: RationaleEntry;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const displayText = entry.rationaleAiSummary || entry.rationaleText;
+  const hasFullText = entry.rationaleText != null && entry.rationaleText.length > 200;
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/50 p-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <Link
+          href={`/drep/${entry.drepId}`}
+          className="text-sm font-medium hover:text-primary transition-colors truncate"
+        >
+          {entry.drepName || `${entry.drepId.slice(0, 16)}\u2026`}
+        </Link>
+        {entry.hashVerified === true && (
+          <ShieldCheck
+            className="h-3.5 w-3.5 text-green-500 shrink-0"
+            aria-label="On-chain verified"
+          />
+        )}
+        {entry.hashVerified === false && (
+          <ShieldAlert className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Hash mismatch" />
+        )}
+      </div>
+      <p className={cn('text-sm text-foreground/80 leading-relaxed', !expanded && 'line-clamp-3')}>
+        {expanded && hasFullText ? entry.rationaleText : displayText}
+      </p>
+      {hasFullText && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onToggle}
+          className="text-xs h-7 px-2 text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? (
+            <>
+              Show less <ChevronUp className="h-3 w-3 ml-1" />
+            </>
+          ) : (
+            <>
+              Read more <ChevronDown className="h-3 w-3 ml-1" />
+            </>
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function DebateSection({ rationales }: DebateSectionProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const withRationale = rationales.filter((r) => r.rationaleAiSummary || r.rationaleText);
+  const yesRationales = withRationale.filter((r) => r.vote === 'Yes');
+  const noRationales = withRationale.filter((r) => r.vote === 'No');
+  const abstainRationales = withRationale.filter((r) => r.vote === 'Abstain');
+
+  return (
+    <section className="rounded-2xl border border-border/50 bg-card/50 overflow-hidden">
+      <div className="px-6 py-4 border-b border-border/50">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <MessageSquare className="h-4 w-4" />
+            The Debate
+          </h2>
+          <span className="text-xs text-muted-foreground">
+            {withRationale.length} rationale{withRationale.length !== 1 ? 's' : ''} published
+          </span>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {withRationale.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            No representatives have published rationales yet.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* For column */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="h-1 w-8 rounded-full bg-emerald-500" />
+                <span className="text-sm font-semibold text-emerald-400">
+                  For ({yesRationales.length})
+                </span>
+              </div>
+              {yesRationales.slice(0, 4).map((r) => (
+                <RationaleCard
+                  key={r.drepId}
+                  entry={r}
+                  expanded={expanded === r.drepId}
+                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
+                />
+              ))}
+              {yesRationales.length === 0 && (
+                <p className="text-sm text-muted-foreground/60 italic">
+                  No supporting rationales yet
+                </p>
+              )}
+            </div>
+
+            {/* Against column */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 mb-4">
+                <div className="h-1 w-8 rounded-full bg-red-500" />
+                <span className="text-sm font-semibold text-red-400">
+                  Against ({noRationales.length})
+                </span>
+              </div>
+              {noRationales.slice(0, 4).map((r) => (
+                <RationaleCard
+                  key={r.drepId}
+                  entry={r}
+                  expanded={expanded === r.drepId}
+                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
+                />
+              ))}
+              {noRationales.length === 0 && (
+                <p className="text-sm text-muted-foreground/60 italic">
+                  No opposing rationales yet
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Abstain rationales */}
+        {abstainRationales.length > 0 && (
+          <div className="mt-6 pt-4 border-t border-border/50">
+            <div className="flex items-center gap-2 mb-3">
+              <div className="h-1 w-8 rounded-full bg-amber-500" />
+              <span className="text-sm font-semibold text-amber-400">
+                Abstained ({abstainRationales.length})
+              </span>
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+              {abstainRationales.slice(0, 2).map((r) => (
+                <RationaleCard
+                  key={r.drepId}
+                  entry={r}
+                  expanded={expanded === r.drepId}
+                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/civica/proposals/IntelligenceBriefing.tsx
+++ b/components/civica/proposals/IntelligenceBriefing.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { ProposalAiSummary } from '@/components/ProposalAiSummary';
+import { ConstitutionalAlignmentCard } from '@/components/ConstitutionalAlignmentCard';
+import { ParamChangesCard } from '@/components/civica/proposals/ParamChangesCard';
+
+interface IntelligenceBriefingProps {
+  txHash: string;
+  proposalIndex: number;
+  aiSummary: string | null;
+  proposalType: string;
+  paramChanges: Record<string, unknown> | null;
+}
+
+export function IntelligenceBriefing({
+  txHash,
+  proposalIndex,
+  aiSummary,
+  proposalType,
+  paramChanges,
+}: IntelligenceBriefingProps) {
+  const hasParams = proposalType === 'ParameterChange' && paramChanges;
+
+  return (
+    <section className="rounded-2xl border border-border/50 bg-muted/20 overflow-hidden">
+      <div className="px-6 py-4 border-b border-border/50">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-primary" />
+          Intelligence Briefing
+        </h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          AI analysis and constitutional context
+        </p>
+      </div>
+
+      <div className="p-6 space-y-6">
+        {aiSummary && <ProposalAiSummary summary={aiSummary} />}
+        <ConstitutionalAlignmentCard txHash={txHash} proposalIndex={proposalIndex} />
+        {hasParams && <ParamChangesCard paramChanges={paramChanges} />}
+      </div>
+    </section>
+  );
+}

--- a/components/civica/proposals/ProposalHeroV2.tsx
+++ b/components/civica/proposals/ProposalHeroV2.tsx
@@ -1,0 +1,165 @@
+import { Badge } from '@/components/ui/badge';
+import { TriBodyVotePanel } from '@/components/TriBodyVotePanel';
+import { DRepVoteCallout } from '@/components/DRepVoteCallout';
+import {
+  ProposalStatusBadge,
+  PriorityBadge,
+  DeadlineBadge,
+  TreasuryTierBadge,
+  TypeExplainerTooltip,
+} from '@/components/ProposalStatusBadge';
+import { ProposalVerdict } from './ProposalVerdict';
+import { getProposalTheme } from './proposal-theme';
+import { cn } from '@/lib/utils';
+import type { TriBodyVotes } from '@/lib/data';
+
+function formatTreasuryPct(amount: number, balance: number): string {
+  const pct = (amount / balance) * 100;
+  if (pct >= 1) return `${pct.toFixed(1)}%`;
+  if (pct >= 0.01) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(3)}%`;
+}
+
+interface ProposalHeroV2Props {
+  txHash: string;
+  proposalIndex: number;
+  title: string;
+  proposalType: string;
+  status: string;
+  withdrawalAmount: number | null;
+  treasuryBalanceAda: number | null;
+  treasuryTier: string | null;
+  proposedEpoch: number | null;
+  expirationEpoch: number | null;
+  ratifiedEpoch: number | null;
+  enactedEpoch: number | null;
+  droppedEpoch: number | null;
+  expiredEpoch: number | null;
+  currentEpoch: number;
+  triBody: TriBodyVotes | null;
+  blockTime: number | null;
+}
+
+export function ProposalHeroV2({
+  txHash,
+  proposalIndex,
+  title,
+  proposalType,
+  status,
+  withdrawalAmount,
+  treasuryBalanceAda,
+  treasuryTier,
+  proposedEpoch,
+  expirationEpoch,
+  ratifiedEpoch,
+  enactedEpoch,
+  droppedEpoch,
+  expiredEpoch,
+  currentEpoch,
+  triBody,
+  blockTime,
+}: ProposalHeroV2Props) {
+  const theme = getProposalTheme(proposalType);
+  const TypeIcon = theme.icon;
+
+  const date = blockTime
+    ? new Date(blockTime * 1000).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null;
+
+  const isOpen = !ratifiedEpoch && !enactedEpoch && !droppedEpoch && !expiredEpoch;
+  const remaining = expirationEpoch != null ? Math.max(0, expirationEpoch - currentEpoch) : null;
+  const isUrgent = isOpen && remaining != null && remaining > 0 && remaining <= 2;
+
+  return (
+    <div className="space-y-4">
+      {/* Hero card with type-specific gradient */}
+      <div
+        className="rounded-2xl border border-border/50 overflow-hidden"
+        style={{ background: theme.heroBg }}
+      >
+        <div className="px-6 pt-6 pb-4 space-y-4">
+          {/* Type indicator + status badges */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="outline" className={cn('gap-1.5 font-semibold', theme.badgeClass)}>
+              <TypeIcon className="h-3.5 w-3.5" />
+              {theme.label}
+            </Badge>
+            <TypeExplainerTooltip proposalType={proposalType} />
+            <ProposalStatusBadge
+              ratifiedEpoch={ratifiedEpoch}
+              enactedEpoch={enactedEpoch}
+              droppedEpoch={droppedEpoch}
+              expiredEpoch={expiredEpoch}
+            />
+            <PriorityBadge proposalType={proposalType} />
+            {treasuryTier && <TreasuryTierBadge tier={treasuryTier} />}
+            {proposedEpoch && (
+              <Badge variant="secondary" className="text-[10px]">
+                Epoch {proposedEpoch}
+              </Badge>
+            )}
+            <DeadlineBadge expirationEpoch={expirationEpoch} currentEpoch={currentEpoch} />
+          </div>
+
+          {/* Urgency callout */}
+          {isUrgent && remaining != null && (
+            <div
+              className={cn(
+                'rounded-lg px-4 py-2.5 text-sm font-medium',
+                remaining <= 1
+                  ? 'bg-red-500/10 text-red-700 dark:text-red-400 border border-red-500/30'
+                  : 'bg-amber-500/10 text-amber-700 dark:text-amber-400 border border-amber-500/30',
+              )}
+            >
+              {remaining <= 1
+                ? `Voting closes this epoch \u2014 roughly ${remaining * 5} days remaining`
+                : `Voting closes in ${remaining} epochs (~${remaining * 5} days)`}
+            </div>
+          )}
+
+          {/* Title */}
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold leading-tight tracking-tight">
+            {title}
+          </h1>
+
+          {/* Treasury withdrawal callout */}
+          {proposalType === 'TreasuryWithdrawals' && withdrawalAmount != null && (
+            <div
+              className="inline-flex items-baseline gap-2 rounded-lg px-4 py-2.5"
+              style={{ backgroundColor: theme.accentMuted }}
+            >
+              <span className="text-2xl font-bold tabular-nums" style={{ color: theme.accent }}>
+                {withdrawalAmount.toLocaleString()} ADA
+              </span>
+              {treasuryBalanceAda != null && treasuryBalanceAda > 0 && (
+                <span className="text-sm text-muted-foreground">
+                  {formatTreasuryPct(withdrawalAmount, treasuryBalanceAda)} of treasury
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Date */}
+          {date && <p className="text-xs text-muted-foreground">Proposed {date}</p>}
+        </div>
+
+        {/* Verdict strip at bottom of hero */}
+        <div className="px-6 pb-5">
+          <ProposalVerdict status={status} triBody={triBody} accentColor={theme.accent} />
+        </div>
+      </div>
+
+      {/* Tri-body vote bars */}
+      {triBody && (
+        <TriBodyVotePanel triBody={triBody} txHash={txHash} proposalIndex={proposalIndex} />
+      )}
+
+      {/* User's DRep vote */}
+      <DRepVoteCallout txHash={txHash} proposalIndex={proposalIndex} />
+    </div>
+  );
+}

--- a/components/civica/proposals/ProposalVerdict.tsx
+++ b/components/civica/proposals/ProposalVerdict.tsx
@@ -1,0 +1,65 @@
+import { CheckCircle2, XCircle, Scale, Clock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getVerdict, type VerdictType } from './proposal-theme';
+
+const VERDICT_ICONS: Record<VerdictType, typeof CheckCircle2> = {
+  passing: CheckCircle2,
+  failing: XCircle,
+  contested: Scale,
+  passed: CheckCircle2,
+  rejected: XCircle,
+  expired: Clock,
+};
+
+interface ProposalVerdictProps {
+  status: string;
+  triBody?: {
+    drep: { yes: number; no: number; abstain: number };
+    spo: { yes: number; no: number; abstain: number };
+    cc: { yes: number; no: number; abstain: number };
+  } | null;
+  accentColor?: string;
+}
+
+export function ProposalVerdict({ status, triBody, accentColor }: ProposalVerdictProps) {
+  const verdict = getVerdict(status, triBody);
+  const Icon = VERDICT_ICONS[verdict.type];
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-lg border px-4 py-3',
+        verdict.bgColor,
+        verdict.borderColor,
+      )}
+      style={accentColor ? { borderLeftWidth: '3px', borderLeftColor: accentColor } : undefined}
+    >
+      <Icon className={cn('h-5 w-5 shrink-0', verdict.color)} />
+      <span className={cn('text-sm font-semibold', verdict.color)}>{verdict.label}</span>
+
+      {triBody && (
+        <div className="flex items-center gap-3 ml-auto">
+          {(
+            [
+              { label: 'DRep', data: triBody.drep },
+              { label: 'SPO', data: triBody.spo },
+              { label: 'CC', data: triBody.cc },
+            ] as const
+          ).map(({ label, data }) => {
+            const total = data.yes + data.no + data.abstain;
+            if (total === 0) return null;
+            const yesPct = Math.round((data.yes / total) * 100);
+            const color =
+              yesPct >= 60 ? 'text-emerald-400' : yesPct >= 40 ? 'text-amber-400' : 'text-red-400';
+            return (
+              <span key={label} className="text-xs tabular-nums">
+                <span className="text-muted-foreground">{label}</span>{' '}
+                <span className={cn('font-semibold', color)}>{yesPct}%</span>
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/civica/proposals/proposal-theme.ts
+++ b/components/civica/proposals/proposal-theme.ts
@@ -1,0 +1,273 @@
+/**
+ * Design tokens for proposal type-specific visual identity.
+ * Single source of truth for all proposal theming across the app.
+ */
+
+import { Landmark, Shield, Zap, Eye, Scale, FileText, Gavel } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Type Theme
+// ---------------------------------------------------------------------------
+
+export interface ProposalTypeTheme {
+  label: string;
+  icon: LucideIcon;
+  /** CSS gradient for hero background */
+  heroBg: string;
+  /** Primary accent color (CSS rgb value) */
+  accent: string;
+  /** Muted accent for subtle backgrounds */
+  accentMuted: string;
+  /** Badge classes for detail page */
+  badgeClass: string;
+  /** Badge classes for browse list (dark-mode optimized) */
+  browseBadgeClass: string;
+  /** Left-border accent for browse rows */
+  rowAccent: string;
+}
+
+export const PROPOSAL_TYPE_THEMES: Record<string, ProposalTypeTheme> = {
+  TreasuryWithdrawals: {
+    label: 'Treasury Withdrawal',
+    icon: Landmark,
+    heroBg: 'linear-gradient(180deg, rgb(69 26 3 / 0.45) 0%, transparent 65%)',
+    accent: 'rgb(245 158 11)',
+    accentMuted: 'rgb(245 158 11 / 0.08)',
+    badgeClass: 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/30',
+    browseBadgeClass: 'bg-amber-950/30 text-amber-400 border-amber-800/30',
+    rowAccent: 'rgb(245 158 11 / 0.5)',
+  },
+  ParameterChange: {
+    label: 'Parameter Change',
+    icon: Shield,
+    heroBg: 'linear-gradient(180deg, rgb(12 10 62 / 0.5) 0%, transparent 65%)',
+    accent: 'rgb(59 130 246)',
+    accentMuted: 'rgb(59 130 246 / 0.08)',
+    badgeClass: 'bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/30',
+    browseBadgeClass: 'bg-blue-950/30 text-blue-400 border-blue-800/30',
+    rowAccent: 'rgb(59 130 246 / 0.5)',
+  },
+  HardForkInitiation: {
+    label: 'Hard Fork',
+    icon: Zap,
+    heroBg: 'linear-gradient(180deg, rgb(67 20 7 / 0.55) 0%, transparent 65%)',
+    accent: 'rgb(239 68 68)',
+    accentMuted: 'rgb(239 68 68 / 0.08)',
+    badgeClass: 'bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/30',
+    browseBadgeClass: 'bg-orange-950/30 text-orange-400 border-orange-800/30',
+    rowAccent: 'rgb(239 68 68 / 0.5)',
+  },
+  InfoAction: {
+    label: 'Info Action',
+    icon: Eye,
+    heroBg: 'linear-gradient(180deg, rgb(30 41 59 / 0.25) 0%, transparent 65%)',
+    accent: 'rgb(148 163 184)',
+    accentMuted: 'rgb(148 163 184 / 0.06)',
+    badgeClass: 'bg-slate-500/15 text-slate-700 dark:text-slate-300 border-slate-500/30',
+    browseBadgeClass: 'bg-muted text-muted-foreground',
+    rowAccent: 'rgb(148 163 184 / 0.3)',
+  },
+  NoConfidence: {
+    label: 'No Confidence',
+    icon: Scale,
+    heroBg: 'linear-gradient(180deg, rgb(76 5 25 / 0.45) 0%, transparent 65%)',
+    accent: 'rgb(244 63 94)',
+    accentMuted: 'rgb(244 63 94 / 0.08)',
+    badgeClass: 'bg-rose-500/15 text-rose-700 dark:text-rose-400 border-rose-500/30',
+    browseBadgeClass: 'bg-rose-950/30 text-rose-400 border-rose-800/30',
+    rowAccent: 'rgb(244 63 94 / 0.5)',
+  },
+  NewCommittee: {
+    label: 'Committee Update',
+    icon: Gavel,
+    heroBg: 'linear-gradient(180deg, rgb(46 16 101 / 0.4) 0%, transparent 65%)',
+    accent: 'rgb(139 92 246)',
+    accentMuted: 'rgb(139 92 246 / 0.08)',
+    badgeClass: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30',
+    browseBadgeClass: 'bg-violet-950/30 text-violet-400 border-violet-800/30',
+    rowAccent: 'rgb(139 92 246 / 0.5)',
+  },
+  NewConstitutionalCommittee: {
+    label: 'Committee Update',
+    icon: Gavel,
+    heroBg: 'linear-gradient(180deg, rgb(46 16 101 / 0.4) 0%, transparent 65%)',
+    accent: 'rgb(139 92 246)',
+    accentMuted: 'rgb(139 92 246 / 0.08)',
+    badgeClass: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30',
+    browseBadgeClass: 'bg-violet-950/30 text-violet-400 border-violet-800/30',
+    rowAccent: 'rgb(139 92 246 / 0.5)',
+  },
+  UpdateCommittee: {
+    label: 'Committee Update',
+    icon: Scale,
+    heroBg: 'linear-gradient(180deg, rgb(46 16 101 / 0.4) 0%, transparent 65%)',
+    accent: 'rgb(139 92 246)',
+    accentMuted: 'rgb(139 92 246 / 0.08)',
+    badgeClass: 'bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/30',
+    browseBadgeClass: 'bg-violet-950/30 text-violet-400 border-violet-800/30',
+    rowAccent: 'rgb(139 92 246 / 0.5)',
+  },
+  NewConstitution: {
+    label: 'New Constitution',
+    icon: FileText,
+    heroBg: 'linear-gradient(180deg, rgb(30 27 75 / 0.5) 0%, transparent 65%)',
+    accent: 'rgb(99 102 241)',
+    accentMuted: 'rgb(99 102 241 / 0.08)',
+    badgeClass: 'bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 border-indigo-500/30',
+    browseBadgeClass: 'bg-purple-950/30 text-purple-400 border-purple-800/30',
+    rowAccent: 'rgb(99 102 241 / 0.5)',
+  },
+  UpdateConstitution: {
+    label: 'Constitution Amendment',
+    icon: FileText,
+    heroBg: 'linear-gradient(180deg, rgb(30 27 75 / 0.5) 0%, transparent 65%)',
+    accent: 'rgb(99 102 241)',
+    accentMuted: 'rgb(99 102 241 / 0.08)',
+    badgeClass: 'bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 border-indigo-500/30',
+    browseBadgeClass: 'bg-purple-950/30 text-purple-400 border-purple-800/30',
+    rowAccent: 'rgb(99 102 241 / 0.5)',
+  },
+};
+
+const DEFAULT_THEME: ProposalTypeTheme = {
+  label: 'Governance Action',
+  icon: Scale,
+  heroBg: 'linear-gradient(180deg, rgb(30 41 59 / 0.2) 0%, transparent 65%)',
+  accent: 'rgb(148 163 184)',
+  accentMuted: 'rgb(148 163 184 / 0.06)',
+  badgeClass: 'bg-slate-500/15 text-slate-700 dark:text-slate-300 border-slate-500/30',
+  browseBadgeClass: 'bg-muted text-muted-foreground',
+  rowAccent: 'rgb(148 163 184 / 0.3)',
+};
+
+export function getProposalTheme(proposalType: string): ProposalTypeTheme {
+  return PROPOSAL_TYPE_THEMES[proposalType] ?? DEFAULT_THEME;
+}
+
+// ---------------------------------------------------------------------------
+// Verdict — quick visual indicator of proposal trajectory
+// ---------------------------------------------------------------------------
+
+export type VerdictType = 'passing' | 'failing' | 'contested' | 'passed' | 'rejected' | 'expired';
+
+export interface VerdictInfo {
+  type: VerdictType;
+  label: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+interface TriBodyInput {
+  drep: { yes: number; no: number; abstain: number };
+  spo: { yes: number; no: number; abstain: number };
+  cc: { yes: number; no: number; abstain: number };
+}
+
+export function getVerdict(status: string, triBody?: TriBodyInput | null): VerdictInfo {
+  if (status === 'enacted' || status === 'ratified') {
+    return {
+      type: 'passed',
+      label: status === 'enacted' ? 'Enacted' : 'Ratified',
+      color: 'text-emerald-400',
+      bgColor: 'bg-emerald-500/10',
+      borderColor: 'border-emerald-500/30',
+    };
+  }
+  if (status === 'dropped') {
+    return {
+      type: 'rejected',
+      label: 'Dropped',
+      color: 'text-red-400',
+      bgColor: 'bg-red-500/10',
+      borderColor: 'border-red-500/30',
+    };
+  }
+  if (status === 'expired') {
+    return {
+      type: 'expired',
+      label: 'Expired',
+      color: 'text-slate-400',
+      bgColor: 'bg-slate-500/10',
+      borderColor: 'border-slate-500/30',
+    };
+  }
+
+  if (!triBody) {
+    return {
+      type: 'contested',
+      label: 'Awaiting Votes',
+      color: 'text-slate-400',
+      bgColor: 'bg-slate-500/10',
+      borderColor: 'border-slate-500/30',
+    };
+  }
+
+  const bodies = [triBody.drep, triBody.spo, triBody.cc];
+  const activeBodies = bodies.filter((b) => b.yes + b.no + b.abstain > 0);
+  if (activeBodies.length === 0) {
+    return {
+      type: 'contested',
+      label: 'Awaiting Votes',
+      color: 'text-slate-400',
+      bgColor: 'bg-slate-500/10',
+      borderColor: 'border-slate-500/30',
+    };
+  }
+
+  const yesPcts = activeBodies.map((b) => {
+    const total = b.yes + b.no + b.abstain;
+    return total > 0 ? b.yes / total : 0;
+  });
+
+  const allHigh = yesPcts.every((p) => p >= 0.6);
+  const allLow = yesPcts.every((p) => p < 0.4);
+  const mixed = yesPcts.some((p) => p >= 0.6) && yesPcts.some((p) => p < 0.4);
+
+  if (allHigh) {
+    return {
+      type: 'passing',
+      label: 'On Track to Pass',
+      color: 'text-emerald-400',
+      bgColor: 'bg-emerald-500/10',
+      borderColor: 'border-emerald-500/30',
+    };
+  }
+  if (allLow) {
+    return {
+      type: 'failing',
+      label: 'Likely to Fail',
+      color: 'text-red-400',
+      bgColor: 'bg-red-500/10',
+      borderColor: 'border-red-500/30',
+    };
+  }
+  if (mixed) {
+    return {
+      type: 'contested',
+      label: 'Contested',
+      color: 'text-amber-400',
+      bgColor: 'bg-amber-500/10',
+      borderColor: 'border-amber-500/30',
+    };
+  }
+
+  const avgYes = yesPcts.reduce((a, b) => a + b, 0) / yesPcts.length;
+  if (avgYes >= 0.5) {
+    return {
+      type: 'passing',
+      label: 'Leaning Pass',
+      color: 'text-emerald-400/80',
+      bgColor: 'bg-emerald-500/5',
+      borderColor: 'border-emerald-500/20',
+    };
+  }
+  return {
+    type: 'failing',
+    label: 'Leaning Fail',
+    color: 'text-red-400/80',
+    bgColor: 'bg-red-500/5',
+    borderColor: 'border-red-500/20',
+  };
+}

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -56,8 +56,8 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
   if (bgMode === 'globe') {
     return (
       <div className="relative min-h-[calc(100vh-4rem)]">
-        {/* Subtle globe behind cards */}
-        <div className="fixed inset-0 top-14 pointer-events-none opacity-25">
+        {/* Globe offset past sidebar: left-0 mobile, left-60 desktop (sidebar w-60) */}
+        <div className="fixed top-14 bottom-0 left-0 right-0 sm:left-60 pointer-events-none opacity-25">
           <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
         <div className="relative z-10">
@@ -70,12 +70,12 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
   if (bgMode === 'gradient') {
     return (
       <div className="relative min-h-[calc(100vh-4rem)]">
-        {/* Ambient aurora gradient */}
-        <div className="fixed inset-0 top-14 pointer-events-none overflow-hidden">
-          <div className="absolute -top-1/2 -left-1/2 w-[200%] h-[200%] animate-[spin_120s_linear_infinite]">
-            <div className="absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-primary/20 blur-[120px]" />
-            <div className="absolute top-1/3 right-1/4 w-80 h-80 rounded-full bg-emerald-500/15 blur-[100px]" />
-            <div className="absolute bottom-1/4 left-1/3 w-72 h-72 rounded-full bg-violet-500/12 blur-[100px]" />
+        {/* Aurora gradient offset past sidebar */}
+        <div className="fixed top-14 bottom-0 left-0 right-0 sm:left-60 pointer-events-none overflow-hidden">
+          <div className="absolute inset-0 animate-[spin_120s_linear_infinite]">
+            <div className="absolute top-[10%] left-[15%] w-[500px] h-[500px] rounded-full bg-primary/30 blur-[150px]" />
+            <div className="absolute top-[40%] right-[10%] w-[450px] h-[450px] rounded-full bg-emerald-500/25 blur-[130px]" />
+            <div className="absolute bottom-[5%] left-[30%] w-[400px] h-[400px] rounded-full bg-violet-500/20 blur-[130px]" />
           </div>
         </div>
         <div className="relative z-10">


### PR DESCRIPTION
## Summary
- **Type-specific visual personalities**: Each of the 7 CIP-1694 proposal types (Treasury, ParameterChange, HardFork, etc.) now has a distinct gradient hero background, colored verdict strip, and accent borders — breaking the "card monoculture" where every proposal looked identical.
- **6-zone page layout**: Restructured the proposal detail page from 14 flat Card sections into 6 semantic zones (Hero, Community Signals, Intelligence Briefing, Take Action, The Debate, Deep Dive).
- **Design token consolidation**: Eliminated 4 duplicate TYPE_COLORS/TYPE_LABELS/TYPE_CONFIG maps across ProposalsBrowse, CuratedVoteFlow, ProposalDrawer, and VoteDetailSheet — all now use `getProposalTheme()` from a single source of truth.

## New Components
| Component | Purpose |
|-----------|---------|
| `proposal-theme.ts` | Single source of truth for type colors, labels, icons, gradients, verdicts |
| `ProposalHeroV2` | Type-specific gradient backgrounds with integrated verdict strip |
| `ProposalVerdict` | Tri-body vote analysis (passing/failing/contested/passed/rejected/expired) |
| `IntelligenceBriefing` | Merged AI summary + constitutional alignment + param changes |
| `DebateSection` | Structured pro/con rationale layout (2-column grid) |
| `ActionPanel` | Split layout combining vote flow + citizen voice + ask-your-drep |

## Impact
- **What changed**: Proposal detail pages now have type-specific visual identity; browse/drawer/sheet surfaces use shared design tokens
- **User-facing**: Yes — every proposal page now looks visually distinct based on type, with a clearer information hierarchy
- **Risk**: Low — styling and layout changes only, no data model or API changes
- **Scope**: 6 new files, 7 modified files (page.tsx, loading.tsx, ProposalsBrowse, CuratedVoteFlow, ProposalDrawer, VoteDetailSheet, HubHomePage)

## Test plan
- [ ] Visit proposal detail pages for each type (Treasury, ParameterChange, HardFork, InfoAction, NoConfidence, UpdateCommittee, NewConstitution) — verify distinct gradient backgrounds
- [ ] Verify verdict strip shows correct status (passing/failing/contested) with tri-body percentages
- [ ] Check Intelligence Briefing section renders AI summary, constitutional alignment, and param changes
- [ ] Check debate section shows pro/con rationales in 2-column layout
- [ ] Check action panel renders vote flow + citizen voice side-by-side on desktop
- [ ] Verify ProposalsBrowse rows have colored left border accents
- [ ] Verify ProposalDrawer and VoteDetailSheet show correct type labels
- [ ] Mobile responsiveness — zones should stack cleanly on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)