### PR TITLE
fix: visible glassmorphic border on hub cards

### DIFF
--- a/components/hub/cards/BriefingCard.tsx
+++ b/components/hub/cards/BriefingCard.tsx
@@ -78,7 +78,7 @@ export function BriefingCard() {
         'group block min-h-[6.5rem] rounded-2xl border p-4 sm:p-5',
         'transition-all duration-200 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-        'border-border/40 bg-card/15 backdrop-blur-md',
+        'border-white/[0.08] bg-card/15 backdrop-blur-md',
       )}
     >
       {/* Header row — always a link to the full briefing */}

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 export type CardUrgency = 'default' | 'success' | 'warning' | 'critical';
 
 const URGENCY_STYLES: Record<CardUrgency, string> = {
-  default: 'border-border/40 bg-card/15 backdrop-blur-md',
+  default: 'border-white/[0.08] bg-card/15 backdrop-blur-md',
   success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-md',
   warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-md',
   critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-md',
@@ -54,7 +54,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="min-h-[6.5rem] rounded-2xl border border-border/40 bg-card/15 backdrop-blur-md p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />
@@ -67,7 +67,7 @@ export function HubCardSkeleton() {
 /** Error state for a Hub card — shows a brief message with retry affordance */
 export function HubCardError({ message, onRetry }: { message?: string; onRetry?: () => void }) {
   return (
-    <div className="rounded-2xl border border-border/40 bg-card/15 backdrop-blur-md p-4 sm:p-5">
+    <div className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">{message ?? 'Unable to load'}</p>
         {onRetry && (


### PR DESCRIPTION
## Summary
- Changed hub card border from `border-border/40` to `border-white/[0.08]` for a visible frosted glass edge
- Applied to HubCard (default urgency + skeleton + error) and BriefingCard

## Impact
- **What changed**: Default hub cards now have a subtle white border (8% opacity) that's visible against the dark globe background, giving them a proper card shape
- **User-facing**: Yes — cards now have defined edges instead of blending invisibly into the background
- **Risk**: Low — border color change only, no layout or logic changes
- **Scope**: `components/hub/cards/HubCard.tsx`, `components/hub/cards/BriefingCard.tsx`

## Test plan
- [ ] Verify neutral cards have visible but subtle border in dark mode
- [ ] Verify colored urgency cards (success/warning/critical) still use their colored borders
- [ ] Check light mode doesn't look odd (white border on light bg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)