### PR TITLE
feat: app-wide glassmorphic UX with unified constellation globe

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -564,7 +564,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
 
       {/* 3. Tier Progress + Momentum */}
       {isViewerAuthenticated && tierProgress.pointsToNext != null && (
-        <div className="flex items-center justify-between rounded-xl border border-border bg-card px-5 py-3">
+        <div className="flex items-center justify-between rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-3">
           <div className="flex items-center gap-3">
             <span className="text-sm font-medium">
               {tierProgress.pointsToNext} pts to{' '}
@@ -753,7 +753,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       <DRepDetailedAnalysis>
         {/* Delegation Power Trend */}
         {delegationTrend.length >= 2 ? (
-          <div className="rounded-xl border border-border bg-card px-5 py-4 space-y-2">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-4 space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                 Delegation Trend
@@ -788,7 +788,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
             </div>
           </div>
         ) : (
-          <div className="rounded-xl border border-border bg-card px-5 py-4">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-4">
             <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider block mb-1">
               Delegation Trend
             </span>

--- a/app/engage/EngageClient.tsx
+++ b/app/engage/EngageClient.tsx
@@ -50,7 +50,7 @@ export function EngageClient({ epoch }: EngageClientProps) {
         {currentRankings && currentRankings.rankings.length > 0 ? (
           <EpochRecap current={currentRankings} previous={previousRankings ?? null} epoch={epoch} />
         ) : (
-          <section className="rounded-xl border border-border bg-card p-5">
+          <section className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
             <div className="flex items-center gap-3">
               <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10">
                 <Sparkles className="h-4 w-4 text-primary" />
@@ -135,7 +135,7 @@ function EpochRecap({
   const isStreak = top1 && previousTop1 && top1.priority === previousTop1.priority;
 
   return (
-    <section className="rounded-xl border border-border bg-card p-5 space-y-3">
+    <section className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Info className="h-4 w-4 text-primary" />

--- a/app/governance/health/epoch/[epoch]/page.tsx
+++ b/app/governance/health/epoch/[epoch]/page.tsx
@@ -166,7 +166,7 @@ export default async function EpochReportPage({ params }: Props) {
       </header>
 
       {/* Key Takeaways */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <h3 className="text-sm font-bold">Key Takeaways</h3>
         <ul className="space-y-1.5 text-sm text-muted-foreground list-disc list-inside">
           {data.stats.activeDReps > 0 && (
@@ -271,7 +271,7 @@ function DeltaCard({
 }) {
   const delta = Math.round((current - previous) * 10) / 10;
   return (
-    <div className="rounded-lg border border-border bg-card p-3 text-center">
+    <div className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md p-3 text-center">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="text-lg font-semibold tabular-nums">
         {current}

--- a/app/governance/health/page.tsx
+++ b/app/governance/health/page.tsx
@@ -32,7 +32,10 @@ function HealthFallback() {
       </div>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+          >
             <Skeleton className="h-3 w-24" />
             <Skeleton className="h-8 w-16" />
             <Skeleton className="h-2.5 w-32" />

--- a/app/governance/treasury/page.tsx
+++ b/app/governance/treasury/page.tsx
@@ -27,24 +27,24 @@ function TreasuryFallback() {
   return (
     <div className="space-y-6">
       {/* Balance card skeleton */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <Skeleton className="h-3 w-24" />
         <Skeleton className="h-10 w-36" />
         <Skeleton className="h-16 w-full" />
       </div>
       {/* Stats row skeleton */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
           <Skeleton className="h-3 w-16" />
           <Skeleton className="h-8 w-20" />
         </div>
-        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
           <Skeleton className="h-3 w-20" />
           <Skeleton className="h-8 w-12" />
         </div>
       </div>
       {/* Pending proposals skeleton */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <Skeleton className="h-4 w-40" />
         {Array.from({ length: 3 }).map((_, i) => (
           <Skeleton key={i} className="h-12 w-full" />

--- a/app/help/methodology/page.tsx
+++ b/app/help/methodology/page.tsx
@@ -129,7 +129,7 @@ const TIER_DESCRIPTIONS: Record<string, string> = {
 
 export default function MethodologyPage() {
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen">
       <div className="max-w-3xl mx-auto px-4 py-12 space-y-16">
         <div className="space-y-4">
           <h1 className="text-3xl font-bold text-foreground sm:text-4xl">
@@ -167,7 +167,7 @@ export default function MethodologyPage() {
 
         <section className="space-y-6">
           <h2 className="text-xl font-bold">DRep Score V3</h2>
-          <div className="rounded-xl border border-border bg-card p-4">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
             <code className="block text-xs text-muted-foreground font-mono">
               Score = (Engagement Quality x 0.35) + (Effective Participation x 0.25) + (Reliability
               x 0.25) + (Governance Identity x 0.15)
@@ -175,7 +175,10 @@ export default function MethodologyPage() {
           </div>
           <div className="space-y-4">
             {DREP_PILLARS.map((p) => (
-              <div key={p.name} className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div
+                key={p.name}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3"
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <div className={cn('h-3 w-3 rounded-full', p.color)} />
@@ -233,7 +236,7 @@ export default function MethodologyPage() {
 
         <section className="space-y-6">
           <h2 className="text-xl font-bold">SPO Governance Score V3</h2>
-          <div className="rounded-xl border border-border bg-card p-4">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
             <code className="block text-xs text-muted-foreground font-mono">
               Score = (Participation x 0.35) + (Deliberation Quality x 0.25) + (Reliability x 0.25)
               + (Governance Identity x 0.15)
@@ -241,7 +244,10 @@ export default function MethodologyPage() {
           </div>
           <div className="space-y-4">
             {SPO_PILLARS.map((p) => (
-              <div key={p.name} className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div
+                key={p.name}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3"
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <div className={cn('h-3 w-3 rounded-full', p.color)} />

--- a/app/learn/LearnClient.tsx
+++ b/app/learn/LearnClient.tsx
@@ -90,7 +90,7 @@ export function LearnClient() {
             return (
               <div
                 key={item.title}
-                className="rounded-xl border border-border bg-card p-5 space-y-3"
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3"
               >
                 <div className="flex items-center gap-3">
                   <div

--- a/app/methodology/page.tsx
+++ b/app/methodology/page.tsx
@@ -288,7 +288,7 @@ function TableOfContents() {
   ];
 
   return (
-    <nav className="rounded-xl border border-border bg-card p-4">
+    <nav className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
       <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
         On this page
       </p>
@@ -310,7 +310,7 @@ function TableOfContents() {
 
 export default function MethodologyPage() {
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen">
       <div className="max-w-3xl mx-auto px-4 py-12 space-y-16">
         {/* Hero */}
         <div className="space-y-4">
@@ -374,7 +374,7 @@ export default function MethodologyPage() {
             pillars. Each pillar is percentile-normalized across all active DReps, ensuring the
             score reflects relative standing. The composite formula:
           </p>
-          <div className="rounded-xl border border-border bg-card p-4">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
             <code className="block text-xs text-muted-foreground font-mono">
               Score = (Engagement Quality x 0.35) + (Effective Participation x 0.25) + (Reliability
               x 0.25) + (Governance Identity x 0.15)
@@ -383,7 +383,10 @@ export default function MethodologyPage() {
 
           <div className="space-y-4">
             {DREP_PILLARS.map((p) => (
-              <div key={p.name} className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div
+                key={p.name}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3"
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <div className={cn('h-3 w-3 rounded-full', p.color)} />
@@ -455,7 +458,7 @@ export default function MethodologyPage() {
             system as DReps. The four pillars are tailored to SPO governance behavior, with
             confidence-weighted percentile normalization and a 30-day momentum window.
           </p>
-          <div className="rounded-xl border border-border bg-card p-4">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
             <code className="block text-xs text-muted-foreground font-mono">
               Score = (Participation x 0.35) + (Deliberation Quality x 0.25) + (Reliability x 0.25)
               + (Governance Identity x 0.15)
@@ -464,7 +467,10 @@ export default function MethodologyPage() {
 
           <div className="space-y-4">
             {SPO_PILLARS.map((p) => (
-              <div key={p.name} className="rounded-xl border border-border bg-card p-4 space-y-3">
+              <div
+                key={p.name}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3"
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <div className={cn('h-3 w-3 rounded-full', p.color)} />
@@ -511,7 +517,7 @@ export default function MethodologyPage() {
             {CC_PILLARS.map((p) => (
               <div
                 key={p.name}
-                className="flex items-start gap-3 rounded-lg border border-border bg-card px-4 py-3"
+                className="flex items-start gap-3 rounded-lg border border-border/50 bg-card/70 backdrop-blur-md px-4 py-3"
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium">{p.name}</p>
@@ -545,7 +551,7 @@ export default function MethodologyPage() {
             {ALIGNMENT_DIMENSIONS.map((d) => (
               <div
                 key={d.name}
-                className="rounded-lg border border-border bg-card px-4 py-3 space-y-1"
+                className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md px-4 py-3 space-y-1"
               >
                 <div className="flex items-center gap-2">
                   <div
@@ -585,7 +591,7 @@ export default function MethodologyPage() {
                 {GHI_COMPONENTS.filter((c) => c.category === category).map((c) => (
                   <div
                     key={c.name}
-                    className="flex items-start gap-3 rounded-lg border border-border bg-card px-4 py-3"
+                    className="flex items-start gap-3 rounded-lg border border-border/50 bg-card/70 backdrop-blur-md px-4 py-3"
                   >
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium">{c.name}</p>
@@ -628,7 +634,7 @@ export default function MethodologyPage() {
               , a community-maintained, open-source query layer for Cardano. Governada does not run
               its own indexer — we consume the same public data available to every researcher.
             </p>
-            <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Sync pipeline</p>
               <ul className="space-y-1 text-[11px]">
                 <li className="pl-3 border-l-2 border-border">
@@ -673,21 +679,21 @@ export default function MethodologyPage() {
             scores in their work. We suggest the following formats:
           </p>
           <div className="space-y-3">
-            <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Individual DRep score</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded">
                 &ldquo;[DRep Name] holds a Governada DRep Score of [X]/100 ([Tier] tier) as of epoch
                 [N]. Source: governada.io/drep/[drep_id]&rdquo;
               </code>
             </div>
-            <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">GHI reference</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded">
                 &ldquo;Cardano governance health stands at [X]/100 ([Band]) per the Governada
                 Governance Health Index, epoch [N]. Source: governada.io/governance/health&rdquo;
               </code>
             </div>
-            <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
               <p className="text-xs font-semibold text-foreground">Academic citation</p>
               <code className="block text-[11px] text-muted-foreground font-mono bg-muted p-2 rounded whitespace-pre-wrap">
                 Governada. (2026). Scoring Methodology: DRep Score V3, SPO Governance Score V3, CC

--- a/app/pulse/loading.tsx
+++ b/app/pulse/loading.tsx
@@ -12,7 +12,10 @@ export default function PulseLoading() {
       {/* Stat cards — matches lg:grid-cols-4 */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+          >
             <Skeleton className="h-3 w-24" />
             <Skeleton className="h-8 w-16" />
             <Skeleton className="h-2.5 w-32" />

--- a/app/pulse/page.tsx
+++ b/app/pulse/page.tsx
@@ -32,7 +32,10 @@ function PulseFallback() {
       </div>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+          >
             <Skeleton className="h-3 w-24" />
             <Skeleton className="h-8 w-16" />
             <Skeleton className="h-2.5 w-32" />

--- a/app/pulse/report/[epoch]/page.tsx
+++ b/app/pulse/report/[epoch]/page.tsx
@@ -166,7 +166,7 @@ export default async function StateOfGovernancePage({ params }: Props) {
       </header>
 
       {/* Key Takeaways */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <h3 className="text-sm font-bold">Key Takeaways</h3>
         <ul className="space-y-1.5 text-sm text-muted-foreground list-disc list-inside">
           {data.stats.activeDReps > 0 && (
@@ -271,7 +271,7 @@ function DeltaCard({
 }) {
   const delta = Math.round((current - previous) * 10) / 10;
   return (
-    <div className="rounded-lg border border-border bg-card p-3 text-center">
+    <div className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md p-3 text-center">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="text-lg font-semibold tabular-nums">
         {current}

--- a/app/wrapped/[entityType]/[entityId]/[period]/page.tsx
+++ b/app/wrapped/[entityType]/[entityId]/[period]/page.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
 
 function StatCard({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex flex-col items-center gap-1 rounded-xl border border-border bg-card p-5 text-center">
+    <div className="flex flex-col items-center gap-1 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 text-center">
       <p className="text-3xl font-bold text-foreground">{value}</p>
       <p className="text-xs text-muted-foreground">{label}</p>
     </div>
@@ -80,7 +80,7 @@ function ScoreProgression({
       ? 'text-rose-400'
       : 'text-muted-foreground';
   return (
-    <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
       <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium text-center">
         Score Progression
       </p>
@@ -211,7 +211,7 @@ export default async function PublicWrappedPage({ params }: { params: Promise<Pa
   const label = entityLabel(entityType, entityId);
 
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen">
       <div className="max-w-2xl mx-auto px-4 py-12 space-y-8">
         {/* Header */}
         <div className="text-center space-y-2">

--- a/components/ActivityTicker.tsx
+++ b/components/ActivityTicker.tsx
@@ -153,7 +153,7 @@ export function ActivityTicker({
 
   if (variant === 'inline') {
     return (
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md overflow-hidden">
         <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
           <span className="relative flex h-2 w-2">
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense, useEffect, useState, useCallback } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
 import { SegmentProvider } from '@/components/providers/SegmentProvider';
@@ -55,8 +55,6 @@ function DeepLinkHandler() {
  * Sidebar is persona-adaptive via the nav config.
  */
 export function CivicaShell({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const isHome = pathname === '/';
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   useEffect(() => {
@@ -81,22 +79,20 @@ export function CivicaShell({ children }: { children: React.ReactNode }) {
         <CivicaHeader />
         <CivicaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
 
-        {/* Global constellation globe — subtle background on all pages except homepage */}
-        {!isHome && (
-          <div
-            className={cn(
-              'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
-              sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
-            )}
-            aria-hidden="true"
-          >
-            <div className="absolute inset-0 opacity-20">
-              <ConstellationScene interactive={false} className="w-full h-full" />
-            </div>
-            {/* Gradient fade — globe is most visible at top, fades toward bottom */}
-            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent via-40% to-background" />
+        {/* Global constellation globe — subtle glassmorphic background on all pages */}
+        <div
+          className={cn(
+            'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
+            sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
+          )}
+          aria-hidden="true"
+        >
+          <div className="absolute inset-0 opacity-30">
+            <ConstellationScene interactive={false} className="w-full h-full" />
           </div>
-        )}
+          {/* Gradient fade — globe is most visible at top, fades toward bottom */}
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent via-60% to-background" />
+        </div>
 
         <main
           id="main-content"

--- a/components/civica/CivicaSidebar.tsx
+++ b/components/civica/CivicaSidebar.tsx
@@ -116,7 +116,7 @@ export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
   return (
     <aside
       className={cn(
-        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/50 bg-background transition-[width] duration-200',
+        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/30 bg-background/80 backdrop-blur-xl transition-[width] duration-200',
         collapsed ? 'w-16' : 'w-60',
       )}
     >

--- a/components/civica/cards/CivicaDRepCard.tsx
+++ b/components/civica/cards/CivicaDRepCard.tsx
@@ -57,7 +57,7 @@ export function CivicaDRepCard({ drep, rank, matchScore }: CivicaDRepCardProps) 
       href={`/drep/${drep.drepId}`}
       aria-label={`${displayName}, DRep score ${score}, ${tier} tier${matchScore != null ? `, ${matchScore}% match` : ''}`}
       className={cn(
-        'group relative flex flex-col rounded-xl border overflow-hidden transition-all duration-200',
+        'group relative flex flex-col rounded-xl border overflow-hidden transition-all duration-200 backdrop-blur-md',
         'hover:shadow-lg hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],

--- a/components/civica/cards/CivicaSPOCard.tsx
+++ b/components/civica/cards/CivicaSPOCard.tsx
@@ -72,7 +72,7 @@ export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
       href={`/pool/${pool.poolId}`}
       aria-label={`${pool.ticker || pool.poolName || pool.poolId.slice(0, 16)}, governance score ${score}, ${tier} tier`}
       className={cn(
-        'group relative flex flex-col rounded-xl border p-4 transition-all duration-200',
+        'group relative flex flex-col rounded-xl border p-4 transition-all duration-200 backdrop-blur-md',
         'hover:shadow-lg hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],

--- a/components/civica/cards/tierStyles.ts
+++ b/components/civica/cards/tierStyles.ts
@@ -25,12 +25,12 @@ export const TIER_BORDER: Record<TierKey, string> = {
 };
 
 export const TIER_BG: Record<TierKey, string> = {
-  Emerging: 'bg-card',
-  Bronze: 'bg-amber-50 dark:bg-amber-950/15',
-  Silver: 'bg-slate-50 dark:bg-slate-900/20',
-  Gold: 'bg-yellow-50 dark:bg-yellow-950/15',
-  Diamond: 'bg-cyan-50 dark:bg-cyan-950/15',
-  Legendary: 'bg-violet-50 dark:bg-violet-950/20',
+  Emerging: 'bg-card/70',
+  Bronze: 'bg-amber-50/70 dark:bg-amber-950/15',
+  Silver: 'bg-slate-50/70 dark:bg-slate-900/20',
+  Gold: 'bg-yellow-50/70 dark:bg-yellow-950/15',
+  Diamond: 'bg-cyan-50/70 dark:bg-cyan-950/15',
+  Legendary: 'bg-violet-50/70 dark:bg-violet-950/20',
 };
 
 export const TIER_GLOW: Record<TierKey, string> = {

--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -457,7 +457,7 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
       <AnonymousNudge variant="representatives" />
 
       {/* ── Sticky filter bar ────────────────────────────────────── */}
-      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-background/90 backdrop-blur-xl border-b border-border/30">
+      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
         <DiscoverFilterBar
           search={filters.search}
           onSearchChange={(v) => setFilter('search', v)}
@@ -630,9 +630,9 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
           )}
         </div>
       ) : (
-        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
+        <div className="rounded-xl border border-border/50 divide-y divide-border/50 overflow-hidden bg-card/40 backdrop-blur-md">
           {/* Table header */}
-          <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+          <div className="flex items-center gap-3 px-4 py-2 bg-muted/20 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
             <span className="w-6 text-right shrink-0">#</span>
             <span className="w-10 text-center shrink-0">Score</span>
             <span className="flex-1">Representative</span>

--- a/components/civica/discover/CivicaDiscover.tsx
+++ b/components/civica/discover/CivicaDiscover.tsx
@@ -122,7 +122,7 @@ export function CivicaDiscover({
         message="Browse and compare governance participants. Scores reflect actual voting behavior, not popularity."
       />
       {/* ── Tab bar ──────────────────────────────────────────── */}
-      <div className="border-b border-border sticky top-14 z-30 bg-background/90 backdrop-blur-sm -mx-4 px-4 sm:-mx-6 sm:px-6">
+      <div className="border-b border-border/30 sticky top-14 z-30 bg-card/60 backdrop-blur-xl -mx-4 px-4 sm:-mx-6 sm:px-6">
         <div
           className="flex gap-0 overflow-x-auto scrollbar-none max-w-4xl"
           role="tablist"

--- a/components/civica/discover/CivicaSPOBrowse.tsx
+++ b/components/civica/discover/CivicaSPOBrowse.tsx
@@ -103,28 +103,31 @@ export function CivicaSPOBrowse() {
 
   return (
     <div ref={contentRef} className="space-y-4 pt-4">
-      <DiscoverFilterBar
-        search={search}
-        onSearchChange={setFilter(setSearch)}
-        searchPlaceholder="Search ticker, pool name, or ID…"
-        chipGroups={[
-          {
-            label: 'Tier',
-            value: tier,
-            options: TIER_CHIPS.map((t) => ({ value: t, label: t })),
-            onChange: setFilter(setTier),
-          },
-        ]}
-        toggles={[
-          { label: 'Claimed only', checked: claimedOnly, onChange: setFilter(setClaimedOnly) },
-        ]}
-        resultCount={filtered.length}
-        totalCount={pools.length}
-        entityLabel="pools"
-        isFiltered={!isDefault}
-        onReset={resetFilters}
-        pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
-      />
+      {/* ── Sticky filter bar ────────────────────────────────────── */}
+      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+        <DiscoverFilterBar
+          search={search}
+          onSearchChange={setFilter(setSearch)}
+          searchPlaceholder="Search ticker, pool name, or ID…"
+          chipGroups={[
+            {
+              label: 'Tier',
+              value: tier,
+              options: TIER_CHIPS.map((t) => ({ value: t, label: t })),
+              onChange: setFilter(setTier),
+            },
+          ]}
+          toggles={[
+            { label: 'Claimed only', checked: claimedOnly, onChange: setFilter(setClaimedOnly) },
+          ]}
+          resultCount={filtered.length}
+          totalCount={pools.length}
+          entityLabel="pools"
+          isFiltered={!isDefault}
+          onReset={resetFilters}
+          pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
+        />
+      </div>
 
       {/* Card grid */}
       {pageItems.length === 0 ? (

--- a/components/civica/discover/ProposalCard.tsx
+++ b/components/civica/discover/ProposalCard.tsx
@@ -169,7 +169,7 @@ export function ProposalCard({
     return (
       <Link
         href={href}
-        className="group flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/40 bg-card/30 hover:bg-muted/40 hover:border-border/70 hover:shadow-sm transition-all duration-200 animate-in fade-in fill-mode-backwards"
+        className="group flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/40 bg-card/30 backdrop-blur-sm hover:bg-muted/40 hover:border-border/70 hover:shadow-sm transition-all duration-200 animate-in fade-in fill-mode-backwards"
         style={{ animationDelay: `${animationDelay}ms` }}
       >
         {TypeIcon && <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />}
@@ -209,7 +209,7 @@ export function ProposalCard({
     <Link
       href={href}
       className={cn(
-        'group block rounded-xl border bg-card/80 transition-all duration-200 animate-in fade-in fill-mode-backwards overflow-hidden',
+        'group block rounded-xl border bg-card/70 backdrop-blur-md transition-all duration-200 animate-in fade-in fill-mode-backwards overflow-hidden',
         'hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/30',
         isUrgent
           ? 'border-amber-500/40 shadow-[0_0_20px_rgba(245,158,11,0.06)]'

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -152,7 +152,7 @@ export function ProposalsBrowse() {
 
       {/* Status pipeline overview */}
       {statusCounts.length > 1 && (
-        <div className="rounded-xl border border-border bg-card p-4">
+        <div className="rounded-xl border border-border/50 bg-card/60 backdrop-blur-md p-4">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
             Governance Pipeline
           </p>
@@ -160,7 +160,7 @@ export function ProposalsBrowse() {
         </div>
       )}
 
-      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-background/90 backdrop-blur-xl border-b border-border/30">
+      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
         <DiscoverFilterBar
           search={search}
           onSearchChange={setFilter(setSearch)}

--- a/components/civica/home/HomeDRep.tsx
+++ b/components/civica/home/HomeDRep.tsx
@@ -37,12 +37,16 @@ const TIER_COLORS: Record<string, string> = {
 };
 
 const TIER_BG: Record<string, string> = {
-  Emerging: 'bg-card border-border',
-  Bronze: 'bg-amber-50 dark:bg-amber-950/20 border-amber-300/40 dark:border-amber-800/25',
-  Silver: 'bg-slate-50 dark:bg-slate-900/30 border-slate-300/40 dark:border-slate-700/25',
-  Gold: 'bg-yellow-50 dark:bg-yellow-950/20 border-yellow-300/50 dark:border-yellow-800/25',
-  Diamond: 'bg-cyan-50 dark:bg-cyan-950/20 border-cyan-300/50 dark:border-cyan-800/25',
-  Legendary: 'bg-violet-50 dark:bg-violet-950/20 border-violet-300/50 dark:border-violet-800/25',
+  Emerging: 'bg-card/70 border-border/50 backdrop-blur-md',
+  Bronze:
+    'bg-amber-50/70 dark:bg-amber-950/20 border-amber-300/40 dark:border-amber-800/25 backdrop-blur-md',
+  Silver:
+    'bg-slate-50/70 dark:bg-slate-900/30 border-slate-300/40 dark:border-slate-700/25 backdrop-blur-md',
+  Gold: 'bg-yellow-50/70 dark:bg-yellow-950/20 border-yellow-300/50 dark:border-yellow-800/25 backdrop-blur-md',
+  Diamond:
+    'bg-cyan-50/70 dark:bg-cyan-950/20 border-cyan-300/50 dark:border-cyan-800/25 backdrop-blur-md',
+  Legendary:
+    'bg-violet-50/70 dark:bg-violet-950/20 border-violet-300/50 dark:border-violet-800/25 backdrop-blur-md',
 };
 
 /* White-on-constellation tier colors for the hero overlay */
@@ -230,7 +234,7 @@ export function HomeDRep() {
         <div
           className={cn(
             'rounded-2xl border p-6 space-y-4',
-            TIER_BG[tier] ?? 'bg-card border-border',
+            TIER_BG[tier] ?? 'bg-card/70 border-border/50 backdrop-blur-md',
           )}
         >
           <div className="flex items-start justify-between gap-3">

--- a/components/civica/home/HomeSPO.tsx
+++ b/components/civica/home/HomeSPO.tsx
@@ -28,12 +28,16 @@ const TIER_COLORS: Record<string, string> = {
 };
 
 const TIER_BG: Record<string, string> = {
-  Emerging: 'bg-card border-border',
-  Bronze: 'bg-amber-50 dark:bg-amber-950/20 border-amber-300/40 dark:border-amber-800/25',
-  Silver: 'bg-slate-50 dark:bg-slate-900/30 border-slate-300/40 dark:border-slate-700/25',
-  Gold: 'bg-yellow-50 dark:bg-yellow-950/20 border-yellow-300/50 dark:border-yellow-800/25',
-  Diamond: 'bg-cyan-50 dark:bg-cyan-950/20 border-cyan-300/50 dark:border-cyan-800/25',
-  Legendary: 'bg-violet-50 dark:bg-violet-950/20 border-violet-300/50 dark:border-violet-800/25',
+  Emerging: 'bg-card/70 border-border/50 backdrop-blur-md',
+  Bronze:
+    'bg-amber-50/70 dark:bg-amber-950/20 border-amber-300/40 dark:border-amber-800/25 backdrop-blur-md',
+  Silver:
+    'bg-slate-50/70 dark:bg-slate-900/30 border-slate-300/40 dark:border-slate-700/25 backdrop-blur-md',
+  Gold: 'bg-yellow-50/70 dark:bg-yellow-950/20 border-yellow-300/50 dark:border-yellow-800/25 backdrop-blur-md',
+  Diamond:
+    'bg-cyan-50/70 dark:bg-cyan-950/20 border-cyan-300/50 dark:border-cyan-800/25 backdrop-blur-md',
+  Legendary:
+    'bg-violet-50/70 dark:bg-violet-950/20 border-violet-300/50 dark:border-violet-800/25 backdrop-blur-md',
 };
 
 const TIER_HERO_COLORS: Record<string, string> = {
@@ -228,7 +232,7 @@ export function HomeSPO() {
         <div
           className={cn(
             'rounded-2xl border p-6 space-y-4',
-            TIER_BG[tier] ?? 'bg-card border-border',
+            TIER_BG[tier] ?? 'bg-card/70 border-border/50 backdrop-blur-md',
           )}
         >
           <div className="flex items-start justify-between gap-3">

--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -151,7 +151,7 @@ export function CivicIdentityProfile() {
 
   if (segment === 'anonymous' && !segmentLoading) {
     return (
-      <div className="rounded-xl border border-border bg-card p-8 text-center space-y-4">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-8 text-center space-y-4">
         <Shield className="h-8 w-8 text-primary mx-auto" />
         <p className="text-lg font-bold">Your Civic Identity</p>
         <p className="text-sm text-muted-foreground max-w-sm mx-auto">

--- a/components/civica/pulse/CivicaEpochReport.tsx
+++ b/components/civica/pulse/CivicaEpochReport.tsx
@@ -109,7 +109,7 @@ export function CivicaEpochReport() {
   return (
     <div className="space-y-6">
       {/* Epoch progress */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-4">
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
@@ -155,7 +155,10 @@ export function CivicaEpochReport() {
         {isLoading ? (
           <div className="flex gap-2">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="flex-1 rounded-xl border border-border bg-card p-3">
+              <div
+                key={i}
+                className="flex-1 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-3"
+              >
                 <Skeleton className="h-4 w-4 mx-auto mb-2" />
                 <Skeleton className="h-6 w-8 mx-auto mb-1" />
                 <Skeleton className="h-2.5 w-16 mx-auto" />
@@ -189,7 +192,7 @@ export function CivicaEpochReport() {
       </div>
 
       {/* DRep participation */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-4">
         <div className="flex items-center gap-2">
           <Users className="h-4 w-4 text-muted-foreground" />
           <p className="text-sm font-semibold">DRep Participation</p>

--- a/components/civica/pulse/CivicaGovernanceCalendar.tsx
+++ b/components/civica/pulse/CivicaGovernanceCalendar.tsx
@@ -131,7 +131,7 @@ function EpochRecapCard({ recap }: { recap: Record<string, unknown> }) {
     | undefined;
 
   return (
-    <div className="rounded-xl border border-border bg-card overflow-hidden">
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
         className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/20 transition-colors text-left"
@@ -242,7 +242,7 @@ export function CivicaGovernanceCalendar() {
 
       {/* Current epoch hero */}
       {calendarLoading ? (
-        <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
           <Skeleton className="h-8 w-20" />
           <Skeleton className="h-3 w-full" />
         </div>
@@ -252,7 +252,7 @@ export function CivicaGovernanceCalendar() {
 
       {/* Participation trend mini-chart */}
       {participationRows.length >= 4 && (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
           <div className="flex items-center justify-between">
             <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
               Participation Trend
@@ -311,7 +311,7 @@ export function CivicaGovernanceCalendar() {
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
             Upcoming Deadlines
           </p>
-          <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md divide-y divide-border overflow-hidden">
             {calendar.upcoming.map((p) => (
               <ProposalDeadline key={`${p.txHash}-${p.index}`} proposal={p} />
             ))}
@@ -323,7 +323,7 @@ export function CivicaGovernanceCalendar() {
       {((pulse?.activeProposals as number | undefined) ?? 0) > 0 && (
         <Link
           href="/governance/proposals"
-          className="flex items-center justify-between rounded-xl border border-border bg-card p-4 hover:border-primary/30 transition-colors group"
+          className="flex items-center justify-between rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 hover:border-primary/30 transition-colors group"
         >
           <div>
             <p className="text-sm font-medium">

--- a/components/civica/pulse/CivicaGovernanceTrends.tsx
+++ b/components/civica/pulse/CivicaGovernanceTrends.tsx
@@ -220,7 +220,7 @@ export function CivicaGovernanceTrends() {
   return (
     <div className="space-y-6">
       {/* Participation + rationale dual-line */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <div className="flex items-center justify-between">
           <p className="text-sm font-semibold">Participation & Rationale Rate</p>
           <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
@@ -264,7 +264,7 @@ export function CivicaGovernanceTrends() {
       </div>
 
       {/* GHI gauge + sparkline */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
         <p className="text-sm font-semibold">Governance Health Index</p>
 
         {isLoading ? (
@@ -308,7 +308,7 @@ export function CivicaGovernanceTrends() {
       </div>
 
       {/* Tier distribution */}
-      <div className="rounded-xl border border-border bg-card p-5 space-y-4">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-4">
         <p className="text-sm font-semibold">DRep Tier Distribution</p>
         {dreps.length > 0 ? (
           <TierDistribution dreps={dreps} />
@@ -331,7 +331,7 @@ export function CivicaGovernanceTrends() {
 
       {/* Participation heatmap */}
       {participationRows.length > 4 && (
-        <div className="rounded-xl border border-border bg-card p-5 space-y-3">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
           <p className="text-sm font-semibold">Participation Activity</p>
           <p className="text-xs text-muted-foreground">
             Epoch-by-epoch DRep participation rate — darker = higher engagement.

--- a/components/civica/pulse/CivicaObservatory.tsx
+++ b/components/civica/pulse/CivicaObservatory.tsx
@@ -135,7 +135,7 @@ function EDICard({ metric }: { metric: EDIMetric }) {
         : 'text-muted-foreground';
 
   return (
-    <div className="rounded-xl border border-border bg-card p-4 space-y-2 group relative">
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2 group relative">
       <div className="flex items-center justify-between">
         <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
           {metric.label}
@@ -219,7 +219,10 @@ function DecentralizationTrends({ history }: { history: Record<string, unknown>[
         const prev = values[values.length - 2];
         const delta = latest - prev;
         return (
-          <div key={m.key} className="rounded-xl border border-border bg-card p-3 space-y-1.5">
+          <div
+            key={m.key}
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-3 space-y-1.5"
+          >
             <div className="flex items-center justify-between">
               <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
                 {m.label}
@@ -272,7 +275,10 @@ function InterBodySummary({ interBody }: { interBody: InterBodyRecord }) {
           const pct = Math.round(p.value!);
 
           return (
-            <div key={p.label} className="rounded-xl border border-border bg-card p-4 space-y-2">
+            <div
+              key={p.label}
+              className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+            >
               <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">
                 {p.label}
               </p>
@@ -446,7 +452,10 @@ export function CivicaObservatory() {
         {loading ? (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 7 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+              <div
+                key={i}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+              >
                 <Skeleton className="h-3 w-28" />
                 <Skeleton className="h-7 w-14" />
               </div>
@@ -492,7 +501,10 @@ export function CivicaObservatory() {
         {benchLoading ? (
           <div className="space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="rounded-xl border border-border bg-card p-4 space-y-2">
+              <div
+                key={i}
+                className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+              >
                 <Skeleton className="h-4 w-24" />
                 <Skeleton className="h-3 w-full" />
                 <Skeleton className="h-2 w-3/4" />
@@ -502,7 +514,7 @@ export function CivicaObservatory() {
         ) : benchmarks.length > 0 ? (
           <div className="space-y-4">
             {/* Radar chart */}
-            <div className="rounded-xl border border-border bg-card p-4">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
               <CrossChainRadar
                 chains={benchmarks.map((b) => ({
                   chain: b.chain,
@@ -543,7 +555,10 @@ export function CivicaObservatory() {
                 </div>
               )}
               {otherBenchmarks.map((b) => (
-                <div key={b.chain} className="rounded-xl border border-border bg-card p-4">
+                <div
+                  key={b.chain}
+                  className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4"
+                >
                   <ChainComparisonBar chain={b.chain} benchmark={b} />
                 </div>
               ))}

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -127,7 +127,7 @@ function StatCard({
     <Wrap
       href={href as string}
       className={cn(
-        'rounded-xl border border-border bg-card p-4 space-y-2 transition-colors',
+        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2 transition-colors',
         href &&
           'hover:border-primary/30 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
       )}
@@ -168,7 +168,7 @@ function StatCard({
 
 function StatCardSkeleton() {
   return (
-    <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
       <Skeleton className="h-3 w-24" />
       <Skeleton className="h-8 w-16" />
       <Skeleton className="h-2.5 w-32" />
@@ -269,7 +269,7 @@ export function CivicaPulseOverview() {
       <AnonymousNudge variant="health" />
       {/* ── Tab bar ─────────────────────────────────────────── */}
       <div
-        className="flex gap-1 border-b border-border -mb-2 overflow-x-auto"
+        className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 flex gap-1 border-b border-border/30 -mb-2 overflow-x-auto bg-card/60 backdrop-blur-xl"
         role="tablist"
         aria-label="Pulse view"
       >
@@ -542,7 +542,7 @@ export function CivicaPulseOverview() {
 
           {/* ── Community vs DRep Sentiment Gap ─────────────────── */}
           {(pulse?.communityGap?.length ?? 0) > 0 && (
-            <div className="rounded-xl border-l-2 border-l-primary border border-border bg-card p-4 space-y-3">
+            <div className="rounded-xl border-l-2 border-l-primary border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
               <div className="flex items-center gap-2">
                 <h3 className="text-sm font-semibold">Where Citizens & DReps Diverge</h3>
                 <span className="text-[10px] text-muted-foreground px-1.5 py-0.5 rounded bg-muted">
@@ -719,7 +719,7 @@ export function CivicaPulseOverview() {
                     {components.map((c: TreasuryHealthComponent) => (
                       <div
                         key={c.name ?? c.label}
-                        className="rounded-xl border border-border bg-card px-4 py-3 space-y-1.5"
+                        className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-4 py-3 space-y-1.5"
                       >
                         <div className="flex items-center justify-between">
                           <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium truncate">

--- a/components/civica/pulse/CivicaTreasury.tsx
+++ b/components/civica/pulse/CivicaTreasury.tsx
@@ -158,7 +158,7 @@ export function CivicaTreasury() {
   return (
     <div className="space-y-6">
       {/* Balance + sparkline */}
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md overflow-hidden">
         <div className="p-5 space-y-1">
           <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
             Treasury Balance
@@ -201,7 +201,7 @@ export function CivicaTreasury() {
 
       {/* Stats row */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-border bg-card p-4 space-y-1.5">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-1.5">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground uppercase tracking-wider font-medium">
             <Clock className="h-3.5 w-3.5" />
             Runway
@@ -231,7 +231,7 @@ export function CivicaTreasury() {
           )}
         </div>
 
-        <div className="rounded-xl border border-border bg-card p-4 space-y-1.5">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-1.5">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground uppercase tracking-wider font-medium">
             <DollarSign className="h-3.5 w-3.5" />
             Withdrawals
@@ -258,7 +258,7 @@ export function CivicaTreasury() {
 
       {/* Health score */}
       {treasury?.healthScore != null && (
-        <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
           <div className="flex items-center justify-between">
             <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
               Treasury Health Score
@@ -298,7 +298,7 @@ export function CivicaTreasury() {
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
             Pending Withdrawals
           </p>
-          <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md divide-y divide-border overflow-hidden">
             {pendingItems.map((item, idx: number) => (
               <div key={idx} className="flex items-center justify-between px-4 py-3">
                 <div className="min-w-0">

--- a/components/civica/pulse/GHIExplorer.tsx
+++ b/components/civica/pulse/GHIExplorer.tsx
@@ -182,7 +182,7 @@ export function GHIExplorer({
                 <motion.div
                   key={comp.name}
                   variants={fadeInUp}
-                  className="rounded-lg border border-border bg-card p-3 space-y-2"
+                  className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md p-3 space-y-2"
                 >
                   <div className="flex items-center justify-between">
                     {tooltipText ? (

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -66,7 +66,7 @@ export function GHIHero() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center gap-5 p-5 rounded-xl border border-border bg-card">
+      <div className="flex items-center gap-5 p-5 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md">
         <Skeleton className="h-20 w-20 rounded-full shrink-0" />
         <div className="space-y-2 flex-1">
           <Skeleton className="h-5 w-40" />
@@ -109,7 +109,7 @@ export function GHIHero() {
   return (
     <div
       className={cn(
-        'flex items-center gap-5 p-5 rounded-xl border border-border bg-card',
+        'flex items-center gap-5 p-5 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md',
         band === 'strong' &&
           'ring-1 ring-emerald-500/20 shadow-[0_0_15px_-3px] shadow-emerald-500/10',
       )}

--- a/components/civica/pulse/GovernanceImpactCard.tsx
+++ b/components/civica/pulse/GovernanceImpactCard.tsx
@@ -62,7 +62,7 @@ export function GovernanceImpactCard({
   // No-wallet preview: blurred mock stats create FOMO
   if (!connected) {
     return (
-      <div className="relative rounded-xl border border-border bg-card p-4 overflow-hidden">
+      <div className="relative rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 overflow-hidden">
         <div className="absolute inset-0 backdrop-blur-sm bg-card/60 z-10 flex flex-col items-center justify-center gap-2">
           <Shield className="h-5 w-5 text-primary" aria-hidden />
           <p className="text-sm font-medium">Your Governance This Epoch</p>
@@ -99,7 +99,7 @@ export function GovernanceImpactCard({
       : null;
 
     return (
-      <div className="rounded-xl border border-border bg-card p-4 space-y-2">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
         <div className="flex items-center gap-2">
           <Shield className="h-4 w-4 text-primary" aria-hidden />
           <h3 className="text-xs font-semibold text-primary uppercase tracking-wider">
@@ -162,7 +162,7 @@ export function GovernanceImpactCard({
 
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border bg-card p-4 space-y-3">
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
         <div className="flex items-center gap-2">
           <Skeleton className="h-4 w-4" />
           <Skeleton className="h-3.5 w-40" />

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -4,7 +4,6 @@ import { useSegment } from '@/components/providers/SegmentProvider';
 import { HubCardRenderer } from './HubCardRenderer';
 import { AnonymousLanding } from './AnonymousLanding';
 import { HubCardSkeleton } from './cards/HubCard';
-import { ConstellationScene } from '@/components/ConstellationScene';
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -46,17 +45,6 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     return <AnonymousLanding pulseData={pulseData} />;
   }
 
-  // Authenticated homepage — globe background with glassmorphic cards
-  return (
-    <div className="relative min-h-[calc(100vh-4rem)]">
-      {/* Globe extends to top-0 so it shows through the transparent header.
-          lg:left-60 offsets past the sidebar (visible from lg breakpoint). */}
-      <div className="fixed inset-0 lg:left-60 pointer-events-none opacity-25">
-        <ConstellationScene className="w-full h-full" interactive={false} />
-      </div>
-      <div className="relative z-10">
-        <HubCardRenderer persona={segment} />
-      </div>
-    </div>
-  );
+  // Authenticated homepage — globe provided by CivicaShell, cards float on glass
+  return <HubCardRenderer persona={segment} />;
 }


### PR DESCRIPTION
## Summary
- Boost constellation globe to 30% opacity and render on ALL pages uniformly (including homepage), removing the duplicate globe from HubHomePage
- Replace opaque `bg-card` backgrounds with `bg-card/70 backdrop-blur-md` across 35+ files so the globe shows through all content containers
- Make sidebar, filter bars, tab bars, and entity cards semi-transparent with glassmorphic frosted-glass effect
- Add sticky positioning to SPO browse filter bar and pulse overview tab bar
- Soften borders to `border-border/50` and `border-border/30` for cohesive glassmorphic feel

## Impact
- **What changed**: Every content container across the app now uses semi-transparent backgrounds with backdrop blur, creating a unified glassmorphic design language where the constellation globe is visible through all UI layers
- **User-facing**: Yes — the entire app feels more premium and distinctive with frosted-glass cards floating over the animated globe background. SPO browse and pulse tabs now stick on scroll.
- **Risk**: Low — styling-only changes, no data/logic/API modifications. All 590 tests pass.
- **Scope**: 36 files across app pages, civica components, pulse components, discover components, hub, and shared tier styles

## Test plan
- [x] Preflight passes (590/590 tests, 0 errors)
- [ ] Verify globe visible through cards on all pages (home, discover, pulse, profiles)
- [ ] Verify text readability on all tiers (Emerging through Legendary)
- [ ] Verify sticky filter bars on SPO browse and pulse overview
- [ ] Verify sidebar glassmorphic effect on desktop
- [ ] Check light mode tier cards still readable with /70 opacity backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)