### PR TITLE
feat: globe background, glassmorphic cards, transparent header

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -110,8 +110,10 @@ export function CivicaHeader() {
     <header
       className={cn(
         'sticky top-0 z-50 hidden sm:block transition-[background-color,border-color,backdrop-filter] duration-300',
-        headerTransparent
-          ? 'bg-transparent'
+        isHome
+          ? headerTransparent
+            ? 'bg-transparent'
+            : 'border-b border-border/30 bg-background/30 backdrop-blur-xl'
           : 'border-b border-border/50 bg-background/80 backdrop-blur-xl',
       )}
     >

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { HubCardRenderer } from './HubCardRenderer';
 import { AnonymousLanding } from './AnonymousLanding';
@@ -23,18 +22,13 @@ interface HubHomePageProps {
 }
 
 /**
- * HubHomePage — The new home page dispatcher.
+ * HubHomePage — The home page dispatcher.
  *
  * Anonymous: Clean conversion landing page.
- * Authenticated: Hub card renderer based on persona.
- *
- * Background exploration: use ?bg=globe or ?bg=gradient to compare styles.
- * Remove the exploration code once a decision is made.
+ * Authenticated: Hub cards over a subtle constellation globe background.
  */
 export function HubHomePage({ pulseData }: HubHomePageProps) {
   const { segment, isLoading } = useSegment();
-  const searchParams = useSearchParams();
-  const bgMode = searchParams.get('bg');
 
   // While detecting segment, show skeleton cards to prevent CLS flash
   if (isLoading) {
@@ -52,39 +46,17 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     return <AnonymousLanding pulseData={pulseData} />;
   }
 
-  // Authenticated homepage — optional background exploration
-  if (bgMode === 'globe') {
-    return (
-      <div className="relative min-h-[calc(100vh-4rem)]">
-        {/* Globe offset past sidebar: left-0 mobile, left-60 desktop (sidebar w-60) */}
-        <div className="fixed top-14 bottom-0 left-0 right-0 sm:left-60 pointer-events-none opacity-25">
-          <ConstellationScene className="w-full h-full" interactive={false} />
-        </div>
-        <div className="relative z-10">
-          <HubCardRenderer persona={segment} />
-        </div>
+  // Authenticated homepage — globe background with glassmorphic cards
+  return (
+    <div className="relative min-h-[calc(100vh-4rem)]">
+      {/* Globe extends to top-0 so it shows through the transparent header.
+          lg:left-60 offsets past the sidebar (visible from lg breakpoint). */}
+      <div className="fixed inset-0 lg:left-60 pointer-events-none opacity-25">
+        <ConstellationScene className="w-full h-full" interactive={false} />
       </div>
-    );
-  }
-
-  if (bgMode === 'gradient') {
-    return (
-      <div className="relative min-h-[calc(100vh-4rem)]">
-        {/* Aurora gradient offset past sidebar */}
-        <div className="fixed top-14 bottom-0 left-0 right-0 sm:left-60 pointer-events-none overflow-hidden">
-          <div className="absolute inset-0 animate-[spin_120s_linear_infinite]">
-            <div className="absolute top-[10%] left-[15%] w-[500px] h-[500px] rounded-full bg-primary/30 blur-[150px]" />
-            <div className="absolute top-[40%] right-[10%] w-[450px] h-[450px] rounded-full bg-emerald-500/25 blur-[130px]" />
-            <div className="absolute bottom-[5%] left-[30%] w-[400px] h-[400px] rounded-full bg-violet-500/20 blur-[130px]" />
-          </div>
-        </div>
-        <div className="relative z-10">
-          <HubCardRenderer persona={segment} />
-        </div>
+      <div className="relative z-10">
+        <HubCardRenderer persona={segment} />
       </div>
-    );
-  }
-
-  // Default — no background (current behavior)
-  return <HubCardRenderer persona={segment} />;
+    </div>
+  );
 }

--- a/components/hub/cards/BriefingCard.tsx
+++ b/components/hub/cards/BriefingCard.tsx
@@ -75,9 +75,10 @@ export function BriefingCard() {
   return (
     <div
       className={cn(
-        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5 transition-colors hover:border-primary/40',
+        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5',
+        'transition-all duration-200 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-        'border-border bg-card',
+        'border-border/60 bg-card/60 backdrop-blur-sm',
       )}
     >
       {/* Header row — always a link to the full briefing */}

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -7,10 +7,10 @@ import { cn } from '@/lib/utils';
 export type CardUrgency = 'default' | 'success' | 'warning' | 'critical';
 
 const URGENCY_STYLES: Record<CardUrgency, string> = {
-  default: 'border-border bg-card',
-  success: 'border-emerald-500/30 bg-emerald-500/5',
-  warning: 'border-amber-500/30 bg-amber-500/5',
-  critical: 'border-red-500/30 bg-red-500/5',
+  default: 'border-border/60 bg-card/60 backdrop-blur-sm',
+  success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-sm',
+  warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-sm',
+  critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-sm',
 };
 
 interface HubCardProps {
@@ -25,6 +25,7 @@ interface HubCardProps {
 /**
  * Base Hub card wrapper.
  * Every card is a link — no dead-end cards. Conclusion + link, not a dashboard widget.
+ * Glassmorphic style lets the globe background show through.
  */
 export function HubCard({ href, urgency = 'default', className, children, label }: HubCardProps) {
   return (
@@ -32,7 +33,8 @@ export function HubCard({ href, urgency = 'default', className, children, label 
       href={href}
       aria-label={label}
       className={cn(
-        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5 transition-colors hover:border-primary/40',
+        'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5',
+        'transition-all duration-200 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         URGENCY_STYLES[urgency],
         className,
@@ -41,7 +43,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
       <div className="flex items-start justify-between gap-3">
         <div className="flex-1 min-w-0">{children}</div>
         <ArrowRight
-          className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+          className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground opacity-40 transition-all duration-200 group-hover:opacity-100 group-hover:translate-x-0.5"
           aria-hidden
         />
       </div>
@@ -52,7 +54,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="min-h-[6.5rem] rounded-2xl border border-border bg-card p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-border/60 bg-card/60 backdrop-blur-sm p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />
@@ -65,7 +67,7 @@ export function HubCardSkeleton() {
 /** Error state for a Hub card — shows a brief message with retry affordance */
 export function HubCardError({ message, onRetry }: { message?: string; onRetry?: () => void }) {
   return (
-    <div className="rounded-2xl border border-border bg-card p-4 sm:p-5">
+    <div className="rounded-2xl border border-border/60 bg-card/60 backdrop-blur-sm p-4 sm:p-5">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">{message ?? 'Unable to load'}</p>
         {onRetry && (


### PR DESCRIPTION
## Summary
- Globe constellation background is now the **default** for all authenticated homepage users (removed gradient variant and URL param exploration code)
- All hub cards use **glassmorphic styling** (`bg-card/60 backdrop-blur-sm`) so the globe subtly shows through
- Enhanced **card hover states**: subtle lift, shadow glow, stronger border highlight, arrow slides right
- Homepage header stays **transparent even when scrolled** (`bg-background/30 backdrop-blur-xl`) to maintain the globe aesthetic

## Impact
- **What changed**: Authenticated homepage now has a permanent globe background with glass-effect cards and a transparent header
- **User-facing**: Yes — all authenticated users see the globe background, translucent cards, and improved hover interactions on the homepage
- **Risk**: Low — styling only, no data/logic changes. All existing card functionality preserved.
- **Scope**: `HubHomePage.tsx`, `HubCard.tsx`, `BriefingCard.tsx`, `CivicaHeader.tsx`

## Test plan
- [x] Preflight passes (format, lint, types, 590 tests)
- [ ] Verify globe renders behind cards on homepage
- [ ] Verify cards are translucent (globe visible through them)
- [ ] Verify card hover: lift effect, shadow, arrow animation
- [ ] Verify header is transparent on homepage (scrolled and unscrolled)
- [ ] Verify header is opaque on non-homepage routes
- [ ] Verify anonymous landing page unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)