### PR TITLE
feat: global globe background and transparent header across all pages

### DIFF
--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import {
   Search,
@@ -67,7 +67,6 @@ const SEGMENT_ICONS: Record<UserSegment, typeof User> = {
 };
 
 export function CivicaHeader() {
-  const pathname = usePathname();
   const router = useRouter();
   const { connected, disconnect, logout, isAuthenticated } = useWallet();
   const {
@@ -94,8 +93,6 @@ export function CivicaHeader() {
     firstId: string;
   } | null>(null);
 
-  const isHome = pathname === '/';
-
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 32);
@@ -104,17 +101,15 @@ export function CivicaHeader() {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const headerTransparent = isHome && !scrolled;
+  const headerTransparent = !scrolled;
 
   return (
     <header
       className={cn(
         'sticky top-0 z-50 hidden sm:block transition-[background-color,border-color,backdrop-filter] duration-300',
-        isHome
-          ? headerTransparent
-            ? 'bg-transparent'
-            : 'border-b border-border/30 bg-background/30 backdrop-blur-xl'
-          : 'border-b border-border/50 bg-background/80 backdrop-blur-xl',
+        headerTransparent
+          ? 'bg-transparent'
+          : 'border-b border-border/30 bg-background/30 backdrop-blur-xl',
       )}
     >
       <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { Suspense, useEffect, useState, useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { SegmentProvider } from '@/components/providers/SegmentProvider';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { CivicaHeader } from './CivicaHeader';
 import { CivicaBottomNav } from './CivicaBottomNav';
 import { CivicaSidebar } from './CivicaSidebar';
+
+const ConstellationScene = dynamic(
+  () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
+  { ssr: false },
+);
 
 const SIDEBAR_STORAGE_KEY = 'governada_sidebar_collapsed';
 
@@ -49,6 +55,8 @@ function DeepLinkHandler() {
  * Sidebar is persona-adaptive via the nav config.
  */
 export function CivicaShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isHome = pathname === '/';
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   useEffect(() => {
@@ -72,6 +80,24 @@ export function CivicaShell({ children }: { children: React.ReactNode }) {
         </Suspense>
         <CivicaHeader />
         <CivicaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+
+        {/* Global constellation globe — subtle background on all pages except homepage */}
+        {!isHome && (
+          <div
+            className={cn(
+              'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
+              sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
+            )}
+            aria-hidden="true"
+          >
+            <div className="absolute inset-0 opacity-20">
+              <ConstellationScene interactive={false} className="w-full h-full" />
+            </div>
+            {/* Gradient fade — globe is most visible at top, fades toward bottom */}
+            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent via-40% to-background" />
+          </div>
+        )}
+
         <main
           id="main-content"
           className={cn(

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useState, useMemo, useRef, useCallback, useDeferredValue, useEffect } from 'react';
+import { useState, useMemo, useRef, useCallback, useDeferredValue } from 'react';
 import Link from 'next/link';
-import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -44,11 +43,6 @@ import {
   getIdentityColor,
 } from '@/lib/drepIdentity';
 import type { AlignmentScores } from '@/lib/drepIdentity';
-
-const ConstellationScene = dynamic(
-  () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
-  { ssr: false },
-);
 
 const TIER_CHIPS: { value: string; label: string; tooltip?: string }[] = [
   { value: 'All', label: 'All' },
@@ -299,7 +293,6 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
 
   const searchParams = useSearchParams();
   const contentRef = useRef<HTMLDivElement>(null);
-  const heroRef = useRef<HTMLDivElement>(null);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [page, setPage] = useState(0);
   const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
@@ -312,23 +305,6 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     if (typeof window === 'undefined') return 'score';
     return sortParam === 'match' && loadMatchProfile() ? 'match' : 'score';
   });
-
-  // Globe fade on scroll
-  const [globeOpacity, setGlobeOpacity] = useState(1);
-  useEffect(() => {
-    const hero = heroRef.current;
-    if (!hero) return;
-    const handleScroll = () => {
-      const rect = hero.getBoundingClientRect();
-      const heroBottom = rect.bottom;
-      // Fade out as hero scrolls off screen
-      const opacity = Math.max(0, Math.min(1, heroBottom / (rect.height || 1)));
-      setGlobeOpacity(opacity);
-    };
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    handleScroll();
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const deferredSearch = useDeferredValue(filters.search);
   const pageSize = viewMode === 'table' ? TABLE_PAGE_SIZE : CARD_PAGE_SIZE;
@@ -465,33 +441,17 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
 
   return (
     <div ref={contentRef} className="space-y-3">
-      {/* ── Hero: header + globe background ──────────────────────── */}
-      <div ref={heroRef} className="relative overflow-hidden -mx-4 sm:-mx-6 px-4 sm:px-6 pt-2 pb-3">
-        {/* Globe background — decorative, non-interactive */}
-        <div
-          className="absolute inset-0 pointer-events-none select-none"
-          style={{ opacity: globeOpacity, transition: 'opacity 150ms ease-out' }}
-          aria-hidden="true"
-        >
-          <div className="absolute inset-0 w-full h-full [&_canvas]:!w-full [&_canvas]:!h-full">
-            <ConstellationScene interactive={false} className="w-full h-full opacity-[0.12]" />
-          </div>
-          {/* Bottom gradient fade */}
-          <div className="absolute bottom-0 left-0 right-0 h-1/2 bg-gradient-to-t from-background to-transparent" />
+      {/* ── Page header ──────────────────────────────────────────── */}
+      <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 pt-2 pb-3">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="text-xl font-bold tracking-tight">Find Your Representative</h1>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
+          </span>
         </div>
-
-        {/* Heading content over globe */}
-        <div className="relative z-10">
-          <div className="flex items-baseline justify-between gap-4">
-            <h1 className="text-xl font-bold tracking-tight">Find Your Representative</h1>
-            <span className="text-xs text-muted-foreground shrink-0">
-              {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
-            </span>
-          </div>
-          <p className="text-sm text-muted-foreground mt-1 max-w-xl">
-            Every DRep has a unique governance philosophy. Find someone who represents your values.
-          </p>
-        </div>
+        <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+          Every DRep has a unique governance philosophy. Find someone who represents your values.
+        </p>
       </div>
 
       <AnonymousNudge variant="representatives" />


### PR DESCRIPTION
## Summary
- Moves the constellation globe from per-page (representatives only) to a global shell-level fixed background on all pages except homepage
- Globe renders at 20% opacity with a gradient fade toward the bottom of the viewport
- Header is now transparent on all pages (not just homepage) — same scroll-based frosted glass behavior everywhere
- Globe position responds to sidebar collapse state for proper alignment
- Homepage retains its own more prominent globe (25% authenticated, full anonymous)

## Impact
- **What changed**: Every page now has a subtle constellation background and transparent header, giving the site consistent visual character
- **User-facing**: Yes — users see the globe subtly behind all pages and the header is transparent until scrolled
- **Risk**: Low — visual/layout only, no data or API changes. Single globe instance per page (no duplication with homepage)
- **Scope**: 3 files: `CivicaShell.tsx` (global globe), `CivicaHeader.tsx` (transparent everywhere), `CivicaDRepBrowse.tsx` (removed per-page globe)

## Test plan
- [ ] Globe visible behind header on representatives page at ~20% opacity
- [ ] Globe visible on proposals, pools, committee, health, and other governance pages
- [ ] Header transparent at top of page, frosted glass on scroll — all pages
- [ ] Homepage still has its own prominent globe (no duplication)
- [ ] Globe properly offset when sidebar is expanded vs collapsed
- [ ] Mobile: globe visible, header behavior correct
- [ ] No performance regression from global Three.js scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)