### PR TITLE
fix: glassmorphic card opacity for globe visibility

### DIFF
--- a/components/hub/cards/BriefingCard.tsx
+++ b/components/hub/cards/BriefingCard.tsx
@@ -78,7 +78,7 @@ export function BriefingCard() {
         'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5',
         'transition-all duration-200 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-        'border-border/60 bg-card/60 backdrop-blur-sm',
+        'border-border/40 bg-card/15 backdrop-blur-md',
       )}
     >
       {/* Header row — always a link to the full briefing */}

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -7,10 +7,10 @@ import { cn } from '@/lib/utils';
 export type CardUrgency = 'default' | 'success' | 'warning' | 'critical';
 
 const URGENCY_STYLES: Record<CardUrgency, string> = {
-  default: 'border-border/60 bg-card/60 backdrop-blur-sm',
-  success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-sm',
-  warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-sm',
-  critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-sm',
+  default: 'border-border/40 bg-card/15 backdrop-blur-md',
+  success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-md',
+  warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-md',
+  critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-md',
 };
 
 interface HubCardProps {
@@ -54,7 +54,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="min-h-[6.5rem] rounded-2xl border border-border/60 bg-card/60 backdrop-blur-sm p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-border/40 bg-card/15 backdrop-blur-md p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />
@@ -67,7 +67,7 @@ export function HubCardSkeleton() {
 /** Error state for a Hub card — shows a brief message with retry affordance */
 export function HubCardError({ message, onRetry }: { message?: string; onRetry?: () => void }) {
   return (
-    <div className="rounded-2xl border border-border/60 bg-card/60 backdrop-blur-sm p-4 sm:p-5">
+    <div className="rounded-2xl border border-border/40 bg-card/15 backdrop-blur-md p-4 sm:p-5">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">{message ?? 'Unable to load'}</p>
         {onRetry && (


### PR DESCRIPTION
## Summary
- Reduced hub card background from `bg-card/60` (60% of near-black = still opaque) to `bg-card/15` for true transparency
- Bumped `backdrop-blur-sm` to `backdrop-blur-md` for text readability compensation
- Applied to HubCard (default urgency + skeleton + error) and BriefingCard (inline styles)

## Impact
- **What changed**: All homepage hub cards now have 15% background opacity instead of 60%, letting the constellation globe show through uniformly
- **User-facing**: Yes — all cards now have consistent glassmorphic appearance on the homepage, no more opaque blocks hiding the globe
- **Risk**: Low — styling only, no data or logic changes. Colored urgency cards (success/warning/critical) already used 8% opacity and were unaffected
- **Scope**: `components/hub/cards/HubCard.tsx`, `components/hub/cards/BriefingCard.tsx`

## Test plan
- [ ] Verify all homepage cards show globe through them in dark mode
- [ ] Check text readability on all card types (default, success, warning, critical)
- [ ] Verify skeleton and error states also have glassmorphic appearance
- [ ] Test across citizen, drep, spo personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)