### PR TITLE
feat: proposals page card redesign with visual vote bars

### DIFF
--- a/components/civica/discover/ProposalCard.tsx
+++ b/components/civica/discover/ProposalCard.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, Clock, Landmark, AlertTriangle, CircleDot } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { getProposalTheme, getVerdict } from '@/components/civica/proposals/proposal-theme';
+import { ProposalDeliveryBadge } from '@/components/civica/proposals/ProposalDeliveryBadge';
+import type { DeliveryStatus } from '@/lib/proposalOutcomes';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface TriBody {
+  drep: { yes: number; no: number; abstain: number };
+  spo: { yes: number; no: number; abstain: number };
+  cc: { yes: number; no: number; abstain: number };
+}
+
+export interface BrowseProposal {
+  txHash: string;
+  index: number;
+  title?: string;
+  type?: string;
+  status?: string;
+  expirationEpoch?: number;
+  withdrawalAmount?: number;
+  treasuryPct?: number;
+  deliveryStatus?: string;
+  deliveryScore?: number;
+  triBody?: TriBody;
+  relevantPrefs?: string[];
+  [key: string]: unknown;
+}
+
+interface ProposalCardProps {
+  proposal: BrowseProposal;
+  currentEpoch: number | null;
+  drepVote?: string;
+  delegatedDrepId?: string | null;
+  hasDrepVotes: boolean;
+  animationDelay: number;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const VOTE_PILL: Record<string, { label: string; cls: string }> = {
+  Yes: { label: 'Yes', cls: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20' },
+  No: { label: 'No', cls: 'text-red-400 bg-red-500/10 border-red-500/20' },
+  Abstain: { label: 'Abstain', cls: 'text-amber-400 bg-amber-500/10 border-amber-500/20' },
+};
+
+const PREF_LABELS: Record<string, string> = {
+  'treasury-conservative': 'Treasury',
+  'smart-treasury-growth': 'Growth',
+  'strong-decentralization': 'Decentral',
+  'protocol-security-first': 'Security',
+  'innovation-defi-growth': 'Innovation',
+  'responsible-governance': 'Transparency',
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function fmtAda(ada: number): string {
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toLocaleString();
+}
+
+function fmtPct(pct: number): string {
+  if (pct < 0.01) return '<0.01%';
+  if (pct < 1) return `${pct.toFixed(2)}%`;
+  return `${pct.toFixed(1)}%`;
+}
+
+// ─── Vote visualization ─────────────────────────────────────────────────────
+
+function VoteBar({
+  label,
+  data,
+}: {
+  label: string;
+  data: { yes: number; no: number; abstain: number };
+}) {
+  const total = data.yes + data.no + data.abstain;
+  if (total === 0) return null;
+  const yesPct = (data.yes / total) * 100;
+  const noPct = (data.no / total) * 100;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="text-[10px] text-muted-foreground w-8 text-right shrink-0 font-medium">
+        {label}
+      </span>
+      <div className="flex-1 h-[5px] rounded-full bg-muted/40 overflow-hidden flex">
+        {yesPct > 0 && (
+          <div
+            className="bg-emerald-500/90 transition-all duration-700 ease-out rounded-l-full"
+            style={{ width: `${yesPct}%` }}
+          />
+        )}
+        {noPct > 0 && (
+          <div
+            className="bg-red-500/80 transition-all duration-700 ease-out"
+            style={{ width: `${noPct}%` }}
+          />
+        )}
+      </div>
+      <span
+        className={cn(
+          'text-[10px] tabular-nums w-8 text-right shrink-0 font-semibold',
+          yesPct >= 60
+            ? 'text-emerald-400'
+            : yesPct >= 40
+              ? 'text-muted-foreground'
+              : 'text-red-400',
+        )}
+      >
+        {Math.round(yesPct)}%
+      </span>
+    </div>
+  );
+}
+
+function TriBodyVoteBars({ triBody }: { triBody: TriBody }) {
+  const hasAny =
+    triBody.drep.yes + triBody.drep.no + triBody.drep.abstain > 0 ||
+    triBody.spo.yes + triBody.spo.no + triBody.spo.abstain > 0 ||
+    triBody.cc.yes + triBody.cc.no + triBody.cc.abstain > 0;
+  if (!hasAny) return null;
+
+  return (
+    <div className="space-y-1 flex-1 min-w-0 max-w-[260px]">
+      <VoteBar label="DRep" data={triBody.drep} />
+      <VoteBar label="SPO" data={triBody.spo} />
+      <VoteBar label="CC" data={triBody.cc} />
+    </div>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────
+
+export function ProposalCard({
+  proposal: p,
+  currentEpoch,
+  drepVote,
+  delegatedDrepId,
+  hasDrepVotes,
+  animationDelay,
+}: ProposalCardProps) {
+  const status = p.status ?? 'Open';
+  const statusLower = status.toLowerCase();
+  const isOpen = statusLower === 'open';
+  const isResolved = ['enacted', 'ratified', 'expired', 'dropped'].includes(statusLower);
+  const theme = p.type ? getProposalTheme(p.type) : null;
+  const TypeIcon = theme?.icon;
+  const verdict = getVerdict(statusLower, p.triBody);
+  const epochsLeft =
+    isOpen && currentEpoch && p.expirationEpoch ? p.expirationEpoch - currentEpoch : null;
+  const isUrgent = epochsLeft != null && epochsLeft <= 2;
+  const hasTreasury = p.type === 'TreasuryWithdrawals' && p.withdrawalAmount;
+  const pill = drepVote ? VOTE_PILL[drepVote] : null;
+  const needsVote = !pill && isOpen && !!delegatedDrepId && hasDrepVotes;
+
+  const href = `/proposal/${p.txHash}/${p.index}`;
+  const title = p.title || `${p.txHash?.slice(0, 16)}…`;
+
+  // ── Resolved proposals: compact card ──────────────────────────────────────
+
+  if (isResolved) {
+    return (
+      <Link
+        href={href}
+        className="group flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/40 bg-card/30 hover:bg-muted/30 transition-all animate-in fade-in duration-200 fill-mode-backwards"
+        style={{ animationDelay: `${animationDelay}ms` }}
+      >
+        {TypeIcon && <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />}
+        <span className="flex-1 text-sm text-muted-foreground/80 truncate min-w-0">{title}</span>
+        {hasTreasury && (
+          <span className="text-[11px] tabular-nums text-muted-foreground/60 shrink-0">
+            ₳{fmtAda(p.withdrawalAmount!)}
+          </span>
+        )}
+        {p.deliveryStatus && p.deliveryStatus !== 'unknown' && (
+          <ProposalDeliveryBadge
+            status={p.deliveryStatus as DeliveryStatus}
+            score={p.deliveryScore}
+            compact
+          />
+        )}
+        <span
+          className={cn(
+            'text-[11px] font-medium px-2 py-0.5 rounded-full border shrink-0',
+            verdict.color,
+            verdict.bgColor,
+            verdict.borderColor,
+          )}
+        >
+          {verdict.label}
+        </span>
+        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/30 shrink-0 group-hover:text-muted-foreground/60 transition-colors" />
+      </Link>
+    );
+  }
+
+  // ── Open proposals: full card ─────────────────────────────────────────────
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'group block rounded-xl border bg-card transition-all animate-in fade-in duration-300 fill-mode-backwards overflow-hidden',
+        'hover:shadow-md hover:border-border',
+        isUrgent
+          ? 'border-amber-500/40 shadow-[0_0_20px_rgba(245,158,11,0.06)]'
+          : needsVote
+            ? 'border-violet-500/30 shadow-[0_0_16px_rgba(139,92,246,0.05)]'
+            : 'border-border/60',
+      )}
+      style={{ animationDelay: `${animationDelay}ms` }}
+    >
+      {/* Accent gradient bar */}
+      <div
+        className="h-[2px]"
+        style={{
+          background: theme
+            ? `linear-gradient(90deg, ${theme.accent} 0%, transparent 70%)`
+            : 'transparent',
+        }}
+      />
+
+      <div className="px-4 pt-3 pb-3.5 space-y-3">
+        {/* Header: type label + urgency */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            {TypeIcon && (
+              <TypeIcon className="h-3.5 w-3.5 shrink-0" style={{ color: theme?.accent }} />
+            )}
+            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider truncate">
+              {theme?.label ?? 'Governance Action'}
+            </span>
+          </div>
+          {isUrgent ? (
+            <span className="flex items-center gap-1 text-[11px] font-bold text-amber-400 shrink-0">
+              <AlertTriangle className="h-3 w-3 animate-pulse" />
+              {epochsLeft === 1 ? 'Last epoch!' : `${epochsLeft} epochs left`}
+            </span>
+          ) : epochsLeft != null && epochsLeft > 0 ? (
+            <span className="flex items-center gap-1 text-[11px] text-muted-foreground shrink-0">
+              <Clock className="h-3 w-3" />
+              {epochsLeft} epochs left
+            </span>
+          ) : null}
+        </div>
+
+        {/* Title */}
+        <h3 className="text-[15px] font-semibold text-foreground leading-snug group-hover:text-primary/90 transition-colors pr-6">
+          {title}
+        </h3>
+
+        {/* Body: vote visualization + key metrics */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          {/* Vote bars */}
+          {p.triBody && <TriBodyVoteBars triBody={p.triBody} />}
+
+          {/* Right column: treasury amount + verdict */}
+          <div className="flex sm:flex-col items-center sm:items-end gap-2 shrink-0">
+            {hasTreasury && (
+              <div className="text-right">
+                <div className="flex items-center gap-1">
+                  <Landmark className="h-3 w-3 text-amber-400/80" />
+                  <span className="text-base font-bold tabular-nums text-amber-300">
+                    ₳{fmtAda(p.withdrawalAmount!)}
+                  </span>
+                </div>
+                {p.treasuryPct != null && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {fmtPct(p.treasuryPct * 100)} of treasury
+                  </span>
+                )}
+              </div>
+            )}
+            <span
+              className={cn(
+                'text-[11px] font-semibold px-2.5 py-0.5 rounded-full border whitespace-nowrap',
+                verdict.color,
+                verdict.bgColor,
+                verdict.borderColor,
+              )}
+            >
+              {verdict.label}
+            </span>
+          </div>
+        </div>
+
+        {/* Footer: DRep vote + tags */}
+        <div className="flex items-center gap-2 pt-2 border-t border-border/30 flex-wrap">
+          {pill && (
+            <span
+              className={cn(
+                'text-[11px] font-semibold px-2 py-0.5 rounded-full border shrink-0',
+                pill.cls,
+              )}
+            >
+              Your DRep: {pill.label}
+            </span>
+          )}
+          {needsVote && (
+            <span className="flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full border text-violet-400 bg-violet-500/10 border-violet-500/20 shrink-0">
+              <CircleDot className="h-3 w-3" />
+              Needs vote
+            </span>
+          )}
+          {p.deliveryStatus && p.deliveryStatus !== 'unknown' && (
+            <ProposalDeliveryBadge
+              status={p.deliveryStatus as DeliveryStatus}
+              score={p.deliveryScore}
+              compact
+            />
+          )}
+          <div className="flex items-center gap-1.5 ml-auto">
+            {(p.relevantPrefs?.length ?? 0) > 0 &&
+              p.relevantPrefs!.slice(0, 2).map((pref: string) => {
+                const label = PREF_LABELS[pref];
+                if (!label) return null;
+                return (
+                  <span
+                    key={pref}
+                    className="text-[10px] text-muted-foreground/70 px-1.5 py-0.5 rounded bg-muted/40"
+                  >
+                    {label}
+                  </span>
+                );
+              })}
+            <ChevronRight className="h-4 w-4 text-muted-foreground/30 shrink-0 group-hover:text-muted-foreground/60 transition-colors" />
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -2,57 +2,18 @@
 
 import { useState, useMemo, useRef, useCallback } from 'react';
 import Link from 'next/link';
-import {
-  ChevronRight,
-  Clock,
-  Landmark,
-  Users,
-  Shield,
-  Scale,
-  AlertTriangle,
-  CircleDot,
-} from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { CircleDot } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { useProposals, useDRepVotes } from '@/hooks/queries';
 import { useWallet } from '@/utils/wallet-context';
 import { ProposalStatusFunnel } from '@/components/civica/charts/ProposalStatusFunnel';
 import type { VotesResponseData, VoteItem } from '@/types/api';
-
-interface BrowseProposal {
-  txHash: string;
-  index: number;
-  title?: string;
-  type?: string;
-  status?: string;
-  expirationEpoch?: number;
-  withdrawalAmount?: number;
-  treasuryPct?: number;
-  deliveryStatus?: string;
-  deliveryScore?: number;
-  triBody?: {
-    drep: { yes: number; no: number; abstain: number };
-    spo: { yes: number; no: number; abstain: number };
-    cc: { yes: number; no: number; abstain: number };
-  };
-  relevantPrefs?: string[];
-  [key: string]: unknown;
-}
-import { ProposalDeliveryBadge } from '@/components/civica/proposals/ProposalDeliveryBadge';
-import type { DeliveryStatus } from '@/lib/proposalOutcomes';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
-import { getProposalTheme } from '@/components/civica/proposals/proposal-theme';
+import { ProposalCard } from './ProposalCard';
+import type { BrowseProposal } from './ProposalCard';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
-
-const STATUS_COLORS: Record<string, string> = {
-  Open: 'text-emerald-400',
-  Ratified: 'text-sky-400',
-  Enacted: 'text-violet-400',
-  Dropped: 'text-muted-foreground',
-  Expired: 'text-muted-foreground/70',
-};
 
 const STATUS_FILTERS = ['All', 'Open', 'Ratified', 'Enacted', 'Expired', 'Dropped'];
 const TYPE_FILTERS = [
@@ -65,92 +26,6 @@ const TYPE_FILTERS = [
   { value: 'UpdateCommittee', label: 'Committee' },
   { value: 'InfoAction', label: 'Info' },
 ];
-
-const VOTE_PILL: Record<string, { label: string; color: string }> = {
-  Yes: { label: 'Yes', color: 'text-green-500 bg-green-500/10 border-green-500/20' },
-  No: { label: 'No', color: 'text-red-500 bg-red-500/10 border-red-500/20' },
-  Abstain: { label: 'Abstain', color: 'text-amber-500 bg-amber-500/10 border-amber-500/20' },
-};
-
-function formatAdaShort(ada: number): string {
-  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
-  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
-  return ada.toLocaleString();
-}
-
-function formatPct(pct: number): string {
-  if (pct < 0.01) return '<0.01%';
-  if (pct < 1) return `${pct.toFixed(2)}%`;
-  return `${pct.toFixed(1)}%`;
-}
-
-const PREF_LABELS: Record<string, { label: string; color: string }> = {
-  'treasury-conservative': { label: 'Treasury', color: 'text-red-400 bg-red-500/10' },
-  'smart-treasury-growth': { label: 'Growth', color: 'text-emerald-400 bg-emerald-500/10' },
-  'strong-decentralization': { label: 'Decentral', color: 'text-purple-400 bg-purple-500/10' },
-  'protocol-security-first': { label: 'Security', color: 'text-blue-400 bg-blue-500/10' },
-  'innovation-defi-growth': { label: 'Innovation', color: 'text-cyan-400 bg-cyan-500/10' },
-  'responsible-governance': { label: 'Transparency', color: 'text-amber-400 bg-amber-500/10' },
-};
-
-function TriBodyMini({
-  triBody,
-}: {
-  triBody: {
-    drep: { yes: number; no: number; abstain: number };
-    spo: { yes: number; no: number; abstain: number };
-    cc: { yes: number; no: number; abstain: number };
-  };
-}) {
-  const bodies = [
-    { label: 'DRep', data: triBody.drep, icon: Users },
-    { label: 'SPO', data: triBody.spo, icon: Shield },
-    { label: 'CC', data: triBody.cc, icon: Scale },
-  ] as const;
-
-  return (
-    <div className="flex items-center gap-2">
-      {bodies.map(({ label, data, icon: Icon }) => {
-        const total = data.yes + data.no + data.abstain;
-        if (total === 0) return null;
-        const yesPct = Math.round((data.yes / total) * 100);
-        const color =
-          yesPct >= 60 ? 'text-green-500' : yesPct >= 40 ? 'text-amber-500' : 'text-red-500';
-        return (
-          <span
-            key={label}
-            className="flex items-center gap-0.5 text-[10px]"
-            title={`${label}: ${data.yes}Y / ${data.no}N / ${data.abstain}A`}
-          >
-            <Icon className="h-2.5 w-2.5 text-muted-foreground" />
-            <span className={cn('font-semibold tabular-nums', color)}>{yesPct}%</span>
-          </span>
-        );
-      })}
-    </div>
-  );
-}
-
-function getConsensusLabel(triBody: {
-  drep: { yes: number; no: number; abstain: number };
-  spo: { yes: number; no: number; abstain: number };
-  cc: { yes: number; no: number; abstain: number };
-}): { label: string; color: string } | null {
-  const bodies = [triBody.drep, triBody.spo, triBody.cc];
-  const activeBodies = bodies.filter((b) => b.yes + b.no + b.abstain > 0);
-  if (activeBodies.length < 2) return null;
-  const yesPcts = activeBodies.map((b) => {
-    const total = b.yes + b.no + b.abstain;
-    return total > 0 ? b.yes / total : 0;
-  });
-  const allHigh = yesPcts.every((p) => p >= 0.6);
-  const allLow = yesPcts.every((p) => p < 0.4);
-  const mixed = yesPcts.some((p) => p >= 0.6) && yesPcts.some((p) => p < 0.4);
-  if (allHigh) return { label: 'Consensus', color: 'text-emerald-400' };
-  if (allLow) return { label: 'Opposed', color: 'text-rose-400' };
-  if (mixed) return { label: 'Contested', color: 'text-amber-400' };
-  return null;
-}
 
 const PAGE_SIZE = 25;
 
@@ -223,6 +98,15 @@ export function ProposalsBrowse() {
     return r;
   }, [proposals, search, statusFilter, typeFilter]);
 
+  // Count proposals needing the delegated DRep's vote
+  const needsAttentionCount = useMemo(() => {
+    if (!delegatedDrepId || drepVoteMap.size === 0) return 0;
+    return proposals.filter((p) => {
+      if ((p.status ?? 'Open').toLowerCase() !== 'open') return false;
+      return !drepVoteMap.get(`${p.txHash}:${p.index}`);
+    }).length;
+  }, [proposals, delegatedDrepId, drepVoteMap]);
+
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const p of proposals) {
@@ -246,9 +130,9 @@ export function ProposalsBrowse() {
 
   if (isLoading) {
     return (
-      <div className="space-y-2 pt-4">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-14 rounded-lg" />
+      <div className="space-y-3 pt-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-36 rounded-xl" />
         ))}
       </div>
     );
@@ -304,7 +188,21 @@ export function ProposalsBrowse() {
         pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
       />
 
-      {/* List */}
+      {/* Needs attention banner */}
+      {needsAttentionCount > 0 &&
+        (statusFilter === 'All' || statusFilter === 'Open') &&
+        page === 0 && (
+          <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-lg bg-violet-500/5 border border-violet-500/20">
+            <CircleDot className="h-4 w-4 text-violet-400 shrink-0" />
+            <span className="text-sm text-muted-foreground">
+              Your DRep hasn&apos;t voted on{' '}
+              <strong className="text-violet-300">{needsAttentionCount}</strong> open proposal
+              {needsAttentionCount !== 1 ? 's' : ''}
+            </span>
+          </div>
+        )}
+
+      {/* Proposal cards */}
       {pageItems.length === 0 ? (
         <div className="py-16 text-center space-y-4">
           <p className="text-muted-foreground text-sm">No proposals match your filters.</p>
@@ -320,142 +218,18 @@ export function ProposalsBrowse() {
           </div>
         </div>
       ) : (
-        <div
-          key={page}
-          className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden"
-        >
-          {pageItems.map((p, i: number) => {
-            const status = p.status ?? 'Open';
-            const drepVote = drepVoteMap.get(`${p.txHash}:${p.index}`);
-            const pill = drepVote ? VOTE_PILL[drepVote] : null;
-            const epochsLeft =
-              status === 'Open' && currentEpoch && p.expirationEpoch
-                ? p.expirationEpoch - currentEpoch
-                : null;
-            const hasTreasury = p.type === 'TreasuryWithdrawals' && p.withdrawalAmount;
-            return (
-              <Link
-                key={`${p.txHash}-${p.index}`}
-                href={`/proposal/${p.txHash}/${p.index}`}
-                className="flex flex-col gap-1 px-4 py-3 hover:bg-muted/30 transition-colors group animate-in fade-in duration-200 fill-mode-backwards border-l-2"
-                style={{
-                  animationDelay: `${Math.min(i, 14) * 20}ms`,
-                  borderLeftColor: p.type ? getProposalTheme(p.type).rowAccent : 'transparent',
-                }}
-              >
-                {/* Row 1: Type + Title + Status */}
-                <div className="flex items-center gap-3">
-                  {p.type && (
-                    <span
-                      className={cn(
-                        'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border shrink-0',
-                        getProposalTheme(p.type).browseBadgeClass,
-                      )}
-                    >
-                      {getProposalTheme(p.type).label}
-                    </span>
-                  )}
-                  <span className="flex-1 text-sm text-foreground truncate min-w-0">
-                    {p.title || `${p.txHash?.slice(0, 16)}…`}
-                  </span>
-                  <span
-                    className={cn(
-                      'text-xs font-medium shrink-0',
-                      STATUS_COLORS[status] ?? 'text-muted-foreground',
-                    )}
-                  >
-                    {status}
-                  </span>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground/70 shrink-0 group-hover:text-muted-foreground transition-colors" />
-                </div>
-
-                {/* Row 2: Metadata chips */}
-                <div className="flex items-center gap-3 pl-0 sm:pl-[calc(1.5rem+0.75rem)] flex-wrap">
-                  {hasTreasury && (
-                    <span className="flex items-center gap-1 text-[10px] text-emerald-500">
-                      <Landmark className="h-2.5 w-2.5" />
-                      <span className="font-semibold tabular-nums">
-                        {formatAdaShort(p.withdrawalAmount ?? 0)} ADA
-                      </span>
-                      {p.treasuryPct != null && (
-                        <span className="text-muted-foreground">
-                          ({formatPct(p.treasuryPct * 100)})
-                        </span>
-                      )}
-                    </span>
-                  )}
-                  {p.deliveryStatus && p.deliveryStatus !== 'unknown' && (
-                    <ProposalDeliveryBadge
-                      status={p.deliveryStatus as DeliveryStatus}
-                      score={p.deliveryScore}
-                      compact
-                    />
-                  )}
-                  {p.triBody && <TriBodyMini triBody={p.triBody} />}
-                  {p.triBody &&
-                    (() => {
-                      const consensus = getConsensusLabel(p.triBody);
-                      if (!consensus) return null;
-                      return (
-                        <span className={cn('text-[10px] font-semibold', consensus.color)}>
-                          {consensus.label}
-                        </span>
-                      );
-                    })()}
-                  {pill && (
-                    <span
-                      className={cn(
-                        'text-[10px] font-semibold px-1.5 py-0.5 rounded border shrink-0',
-                        pill.color,
-                      )}
-                      title={`Your DRep voted ${pill.label}`}
-                    >
-                      DRep: {pill.label}
-                    </span>
-                  )}
-                  {!pill && status === 'Open' && delegatedDrepId && drepVoteMap.size > 0 && (
-                    <span
-                      className="flex items-center gap-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded border text-violet-400 bg-violet-500/10 border-violet-500/20 shrink-0"
-                      title="Your DRep has not yet voted on this proposal"
-                    >
-                      <CircleDot className="h-2.5 w-2.5" />
-                      Needs vote
-                    </span>
-                  )}
-                  {epochsLeft != null && epochsLeft > 0 && (
-                    <span
-                      className={cn(
-                        'flex items-center gap-1 text-[10px]',
-                        epochsLeft <= 2 ? 'text-amber-400 font-semibold' : 'text-muted-foreground',
-                      )}
-                    >
-                      {epochsLeft <= 2 && <AlertTriangle className="h-2.5 w-2.5" />}
-                      {epochsLeft > 2 && <Clock className="h-2.5 w-2.5" />}
-                      <span className="tabular-nums">
-                        {epochsLeft === 1 ? '1 epoch left' : `${epochsLeft} epochs left`}
-                      </span>
-                    </span>
-                  )}
-                  {(p.relevantPrefs?.length ?? 0) > 0 &&
-                    p.relevantPrefs!.slice(0, 2).map((pref: string) => {
-                      const info = PREF_LABELS[pref];
-                      if (!info) return null;
-                      return (
-                        <span
-                          key={pref}
-                          className={cn(
-                            'text-[10px] font-medium px-1.5 py-0.5 rounded',
-                            info.color,
-                          )}
-                        >
-                          {info.label}
-                        </span>
-                      );
-                    })}
-                </div>
-              </Link>
-            );
-          })}
+        <div key={page} className="space-y-3">
+          {pageItems.map((p, i: number) => (
+            <ProposalCard
+              key={`${p.txHash}-${p.index}`}
+              proposal={p}
+              currentEpoch={currentEpoch}
+              drepVote={drepVoteMap.get(`${p.txHash}:${p.index}`)}
+              delegatedDrepId={delegatedDrepId}
+              hasDrepVotes={drepVoteMap.size > 0}
+              animationDelay={Math.min(i, 14) * 30}
+            />
+          ))}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Replace uniform flat rows with a two-treatment card system: full cards for open proposals (vote progress bars, verdict badges, treasury callouts, urgency signals) and compact muted rows for resolved proposals
- Visual tri-body vote progress bars replace tiny colored percentage text — DRep/SPO/CC approval visible at a glance
- Verdict-driven card styling ("On Track to Pass", "Contested", "Likely to Fail") as primary visual signal
- Type-colored gradient accent bars replace loud uppercase type badges
- "Needs attention" banner for delegated users showing pending DRep votes count
- Color restraint: preference tags muted, type communicated by icon + accent gradient

## Impact
- **What changed**: Complete visual overhaul of the proposals browse page card rendering
- **User-facing**: Yes — proposals page has new card layout with vote visualization bars and visual hierarchy between open/resolved proposals
- **Risk**: Low — styling/component only, no data fetching or API changes. All existing data preserved.
- **Scope**: New `ProposalCard.tsx`, modified `ProposalsBrowse.tsx`. No migrations, no env vars, no Inngest changes.

## Test plan
- [ ] Verify proposals page loads with new card layout
- [ ] Confirm vote progress bars render correctly for DRep/SPO/CC
- [ ] Check verdict badges show correct labels (On Track, Contested, Likely to Fail, etc.)
- [ ] Verify resolved proposals (Enacted/Expired/Dropped) render as compact rows
- [ ] Test urgency indicators on proposals expiring in ≤2 epochs
- [ ] Confirm "Needs attention" banner appears for delegated users
- [ ] Test mobile responsiveness of the new card layout
- [ ] Verify filters and pagination still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)