### PR TITLE
feat: overhaul SPO governance browse page

### DIFF
--- a/app/api/governance/pools/route.ts
+++ b/app/api/governance/pools/route.ts
@@ -12,11 +12,10 @@ export const GET = withRouteHandler(async () => {
     const { data: poolRows } = await supabase
       .from('pools')
       .select(
-        'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, current_tier, delegator_count, live_stake_lovelace, claimed_by, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, governance_statement, pool_status',
+        'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, current_tier, delegator_count, live_stake_lovelace, claimed_by, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency, governance_statement, pool_status, score_momentum',
       )
       .gt('vote_count', 0)
-      .order('governance_score', { ascending: false, nullsFirst: false })
-      .limit(200);
+      .order('governance_score', { ascending: false, nullsFirst: false });
 
     if (poolRows?.length) {
       const pools = poolRows.map((p) => ({
@@ -40,6 +39,7 @@ export const GET = withRouteHandler(async () => {
         claimedBy: p.claimed_by ?? null,
         governanceStatement: p.governance_statement ?? null,
         poolStatus: p.pool_status ?? 'registered',
+        scoreMomentum: p.score_momentum ?? null,
       }));
       return { pools };
     }

--- a/components/civica/cards/CivicaSPOCard.tsx
+++ b/components/civica/cards/CivicaSPOCard.tsx
@@ -1,17 +1,19 @@
 'use client';
 
 import Link from 'next/link';
-import { ShieldCheck, ChevronRight, AlertTriangle, Archive } from 'lucide-react';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  ChevronRight,
+  AlertTriangle,
+  Archive,
+  Users,
+  Coins,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { computeTier } from '@/lib/scoring/tiers';
-import {
-  TIER_SCORE_COLOR,
-  TIER_BORDER,
-  TIER_BG,
-  TIER_GLOW,
-  TIER_LEFT_ACCENT,
-  tierKey,
-} from './tierStyles';
+import { TIER_SCORE_COLOR, TIER_BORDER, TIER_BG, TIER_GLOW, tierKey } from './tierStyles';
 import { TierBadge } from './TierBadge';
 import { ScoreExplainer } from '@/components/ui/ScoreExplainer';
 
@@ -32,6 +34,7 @@ export interface CivicaSPOData {
   claimedBy?: string | null;
   governanceStatement?: string | null;
   poolStatus?: string | null;
+  scoreMomentum?: number | null;
 }
 
 function formatAda(ada: number): string {
@@ -39,6 +42,21 @@ function formatAda(ada: number): string {
   if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
   if (ada >= 1_000) return `${Math.round(ada / 1_000)}K`;
   return String(ada);
+}
+
+/** Returns the top 1-2 governance strengths (scores >= 60) as citizen-friendly labels. */
+export function getPoolStrengths(pool: CivicaSPOData): string[] {
+  const pillars: [string, number][] = [
+    ['Active voter', pool.participationPct ?? 0],
+    ['Thoughtful', pool.deliberationPct ?? 0],
+    ['Reliable', pool.reliabilityPct ?? 0],
+    ['Clear identity', pool.governanceIdentityPct ?? 0],
+  ];
+  return pillars
+    .filter(([, v]) => v >= 60)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([label]) => label);
 }
 
 interface CivicaSPOCardProps {
@@ -49,171 +67,161 @@ interface CivicaSPOCardProps {
 export function CivicaSPOCard({ pool, rank }: CivicaSPOCardProps) {
   const score = pool.governanceScore ?? 0;
   const tier = tierKey(computeTier(score));
-  const isClaimed = !!pool.claimedBy;
   const isProvisional = pool.confidence != null && pool.confidence < 60;
   const isRetired = pool.poolStatus === 'retired';
   const isRetiring = pool.poolStatus === 'retiring';
+  const momentum = pool.scoreMomentum ?? null;
+  const strengths = getPoolStrengths(pool);
 
-  const pillars: { label: string; value: number | null | undefined; weight: string }[] = [
-    { label: 'Participation', value: pool.participationPct, weight: '35%' },
-    { label: 'Deliberation', value: pool.deliberationPct, weight: '25%' },
-    { label: 'Reliability', value: pool.reliabilityPct, weight: '25%' },
-    { label: 'Identity', value: pool.governanceIdentityPct, weight: '15%' },
-  ];
+  const displayName = pool.ticker
+    ? pool.ticker
+    : pool.poolName || `${pool.poolId.slice(0, 16)}\u2026`;
+
+  const subtitle =
+    pool.ticker && pool.poolName && pool.poolName !== pool.ticker ? pool.poolName : null;
 
   const statementPreview = pool.governanceStatement
-    ? pool.governanceStatement.length > 80
-      ? `${pool.governanceStatement.slice(0, 80)}…`
+    ? pool.governanceStatement.length > 100
+      ? `${pool.governanceStatement.slice(0, 100)}\u2026`
       : pool.governanceStatement
     : null;
 
   return (
     <Link
       href={`/pool/${pool.poolId}`}
-      aria-label={`${pool.ticker || pool.poolName || pool.poolId.slice(0, 16)}, governance score ${score}, ${tier} tier`}
+      aria-label={`${displayName}, governance score ${score}, ${tier} tier`}
       className={cn(
-        'group relative flex flex-col rounded-xl border p-4 transition-all duration-200 backdrop-blur-md',
+        'group relative flex flex-col rounded-xl border overflow-hidden transition-all duration-200 backdrop-blur-md',
         'hover:shadow-lg hover:-translate-y-0.5',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
         TIER_BG[tier],
         TIER_BORDER[tier],
         TIER_GLOW[tier],
-        TIER_LEFT_ACCENT[tier],
       )}
     >
-      {/* ── Header ──────────────────────────────────────────── */}
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="min-w-0 flex-1">
-          {rank && (
-            <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums mb-0.5 block">
-              #{rank}
-            </span>
-          )}
-          <h3 className="font-semibold text-sm text-foreground truncate leading-tight">
-            {pool.ticker ? (
-              <>
-                <span className="font-bold">{pool.ticker}</span>
-                {pool.poolName && pool.poolName !== pool.ticker && (
-                  <span className="text-muted-foreground font-normal ml-1 text-xs">
-                    {pool.poolName}
-                  </span>
-                )}
-              </>
-            ) : (
-              pool.poolName || pool.poolId.slice(0, 16)
+      {/* ── Tier accent bar ──────────────────────────────────────── */}
+      <div
+        className={cn(
+          'h-[2px]',
+          tier === 'Emerging' && 'bg-border',
+          tier === 'Bronze' && 'bg-gradient-to-r from-amber-500/60 to-amber-500/10',
+          tier === 'Silver' && 'bg-gradient-to-r from-slate-400/60 to-slate-400/10',
+          tier === 'Gold' && 'bg-gradient-to-r from-yellow-500/70 to-yellow-500/10',
+          tier === 'Diamond' && 'bg-gradient-to-r from-cyan-500/70 to-cyan-500/10',
+          tier === 'Legendary' && 'bg-gradient-to-r from-violet-500/70 to-violet-500/10',
+        )}
+      />
+
+      {/* ── Card body ────────────────────────────────────────────── */}
+      <div className="flex flex-col p-4 flex-1">
+        {/* Header: name + score */}
+        <div className="flex items-start justify-between gap-2 mb-2">
+          <div className="min-w-0 flex-1">
+            {rank != null && (
+              <span className="text-[10px] text-muted-foreground/50 font-medium tabular-nums">
+                #{rank}
+              </span>
             )}
-          </h3>
-          <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+            <h3 className="font-semibold text-[15px] text-foreground truncate leading-tight group-hover:text-primary/90 transition-colors">
+              {displayName}
+            </h3>
+            {subtitle && (
+              <p className="text-xs text-muted-foreground truncate mt-0.5">{subtitle}</p>
+            )}
+          </div>
+          <div className="text-right shrink-0">
+            <div className="flex items-start gap-0.5 justify-end">
+              <ScoreExplainer type="spo" className="mt-1" />
+              <div
+                className={cn(
+                  'font-display text-2xl font-bold tabular-nums leading-none',
+                  TIER_SCORE_COLOR[tier],
+                )}
+              >
+                {score}
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-1 mt-1">
+              <TierBadge tier={tier} />
+              {isProvisional && <AlertTriangle className="h-2.5 w-2.5 text-amber-500" />}
+            </div>
+          </div>
+        </div>
+
+        {/* Status badges */}
+        {(isRetired || isRetiring) && (
+          <div className="flex items-center gap-1.5 mb-2">
             {isRetired && (
-              <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground font-medium">
+              <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground font-medium bg-muted/50 px-1.5 py-0.5 rounded-full">
                 <Archive className="h-3 w-3" /> Retired
               </span>
             )}
             {isRetiring && (
-              <span className="flex items-center gap-0.5 text-[10px] text-amber-500 font-medium">
+              <span className="flex items-center gap-0.5 text-[10px] text-amber-500 font-medium bg-amber-500/10 px-1.5 py-0.5 rounded-full">
                 <AlertTriangle className="h-3 w-3" /> Retiring
               </span>
             )}
-            {isClaimed && (
-              <span className="flex items-center gap-0.5 text-[10px] text-primary font-medium">
-                <ShieldCheck className="h-3 w-3" /> Claimed
-              </span>
-            )}
-            {pool.delegatorCount > 0 && (
-              <span className="text-[10px] text-muted-foreground">
-                {isClaimed ? '· ' : ''}
-                {pool.delegatorCount.toLocaleString()} delegators
-              </span>
-            )}
-            {pool.liveStakeAda > 0 && (
-              <span className="text-[10px] text-muted-foreground">
-                · ₳{formatAda(pool.liveStakeAda)}
-              </span>
-            )}
           </div>
-        </div>
+        )}
 
-        {/* Score + tier */}
-        <div className="text-right shrink-0">
-          <div className="flex items-start gap-0.5 justify-end">
-            <ScoreExplainer type="spo" className="mt-1" />
-            <div
-              className={cn(
-                'font-display text-3xl font-bold tabular-nums leading-none',
-                TIER_SCORE_COLOR[tier],
-              )}
-            >
-              {score}
-            </div>
-          </div>
-          <div className="flex items-center justify-end gap-1 mt-1">
-            <TierBadge tier={tier} />
-            {isProvisional && (
-              <span className="inline-flex items-center gap-0.5 text-[9px] text-amber-500 font-medium">
-                <AlertTriangle className="h-2.5 w-2.5" />
+        {/* Strength labels */}
+        {strengths.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap mb-2">
+            {strengths.map((label) => (
+              <span
+                key={label}
+                className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full"
+              >
+                {label}
               </span>
-            )}
+            ))}
           </div>
-        </div>
-      </div>
+        )}
 
-      {/* ── Governance statement preview ────────────────────── */}
-      {statementPreview && (
-        <p className="text-[10px] text-muted-foreground/80 italic leading-relaxed mb-2 line-clamp-2">
-          &ldquo;{statementPreview}&rdquo;
-        </p>
-      )}
+        {/* Governance statement preview */}
+        {statementPreview && (
+          <p className="text-[11px] text-muted-foreground/80 italic leading-relaxed mb-2 line-clamp-2">
+            &ldquo;{statementPreview}&rdquo;
+          </p>
+        )}
 
-      {/* ── 4-Pillar bars ──────────────────────────────────────── */}
-      {pillars.some((p) => p.value != null) && (
-        <div className="space-y-1.5 mb-2">
-          {pillars.map(({ label, value, weight }) => {
-            if (value == null) return null;
-            const pct = Math.round(value);
-            return (
-              <div key={label} className="space-y-0.5">
-                <div className="flex justify-between text-[10px] text-muted-foreground/70">
-                  <span>
-                    {label} <span className="opacity-50">({weight})</span>
-                  </span>
-                  <span className="tabular-nums">{pct}%</span>
-                </div>
-                <div
-                  className="h-0.5 rounded-full bg-muted overflow-hidden"
-                  role="progressbar"
-                  aria-valuenow={pct}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-label={`${label}: ${pct}%`}
-                >
-                  <div
-                    className="h-full rounded-full transition-all duration-500"
-                    style={{
-                      width: `${pct}%`,
-                      background: `hsl(var(--primary) / ${0.4 + pct / 250})`,
-                    }}
-                  />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {/* ── Footer ──────────────────────────────────────────── */}
-      <div className="mt-auto pt-2 flex items-center justify-between">
-        <span className="text-[10px] text-muted-foreground/70 tabular-nums">
-          {pool.voteCount} governance votes
-          {isProvisional && <span className="text-amber-500/80 ml-1">· Provisional</span>}
-        </span>
-        <span
-          className={cn(
-            'flex items-center gap-0.5 text-xs font-medium transition-colors',
-            'text-muted-foreground group-hover:text-primary',
+        {/* Key metrics row */}
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-2 flex-wrap">
+          <span className="tabular-nums font-medium">
+            {pool.voteCount} vote{pool.voteCount !== 1 ? 's' : ''}
+          </span>
+          {pool.participationPct != null && (
+            <span className="tabular-nums">{Math.round(pool.participationPct)}% participation</span>
           )}
-        >
-          View <ChevronRight className="h-3.5 w-3.5" />
-        </span>
+          {pool.delegatorCount > 0 && (
+            <span className="flex items-center gap-0.5 tabular-nums">
+              <Users className="h-3 w-3" />
+              {pool.delegatorCount.toLocaleString()}
+            </span>
+          )}
+          {pool.liveStakeAda > 0 && (
+            <span className="flex items-center gap-0.5 tabular-nums">
+              <Coins className="h-3 w-3" />₳{formatAda(pool.liveStakeAda)}
+            </span>
+          )}
+        </div>
+
+        {/* Footer: momentum + CTA */}
+        <div className="mt-auto flex items-center justify-between pt-2 border-t border-border/30">
+          <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+            <span className="flex items-center gap-0.5">
+              {momentum !== null && momentum > 0.5 ? (
+                <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
+              ) : momentum !== null && momentum < -0.5 ? (
+                <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
+              ) : (
+                <Minus className="h-3 w-3 text-muted-foreground/40" aria-hidden="true" />
+              )}
+            </span>
+            {isProvisional && <span className="text-amber-500/80">Provisional</span>}
+          </div>
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 group-hover:text-primary group-hover:translate-x-0.5 transition-all" />
+        </div>
       </div>
     </Link>
   );

--- a/components/civica/discover/CivicaSPOBrowse.tsx
+++ b/components/civica/discover/CivicaSPOBrowse.tsx
@@ -1,15 +1,95 @@
 'use client';
 
-import { useState, useMemo, useRef, useCallback } from 'react';
+import { useState, useMemo, useRef, useCallback, useDeferredValue } from 'react';
+import Link from 'next/link';
+import {
+  LayoutGrid,
+  TableProperties,
+  ChevronRight,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Users,
+  Coins,
+  Search as SearchIcon,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { CivicaSPOCard, type CivicaSPOData } from '@/components/civica/cards/CivicaSPOCard';
+import { cn } from '@/lib/utils';
+import {
+  CivicaSPOCard,
+  getPoolStrengths,
+  type CivicaSPOData,
+} from '@/components/civica/cards/CivicaSPOCard';
 import { computeTier } from '@/lib/scoring/tiers';
+import { TIER_SCORE_COLOR, TIER_LEFT_ACCENT, tierKey } from '@/components/civica/cards/tierStyles';
+import { TierBadge } from '@/components/civica/cards/TierBadge';
 import { useQuery } from '@tanstack/react-query';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
 
-const TIER_CHIPS = ['All', 'Emerging', 'Bronze', 'Silver', 'Gold', 'Diamond', 'Legendary'];
-const PAGE_SIZE = 24;
+/* ── Constants ──────────────────────────────────────────────────── */
+
+const TIER_CHIPS: { value: string; label: string; tooltip?: string }[] = [
+  { value: 'All', label: 'All' },
+  {
+    value: 'Emerging',
+    label: 'Emerging',
+    tooltip: 'Score 0-39. Pools beginning their governance journey.',
+  },
+  {
+    value: 'Bronze',
+    label: 'Bronze',
+    tooltip: 'Score 40-54. Pools with initial governance activity.',
+  },
+  {
+    value: 'Silver',
+    label: 'Silver',
+    tooltip: 'Score 55-69. Pools with consistent governance participation.',
+  },
+  {
+    value: 'Gold',
+    label: 'Gold',
+    tooltip: 'Score 70-84. Active pools with strong voting records.',
+  },
+  { value: 'Diamond', label: 'Diamond', tooltip: 'Score 85-94. Top-tier governance engagement.' },
+  { value: 'Legendary', label: 'Legendary', tooltip: 'Score 95-100. Elite governance leaders.' },
+];
+
+const STATUS_CHIPS: { value: string; label: string }[] = [
+  { value: 'all', label: 'Any status' },
+  { value: 'registered', label: 'Active' },
+  { value: 'retiring', label: 'Retiring' },
+  { value: 'retired', label: 'Retired' },
+];
+
+type ViewMode = 'cards' | 'table';
+const VIEW_MODE_KEY = 'civica_spo_view';
+const CARD_PAGE_SIZE = 24;
+const TABLE_PAGE_SIZE = 50;
+
+function getInitialViewMode(): ViewMode {
+  if (typeof window === 'undefined') return 'cards';
+  try {
+    const stored = localStorage.getItem(VIEW_MODE_KEY);
+    if (stored === 'table' || stored === 'cards') return stored;
+  } catch {}
+  return 'cards';
+}
+
+interface FilterState {
+  search: string;
+  tier: string;
+  status: string;
+}
+
+const DEFAULT_FILTERS: FilterState = {
+  search: '',
+  tier: 'All',
+  status: 'all',
+};
+
+/* ── Data hook ──────────────────────────────────────────────────── */
 
 function usePools() {
   return useQuery({
@@ -22,42 +102,160 @@ function usePools() {
   });
 }
 
+/* ── Table row component ────────────────────────────────────────── */
+
+function formatAda(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${Math.round(ada / 1_000)}K`;
+  return String(ada);
+}
+
+function SPOTableRow({ pool, rank }: { pool: CivicaSPOData; rank: number }) {
+  const score = pool.governanceScore ?? 0;
+  const tier = tierKey(computeTier(score));
+  const momentum = pool.scoreMomentum ?? null;
+  const strengths = getPoolStrengths(pool);
+
+  const displayName = pool.ticker
+    ? pool.ticker
+    : pool.poolName || `${pool.poolId.slice(0, 16)}\u2026`;
+
+  const subtitle =
+    pool.ticker && pool.poolName && pool.poolName !== pool.ticker ? pool.poolName : null;
+
+  return (
+    <Link
+      href={`/pool/${pool.poolId}`}
+      className={cn(
+        'group flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-all duration-200',
+        TIER_LEFT_ACCENT[tier],
+      )}
+    >
+      {/* Rank */}
+      <span className="text-[10px] text-muted-foreground/60 font-medium tabular-nums w-6 text-right shrink-0">
+        #{rank}
+      </span>
+
+      {/* Score pill */}
+      <div className="shrink-0 flex flex-col items-center w-10">
+        <span className={cn('text-lg font-bold tabular-nums leading-none', TIER_SCORE_COLOR[tier])}>
+          {score}
+        </span>
+        <span
+          className={cn(
+            'text-[8px] font-semibold uppercase tracking-wider mt-0.5',
+            TIER_SCORE_COLOR[tier],
+          )}
+        >
+          {tier === 'Emerging' ? 'NEW' : tier.slice(0, 3).toUpperCase()}
+        </span>
+      </div>
+
+      {/* Name + stats */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-sm text-foreground truncate">{displayName}</span>
+          {subtitle && (
+            <span className="hidden md:inline text-xs text-muted-foreground truncate max-w-[180px]">
+              {subtitle}
+            </span>
+          )}
+          {strengths.length > 0 && (
+            <div className="hidden sm:flex items-center gap-1">
+              {strengths.map((label) => (
+                <span
+                  key={label}
+                  className="text-[9px] font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-1.5 py-0.5 rounded-full shrink-0"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
+          <span className="tabular-nums">
+            {pool.voteCount} vote{pool.voteCount !== 1 ? 's' : ''}
+          </span>
+          {pool.participationPct != null && (
+            <span className="tabular-nums">
+              \u00b7 {Math.round(pool.participationPct)}% participation
+            </span>
+          )}
+          {pool.delegatorCount > 0 && (
+            <span className="hidden sm:inline tabular-nums">
+              \u00b7 {pool.delegatorCount.toLocaleString()} delegators
+            </span>
+          )}
+          {pool.liveStakeAda > 0 && (
+            <span className="hidden sm:inline tabular-nums">
+              \u00b7 \u20b3{formatAda(pool.liveStakeAda)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Momentum */}
+      <span className="shrink-0">
+        {momentum !== null && momentum > 0.5 ? (
+          <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
+        ) : momentum !== null && momentum < -0.5 ? (
+          <TrendingDown className="h-3.5 w-3.5 text-rose-400" />
+        ) : (
+          <Minus className="h-3 w-3 text-muted-foreground/40" />
+        )}
+      </span>
+
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0 group-hover:text-primary group-hover:translate-x-0.5 transition-all" />
+    </Link>
+  );
+}
+
+/* ── Main browse component ──────────────────────────────────────── */
+
 export function CivicaSPOBrowse() {
   const contentRef = useRef<HTMLDivElement>(null);
   const { data: rawPools, isLoading } = usePools();
   const pools: CivicaSPOData[] = useMemo(() => (rawPools as CivicaSPOData[]) ?? [], [rawPools]);
 
-  const [search, setSearch] = useState('');
-  const [tier, setTier] = useState('All');
-  const [claimedOnly, setClaimedOnly] = useState(false);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [page, setPage] = useState(0);
+  const [viewMode, setViewMode] = useState<ViewMode>(getInitialViewMode);
+  const deferredSearch = useDeferredValue(filters.search);
+  const pageSize = viewMode === 'table' ? TABLE_PAGE_SIZE : CARD_PAGE_SIZE;
+
+  const toggleViewMode = (mode: ViewMode) => {
+    setViewMode(mode);
+    setPage(0);
+    try {
+      localStorage.setItem(VIEW_MODE_KEY, mode);
+    } catch {}
+  };
 
   const handlePageChange = useCallback((newPage: number) => {
     setPage(newPage);
     contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
 
-  const isDefault = search === '' && tier === 'All' && !claimedOnly;
+  const isDefaultFilters =
+    filters.search === '' && filters.tier === 'All' && filters.status === 'all';
 
-  const resetFilters = () => {
-    setSearch('');
-    setTier('All');
-    setClaimedOnly(false);
+  const setFilter = <K extends keyof FilterState>(key: K, value: FilterState[K]) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
     setPage(0);
   };
 
-  const setFilter =
-    <T,>(setter: (v: T) => void) =>
-    (v: T) => {
-      setter(v);
-      setPage(0);
-    };
+  const resetFilters = () => {
+    setFilters(DEFAULT_FILTERS);
+    setPage(0);
+  };
 
   const filtered = useMemo(() => {
     let result = pools;
 
-    if (search.trim()) {
-      const q = search.toLowerCase();
+    if (deferredSearch.trim()) {
+      const q = deferredSearch.toLowerCase();
       result = result.filter(
         (p) =>
           p.ticker?.toLowerCase().includes(q) ||
@@ -66,26 +264,33 @@ export function CivicaSPOBrowse() {
       );
     }
 
-    if (tier !== 'All') {
-      result = result.filter((p) => computeTier(p.governanceScore ?? 0) === tier);
+    if (filters.tier !== 'All') {
+      result = result.filter((p) => computeTier(p.governanceScore ?? 0) === filters.tier);
     }
 
-    if (claimedOnly) {
-      result = result.filter((p) => !!p.claimedBy);
+    if (filters.status !== 'all') {
+      result = result.filter((p) => (p.poolStatus ?? 'registered') === filters.status);
     }
 
     return result;
-  }, [pools, search, tier, claimedOnly]);
+  }, [pools, deferredSearch, filters]);
 
-  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
-  const pageItems = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const pageItems = filtered.slice(page * pageSize, (page + 1) * pageSize);
+
+  // Determine if search hit the "governance-active only" boundary
+  const searchHasResults = !deferredSearch.trim() || filtered.length > 0;
 
   if (isLoading) {
     return (
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 pt-4">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <Skeleton key={i} className="h-44 rounded-xl" />
-        ))}
+      <div className="space-y-4 pt-4">
+        <Skeleton className="h-8 w-48 rounded-lg" />
+        <Skeleton className="h-4 w-64 rounded" />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 pt-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 rounded-xl" />
+          ))}
+        </div>
       </div>
     );
   }
@@ -102,48 +307,129 @@ export function CivicaSPOBrowse() {
   }
 
   return (
-    <div ref={contentRef} className="space-y-4 pt-4">
+    <div ref={contentRef} className="space-y-3">
+      {/* ── Page header ──────────────────────────────────────────── */}
+      <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 pt-2 pb-3">
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="text-xl font-bold tracking-tight">Stake Pool Governance</h1>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {pools.length > 0 ? `${pools.length} governance-active pools` : ''}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+          How are stake pools participating in Cardano governance? Find pools that vote actively and
+          align with your values.
+        </p>
+      </div>
+
       {/* ── Sticky filter bar ────────────────────────────────────── */}
       <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
         <DiscoverFilterBar
-          search={search}
-          onSearchChange={setFilter(setSearch)}
-          searchPlaceholder="Search ticker, pool name, or ID…"
+          search={filters.search}
+          onSearchChange={(v) => setFilter('search', v)}
+          searchPlaceholder="Search ticker, pool name, or ID\u2026"
           chipGroups={[
             {
               label: 'Tier',
-              value: tier,
-              options: TIER_CHIPS.map((t) => ({ value: t, label: t })),
-              onChange: setFilter(setTier),
+              value: filters.tier,
+              options: TIER_CHIPS,
+              onChange: (v) => setFilter('tier', v),
             },
-          ]}
-          toggles={[
-            { label: 'Claimed only', checked: claimedOnly, onChange: setFilter(setClaimedOnly) },
+            {
+              label: 'Status',
+              value: filters.status,
+              options: STATUS_CHIPS,
+              onChange: (v) => setFilter('status', v),
+            },
           ]}
           resultCount={filtered.length}
           totalCount={pools.length}
           entityLabel="pools"
-          isFiltered={!isDefault}
+          isFiltered={!isDefaultFilters}
           onReset={resetFilters}
           pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
         />
+
+        {/* View toggle toolbar */}
+        <div className="flex items-center justify-end mt-2 pt-2 border-t border-border/20">
+          <div className="hidden sm:flex items-center gap-0.5">
+            <button
+              onClick={() => toggleViewMode('cards')}
+              className={cn(
+                'p-1.5 rounded transition-colors',
+                viewMode === 'cards'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Card view"
+            >
+              <LayoutGrid className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => toggleViewMode('table')}
+              className={cn(
+                'p-1.5 rounded transition-colors',
+                viewMode === 'table'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              title="Table view"
+            >
+              <TableProperties className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* Card grid */}
+      {/* ── Content ──────────────────────────────────────────────── */}
       {pageItems.length === 0 ? (
-        <div className="py-16 text-center text-muted-foreground text-sm">
-          No pools match your filters.
+        <div className="py-16 text-center space-y-3">
+          {!searchHasResults ? (
+            <>
+              <div className="flex justify-center mb-2">
+                <SearchIcon className="h-8 w-8 text-muted-foreground/30" />
+              </div>
+              <p className="text-muted-foreground text-sm">
+                No pool found matching &ldquo;{deferredSearch}&rdquo;
+              </p>
+              <p className="text-xs text-muted-foreground/70 max-w-md mx-auto">
+                Only pools that have voted on governance actions are shown here. If you&apos;re
+                looking for a specific pool, they may not have participated in governance yet.
+              </p>
+            </>
+          ) : (
+            <p className="text-muted-foreground text-sm">No pools match your filters.</p>
+          )}
+          {!isDefaultFilters && (
+            <Button variant="ghost" size="sm" onClick={resetFilters}>
+              Clear filters
+            </Button>
+          )}
         </div>
-      ) : (
+      ) : viewMode === 'cards' ? (
         <div key={page} className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {pageItems.map((pool, i: number) => (
+          {pageItems.map((pool, i) => (
             <div
               key={pool.poolId}
               className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
               style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
             >
-              <CivicaSPOCard pool={pool} rank={page * PAGE_SIZE + i + 1} />
+              <CivicaSPOCard pool={pool} rank={page * pageSize + i + 1} />
             </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border/50 divide-y divide-border/50 overflow-hidden bg-card/40 backdrop-blur-md">
+          {/* Table header */}
+          <div className="flex items-center gap-3 px-4 py-2 bg-muted/20 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+            <span className="w-6 text-right shrink-0">#</span>
+            <span className="w-10 text-center shrink-0">Score</span>
+            <span className="flex-1">Pool</span>
+            <span className="w-5 shrink-0" />
+            <span className="w-3.5 shrink-0" />
+          </div>
+          {pageItems.map((pool, i) => (
+            <SPOTableRow key={pool.poolId} pool={pool} rank={page * pageSize + i + 1} />
           ))}
         </div>
       )}

--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -553,8 +553,8 @@ export const syncSpoScores = inngest.createFunction(
       }
     });
 
-    if ('skipped' in computeResult && computeResult.skipped) return computeResult;
-
+    // Always run metadata + enrichment steps even if scoring was skipped —
+    // pools may still be missing tickers, names, delegator counts, etc.
     await step.run('fetch-koios-metadata', async () => {
       const supabase = getSupabaseAdmin();
       // Fetch ALL pools that are missing metadata (ticker IS NULL)


### PR DESCRIPTION
## Summary
- **Card redesign**: Replace pillar progress bars with strength labels, momentum indicator, governance statement preview, and tier-aware styling matching the DRep card pattern
- **Table view**: Add SPOTableRow component with card/table toggle (localStorage persistence), matching the DRep browse pattern
- **Better filters**: Replace "Claimed only" toggle with status filter (Active/Retiring/Retired), add tier tooltips with score ranges
- **Remove 200-pool limit**: Return all governance-active pools (~519) with score_momentum field
- **Sync fix**: Remove early return in sync-spo-scores that prevented Koios metadata fetch from running, ensuring tickers, pool names, delegator counts, and stake data are populated
- **Empty states**: Explain that only governance-active pools are shown when search returns no results

## Impact
- **What changed**: Complete UX overhaul of /governance/pools — cards tell a story about each pool, table view added, filters improved, all pools shown with real names
- **User-facing**: Yes — pool cards now show strengths, momentum, governance statements, and proper pool names instead of raw IDs. Users can switch between card and table views.
- **Risk**: Low — UI-only changes + sync fix that only adds metadata fetching that was already coded but skipped
- **Scope**: 4 files (CivicaSPOCard.tsx, CivicaSPOBrowse.tsx, pools/route.ts, sync-spo-scores.ts)

## Test plan
- [x] Preflight passes (format + lint + types + 591 tests)
- [ ] Verify /governance/pools shows pool names/tickers instead of raw IDs
- [ ] Verify card/table toggle works and persists across page reloads
- [ ] Verify tier, search, and status filters work correctly
- [ ] Verify empty state messaging when search has no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)