### PR TITLE
fix: proposal card contrast, compact hover, sticky filters, tighter layout

### DIFF
--- a/app/governance/proposals/page.tsx
+++ b/app/governance/proposals/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 
 export default function ProposalsPage() {
   return (
-    <div className="container mx-auto px-4 sm:px-6 py-6">
+    <div className="container mx-auto px-4 sm:px-6 py-3 sm:py-4">
       <PageViewTracker event="governance_proposals_viewed" />
       <ProposalsBrowse />
     </div>

--- a/components/civica/discover/ProposalCard.tsx
+++ b/components/civica/discover/ProposalCard.tsx
@@ -173,7 +173,9 @@ export function ProposalCard({
         style={{ animationDelay: `${animationDelay}ms` }}
       >
         {TypeIcon && <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />}
-        <span className="flex-1 text-sm text-muted-foreground/80 truncate min-w-0">{title}</span>
+        <span className="flex-1 text-sm text-muted-foreground/80 group-hover:text-foreground/90 truncate min-w-0 transition-colors duration-200">
+          {title}
+        </span>
         {hasTreasury && (
           <span className="text-[11px] tabular-nums text-muted-foreground/60 shrink-0">
             ₳{fmtAda(p.withdrawalAmount!)}
@@ -207,13 +209,13 @@ export function ProposalCard({
     <Link
       href={href}
       className={cn(
-        'group block rounded-xl border bg-card transition-all duration-200 animate-in fade-in fill-mode-backwards overflow-hidden',
-        'hover:shadow-lg hover:-translate-y-0.5 hover:border-border',
+        'group block rounded-xl border bg-card/80 transition-all duration-200 animate-in fade-in fill-mode-backwards overflow-hidden',
+        'hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/30',
         isUrgent
           ? 'border-amber-500/40 shadow-[0_0_20px_rgba(245,158,11,0.06)]'
           : needsVote
             ? 'border-violet-500/30 shadow-[0_0_16px_rgba(139,92,246,0.05)]'
-            : 'border-border/60',
+            : 'border-border',
       )}
       style={{ animationDelay: `${animationDelay}ms` }}
     >

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -139,15 +139,13 @@ export function ProposalsBrowse() {
   }
 
   return (
-    <div ref={contentRef} className="space-y-4 pt-4">
+    <div ref={contentRef} className="space-y-3">
       {/* Page heading */}
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">What&apos;s Being Decided</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {delegatedDrepId
-            ? 'Active governance proposals and how your representative voted'
-            : 'Active governance proposals in Cardano'}
-        </p>
+      <div className="flex items-baseline justify-between gap-4">
+        <h1 className="text-xl font-bold tracking-tight">What&apos;s Being Decided</h1>
+        <span className="text-xs text-muted-foreground shrink-0">
+          {delegatedDrepId ? "Your DRep's votes shown" : ''}
+        </span>
       </div>
 
       <AnonymousNudge variant="proposals" />
@@ -162,31 +160,33 @@ export function ProposalsBrowse() {
         </div>
       )}
 
-      <DiscoverFilterBar
-        search={search}
-        onSearchChange={setFilter(setSearch)}
-        searchPlaceholder="Search proposals…"
-        chipGroups={[
-          {
-            label: 'Status',
-            value: statusFilter,
-            options: STATUS_FILTERS.map((s) => ({ value: s, label: s })),
-            onChange: setFilter(setStatusFilter),
-          },
-          {
-            label: 'Type',
-            value: typeFilter,
-            options: TYPE_FILTERS,
-            onChange: setFilter(setTypeFilter),
-          },
-        ]}
-        resultCount={filtered.length}
-        totalCount={proposals.length}
-        entityLabel="proposals"
-        isFiltered={!isDefault}
-        onReset={resetFilters}
-        pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
-      />
+      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-background/90 backdrop-blur-xl border-b border-border/30">
+        <DiscoverFilterBar
+          search={search}
+          onSearchChange={setFilter(setSearch)}
+          searchPlaceholder="Search proposals…"
+          chipGroups={[
+            {
+              label: 'Status',
+              value: statusFilter,
+              options: STATUS_FILTERS.map((s) => ({ value: s, label: s })),
+              onChange: setFilter(setStatusFilter),
+            },
+            {
+              label: 'Type',
+              value: typeFilter,
+              options: TYPE_FILTERS,
+              onChange: setFilter(setTypeFilter),
+            },
+          ]}
+          resultCount={filtered.length}
+          totalCount={proposals.length}
+          entityLabel="proposals"
+          isFiltered={!isDefault}
+          onReset={resetFilters}
+          pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
+        />
+      </div>
 
       {/* Needs attention banner */}
       {needsAttentionCount > 0 &&


### PR DESCRIPTION
## Summary
- Improve card-to-card contrast in dark mode by bumping borders from border/60 to border
- Add title color transition + border brightening on compact resolved cards
- Make filter bar sticky on scroll with backdrop blur
- Reduce page heading size and page padding to reclaim vertical space

## Impact
- **What changed**: 4 UX polish items — card visibility, compact hover feel, sticky filters, tighter layout
- **User-facing**: Yes — cards are more distinguishable, compact cards feel clickable, filters stay visible on scroll, less wasted space above the fold
- **Risk**: Low — CSS/layout changes only, no data or logic
- **Scope**: `ProposalCard.tsx`, `ProposalsBrowse.tsx`, `page.tsx`

## Test plan
- [ ] Cards should have visible borders separating them in dark mode
- [ ] Open cards: hover shows primary border tint + shadow lift
- [ ] Compact cards: hover brightens title text + border + subtle shadow
- [ ] Scroll down — filter bar sticks below header with blur backdrop
- [ ] Mobile: less vertical space above first card

🤖 Generated with [Claude Code](https://claude.com/claude-code)