### PR TITLE
feat: redesign representatives page with identity-driven cards and sticky filters

### DIFF
--- a/app/governance/representatives/page.tsx
+++ b/app/governance/representatives/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 
 export default function RepresentativesPage() {
   return (
-    <div className="container mx-auto px-4 sm:px-6 py-6">
+    <div className="container mx-auto px-4 sm:px-6 py-3 sm:py-4">
       <PageViewTracker event="governance_representatives_viewed" />
       <CivicaDRepBrowse />
     </div>

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -1,54 +1,25 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  TrendingUp,
-  TrendingDown,
-  Minus,
-  CheckCircle2,
-  XCircle,
-  ChevronRight,
-  Heart,
-} from 'lucide-react';
+import { TrendingUp, TrendingDown, Minus, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { computeTier } from '@/lib/scoring/tiers';
-import { getScoreNarrative } from '@/lib/scoring/scoreNarratives';
 import { TIER_SCORE_COLOR, TIER_BORDER, TIER_BG, TIER_GLOW, tierKey } from './tierStyles';
 import { TierBadge } from './TierBadge';
 import type { EnrichedDRep } from '@/lib/koios';
 import { ScoreExplainer } from '@/components/ui/ScoreExplainer';
-import { getDRepTraitTags } from '@/lib/alignment';
 import {
   extractAlignments,
   getPersonalityLabel,
   getDominantDimension,
   getIdentityColor,
+  getIdentityGradient,
 } from '@/lib/drepIdentity';
-
-function formatRecency(lastVoteTime: number | null): string | null {
-  if (!lastVoteTime) return null;
-  const now = Date.now() / 1000;
-  const diff = now - lastVoteTime;
-  if (diff < 0) return null;
-  const days = Math.floor(diff / 86400);
-  if (days === 0) return 'today';
-  if (days === 1) return '1d ago';
-  if (days < 30) return `${days}d ago`;
-  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
-  return `${Math.floor(days / 365)}y ago`;
-}
-
-interface CivicaDRepCardProps {
-  drep: EnrichedDRep;
-  rank?: number;
-  matchScore?: number | null;
-  endorsementCount?: number;
-}
 
 /** Returns the top 1-2 pillar strengths (scores >= 65) as citizen-friendly labels. */
 function getPillarStrengths(drep: EnrichedDRep): string[] {
   const pillars: [string, number][] = [
-    ['Strong rationale', drep.engagementQuality ?? 0],
+    ['Explains votes', drep.engagementQuality ?? 0],
     ['Active voter', drep.effectiveParticipationV3 ?? 0],
     ['Reliable', drep.reliabilityV3 ?? 0],
     ['Clear identity', drep.governanceIdentity ?? 0],
@@ -60,7 +31,14 @@ function getPillarStrengths(drep: EnrichedDRep): string[] {
     .map(([label]) => label);
 }
 
-export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: CivicaDRepCardProps) {
+interface CivicaDRepCardProps {
+  drep: EnrichedDRep;
+  rank?: number;
+  matchScore?: number | null;
+  endorsementCount?: number;
+}
+
+export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) {
   const score = drep.drepScore ?? 0;
   const tier = tierKey(computeTier(score));
   const momentum = drep.scoreMomentum ?? null;
@@ -71,19 +49,15 @@ export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: Civ
   const personalityLabel = hasAlignment ? getPersonalityLabel(alignments) : null;
   const dominantDim = hasAlignment ? getDominantDimension(alignments) : null;
   const identityColor = dominantDim ? getIdentityColor(dominantDim) : null;
-  const traitTags = getDRepTraitTags(drep);
+  const identityGradient = dominantDim ? getIdentityGradient(dominantDim) : undefined;
   const pillarStrengths = getPillarStrengths(drep);
-
-  const recency = formatRecency(drep.lastVoteTime);
-  const rationaleRate = Math.round(drep.rationaleRate ?? 0);
-  const scoreNarrative = getScoreNarrative({ score, percentile: 0 });
 
   return (
     <Link
       href={`/drep/${drep.drepId}`}
       aria-label={`${displayName}, DRep score ${score}, ${tier} tier${matchScore != null ? `, ${matchScore}% match` : ''}`}
       className={cn(
-        'group relative flex flex-col rounded-xl border p-4 transition-all duration-200',
+        'group relative flex flex-col rounded-xl border overflow-hidden transition-all duration-200',
         'hover:shadow-lg hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],
@@ -91,62 +65,89 @@ export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: Civ
         TIER_GLOW[tier],
       )}
     >
-      {/* ── Header row ─────────────────────────────────────── */}
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="min-w-0 flex-1">
-          {rank && (
-            <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums mb-0.5 block">
-              #{rank}
-            </span>
-          )}
-          <h3 className="font-semibold text-sm text-foreground truncate leading-tight">
-            {displayName}
-          </h3>
-          <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
-            {drep.isActive ? (
-              <span className="flex items-center gap-0.5 text-[10px] text-emerald-400 font-medium">
-                <CheckCircle2 className="h-3 w-3" /> Active
-              </span>
-            ) : (
-              <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground">
-                <XCircle className="h-3 w-3" /> Inactive
-              </span>
-            )}
-            {drep.delegatorCount > 0 && (
-              <span className="text-[10px] text-muted-foreground">
-                · {drep.delegatorCount.toLocaleString()} delegators
+      {/* ── Identity accent bar ──────────────────────────────────── */}
+      <div
+        className="h-[2px]"
+        style={{
+          background: identityColor
+            ? `linear-gradient(90deg, ${identityColor.hex}80 0%, ${identityColor.hex}20 100%)`
+            : undefined,
+        }}
+      />
+
+      {/* ── Card body ────────────────────────────────────────────── */}
+      <div className="flex flex-col p-4 flex-1" style={{ backgroundImage: identityGradient }}>
+        {/* Top: rank + score + tier */}
+        <div className="flex items-start justify-between gap-2 mb-3">
+          <div className="min-w-0 flex-1">
+            {rank && (
+              <span className="text-[10px] text-muted-foreground/50 font-medium tabular-nums">
+                #{rank}
               </span>
             )}
-            {endorsementCount != null && endorsementCount > 0 && (
-              <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
-                · <Heart className="h-2.5 w-2.5" aria-hidden="true" />
-                <span className="tabular-nums">{endorsementCount}</span>
-              </span>
-            )}
-            {recency && (
-              <span className="text-[10px] text-muted-foreground">· Voted {recency}</span>
-            )}
+            <h3 className="font-semibold text-[15px] text-foreground truncate leading-tight">
+              {displayName}
+            </h3>
+          </div>
+          <div className="text-right shrink-0">
+            <div className="flex items-start gap-0.5 justify-end">
+              <ScoreExplainer type="drep" className="mt-1" />
+              <div
+                className={cn(
+                  'font-display text-2xl font-bold tabular-nums leading-none',
+                  TIER_SCORE_COLOR[tier],
+                )}
+              >
+                {score}
+              </div>
+            </div>
+            <TierBadge tier={tier} className="mt-1" />
           </div>
         </div>
 
-        {/* Score + tier badge */}
-        <div className="text-right shrink-0">
-          <div className="flex items-start gap-0.5 justify-end">
-            <ScoreExplainer type="drep" className="mt-1" />
-            <div
-              className={cn(
-                'font-display text-3xl font-bold tabular-nums leading-none',
-                TIER_SCORE_COLOR[tier],
-              )}
+        {/* ── Personality archetype — the hero element ────────────── */}
+        {personalityLabel && identityColor && (
+          <div className="mb-3">
+            <span
+              className="inline-flex items-center gap-1.5 text-xs font-semibold px-2 py-1 rounded-lg border"
+              style={{
+                borderColor: `${identityColor.hex}30`,
+                backgroundColor: `${identityColor.hex}08`,
+                color: identityColor.hex,
+              }}
             >
-              {score}
-            </div>
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{
+                  backgroundColor: identityColor.hex,
+                  boxShadow: `0 0 6px ${identityColor.hex}40`,
+                }}
+              />
+              {personalityLabel}
+            </span>
           </div>
-          <TierBadge tier={tier} className="mt-1" />
-          {matchScore != null && (
+        )}
+
+        {/* ── Pillar strengths ─────────────────────────────────────── */}
+        {pillarStrengths.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap mb-3">
+            {pillarStrengths.map((label) => (
+              <span
+                key={label}
+                className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* ── Match score (only when sorting by match) ────────────── */}
+        {matchScore != null && (
+          <div className="mb-3">
             <span
               className={cn(
-                'text-[10px] font-bold tabular-nums px-1.5 py-0.5 rounded-full mt-1 ml-1 inline-block',
+                'text-xs font-bold tabular-nums px-2 py-0.5 rounded-full',
                 matchScore >= 70
                   ? 'bg-green-500/10 text-green-600 dark:text-green-400'
                   : matchScore >= 50
@@ -156,110 +157,36 @@ export function CivicaDRepCard({ drep, rank, matchScore, endorsementCount }: Civ
             >
               {matchScore}% match
             </span>
-          )}
-        </div>
-      </div>
+          </div>
+        )}
 
-      {/* ── Score narrative ──────────────────────────────────── */}
-      <p className="text-xs text-muted-foreground mb-2">{scoreNarrative}</p>
-
-      {/* ── Governance identity ───────────────────────────────── */}
-      {(personalityLabel || traitTags.length > 0) && (
-        <div className="flex items-center gap-1.5 flex-wrap mb-2">
-          {personalityLabel && identityColor && (
-            <span
-              className="inline-flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full border"
-              style={{
-                borderColor: `${identityColor.hex}40`,
-                backgroundColor: `${identityColor.hex}10`,
-                color: identityColor.hex,
-              }}
-            >
-              <span
-                className="h-1.5 w-1.5 rounded-full"
-                style={{ backgroundColor: identityColor.hex }}
-              />
-              {personalityLabel}
+        {/* ── Footer stats + CTA ──────────────────────────────────── */}
+        <div className="mt-auto flex items-center justify-between pt-2 border-t border-border/30">
+          <div className="flex items-center gap-2.5 text-[10px] text-muted-foreground">
+            {drep.delegatorCount > 0 && (
+              <span className="tabular-nums">
+                {drep.delegatorCount.toLocaleString()} delegators
+              </span>
+            )}
+            <span className="flex items-center gap-0.5">
+              {momentum !== null && momentum > 0.5 ? (
+                <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
+              ) : momentum !== null && momentum < -0.5 ? (
+                <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
+              ) : (
+                <Minus className="h-3 w-3 text-muted-foreground/40" aria-hidden="true" />
+              )}
             </span>
-          )}
-          {traitTags.slice(0, 2).map((tag) => (
-            <span
-              key={tag}
-              className="text-[9px] text-muted-foreground bg-muted/60 px-1.5 py-0.5 rounded-full"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {/* ── Pillar strengths ─────────────────────────────────── */}
-      {pillarStrengths.length > 0 && (
-        <div className="flex items-center gap-1.5 flex-wrap mb-2">
-          {pillarStrengths.map((label) => (
-            <span
-              key={label}
-              className="text-[9px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full"
-            >
-              {label}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {/* ── Key stats (always visible) ────────────────────────── */}
-      <div className="flex items-center justify-between text-[10px] text-muted-foreground border-t border-border/30 pt-2 mb-2">
-        <span>
-          Rationale{' '}
+          </div>
           <span
             className={cn(
-              'font-medium tabular-nums',
-              rationaleRate >= 70
-                ? 'text-emerald-400'
-                : rationaleRate >= 40
-                  ? 'text-foreground'
-                  : 'text-muted-foreground',
+              'flex items-center gap-0.5 text-xs font-medium transition-colors',
+              'text-muted-foreground group-hover:text-primary',
             )}
           >
-            {rationaleRate}%
+            View <ChevronRight className="h-3.5 w-3.5" />
           </span>
-        </span>
-        <span>
-          Participation{' '}
-          <span className="font-medium text-foreground tabular-nums">
-            {drep.effectiveParticipation != null
-              ? `${Math.round(drep.effectiveParticipation)}%`
-              : '—'}
-          </span>
-        </span>
-        <span className="flex items-center gap-0.5">
-          {momentum !== null && momentum > 0.5 ? (
-            <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
-          ) : momentum !== null && momentum < -0.5 ? (
-            <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
-          ) : (
-            <Minus className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
-          )}
-          <span className="sr-only">
-            {momentum !== null && momentum > 0.5
-              ? 'Trending up'
-              : momentum !== null && momentum < -0.5
-                ? 'Trending down'
-                : 'Stable'}
-          </span>
-        </span>
-      </div>
-
-      {/* ── CTA ────────────────────────────────────────────── */}
-      <div className="mt-auto flex items-center justify-end">
-        <span
-          className={cn(
-            'flex items-center gap-0.5 text-xs font-medium transition-colors',
-            'text-muted-foreground group-hover:text-primary',
-          )}
-        >
-          View <ChevronRight className="h-3.5 w-3.5" />
-        </span>
+        </div>
       </div>
     </Link>
   );

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -1,15 +1,30 @@
 'use client';
 
-import { useState, useMemo, useRef, useCallback, useDeferredValue } from 'react';
+import { useState, useMemo, useRef, useCallback, useDeferredValue, useEffect } from 'react';
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { RotateCcw, LayoutGrid, TableProperties, ChevronRight, Sparkles } from 'lucide-react';
+import {
+  RotateCcw,
+  LayoutGrid,
+  TableProperties,
+  ChevronRight,
+  Sparkles,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CivicaDRepCard } from '@/components/civica/cards/CivicaDRepCard';
 import { computeTier } from '@/lib/scoring/tiers';
-import { TIER_SCORE_COLOR, TIER_BADGE_BG, tierKey } from '@/components/civica/cards/tierStyles';
+import {
+  TIER_SCORE_COLOR,
+  TIER_BADGE_BG,
+  TIER_LEFT_ACCENT,
+  tierKey,
+} from '@/components/civica/cards/tierStyles';
 import { useBatchEndorsementCounts } from '@/hooks/useEngagement';
 import { useDReps } from '@/hooks/queries';
 import type { EnrichedDRep } from '@/lib/koios';
@@ -22,7 +37,18 @@ import {
   distanceToMatchScore,
   type StoredMatchProfile,
 } from '@/lib/matchStore';
+import {
+  extractAlignments,
+  getPersonalityLabel,
+  getDominantDimension,
+  getIdentityColor,
+} from '@/lib/drepIdentity';
 import type { AlignmentScores } from '@/lib/drepIdentity';
+
+const ConstellationScene = dynamic(
+  () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
+  { ssr: false },
+);
 
 const TIER_CHIPS: { value: string; label: string; tooltip?: string }[] = [
   { value: 'All', label: 'All' },
@@ -110,7 +136,7 @@ function getInitialViewMode(): ViewMode {
     const stored = localStorage.getItem(VIEW_MODE_KEY);
     if (stored === 'table' || stored === 'cards') return stored;
   } catch {}
-  return window.innerWidth >= 768 ? 'cards' : 'cards';
+  return 'cards';
 }
 
 const CARD_PAGE_SIZE = 24;
@@ -132,7 +158,8 @@ const DEFAULT_FILTERS: FilterState = {
 
 type CivicaDRepBrowseProps = Record<string, never>;
 
-function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
+/* ── Compact single-line row for inactive DReps ──────────────────── */
+function InactiveDRepRow({ drep, animationDelay }: { drep: EnrichedDRep; animationDelay: number }) {
   const score = drep.drepScore ?? 0;
   const tier = tierKey(computeTier(score));
   const displayName =
@@ -141,12 +168,9 @@ function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
   return (
     <Link
       href={`/drep/${drep.drepId}`}
-      className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors group"
+      className="group flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/40 bg-card/30 hover:bg-muted/40 hover:border-border/70 hover:shadow-sm transition-all duration-200 animate-in fade-in fill-mode-backwards"
+      style={{ animationDelay: `${animationDelay}ms` }}
     >
-      <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums w-6 text-right shrink-0">
-        #{rank}
-      </span>
-      <span className="flex-1 text-sm font-medium truncate min-w-0">{displayName}</span>
       <span
         className={cn(
           'text-[10px] font-bold px-1.5 py-0.5 rounded-full shrink-0',
@@ -156,12 +180,111 @@ function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
       >
         {score}
       </span>
-      <span className="text-[10px] text-muted-foreground tabular-nums w-14 text-right shrink-0">
-        {Math.round(drep.effectiveParticipation ?? 0)}% part.
+      <span className="flex-1 text-sm text-muted-foreground/80 group-hover:text-foreground/90 truncate min-w-0 transition-colors duration-200">
+        {displayName}
       </span>
-      <span className="text-[10px] text-muted-foreground tabular-nums w-12 text-right shrink-0">
-        {drep.delegatorCount.toLocaleString()}
+      <span className="text-[10px] text-muted-foreground/50">Inactive</span>
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/30 shrink-0" />
+    </Link>
+  );
+}
+
+/* ── Enhanced table row ──────────────────────────────────────────── */
+function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
+  const score = drep.drepScore ?? 0;
+  const tier = tierKey(computeTier(score));
+  const displayName =
+    drep.name || drep.ticker || drep.handle || `${drep.drepId.slice(0, 16)}\u2026`;
+  const momentum = drep.scoreMomentum ?? null;
+
+  const alignments = extractAlignments(drep);
+  const hasAlignment = drep.alignmentDecentralization !== null;
+  const personalityLabel = hasAlignment ? getPersonalityLabel(alignments) : null;
+  const dominantDim = hasAlignment ? getDominantDimension(alignments) : null;
+  const identityColor = dominantDim ? getIdentityColor(dominantDim) : null;
+
+  const participation =
+    drep.effectiveParticipation != null ? Math.round(drep.effectiveParticipation) : null;
+  const rationaleRate = Math.round(drep.rationaleRate ?? 0);
+
+  return (
+    <Link
+      href={`/drep/${drep.drepId}`}
+      className={cn(
+        'group flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-all duration-200',
+        TIER_LEFT_ACCENT[tier],
+      )}
+    >
+      {/* Rank */}
+      <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums w-6 text-right shrink-0">
+        #{rank}
       </span>
+
+      {/* Score pill */}
+      <div className="shrink-0 flex flex-col items-center w-10">
+        <span className={cn('text-lg font-bold tabular-nums leading-none', TIER_SCORE_COLOR[tier])}>
+          {score}
+        </span>
+        <span
+          className={cn(
+            'text-[8px] font-semibold uppercase tracking-wider mt-0.5',
+            TIER_SCORE_COLOR[tier],
+          )}
+        >
+          {tier === 'Emerging' ? 'NEW' : tier.slice(0, 3).toUpperCase()}
+        </span>
+      </div>
+
+      {/* Name + identity */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-sm text-foreground truncate">{displayName}</span>
+          {personalityLabel && identityColor && (
+            <span
+              className="hidden sm:inline-flex items-center gap-1 text-[9px] font-semibold px-1.5 py-0.5 rounded-full border shrink-0"
+              style={{
+                borderColor: `${identityColor.hex}40`,
+                backgroundColor: `${identityColor.hex}10`,
+                color: identityColor.hex,
+              }}
+            >
+              <span
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: identityColor.hex }}
+              />
+              {personalityLabel}
+            </span>
+          )}
+        </div>
+        {/* Subtle stat line */}
+        <div className="flex items-center gap-2 mt-0.5">
+          {participation !== null && (
+            <span className="text-[10px] text-muted-foreground">
+              {participation}% participation
+            </span>
+          )}
+          {rationaleRate > 0 && (
+            <span className="text-[10px] text-muted-foreground">· {rationaleRate}% rationale</span>
+          )}
+          {drep.delegatorCount > 0 && (
+            <span className="text-[10px] text-muted-foreground">
+              · {drep.delegatorCount.toLocaleString()} delegators
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Momentum */}
+      <span className="shrink-0">
+        {momentum !== null && momentum > 0.5 ? (
+          <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
+        ) : momentum !== null && momentum < -0.5 ? (
+          <TrendingDown className="h-3.5 w-3.5 text-rose-400" />
+        ) : (
+          <Minus className="h-3 w-3 text-muted-foreground/40" />
+        )}
+      </span>
+
       <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0 group-hover:text-primary transition-colors" />
     </Link>
   );
@@ -176,10 +299,10 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
 
   const searchParams = useSearchParams();
   const contentRef = useRef<HTMLDivElement>(null);
+  const heroRef = useRef<HTMLDivElement>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [page, setPage] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
-  // Load match profile from localStorage (lazy init -- no effect needed)
   const sortParam = searchParams.get('sort');
   const [matchProfile] = useState<StoredMatchProfile | null>(() => {
     if (typeof window === 'undefined') return null;
@@ -189,6 +312,23 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     if (typeof window === 'undefined') return 'score';
     return sortParam === 'match' && loadMatchProfile() ? 'match' : 'score';
   });
+
+  // Globe fade on scroll
+  const [globeOpacity, setGlobeOpacity] = useState(1);
+  useEffect(() => {
+    const hero = heroRef.current;
+    if (!hero) return;
+    const handleScroll = () => {
+      const rect = hero.getBoundingClientRect();
+      const heroBottom = rect.bottom;
+      // Fade out as hero scrolls off screen
+      const opacity = Math.max(0, Math.min(1, heroBottom / (rect.height || 1)));
+      setGlobeOpacity(opacity);
+    };
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   const deferredSearch = useDeferredValue(filters.search);
   const pageSize = viewMode === 'table' ? TABLE_PAGE_SIZE : CARD_PAGE_SIZE;
@@ -289,13 +429,24 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     return result;
   }, [dreps, deferredSearch, filters, sortMode, matchProfile]);
 
+  // Separate active/inactive for card view compact treatment
+  const { activeItems, inactiveItems } = useMemo(() => {
+    if (filters.activeOnly) return { activeItems: filtered, inactiveItems: [] };
+    return {
+      activeItems: filtered.filter((d) => d.isActive),
+      inactiveItems: filtered.filter((d) => !d.isActive),
+    };
+  }, [filtered, filters.activeOnly]);
+
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);
     contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
 
-  const totalPages = Math.ceil(filtered.length / pageSize);
-  const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);
+  // Pagination operates on active items in card view, all items in table
+  const paginationItems = viewMode === 'cards' ? activeItems : filtered;
+  const totalPages = Math.ceil(paginationItems.length / pageSize);
+  const pageItems = paginationItems.slice(page * pageSize, (page + 1) * pageSize);
 
   // Fetch endorsement counts for visible DReps
   const pageEntityIds = useMemo(() => pageItems.map((d) => d.drepId), [pageItems]);
@@ -313,96 +464,132 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
   }
 
   return (
-    <div ref={contentRef} className="space-y-4 pt-4">
-      <AnonymousNudge variant="representatives" />
-      <DiscoverFilterBar
-        search={filters.search}
-        onSearchChange={(v) => setFilter('search', v)}
-        searchPlaceholder="Search by name, ticker, or ID\u2026"
-        chipGroups={[
-          {
-            label: 'Tier',
-            value: filters.tier,
-            options: TIER_CHIPS,
-            onChange: (v) => setFilter('tier', v),
-          },
-          {
-            label: 'Alignment',
-            value: filters.alignment,
-            options: ALIGNMENT_OPTIONS,
-            onChange: (v) => setFilter('alignment', v),
-          },
-        ]}
-        toggles={[
-          {
-            label: 'Active DReps only',
-            checked: filters.activeOnly,
-            onChange: (v) => setFilter('activeOnly', v),
-          },
-        ]}
-        resultCount={filtered.length}
-        totalCount={dreps.length}
-        entityLabel="DReps"
-        isFiltered={!isDefaultFilters}
-        onReset={resetFilters}
-        pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
-      />
-
-      {/* Match sort banner + view mode toggle */}
-      {matchProfile && (
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setSortMode(sortMode === 'match' ? 'score' : 'match')}
-            className={cn(
-              'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all border',
-              sortMode === 'match'
-                ? 'bg-primary/10 border-primary/30 text-primary'
-                : 'bg-muted/30 border-border text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <Sparkles className="h-3.5 w-3.5" />
-            {sortMode === 'match' ? 'Sorted by match' : 'Sort by match'}
-          </button>
-          {sortMode === 'match' && (
-            <span className="text-xs text-muted-foreground">
-              Based on your{' '}
-              <Link href="/match" className="text-primary hover:underline">
-                governance profile
-              </Link>
-            </span>
-          )}
+    <div ref={contentRef} className="space-y-3">
+      {/* ── Hero: header + globe background ──────────────────────── */}
+      <div ref={heroRef} className="relative overflow-hidden -mx-4 sm:-mx-6 px-4 sm:px-6 pt-2 pb-3">
+        {/* Globe background — decorative, non-interactive */}
+        <div
+          className="absolute inset-0 pointer-events-none select-none"
+          style={{ opacity: globeOpacity, transition: 'opacity 150ms ease-out' }}
+          aria-hidden="true"
+        >
+          <div className="absolute inset-0 w-full h-full [&_canvas]:!w-full [&_canvas]:!h-full">
+            <ConstellationScene interactive={false} className="w-full h-full opacity-[0.12]" />
+          </div>
+          {/* Bottom gradient fade */}
+          <div className="absolute bottom-0 left-0 right-0 h-1/2 bg-gradient-to-t from-background to-transparent" />
         </div>
-      )}
 
-      <div className="hidden sm:flex items-center justify-end gap-1">
-        <button
-          onClick={() => toggleViewMode('cards')}
-          className={cn(
-            'p-1.5 rounded transition-colors',
-            viewMode === 'cards'
-              ? 'bg-primary/10 text-primary'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-          title="Card view"
-        >
-          <LayoutGrid className="h-4 w-4" />
-        </button>
-        <button
-          onClick={() => toggleViewMode('table')}
-          className={cn(
-            'p-1.5 rounded transition-colors',
-            viewMode === 'table'
-              ? 'bg-primary/10 text-primary'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-          title="Table view"
-        >
-          <TableProperties className="h-4 w-4" />
-        </button>
+        {/* Heading content over globe */}
+        <div className="relative z-10">
+          <div className="flex items-baseline justify-between gap-4">
+            <h1 className="text-xl font-bold tracking-tight">Find Your Representative</h1>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+            Every DRep has a unique governance philosophy. Find someone who represents your values.
+          </p>
+        </div>
       </div>
 
-      {/* Content */}
-      {pageItems.length === 0 ? (
+      <AnonymousNudge variant="representatives" />
+
+      {/* ── Sticky filter bar ────────────────────────────────────── */}
+      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-background/90 backdrop-blur-xl border-b border-border/30">
+        <DiscoverFilterBar
+          search={filters.search}
+          onSearchChange={(v) => setFilter('search', v)}
+          searchPlaceholder="Search by name, ticker, or ID\u2026"
+          chipGroups={[
+            {
+              label: 'Tier',
+              value: filters.tier,
+              options: TIER_CHIPS,
+              onChange: (v) => setFilter('tier', v),
+            },
+            {
+              label: 'Alignment',
+              value: filters.alignment,
+              options: ALIGNMENT_OPTIONS,
+              onChange: (v) => setFilter('alignment', v),
+            },
+          ]}
+          toggles={[
+            {
+              label: 'Active DReps only',
+              checked: filters.activeOnly,
+              onChange: (v) => setFilter('activeOnly', v),
+            },
+          ]}
+          resultCount={filtered.length}
+          totalCount={dreps.length}
+          entityLabel="DReps"
+          isFiltered={!isDefaultFilters}
+          onReset={resetFilters}
+          pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
+        />
+
+        {/* Consolidated toolbar: match sort + view toggle */}
+        <div className="flex items-center justify-between mt-2 pt-2 border-t border-border/20">
+          <div className="flex items-center gap-2">
+            {matchProfile && (
+              <>
+                <button
+                  onClick={() => setSortMode(sortMode === 'match' ? 'score' : 'match')}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all border',
+                    sortMode === 'match'
+                      ? 'bg-primary/10 border-primary/30 text-primary'
+                      : 'bg-muted/30 border-border text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <Sparkles className="h-3 w-3" />
+                  {sortMode === 'match' ? 'Sorted by match' : 'Sort by match'}
+                </button>
+                {sortMode === 'match' && (
+                  <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                    Based on your{' '}
+                    <Link href="/match" className="text-primary hover:underline">
+                      profile
+                    </Link>
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+          <div className="hidden sm:flex items-center gap-0.5">
+            <button
+              onClick={() => toggleViewMode('cards')}
+              className={cn(
+                'p-1.5 rounded transition-colors',
+                viewMode === 'cards'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Card view"
+            >
+              <LayoutGrid className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => toggleViewMode('table')}
+              className={cn(
+                'p-1.5 rounded transition-colors',
+                viewMode === 'table'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Table view"
+            >
+              <TableProperties className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Content ──────────────────────────────────────────────── */}
+      {pageItems.length === 0 && inactiveItems.length === 0 ? (
         <div className="py-16 text-center space-y-2">
           {filters.alignment !== 'all' ? (
             <>
@@ -424,45 +611,72 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
           </Button>
         </div>
       ) : viewMode === 'cards' ? (
-        <div key={page} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {pageItems.map((drep, i) => {
-            let ms: number | null = null;
-            if (sortMode === 'match' && matchProfile) {
-              const dAlign: AlignmentScores = {
-                treasuryConservative: drep.alignmentTreasuryConservative,
-                treasuryGrowth: drep.alignmentTreasuryGrowth,
-                decentralization: drep.alignmentDecentralization,
-                security: drep.alignmentSecurity,
-                innovation: drep.alignmentInnovation,
-                transparency: drep.alignmentTransparency,
-              };
-              ms = distanceToMatchScore(alignmentDistance(matchProfile.userAlignments, dAlign));
-            }
-            return (
-              <div
-                key={drep.drepId}
-                className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
-                style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
-              >
-                <CivicaDRepCard
-                  drep={drep}
-                  rank={sortMode === 'match' ? undefined : page * pageSize + i + 1}
-                  matchScore={ms}
-                  endorsementCount={endorsementCounts[drep.drepId]}
-                />
+        <div className="space-y-6">
+          {/* Active DRep cards */}
+          {pageItems.length > 0 && (
+            <div key={page} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {pageItems.map((drep, i) => {
+                let ms: number | null = null;
+                if (sortMode === 'match' && matchProfile) {
+                  const dAlign: AlignmentScores = {
+                    treasuryConservative: drep.alignmentTreasuryConservative,
+                    treasuryGrowth: drep.alignmentTreasuryGrowth,
+                    decentralization: drep.alignmentDecentralization,
+                    security: drep.alignmentSecurity,
+                    innovation: drep.alignmentInnovation,
+                    transparency: drep.alignmentTransparency,
+                  };
+                  ms = distanceToMatchScore(alignmentDistance(matchProfile.userAlignments, dAlign));
+                }
+                return (
+                  <div
+                    key={drep.drepId}
+                    className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
+                    style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
+                  >
+                    <CivicaDRepCard
+                      drep={drep}
+                      rank={sortMode === 'match' ? undefined : page * pageSize + i + 1}
+                      matchScore={ms}
+                      endorsementCount={endorsementCounts[drep.drepId]}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Compact inactive DReps — only shown when activeOnly is off and on first page */}
+          {!filters.activeOnly && inactiveItems.length > 0 && page === 0 && (
+            <div className="space-y-1.5">
+              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-1">
+                Inactive Representatives ({inactiveItems.length})
+              </p>
+              <div className="space-y-1">
+                {inactiveItems.slice(0, 20).map((drep, i) => (
+                  <InactiveDRepRow
+                    key={drep.drepId}
+                    drep={drep}
+                    animationDelay={Math.min(i, 14) * 30}
+                  />
+                ))}
+                {inactiveItems.length > 20 && (
+                  <p className="text-xs text-muted-foreground/60 text-center py-2">
+                    + {inactiveItems.length - 20} more inactive DReps
+                  </p>
+                )}
               </div>
-            );
-          })}
+            </div>
+          )}
         </div>
       ) : (
         <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
           {/* Table header */}
           <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
             <span className="w-6 text-right shrink-0">#</span>
-            <span className="flex-1">Name</span>
-            <span className="shrink-0">Score</span>
-            <span className="w-14 text-right shrink-0">Particip.</span>
-            <span className="w-12 text-right shrink-0">Deleg.</span>
+            <span className="w-10 text-center shrink-0">Score</span>
+            <span className="flex-1">Representative</span>
+            <span className="w-5 shrink-0" />
             <span className="w-3.5 shrink-0" />
           </div>
           {pageItems.map((drep, i) => (


### PR DESCRIPTION
## Summary
- Redesigns `/governance/representatives` for the Citizen persona — find your rep in 60 seconds
- DRep cards now hero the **personality archetype** (e.g., "The Guardian") with identity-colored accents, removing noise like score narratives and trait tags
- Sticky frosted-glass filter bar matching the proposals page pattern
- 3D globe background behind header with scroll-linked opacity fade
- Compact single-line rows for inactive DReps (like resolved proposal cards)
- Consolidated toolbar reduces vertical filter stacking
- Redesigned table rows with tier-colored left accent, archetype badge, and stat line

## Impact
- **What changed**: Representatives page UI completely redesigned — cards, table rows, filters, header
- **User-facing**: Yes — citizens see a cleaner, more differentiated browse experience with personality archetypes as the hero element
- **Risk**: Low — styling and layout only, no data or API changes
- **Scope**: 3 files: `page.tsx` (spacing), `CivicaDRepBrowse.tsx` (orchestrator rewrite), `CivicaDRepCard.tsx` (card redesign)

## Test plan
- [x] Preflight passes (format, lint, types, 590 tests)
- [ ] Visual check: cards show personality archetype with colored dot
- [ ] Visual check: sticky filter bar has frosted glass effect on scroll
- [ ] Visual check: globe fades out as user scrolls past hero
- [ ] Visual check: inactive DReps render as compact rows
- [ ] Visual check: table view rows show tier accent + archetype badge
- [ ] Mobile responsive: filters and cards stack properly on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)