### PR TITLE
feat: CC transparency scoring fix + health verdict foundation

### DIFF
--- a/.claude/checkpoints/committee-redesign-plan.md
+++ b/.claude/checkpoints/committee-redesign-plan.md
@@ -1,0 +1,833 @@
+# Committee Page World-Class Redesign — Work Plan
+
+**Date:** 2026-03-11
+**Scope:** Full MLE redesign of the Constitutional Committee feature surface
+**Routes:** `/governance/committee`, `/discover/committee`, `/committee/[ccHotId]`
+**Source:** MLE critique session — all findings, not just top 5
+
+---
+
+## Architecture Overview
+
+The current committee feature is split across 3 disconnected views with no narrative intelligence, no information budget, and no persona adaptation. This plan consolidates everything into a cohesive, story-driven accountability surface.
+
+### Target State
+
+```
+/governance/committee          → Unified CC Accountability Page (replaces both current views)
+/governance/committee/[ccHotId] → Individual CC Member Profile (relocated, redesigned)
+/discover/committee            → Redirect to /governance/committee
+/committee/[ccHotId]           → Redirect to /governance/committee/[ccHotId]
+/committee                     → Redirect to /governance/committee (already exists)
+```
+
+### Parallel Execution Map
+
+```
+Wave 0 (Scoring fix — DONE):
+  └─ Chunk 0: Redistribute Pillar 5 weight ✅
+
+Wave 1 (Foundation — no dependencies):
+  ┌─ Chunk 1: Data layer + API enrichment
+  ├─ Chunk 2: CC Health Verdict component (new)
+  └─ Chunk 3: CC Narrative Intelligence helpers (new)
+
+Wave 2 (depends on Wave 1):
+  ┌─ Chunk 4: Unified /governance/committee page
+  ├─ Chunk 5: Redesigned member profile page
+  └─ Chunk 6: Route consolidation + redirects
+
+Wave 3 (depends on Wave 2):
+  ┌─ Chunk 7: Mobile card layout + responsive polish
+  ├─ Chunk 8: Persona-gated content adaptation
+  └─ Chunk 9: Craft & delight pass
+
+Wave 4 (independent polish):
+  └─ Chunk 10: UX constraints doc + cleanup
+```
+
+---
+
+## Chunk 0: Scoring Recalibration (COMPLETED)
+
+**Priority:** P0 (scores are wrong without this)
+**Effort:** S (< 1 hour)
+**Status:** DONE
+
+### What was done
+
+**Redistributed Pillar 5 (Community Engagement) weight.** The pillar's data sources (`questionsAnswered`, `endorsementCount`) are hardcoded to 0 in the sync pipeline, meaning every CC member's transparency score was artificially deflated by up to 10 points. Redistributed the 10% weight proportionally across the 4 active pillars:
+
+- Participation: 0.35 → 0.39
+- Rationale Quality: 0.30 → 0.33
+- Responsiveness: 0.15 → 0.17
+- Independence: 0.10 → 0.11
+- Community Engagement: 0.10 → 0 (preserved in interface for future use)
+
+**File modified:** `lib/scoring/ccTransparency.ts`
+
+### Deferred from original Chunk 0 scope
+
+1. **CIP-119 CC metadata sync** — Koios lacks a dedicated CC metadata endpoint (unlike `/drep_metadata` for DReps). CC identity data comes from CIP-136 rationale `author_name` fields, which is already captured. Deferred until Koios adds CC metadata support.
+
+2. **Dual-role detection** — CC hot credentials and DRep/SPO IDs use incompatible formats (raw credential vs bech32-encoded). Cross-matching requires credential hash normalization. Deferred to Phase 2.
+
+### Impact
+
+Next sync run (every 6h) will recompute all CC member scores with corrected weights. Historical snapshots retain old weights — the trend chart may show a one-time calibration jump. This is acceptable and honest.
+
+---
+
+## Chunk 1: Data Layer & API Enrichment
+
+**Priority:** P0 (critical path — blocks Chunks 4, 5)
+**Effort:** M (1-3 hours)
+**Audit dimension(s):** M2 (Narrative Intelligence), M3 (Info Architecture)
+**Expected score impact:** Enables M2: 3→7, M3: 4→7
+**Depends on:** None
+**PR group:** A
+
+### Context
+
+The current data layer returns raw metrics without computed insights. The API route (`/api/governance/committee/route.ts`) returns vote counts and grades but no interpreted intelligence. The `getCCMembersTransparency()` function returns pillar scores but no comparative context (rank, percentile, trend direction). Individual member profiles make 6+ Supabase calls with no narrative metadata.
+
+For the redesigned pages to show "conclusions first," the data layer must provide pre-computed narratives and health signals.
+
+### Scope
+
+**Modify `lib/data.ts`:**
+
+- Add `getCCHealthSummary()` function that returns:
+  - Overall CC health verdict: `healthy | attention | critical` based on avg transparency + participation trends
+  - One-line narrative summary (e.g., "All 7 members actively voting. Average transparency is strong at 73/100.")
+  - Key tension count (proposals where CC diverged from DRep majority)
+  - Trend direction: `improving | stable | declining` (compare current vs previous epoch snapshot)
+  - Active member count, total members, avg transparency
+- Add `getCCMemberVerdict(ccHotId)` function that returns:
+  - Peer rank and percentile
+  - One-line narrative verdict (e.g., "Above average. Strong participation but declining rationale quality.")
+  - Strongest pillar and weakest pillar (name + score)
+  - Trend direction from transparency snapshots
+  - Whether they've voted on the most recent eligible proposals
+
+**Modify `app/api/governance/committee/route.ts`:**
+
+- Add `health` field to API response with the CC health summary
+- Add `narrativeVerdict` field per member (one-line interpreted string)
+- Add `rank` field per member
+- Keep existing fields for backwards compatibility
+
+**Create `lib/cc/narratives.ts`:**
+
+- `generateCCHealthNarrative(members, tensions)` → string
+- `generateMemberVerdict(member, allMembers)` → string
+- `interpretMetric(name, value, context)` → string (e.g., "84% unanimous — healthy consensus with room for independent judgment")
+- These are deterministic template functions, not AI-generated
+
+### Decision Points
+
+None — execute directly. These are additive data functions that don't change existing behavior.
+
+### Verification
+
+- `getCCHealthSummary()` returns a valid verdict, narrative, and trend for current production data
+- `getCCMemberVerdict()` returns rank, narrative, strongest/weakest pillar for each member
+- API response includes new fields without breaking `useCommitteeMembers()` hook
+- Run `npm run preflight` — all existing tests pass
+
+### Files to Read First
+
+- `lib/data.ts` (lines 995-1088 — CC functions)
+- `app/api/governance/committee/route.ts`
+- `hooks/queries.ts` (lines 11-29 — CommitteeMemberQuickView type)
+- `app/discover/committee/page.tsx` (lines 56-189 — tension calculation logic to extract)
+
+---
+
+## Chunk 2: CC Health Verdict Component
+
+**Priority:** P0 (dominant element for the redesigned page)
+**Effort:** M (1-3 hours)
+**Audit dimension(s):** M1 (JTBD Clarity), M2 (Narrative Intelligence), M4 (Emotional Design)
+**Expected score impact:** M1: 4→8, M2: 3→8, M4: 3→7
+**Depends on:** None (can use mock data, will wire to Chunk 1 in Chunk 4)
+**PR group:** B
+
+### Context
+
+The current page has no dominant element — it's a flat list. The 5-second test fails because there's no headline insight. Per UX constraints, every page needs "1 dominant element" that answers the core JTBD.
+
+The CC Health Verdict is the dominant element for `/governance/committee`. It answers the citizen's JTBD ("Are my constitutional guardians trustworthy?") in one glance.
+
+### Scope
+
+**Create `components/cc/CCHealthVerdict.tsx`:**
+
+- Server component (receives data as props)
+- Visual design:
+  - Health band indicator (like a credit score band — green/amber/red arc or bar)
+  - Large verdict text: "Constitutional Committee: Healthy" (or "Needs Attention" / "Critical")
+  - One-sentence narrative below: "All 7 members are actively voting. Average transparency is strong at 73/100."
+  - Trend arrow: improving/stable/declining with context
+  - Secondary stat: "2 proposals with CC-DRep tension this epoch" (links to tension section below)
+- Must pass the 5-second test: a first-time user instantly understands CC accountability status
+- Color system: emerald for healthy, amber for attention, rose for critical
+- Must look purpose-built for Governada, not like a generic card (per product-vision.md: "Every screenshot must be unmistakably Governada")
+
+**Design benchmark:** Apple Health cardio fitness score — one number, one interpretation, one trend, drill down for details.
+
+### Decision Points
+
+**Visual treatment for the health band:** Options include:
+
+1. Arc/gauge visualization (like a credit score) — most distinctive, medium complexity
+2. Horizontal bar with colored segments — simpler, still effective
+3. Large letter grade with color halo — minimal, could pair with the arc
+
+Recommend option 1 (arc) for distinctiveness but the agent should propose what works best and ask if needed.
+
+### Verification
+
+- Component renders with mock data covering all 3 states (healthy, attention, critical)
+- Passes 5-second test: purpose and status are immediately clear
+- Looks distinctive — not a generic shadcn Card
+- Responsive: works on mobile (320px) through desktop (1440px)
+
+### Files to Read First
+
+- `docs/strategy/context/ux-constraints.md` (page constraint format and rules)
+- `.claude/rules/product-vision.md` (visual identity standards)
+- `components/cc/CCTransparencyTrend.tsx` (existing CC visualization style reference)
+- Any existing "health" or "verdict" components in the codebase for pattern consistency
+
+---
+
+## Chunk 3: Narrative Intelligence Helpers
+
+**Priority:** P1 (enables interpreted metrics across both pages)
+**Effort:** S (< 1 hour)
+**Audit dimension(s):** M2 (Narrative Intelligence)
+**Expected score impact:** M2: 3→8
+**Depends on:** None
+**PR group:** A (ships with Chunk 1 — same data domain)
+
+### Context
+
+Every metric on the current pages is a raw number. "73" means nothing without context. "84% unanimous" could mean consensus or groupthink. Per the UX philosophy: "72 is not intelligence. 'Solid governance, but 3 missed votes' is intelligence."
+
+This chunk creates reusable interpretation functions that translate raw metrics into one-line stories.
+
+### Scope
+
+**Create `lib/cc/interpretations.ts`:**
+
+Functions that take a metric value and return an interpreted string:
+
+- `interpretTransparencyScore(score, rank, total)` → "Strong transparency (73/100) — ranked 2nd of 7 members"
+- `interpretParticipation(votescast, eligible)` → "Voted on 95% of proposals — only missed 2 this epoch"
+- `interpretUnanimousRate(rate, count, total)` → "84% unanimous — healthy consensus, with 3 proposals showing independent judgment"
+- `interpretAlignmentTension(tensions[])` → "The CC diverged from DRep majority on 2 proposals — a sign of independent constitutional review"
+- `interpretRationaleQuality(score, provisionRate)` → "Provides rationales on 89% of votes with strong article citations"
+- `interpretIndependence(score, unanimousRate)` → "Moderate independence — votes with the majority on 94% of proposals"
+- `interpretTrend(current, previous, epochs)` → "Improving — up 5 points over the last 3 epochs"
+- `interpretPillarStrengthWeakness(pillars)` → "Strongest: Participation (95/100). Weakest: Independence (42/100)"
+
+Each function:
+
+- Returns a plain-English string suitable for display below a metric
+- Includes contextual framing (is this good? bad? unusual?)
+- Uses specific numbers, not vague language
+- Is deterministic (no AI calls)
+
+### Decision Points
+
+None — execute directly. These are pure utility functions with no side effects.
+
+### Verification
+
+- Each function returns sensible interpretations for edge cases: score of 0, score of 100, null inputs, single member
+- No function returns just a number — every return value includes interpretive context
+- Run `npm run preflight`
+
+### Files to Read First
+
+- `lib/data.ts` (lines 1033-1088 — CCMemberTransparency type for field names)
+- `app/discover/committee/page.tsx` (lines 130-178 — existing tension/unanimous calculation as reference)
+
+---
+
+## Chunk 4: Unified `/governance/committee` Page
+
+**Priority:** P0 (the core deliverable)
+**Effort:** L (3-8 hours)
+**Audit dimension(s):** M1, M2, M3, M4, M6 (all except M5)
+**Expected score impact:** M1: 4→8, M2: 3→8, M3: 4→8, M4: 3→7, M6: 4→7
+**Depends on:** Chunks 1, 2, 3
+**PR group:** C
+
+### Context
+
+Currently the committee content is split across `/governance/committee` (thin member list) and `/discover/committee` (rich transparency index). This chunk consolidates everything into one strong, story-driven page at `/governance/committee`.
+
+The new page structure follows the information budget strictly:
+
+1. **Dominant element:** CC Health Verdict (from Chunk 2)
+2. **Supporting element 1:** Key Insight Card (tension/independence story)
+3. **Supporting element 2:** Member Accountability Rankings
+4. **Below fold:** Methodology (collapsed)
+
+### Scope
+
+**Rewrite `app/governance/committee/page.tsx`:**
+
+- Server component with `force-dynamic`
+- Parallel data fetching: `getCCHealthSummary()`, `getCCMembersTransparency()`, tension data
+- No longer renders `<CommitteeDiscovery />` — builds the full page inline or with new components
+
+**Page sections (in order):**
+
+**Section 1: CC Health Verdict (above fold — dominant)**
+
+- Render `<CCHealthVerdict>` component (Chunk 2)
+- This IS the 5-second answer: "The CC is healthy / needs attention"
+
+**Section 2: Key Insight Card (above fold — supporting)**
+
+- Create `components/cc/CCInsightCard.tsx`
+- Dynamically selects the most interesting current story:
+  - If alignment tensions exist: "CC Independence: X proposals where the committee exercised independent judgment" with mini-table
+  - If a member's score changed significantly: "Notable change: [Member] transparency score dropped 15 points"
+  - If all members have high scores: "Strong accountability: all members maintaining B grade or above"
+  - Fallback: highest-impact recent CC vote with vote breakdown
+- This card makes users go "oh, that's interesting" — it's the editorial voice
+
+**Section 3: Member Accountability Rankings (below fold — supporting)**
+
+- Server-rendered table (not client-side TanStack Query — we have the data server-side)
+- Each member row shows:
+  - Rank number
+  - Name (human-readable — never bare hex as primary. Truncated hex as secondary subtitle only)
+  - Transparency grade (large colored letter)
+  - One-line narrative verdict from `generateMemberVerdict()` (e.g., "Strong participation, improving rationale quality")
+  - Status badge (authorized/expired)
+  - Link to profile: `/governance/committee/[ccHotId]`
+- Sorted by transparency score descending
+- Search: keep `DiscoverFilterBar` for power users but make it secondary (collapsed or subtle)
+- On mobile: member cards instead of table rows (see Chunk 7)
+
+**Section 4: Methodology (below fold — collapsed)**
+
+- Collapsible "How is this calculated?" section
+- Brief 2-sentence explanation + link to `/methodology` for full details
+- NOT the current 5-column grid taking up full viewport
+
+**Remove from this page:**
+
+- The 4 stat cards (Active Members, Total Votes, Unanimous Rate, Avg Transparency) — these are raw data dumps. The Health Verdict absorbs their purpose with interpretation.
+- The detailed Alignment Tension table — absorbed into the Insight Card (summary) and available in full on individual profiles
+- The full methodology grid — collapsed into a link
+
+### Decision Points
+
+1. **Should the member list use client-side search (current) or server-rendered with optional client search?** Recommendation: Server-render the full list (only ~7-10 members) and add client-side filtering as progressive enhancement. The data is small enough that SSR is better for LCP.
+
+2. **Should the insight card be hand-crafted or use AI narratives?** Recommendation: Deterministic template-based (from Chunk 3). AI narratives can come later as a Phase 2 enhancement.
+
+### Verification
+
+- Page passes the 5-second test: a first-time anonymous user understands "this shows CC accountability" immediately
+- CC Health Verdict is the dominant visual element above the fold
+- Member list shows human-readable names with interpreted verdicts (not raw scores)
+- The 4 stat cards are GONE — their information is absorbed into the verdict
+- Methodology is collapsed, not competing for attention
+- Mobile renders cleanly with stacked layout
+- `npm run preflight` passes
+
+### Files to Read First
+
+- `app/governance/committee/page.tsx` (current thin page to replace)
+- `app/discover/committee/page.tsx` (current rich page — absorb its data logic)
+- `components/CommitteeDiscovery.tsx` (current member list — replace)
+- `docs/strategy/context/ux-constraints.md` (information budget rules)
+- `.claude/rules/product-vision.md` (visual standards)
+
+---
+
+## Chunk 5: Redesigned Member Profile Page
+
+**Priority:** P0 (the depth view for accountability)
+**Effort:** L (3-8 hours)
+**Audit dimension(s):** M1, M2, M3, M4, M5
+**Expected score impact:** M1: 5→8, M2: 3→8, M3: 3→8, M4: 3→7, M5: 5→7
+**Depends on:** Chunks 1, 3
+**PR group:** D
+
+### Context
+
+The current profile at `/committee/[ccHotId]` has 7 sections with equal visual weight, massive information overload, redundant data (alignment in stats grid AND inter-body section), and an unbounded voting record table. It violates "1 dominant + 2-3 supporting" and has zero narrative intelligence.
+
+### Scope
+
+**Rewrite `app/committee/[ccHotId]/page.tsx`** (or move to `app/governance/committee/[ccHotId]/page.tsx` if route changes in Chunk 6):
+
+**New structure with progressive disclosure:**
+
+**Hero (above fold — dominant):**
+
+- Member name (large, human-readable)
+- Transparency score + grade (prominent visual — keep the existing card style but larger)
+- Rank badge: "2nd of 7"
+- One-sentence narrative verdict from `generateMemberVerdict()`: "Above average. Strong participation with improving rationale quality. Independence score is notably low."
+- Status + expiration badges
+- Breadcrumb: Governance > Committee > [Name]
+
+**Key Stats (above fold — supporting, max 3 cards):**
+
+- Participation: "Voted on 42/44 proposals (95%)" with interpretation
+- Rationale Quality: "Provides rationales on 89% of votes" with interpretation
+- Independence: "Votes with CC majority on 94% of proposals" with interpretation
+- Remove DRep Alignment and SPO Alignment from the stats grid — they appear in the Alignment tab
+
+**Tab bar (below fold — progressive disclosure):**
+
+- **Overview tab (default):**
+  - 5-pillar breakdown (keep existing `PillarBar` component — it's good)
+  - Transparency trend chart (keep existing `CCTransparencyTrend` — it's strong)
+
+- **Voting Record tab:**
+  - Paginated table: show 10 votes at a time with "Load more" or pagination
+  - Keep existing columns but add the narrative interpretation per vote where rationale exists
+  - Remove the "Votes by Proposal Type" stacked bars — they're interesting for researchers but occupy prime space. Move to a collapsed section within this tab if needed.
+
+- **Alignment tab:**
+  - Inter-body alignment (DRep + SPO consensus bars — keep existing, they're well-designed)
+  - Alignment tension: proposals where this member diverged from DRep majority (elevated from the index page)
+  - Votes by proposal type breakdown (relocated from overview)
+
+**Remove/relocate:**
+
+- DRep/SPO alignment from stats grid (redundant with Alignment tab)
+- Votes by Proposal Type from main flow (moved to Alignment tab)
+- Unbounded voting record (paginated to 10)
+- Raw hex ID as primary display (name first, hex as subtle secondary)
+
+### Decision Points
+
+1. **Tab implementation:** Use simple client-side tabs (URL hash or state) or Next.js parallel routes? Recommendation: Simple client-side tabs with state — the data is already fetched server-side and can be passed as props. No need for additional server round-trips per tab.
+
+2. **Route location:** Keep at `/committee/[ccHotId]` or move to `/governance/committee/[ccHotId]`? Recommendation: Move to `/governance/committee/[ccHotId]` for URL consistency (the parent is `/governance/committee`). Add redirect from old path in Chunk 6.
+
+### Verification
+
+- Hero answers the JTBD in 5 seconds: "This member is doing [well/poorly] because [reason]"
+- Only 3 stat cards above the fold (not 5)
+- Tabs work for switching between Overview, Voting Record, Alignment
+- Voting record is paginated (10 per page)
+- No redundant information between sections
+- Narrative verdicts appear in hero and stat cards
+- `npm run preflight` passes
+
+### Files to Read First
+
+- `app/committee/[ccHotId]/page.tsx` (current 616-line page to redesign)
+- `components/cc/CCTransparencyTrend.tsx` (keep — just needs to be in Overview tab)
+- `lib/data.ts` (CC data functions)
+- `docs/strategy/context/ux-constraints.md`
+
+---
+
+## Chunk 6: Route Consolidation & Redirects
+
+**Priority:** P1 (eliminates confusion, fixes broken links)
+**Effort:** S (< 1 hour)
+**Audit dimension(s):** M1 (JTBD Clarity), M3 (Info Architecture)
+**Expected score impact:** M3: 4→7 (eliminates fragmented views)
+**Depends on:** Chunks 4, 5 (the new pages must exist before redirecting)
+**PR group:** E
+
+### Context
+
+The current setup has 3 entry points for committee content (`/governance/committee`, `/discover/committee`, `/committee/[id]`) with no clear hierarchy. The `CommitteeDiscovery` component has a self-referential "View full Transparency Index" link at line 140 that points to the page the user is already on. The `/discover/committee` page is the better page but is buried at an obscure URL.
+
+### Scope
+
+**Modify `app/discover/committee/page.tsx`:**
+
+- Replace content with a redirect to `/governance/committee`
+- Use `redirect()` from `next/navigation`
+
+**Modify `app/committee/[ccHotId]/page.tsx`:**
+
+- If member profile moved to `/governance/committee/[ccHotId]`: redirect to new location
+- If kept at `/committee/[ccHotId]`: no change needed
+
+**Add redirect in `next.config.ts`:**
+
+- `/discover/committee` → `/governance/committee` (permanent redirect)
+
+**Update `middleware.ts`:**
+
+- Add redirect rule if not handled by next.config.ts
+
+**Delete unused files:**
+
+- `components/CommitteePageClient.tsx` (confirmed unused — not imported anywhere)
+- `app/discover/committee/loading.tsx` (no longer needed if route redirects)
+
+**Fix self-referential link:**
+
+- Remove or repurpose the "View full Transparency Index →" link in any remaining component
+
+### Decision Points
+
+None — execute directly. Redirects are safe and reversible.
+
+### Verification
+
+- `/discover/committee` redirects to `/governance/committee` (HTTP 308)
+- `/committee/[id]` redirects to `/governance/committee/[id]` (if moved)
+- `/committee` still redirects to `/governance/committee` (existing)
+- No 404s for any previously-working committee URLs
+- `CommitteePageClient.tsx` is deleted
+- `npm run preflight` passes
+
+### Files to Read First
+
+- `app/discover/committee/page.tsx`
+- `app/committee/page.tsx` (existing redirect)
+- `next.config.ts` (existing redirect rules)
+- `middleware.ts` (existing redirect rules)
+- `components/CommitteePageClient.tsx` (confirm unused before deleting)
+
+---
+
+## Chunk 7: Mobile Card Layout & Responsive Polish
+
+**Priority:** P2 (better mobile experience)
+**Effort:** M (1-3 hours)
+**Audit dimension(s):** M5 (Craft & Polish)
+**Expected score impact:** M5: 5→7
+**Depends on:** Chunk 4 (needs the new page structure)
+**PR group:** F
+
+### Context
+
+The current rankings table hides Participation, Rationale, and Response columns on mobile via responsive breakpoints. This means mobile users see only Rank, Name, Votes, and Transparency bar — losing the narrative that explains the score. Tables on small screens are an anti-pattern for this content.
+
+### Scope
+
+**Modify the member rankings section in `/governance/committee`:**
+
+- Desktop (lg+): Keep table layout with full columns
+- Tablet (sm-md): Simplified table with fewer columns
+- Mobile (<sm): Replace table with stacked member cards:
+
+**Mobile member card design:**
+
+```
+┌──────────────────────────────────┐
+│  [A]  Member Name            #2 │
+│       ■■■■■■■■■■░░ 73/100       │
+│       "Strong participation,    │
+│        improving rationales"    │
+│       authorized · epoch 120    │
+└──────────────────────────────────┘
+```
+
+Each card shows:
+
+- Grade badge (large, colored)
+- Name
+- Transparency bar + score
+- One-line verdict (from Chunk 3)
+- Status + expiration
+- Tappable — links to profile
+
+**Also polish:**
+
+- CC Health Verdict responsive layout (stack vertically on mobile)
+- Insight Card responsive layout
+- Touch targets: ensure all tappable elements are 44x44px minimum
+
+### Decision Points
+
+None — execute directly. This is a responsive enhancement.
+
+### Verification
+
+- Page renders cleanly at 320px, 375px, 768px, 1024px, 1440px widths
+- Mobile shows cards not tables
+- All touch targets are 44x44px minimum
+- No horizontal scroll on any viewport
+- Grade badges and verdict text are legible at all sizes
+
+### Files to Read First
+
+- The new `/governance/committee/page.tsx` (from Chunk 4)
+- `components/civica/discover/DiscoverFilterBar.tsx` (responsive patterns)
+- Tailwind breakpoint conventions used elsewhere in the app
+
+---
+
+## Chunk 8: Persona-Gated Content Adaptation
+
+**Priority:** P2 (differentiated experience per persona)
+**Effort:** M (1-3 hours)
+**Audit dimension(s):** M1 (JTBD Clarity), M4 (Emotional Design), M6 (Vision & Ambition)
+**Expected score impact:** M1: 7→9, M6: 7→8
+**Depends on:** Chunk 4 (needs the new page structure)
+**PR group:** G
+
+### Context
+
+The vision specifies: "Aggressive persona adaptation. Different personas see different content." Currently the committee page shows the same thing to everyone. Each persona has a different JTBD on this page:
+
+- **Citizen:** "Are my constitutional guardians trustworthy?" → Verdict + simple rankings
+- **DRep:** "Where does the CC disagree with us?" → Tension analysis elevated
+- **SPO:** "How does the CC affect my governance?" → SPO alignment highlighted
+- **CC Member:** "How am I performing vs peers?" → My rank + competitor comparison
+- **Researcher:** "Deep data access" → Full table with export option
+
+### Scope
+
+**Modify the Insight Card selection logic:**
+
+- Citizen (anonymous or delegated): Show the most citizen-relevant insight (general CC health, trust narrative)
+- DRep: Show CC-DRep alignment tension as the primary insight ("The CC diverged from DRep majority on X proposals")
+- SPO: Show CC-SPO alignment as the primary insight
+- CC Member: Show "Your Ranking" as the primary insight (personalized if wallet connected and matches a CC member)
+- Default/anonymous: Show the most broadly interesting story
+
+**Modify member rankings emphasis:**
+
+- For authenticated CC members: Highlight their own row in the rankings with a subtle "You" badge
+- For DReps: Add a "CC-DRep Alignment" column showing agreement % per member
+- For SPOs: Add a "CC-SPO Alignment" column
+
+**Use the existing segment detection:**
+
+- Read from `useSegment()` hook or `SegmentProvider`
+- Server components: use wallet detection from cookies/headers if available, otherwise default to citizen view
+- Client components: `useSegment()` for persona-aware rendering
+
+### Decision Points
+
+1. **How much persona variation?** Recommendation: Start with insight card adaptation (low effort, high impact) and defer column changes to a follow-up if needed. The insight card alone delivers 80% of the persona value.
+
+### Verification
+
+- Anonymous users see general CC health insight
+- DRep segment sees CC-DRep tension insight
+- SPO segment sees CC-SPO alignment insight
+- If a connected wallet matches a CC member, they see their own rank highlighted
+- View As admin tool can simulate each persona and see the correct adaptation
+- `npm run preflight` passes
+
+### Files to Read First
+
+- `components/providers/SegmentProvider.tsx` (segment detection)
+- `lib/admin/viewAsRegistry.ts` (View As registry — may need CC presets)
+- `hooks/useSegment.ts` or equivalent
+- The new `/governance/committee/page.tsx` (from Chunk 4)
+
+---
+
+## Chunk 9: Craft & Delight Pass
+
+**Priority:** P3 (the difference between "good" and "I want to show someone")
+**Effort:** M (1-3 hours)
+**Audit dimension(s):** M4 (Emotional Design), M5 (Craft & Polish)
+**Expected score impact:** M4: 7→9, M5: 7→9
+**Depends on:** Chunks 4, 5, 7 (needs final page structure)
+**PR group:** H
+
+### Context
+
+Per product-vision.md: "Default to the most visually distinctive option." and "If a component could exist in any shadcn/Next.js app, it needs more work." The committee pages should feel purpose-built for constitutional accountability, not like a generic data table.
+
+### Scope
+
+**CC Health Verdict enhancements:**
+
+- Add a subtle animation to the health band on page load (spring physics via Framer Motion, not CSS)
+- Pulsing glow on the verdict text color matching the health state
+
+**Member profile hero:**
+
+- Score ring or arc visualization for the transparency index (similar to Apple Watch rings)
+- Subtle entrance animation for the pillar bars (staggered fill from 0 to actual value)
+
+**Trend chart enhancements (`CCTransparencyTrend.tsx`):**
+
+- Add a gradient fill under the line (matching the grade color)
+- Smooth the line with curve interpolation if not already (check d3 curve type)
+- Add a subtle dot pulse on the current epoch data point
+
+**Loading states:**
+
+- Create `app/governance/committee/loading.tsx` with skeleton matching the new layout (verdict skeleton + member card skeletons)
+- Create loading state for member profile that matches the hero + tabs layout
+
+**Empty states:**
+
+- If no CC votes yet: Illustration + "The Constitutional Committee hasn't voted yet. Check back after proposals are submitted."
+- If member has no data: Contextual message about what this member needs to do
+
+**Micro-interactions:**
+
+- Member row hover: subtle left-border accent in the grade color
+- Tab switching: smooth content transition (no jarring swap)
+- Grade badge: subtle scale pulse on hover
+
+### Decision Points
+
+1. **Framer Motion vs CSS animations?** Recommendation: Use Framer Motion for the verdict hero (it's already in the project for hero sections) and CSS for simpler micro-interactions (hover states, tab transitions). Lazy-load Framer Motion via `next/dynamic`.
+
+### Verification
+
+- Health verdict has entrance animation that feels polished, not flashy
+- Pillar bars animate from 0 on page load
+- Loading skeletons match the actual page layout
+- Empty states are helpful and branded
+- No layout shift (CLS) from animations
+- Animations are disabled for `prefers-reduced-motion`
+- `npm run preflight` passes
+
+### Files to Read First
+
+- The new components from Chunks 2, 4, 5, 7
+- `components/cc/CCTransparencyTrend.tsx` (existing chart to enhance)
+- Any existing Framer Motion usage in the project (search for `framer-motion` imports)
+- `app/governance/committee/loading.tsx` (create if doesn't exist)
+
+---
+
+## Chunk 10: UX Constraints Doc + Cleanup
+
+**Priority:** P3 (documentation + debt)
+**Effort:** S (< 1 hour)
+**Audit dimension(s):** M3 (Info Architecture) — prevents future drift
+**Expected score impact:** Prevents regression
+**Depends on:** Chunks 4, 5 (needs final page structure to document)
+**PR group:** I
+
+### Context
+
+The committee page has no entry in `docs/strategy/context/ux-constraints.md`. This means future agents building on this page have no guardrails against information overload. Additionally, several files will be orphaned after the redesign.
+
+### Scope
+
+**Add to `docs/strategy/context/ux-constraints.md`:**
+
+```markdown
+### `/governance/committee` — CC Accountability
+
+| Attribute               | Constraint                                                              |
+| ----------------------- | ----------------------------------------------------------------------- |
+| **Core JTBD**           | Judge if my constitutional guardians are trustworthy                    |
+| **5-second answer**     | "The CC is [healthy/needs attention] — here's the story"                |
+| **Dominant element**    | CC Health Verdict — interpreted status with trend                       |
+| **Supporting elements** | Key insight card, member accountability rankings with verdicts          |
+| **NOT on this page**    | Raw stat cards, full methodology, unbounded tables, individual profiles |
+| **Benchmark**           | Apple Health cardio fitness: one number, one trend, one insight         |
+
+### `/governance/committee/[id]` — CC Member Profile
+
+| Attribute               | Constraint                                                              |
+| ----------------------- | ----------------------------------------------------------------------- |
+| **Core JTBD**           | Evaluate this CC member's accountability                                |
+| **5-second answer**     | "This member is [above/below average] because [reason]"                 |
+| **Dominant element**    | Verdict hero — name, score, grade, one-line narrative                   |
+| **Supporting elements** | 3 key stats (participation, rationale quality, independence)            |
+| **NOT in the hero**     | Full pillar breakdown, voting record, alignment data (tabs below fold)  |
+| **Benchmark**           | LinkedIn profile: name, headline, key stats above fold. Details scroll. |
+```
+
+**Delete orphaned files:**
+
+- `components/CommitteePageClient.tsx` (if not deleted in Chunk 6)
+- Any unused imports or dead code from the old pages
+
+**Update navigation if needed:**
+
+- Verify governance sidebar/nav links point to `/governance/committee` (not `/discover/committee`)
+
+### Decision Points
+
+None — execute directly.
+
+### Verification
+
+- UX constraints doc has entries for both committee routes
+- No orphaned files remain
+- Navigation links are correct
+- `npm run preflight` passes
+
+### Files to Read First
+
+- `docs/strategy/context/ux-constraints.md`
+- `docs/strategy/context/navigation-architecture.md`
+- Final versions of Chunks 4 and 5 pages
+
+---
+
+## Execution Summary
+
+| Chunk | Name                     | Priority | Effort | Depends On | PR Group | Can Parallel With |
+| ----- | ------------------------ | -------- | ------ | ---------- | -------- | ----------------- |
+| 1     | Data Layer & API         | P0       | M      | None       | A        | 2, 3              |
+| 2     | Health Verdict Component | P0       | M      | None       | B        | 1, 3              |
+| 3     | Narrative Helpers        | P1       | S      | None       | A        | 1, 2              |
+| 4     | Unified Committee Page   | P0       | L      | 1, 2, 3    | C        | 5                 |
+| 5     | Member Profile Redesign  | P0       | L      | 1, 3       | D        | 4                 |
+| 6     | Route Consolidation      | P1       | S      | 4, 5       | E        | —                 |
+| 7     | Mobile Card Layout       | P2       | M      | 4          | F        | 8                 |
+| 8     | Persona Adaptation       | P2       | M      | 4          | G        | 7                 |
+| 9     | Craft & Delight          | P3       | M      | 4, 5, 7    | H        | 10                |
+| 10    | UX Constraints + Cleanup | P3       | S      | 4, 5       | I        | 9                 |
+
+### Optimal Parallel Execution
+
+**Session 1 — Wave 1 (3 agents in parallel):**
+
+- Agent A: Chunk 1 (Data Layer) + Chunk 3 (Narrative Helpers) → PR group A
+- Agent B: Chunk 2 (Health Verdict Component) → PR group B
+
+**Session 2 — Wave 2 (2 agents in parallel, after Wave 1 merges):**
+
+- Agent C: Chunk 4 (Unified Committee Page) → PR group C
+- Agent D: Chunk 5 (Member Profile Redesign) → PR group D
+
+**Session 3 — Wave 3 (3 agents in parallel, after Wave 2 merges):**
+
+- Agent E: Chunk 6 (Route Consolidation) → PR group E
+- Agent F: Chunk 7 (Mobile Cards) → PR group F
+- Agent G: Chunk 8 (Persona Adaptation) → PR group G
+
+**Session 4 — Wave 4 (2 agents in parallel, after Wave 3 merges):**
+
+- Agent H: Chunk 9 (Craft & Delight) → PR group H
+- Agent I: Chunk 10 (UX Constraints + Cleanup) → PR group I
+
+### Total Estimated Effort
+
+| Effort    | Count         | Hours                    |
+| --------- | ------------- | ------------------------ |
+| S         | 3 chunks      | ~2 hours                 |
+| M         | 5 chunks      | ~10 hours                |
+| L         | 2 chunks      | ~10 hours                |
+| **Total** | **10 chunks** | **~22 hours agent time** |
+
+With parallel execution across 4 waves, wall-clock time is approximately **~10 hours**.
+
+### Expected MLE Score Impact
+
+| Dimension                  | Before     | After         | Delta      |
+| -------------------------- | ---------- | ------------- | ---------- |
+| M1: JTBD Clarity           | 4/10       | 8-9/10        | +4-5       |
+| M2: Narrative Intelligence | 3/10       | 8/10          | +5         |
+| M3: Info Architecture      | 4/10       | 8/10          | +4         |
+| M4: Emotional Design       | 3/10       | 8-9/10        | +5-6       |
+| M5: Craft & Polish         | 5/10       | 8-9/10        | +3-4       |
+| M6: Vision & Ambition      | 4/10       | 8/10          | +4         |
+| **Total**                  | **~23/60** | **~49-51/60** | **+26-28** |

--- a/.claude/commands/audit-feature.md
+++ b/.claude/commands/audit-feature.md
@@ -1,0 +1,538 @@
+Deep-dive audit of a specific feature examining it through all relevant dimensions (UX, journey, intelligence, craft, vision) and all persona lenses. Produces a Minimum Lovable Experience verdict with both ambitious improvement recommendations and explicit subtraction/deprecation candidates.
+
+## Purpose
+
+Audit a single page, route, or feature from a **Minimum Lovable Experience** perspective. This command answers: **Does this page tell a clear, compelling story that delights every persona who visits it — and what would make it world-class?**
+
+Unlike `/audit-experience` (one persona, all their routes), this command is **page-first**: one page, all relevant personas. It evaluates whether the page earns its place in the product and whether everything on it earns its place on the page.
+
+The MLE standard is:
+
+- **Minimum**: What's the least this page must do brilliantly? Anything below that bar is P0.
+- **Lovable**: Does interacting with this page create a moment of delight, clarity, or trust? Not just "it works" but "I want to come back."
+- **Experience**: The complete journey — from arriving at the page, through understanding it, to taking action or leaving informed.
+
+---
+
+## Scope
+
+Argument: `$ARGUMENTS`
+
+- If empty: Ask the user which page or feature to audit. Present the main routes from the navigation architecture and WAIT for input.
+- If a route path (e.g., "/governance/committee", "/delegation", "/match"): Audit that page and all sub-routes/related components.
+- If a feature name (e.g., "committee", "matching", "treasury"): Find all relevant routes and audit them as a cohesive feature.
+- If multiple routes share the same feature (e.g., `/governance/committee` + `/discover/committee` + `/committee/[id]`): audit them all as one feature surface.
+
+---
+
+## Phase 1: Context Loading
+
+Read these files to build the evaluation framework. Do NOT skip any — they are essential for calibrated scoring.
+
+1. `docs/strategy/context/persona-quick-ref.md` — all personas and their JTBDs
+2. `docs/strategy/context/ux-constraints.md` — page-level JTBD constraints and information budget rules
+3. `docs/strategy/context/navigation-architecture.md` — route structure and where this page fits
+4. `docs/strategy/context/competitive-landscape.md` — what competitors offer for this feature area
+5. `.claude/rules/product-vision.md` — UX execution standards
+6. `.claude/rules/audit-integrity.md` — scoring calibration and evidence requirements
+
+After loading context, identify:
+
+**A) Which personas visit this page?** Cross-reference with navigation architecture. For each persona, state their JTBD on this specific page (not their global JTBD — their job on THIS page).
+
+**B) Does this page have a constraint entry in ux-constraints.md?** If not, that is itself a finding — propose one.
+
+**C) What is the page's single core JTBD?** State it in <8 words per the UX constraints format.
+
+Confirm the scope and proceed to Phase 2.
+
+---
+
+## Phase 2: Launch 3 Parallel Sub-Agents
+
+Launch ALL 3 simultaneously in a single message using the Agent tool. Each gets a different analytical lens on the same page. Do NOT use `isolation: "worktree"` — these are READ-ONLY audits.
+
+### Sub-agent 1: Page Anatomy & Persona Walk-Through
+
+```
+You are performing a deep page anatomy and persona JTBD walk-through for the [PAGE/FEATURE] in Governada. This is a READ-ONLY audit — do not modify any files.
+
+## Context Loading (MANDATORY — read these before analysis)
+1. Read `docs/strategy/context/persona-quick-ref.md`
+2. Read `docs/strategy/context/ux-constraints.md`
+3. Read `docs/strategy/context/navigation-architecture.md`
+4. Read `.claude/rules/product-vision.md`
+
+## Part A: Full Page Anatomy
+
+Read EVERY file involved in rendering this page:
+- The route file(s): `app/[route]/page.tsx` and any layout.tsx
+- Every component imported by the page (follow the import tree completely)
+- Every data function called (trace into `lib/data.ts` and beyond)
+- Any API routes that serve this page's client components
+- Any hooks used (check `hooks/` directory)
+- Database types relevant to the data shown
+
+For each piece of visible UI, document:
+1. What it shows (the data/content)
+2. Where the data comes from (table, computation, API)
+3. Which personas it serves (or "all")
+4. Whether it tells a story or dumps data
+5. Its visual weight (dominant / supporting / detail / buried)
+
+Build a complete **Page Element Inventory**:
+```
+
+| Element | Data Source | Visual Weight | Story or Data? | Serves Persona(s) | Earns Its Place? |
+
+```
+
+The "Earns Its Place?" column is critical. For each element, ask: "If I removed this, would any persona's primary JTBD on this page be degraded?" If the answer is no, mark it as CANDIDATE FOR REMOVAL.
+
+## Part B: Persona Walk-Through
+
+For each persona who visits this page (reference the navigation architecture):
+
+1. **Arrival context**: How do they get here? What were they doing before? What question are they carrying?
+2. **5-second test**: What would this persona understand about the page in 5 seconds? Does it match their JTBD?
+3. **Information scent**: Can they find what they need? Is the most important information the most prominent?
+4. **JTBD completion**: Can they complete their job on this page? How many clicks? Any dead ends?
+5. **Emotional delivery**: Does the page deliver the target emotion for this persona? (curiosity, trust, clarity, efficiency, etc.)
+6. **What's missing**: What would this persona wish they could see/do here that they can't?
+7. **What overwhelms**: What would this persona ignore or find confusing?
+
+## Part C: Information Budget Analysis
+
+Apply the zero-sum information budget from ux-constraints.md:
+- Count elements above the fold: is it within the "1 dominant + 2-3 supporting" budget?
+- Identify what's competing for attention (nothing should compete — hierarchy must be clear)
+- Check progressive disclosure: are conclusions first, with data behind interactions?
+- Check for anti-patterns: "surface all the intelligence," "show everything, let users filter," "but the data exists"
+
+## Return Format
+
+PAGE_ANATOMY:
+[Complete element inventory table]
+
+SUBTRACTION_CANDIDATES:
+(Elements that don't earn their place — candidates for removal, collapse, or relocation)
+- [element] | [reason it doesn't earn its place] | [where it could go instead, if anywhere] | [file:line]
+
+PERSONA_WALKTHROUGHS:
+For each persona:
+- [Persona]: [JTBD on this page in <8 words]
+  - 5-second test: [PASS/FAIL — what they'd understand]
+  - JTBD completion: [COMPLETE/PARTIAL/BROKEN — clicks, friction]
+  - Emotional delivery: [target emotion] → [delivered emotion] — [evidence]
+  - Missing: [what they'd wish for]
+  - Overwhelms: [what they'd ignore or find confusing]
+
+INFORMATION_BUDGET:
+- Above-fold element count: [N] (budget: 1 dominant + 2-3 supporting)
+- Dominant element: [what it is, or "unclear — multiple elements compete"]
+- Progressive disclosure: [present/absent/partial]
+- Anti-patterns detected: [list, or "none"]
+
+NARRATIVE_INTELLIGENCE:
+(For every metric/number displayed on the page)
+- [metric]: [INTERPRETED — "tells a story: ..." / RAW DATA — "just shows a number with no context"]
+
+ALREADY_STRONG:
+- [specific element that works well] — [why] — [file path]
+```
+
+### Sub-agent 2: Craft, Performance & Mobile
+
+```
+You are auditing the craft quality, performance characteristics, and mobile experience of [PAGE/FEATURE] in Governada. This is a READ-ONLY audit — do not modify any files.
+
+## Context Loading (MANDATORY)
+1. Read `.claude/rules/product-vision.md`
+2. Read `docs/strategy/context/ux-constraints.md`
+
+## Part A: Craft Quality
+
+Read the page component(s) and evaluate:
+
+1. **Visual hierarchy**: Does the eye flow naturally from primary → secondary → tertiary information? Or is everything at the same visual weight?
+2. **Component identity**: Does this page look like it was purpose-built for Governada, or could it exist in any shadcn/Next.js app? (Per product-vision.md: "If a component could exist in any shadcn/Next.js app, it needs more work.")
+3. **Loading states**: Are there skeleton states? Do they match the content layout? What does the user see for the first 500ms?
+4. **Empty states**: What happens when there's no data? Is it graceful, guiding, and motivating — or just "no results found"?
+5. **Error states**: What happens when data fails to load? Is there error handling?
+6. **Micro-interactions**: Hover states, transitions, feedback on actions. What's delightful? What's missing?
+7. **Color and typography**: Is the visual language consistent? Are colors semantic (green = good, amber = warning, red = problem)?
+8. **Accessibility**: Check for aria-labels, semantic HTML, keyboard navigation paths, color contrast, touch target sizes (44x44px minimum).
+
+## Part B: Mobile Experience
+
+Evaluate the page's mobile rendering:
+
+1. Read the responsive CSS/Tailwind classes (look for `sm:`, `md:`, `lg:` breakpoints)
+2. What columns/elements are hidden on mobile? Does hiding them lose critical information?
+3. Are tables replaced with card layouts, or do they just overflow-scroll?
+4. Are touch targets large enough?
+5. Does the page have a clear mobile-first story or is it desktop-first with responsive afterthoughts?
+
+## Part C: Performance Patterns
+
+1. **Server vs Client**: Is the page server-rendered or client-rendered? (Check for `'use client'`, `force-dynamic`)
+2. **Data fetching**: Count Supabase/API calls. Are they parallelized (`Promise.all`) or waterfall?
+3. **Bundle impact**: Are there heavy client-side imports that could be lazy-loaded? (D3, chart libraries, etc.)
+4. **Caching**: Check TanStack Query staleTime, API route cache headers, Redis usage
+5. **Core Web Vitals risks**: LCP (is above-fold content server-rendered?), CLS (explicit dimensions on dynamic content?), INP (heavy click handlers?)
+
+## Return Format
+
+CRAFT_ASSESSMENT:
+- Visual hierarchy: [clear/unclear/competing] — [evidence]
+- Component identity: [distinctive/generic] — [what makes it feel Governada or not]
+- Loading states: [present/partial/missing] — [file paths]
+- Empty states: [graceful/basic/missing] — [what happens]
+- Error states: [handled/unhandled] — [evidence]
+- Micro-interactions: [delightful/functional/missing] — [specifics]
+
+MOBILE_ASSESSMENT:
+- Strategy: [mobile-first/desktop-first/responsive-afterthought]
+- Information loss on mobile: [what's hidden and whether it matters]
+- Touch targets: [adequate/too-small] — [specific elements]
+- Overall mobile experience: [brief verdict]
+
+PERFORMANCE_ASSESSMENT:
+- Rendering: [server/client/hybrid] — [force-dynamic present?]
+- Data fetches: [count] — [parallel/waterfall] — [file path]
+- Bundle risks: [list heavy imports, or "none"]
+- Caching: [strategy summary]
+- CWV risks: [list, or "none detected"]
+
+ACCESSIBILITY:
+- Keyboard nav: [assessment]
+- Screen reader: [assessment]
+- Color contrast: [assessment]
+- WCAG estimate: [A/AA/AAA/partial]
+
+ALREADY_STRONG:
+- [specific craft element that's well done] — [file path] — [why]
+```
+
+### Sub-agent 3: Vision, Competitive & World-Class Blueprint
+
+```
+You are evaluating [PAGE/FEATURE] against the product vision, competitive landscape, and imagining what "world-class" would look like. This is a READ-ONLY audit — do not modify any files.
+
+## Context Loading (MANDATORY — read ALL of these)
+1. Read `docs/strategy/ultimate-vision.md` — the full vision (this audit warrants the full doc)
+2. Read `docs/strategy/context/competitive-landscape.md`
+3. Read `docs/strategy/context/persona-quick-ref.md`
+4. Read `docs/strategy/context/ux-constraints.md`
+5. Read `.claude/rules/product-vision.md`
+6. Read `docs/strategy/context/navigation-architecture.md`
+
+Also read the page/feature code so you understand what currently exists.
+
+## Part A: Vision Alignment
+
+1. What does the vision say this feature/page should be?
+2. Is the current implementation faithful to the vision?
+3. What vision elements are realized? What's missing? What diverges?
+4. Is the page aligned with the correct phase of the build roadmap?
+
+## Part B: Competitive Positioning
+
+For this specific feature area:
+1. What do competitors offer? (GovTool, DRep.tools, Tally, SubSquare, Snapshot, or any relevant tool)
+2. Where is Governada ahead? Where behind? Where at parity?
+3. What does the best non-crypto equivalent look like? (Robinhood, Linear, Apple Health, Stripe — pick the most relevant)
+4. What would it take to be unambiguously the best in the ecosystem for this feature?
+
+## Part C: Flywheel Analysis
+
+Which of the 5 flywheels does this page activate (or could activate)?
+- Accountability, Engagement, Content/Discourse, Viral/Identity, Integration/Distribution
+- For each: [strong/weak/not activated] with specific evidence
+- What one change would most strengthen flywheel activation?
+
+## Part D: The World-Class Blueprint
+
+This is the most important section. Imagine this page has been redesigned by the best product team in tech. What would it look like?
+
+Write a detailed description of the IDEAL version of this page, considering:
+
+1. **The Story**: What narrative does the page tell? What does the user feel and understand?
+2. **The Dominant Element**: What is the ONE thing that commands attention and answers the core JTBD?
+3. **The Supporting Cast**: What 2-3 elements support the story without competing?
+4. **Progressive Disclosure**: How does depth unfold for users who want more?
+5. **The Share-Worthy Moment**: What would make someone screenshot this and share it?
+6. **The Subtraction**: What would be REMOVED compared to today? (This is as important as what's added.)
+7. **Persona Adaptation**: How would the page adapt for different personas seeing it?
+8. **The Delight Detail**: One specific micro-interaction or design detail that would make this page memorable.
+9. **Narrative Intelligence**: How would every metric on the page "tell a story" instead of dump data?
+
+Be ambitious but grounded — every element of the blueprint should be technically feasible with the current stack (Next.js 16, React 19, shadcn, Tailwind v4, D3 for custom viz).
+
+## Part E: Deprecation & Simplification Candidates
+
+Look at what currently exists and recommend what should be:
+- **Removed entirely**: Elements that add cognitive load without serving any persona's JTBD
+- **Collapsed/hidden**: Elements that serve edge cases but shouldn't occupy primary real estate
+- **Relocated**: Elements that serve a JTBD but belong on a different page
+- **Merged**: Redundant elements that show the same information in different forms
+- **Simplified**: Complex elements that could be replaced with a simpler version without losing value
+
+For each, explain WHY the subtraction improves the experience. The goal is maximum delight with minimum surface area.
+
+## Return Format
+
+VISION_ALIGNMENT:
+- Overall: [faithful/partial/divergent]
+- Realized: [list]
+- Missing: [list]
+- Divergent: [list]
+
+COMPETITIVE_POSITIONING:
+- vs [competitor]: [ahead/behind/parity] — [specific evidence]
+- vs [web2 benchmark]: [assessment] — [what we can learn]
+- Ecosystem verdict: [is this the best in Cardano governance for this feature?]
+
+FLYWHEEL_ACTIVATION:
+- [flywheel]: [strong/weak/not activated] — [evidence] — [one change to strengthen]
+
+WORLD_CLASS_BLUEPRINT:
+[The full blueprint as described in Part D — this should be 300-500 words of vivid, specific description that a designer or engineer could execute from]
+
+SUBTRACTION_RECOMMENDATIONS:
+- REMOVE: [element] — [reason] — [file:line]
+- COLLAPSE: [element] — [reason] — [what trigger reveals it]
+- RELOCATE: [element] — [from where] — [to where] — [reason]
+- MERGE: [element A + element B] — [into what] — [reason]
+- SIMPLIFY: [element] — [from what] — [to what] — [reason]
+
+SHARE_WORTHY_MOMENT:
+[1-2 sentences: The single most impactful opportunity to create a moment someone would share]
+
+ALREADY_STRONG:
+- [specific competitive advantage or well-executed element] — [evidence]
+```
+
+---
+
+## Phase 3: Synthesis
+
+After all 3 sub-agents return, synthesize their findings. Read all results carefully — contradictions between sub-agents are valuable signals.
+
+### 3.1 The MLE Verdict
+
+Write a 2-3 paragraph assessment that a founder could read in 60 seconds and understand exactly where this feature stands:
+
+**Paragraph 1: The Story Today.** What is the experience of visiting this page today? Be specific — name routes, components, friction points, and moments of clarity. This should make the reader see through the user's eyes.
+
+**Paragraph 2: The Gap.** What's the distance between "today" and "world-class"? Is this a refinement gap (polish and narrative needed) or a structural gap (wrong information architecture, missing core functionality)? Be honest about severity.
+
+**Paragraph 3: The Path.** What are the 2-3 highest-leverage changes that would close the gap? These should be concrete enough to brief an engineer.
+
+### 3.2 Score Card
+
+Score 6 MLE dimensions. Each dimension is 0-10. Total possible: 60.
+
+Follow all scoring rules from `.claude/rules/audit-integrity.md`.
+
+**M1: JTBD Clarity (10 pts)** — Can every relevant persona complete their job on this page? Is the page's core JTBD clear in 5 seconds?
+
+| Score | Anchor                                                                               |
+| ----- | ------------------------------------------------------------------------------------ |
+| 1-3   | Core JTBD unclear. Users wouldn't know what this page is for.                        |
+| 4-6   | JTBD identifiable but friction, missing edge cases, or competing elements dilute it. |
+| 7-8   | JTBD clear, all personas can complete their job with minor friction.                 |
+| 9-10  | Instant clarity. Every persona knows exactly what to do and can do it effortlessly.  |
+
+**M2: Narrative Intelligence (10 pts)** — Does the page tell stories or dump data? Are conclusions first?
+
+| Score | Anchor                                                                                              |
+| ----- | --------------------------------------------------------------------------------------------------- |
+| 1-3   | Raw data dump. Numbers without context. No interpretation anywhere.                                 |
+| 4-6   | Some metrics have context, but the page leads with data rather than conclusions.                    |
+| 7-8   | Conclusions first, data supports. Most metrics are interpreted. Minor gaps.                         |
+| 9-10  | Every metric tells a story. The page reads like a briefing, not a spreadsheet. Users leave smarter. |
+
+**M3: Information Architecture (10 pts)** — Is the information budget respected? Progressive disclosure? Visual hierarchy?
+
+| Score | Anchor                                                                                  |
+| ----- | --------------------------------------------------------------------------------------- |
+| 1-3   | Everything competing for attention. No clear hierarchy. Overwhelming.                   |
+| 4-6   | Some hierarchy exists but too many elements above the fold or redundant sections.       |
+| 7-8   | Clear dominant element, good progressive disclosure, minor budget violations.           |
+| 9-10  | Perfect hierarchy. Every element at the right depth. Nothing could be added or removed. |
+
+**M4: Emotional Design (10 pts)** — Does the page deliver delight, trust, or clarity — not just information?
+
+| Score | Anchor                                                                             |
+| ----- | ---------------------------------------------------------------------------------- |
+| 1-3   | Clinical data display. No emotional consideration. Generic.                        |
+| 4-6   | Functional but unremarkable. Correct information but no feeling.                   |
+| 7-8   | Target emotions mostly delivered. Some moments of delight. Consistent personality. |
+| 9-10  | The page has a "wow" moment. Users feel something. Share-worthy.                   |
+
+**M5: Craft & Polish (10 pts)** — Loading states, empty states, mobile, accessibility, micro-interactions, visual identity.
+
+| Score | Anchor                                                                         |
+| ----- | ------------------------------------------------------------------------------ |
+| 1-3   | Broken states, missing loading feedback, poor mobile, inaccessible.            |
+| 4-6   | Functional but rough edges. Some missing states. Mobile is an afterthought.    |
+| 7-8   | Polished core, good loading states, responsive works, WCAG AA.                 |
+| 9-10  | Every pixel intentional. Feels like a native app. Distinctive visual identity. |
+
+**M6: Vision & Ambition (10 pts)** — Does this page push boundaries? Is it the best version of this feature in the ecosystem?
+
+| Score | Anchor                                                                                        |
+| ----- | --------------------------------------------------------------------------------------------- |
+| 1-3   | Below competitor parity. Doesn't reflect the vision.                                          |
+| 4-6   | At parity with competitors but nothing distinctive. Vision partially realized.                |
+| 7-8   | Ahead of competitors on most dimensions. Vision mostly realized. Clear differentiator.        |
+| 9-10  | Unambiguously the best in the ecosystem. Competitors would study this. Vision fully realized. |
+
+Present as:
+
+```
+| Dimension                 | Score | Key Evidence                    | Top Gap                    |
+|---------------------------|-------|---------------------------------|----------------------------|
+| M1: JTBD Clarity          | X/10  | [evidence]                      | [gap]                      |
+| M2: Narrative Intelligence| X/10  | [evidence]                      | [gap]                      |
+| M3: Info Architecture     | X/10  | [evidence]                      | [gap]                      |
+| M4: Emotional Design      | X/10  | [evidence]                      | [gap]                      |
+| M5: Craft & Polish        | X/10  | [evidence]                      | [gap]                      |
+| M6: Vision & Ambition     | X/10  | [evidence]                      | [gap]                      |
+|                           |       |                      **TOTAL**  | XX/60                      |
+```
+
+### 3.3 What's Already Strong
+
+**Mandatory section.** List 3-5 things this page does well today. For each:
+
+- What it is (specific component, pattern, or design choice)
+- Why it's strong (evidence from sub-agents)
+- File path(s)
+- Recommendation: KEEP AS-IS or note what would make it a 10/10
+
+### 3.4 The Subtraction Report
+
+**This section is as important as the improvement recommendations.** List everything that should be removed, collapsed, relocated, merged, or simplified — from the sub-agent findings.
+
+For each subtraction:
+
+```
+- [ACTION]: [element]
+  Reason: [why removing/changing this improves the experience]
+  User impact: [what the user gains by NOT seeing this]
+  Code: [file:line]
+  Risk: [what could break or be lost]
+```
+
+### 3.5 The Ambition Report
+
+**This section pushes beyond "fix what's broken" into "what would be remarkable."** Pull from sub-agent 3's World-Class Blueprint and add your own synthesis.
+
+For each ambitious recommendation:
+
+```
+- [Title] — [1 sentence description]
+  Why it matters: [what user emotion or JTBD it serves]
+  What it replaces: [what currently occupies this space, if anything]
+  Effort: [S/M/L/XL]
+  "Would anyone notice?": [Yes — because...] or [Power users only — because...]
+  Share-worthy?: [Yes/No — why]
+```
+
+### 3.6 Priority Stack
+
+Merge ALL findings (improvements, subtractions, ambitious ideas) into a single prioritized list. Every item must meet the evidence requirements from audit-integrity.md.
+
+**P0 — MLE Failures**
+The page fails its core JTBD or a primary persona can't accomplish their goal. These must be fixed for the page to earn its place.
+
+**P1 — Story Gaps**
+The page works but doesn't tell a story. Metrics without interpretation, missing narrative intelligence, information budget violations. These are the difference between "it works" and "it's good."
+
+**P2 — Craft & Delight**
+Polish, performance, mobile refinement, accessibility, micro-interactions. The difference between "it's good" and "I love this."
+
+**P3 — World-Class Ambitions**
+Ambitious improvements that would make this the best version of this feature in the ecosystem. Share-worthy moments. Flywheel activation. The difference between "I love this" and "I need to tell someone about this."
+
+**SUBTRACT — Remove/Simplify**
+Elements that should be removed or simplified regardless of priority. Subtractions often have the highest ROI because they improve the experience by reducing cognitive load — and cost nothing to maintain.
+
+For each item:
+
+```
+- [Title] | [P0/P1/P2/P3/SUBTRACT] | Effort: [S/M/L] | Impact: [what improves]
+  Code: [file:line]
+  User impact: [today vs after change]
+  Evidence: [sub-agent number + finding]
+  Risk: [what could break]
+```
+
+### 3.7 Proposed UX Constraint Entry
+
+If the page doesn't have an entry in `docs/strategy/context/ux-constraints.md`, propose one. If it does, propose updates based on findings.
+
+```
+### [route]
+
+| Attribute               | Constraint                              |
+| ----------------------- | --------------------------------------- |
+| **Core JTBD**           | [<8 words]                              |
+| **5-second answer**     | [what the user should understand]       |
+| **Dominant element**    | [one thing]                             |
+| **Supporting elements** | [2-3 things]                            |
+| **NOT on this page**    | [what must be excluded or below fold]   |
+| **Benchmark**           | [web2 or competitor reference]          |
+```
+
+---
+
+## Rules
+
+1. **Evidence from sub-agents must cite specific files, routes, and line numbers.** Not "the page could be improved" but "CommitteeDiscovery.tsx:140 has a self-referential link."
+
+2. **The Subtraction Report is mandatory.** An audit that only recommends additions is incomplete. The best improvements often come from removing things. If the audit finds nothing to subtract, explicitly state why every element earns its place.
+
+3. **The World-Class Blueprint is mandatory.** Don't just identify gaps — paint a vivid picture of what remarkable looks like. This is the aspirational target that makes the priority stack meaningful.
+
+4. **Narrative intelligence is the highest-leverage dimension.** Most pages in most apps fail not because features are missing but because data is presented without interpretation. Check every number on the page: does it tell a story?
+
+5. **Follow all rules from `.claude/rules/audit-integrity.md`:**
+   - Evidence Requirement (code path + user impact + reproduction)
+   - Cost-Benefit Gate (effort vs impact vs risk)
+   - "Already Good" Requirement (mandatory — list what's strong)
+   - Score Calibration (10 = best in class; 8+ = strong, don't recommend changes without clear reason)
+   - "Would Anyone Notice?" Test (real user, first 3 sessions)
+   - Anti-Patterns to Reject (no refactoring working code, no premature optimization)
+   - Competitor Benchmark (compare against what exists, not imaginary ideals)
+
+6. **Subtractions must pass the inverse "Would Anyone Notice?" test.** If removing an element and NO user would miss it within 3 sessions, the removal is clearly justified. If some users would miss it, specify which persona and whether a collapsed/relocated version serves them.
+
+7. **Balance ambition with pragmatism.** The Ambition Report should be exciting but every recommendation must be technically feasible with the current stack. Wild ideas without implementation paths are not helpful.
+
+8. **Page-first, not product-first.** Stay focused on this specific page. If you find systemic issues, note them briefly but don't deep-dive. The priority stack should be 90%+ specific to the audited page.
+
+9. **Sub-agents run in parallel.** Launch all 3 in a single message. Do not wait for one to finish before launching the next.
+
+---
+
+## Usage Examples
+
+```
+/audit-feature /governance/committee
+/audit-feature committee
+/audit-feature /delegation
+/audit-feature /match
+/audit-feature /governance/proposals
+/audit-feature treasury
+/audit-feature hub (citizen home)
+```
+
+## Recommended Cadence
+
+- **Before building/redesigning a page**: Run to establish baseline and identify priorities
+- **After a major page update**: Run to verify improvements and catch regressions
+- **Monthly rotation**: Cycle through the main pages to prevent quality drift
+- **After adding content to any page**: Run to verify the information budget isn't violated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ C:\Users\dalto\governada\
 | `/audit-experience [persona-state]`              | End-to-end experience audit for one persona (UX + journeys + intelligence + craft)                             | Monthly per persona, quarterly rotation        |
 | `/audit-engine [full\|scoring\|data\|sync]`      | Backend engine: scoring models, data integrity, sync pipeline, calibration                                     | Monthly focused, quarterly full                |
 | `/audit-security [area]`                         | Auth, RLS, API security, data protection, infra hardening, anti-gaming                                         | Pre-launch full, quarterly, after auth changes |
+| `/audit-feature [route\|feature]`                | MLE audit of a single page through all persona lenses — JTBD, narrative, info budget, craft, subtraction recs  | Before/after page builds, monthly rotation     |
 | `/audit-all [full\|experiences\|systems\|quick]` | Orchestrator: launches experience + engine + security audits as parallel subagents, synthesizes unified report | Quarterly full, monthly quick                  |
 
 ## Strategy Commands

--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { createClient } from '@/lib/supabase';
+import { getCCHealthSummary, getCCMemberVerdicts } from '@/lib/data';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -8,16 +9,20 @@ export const dynamic = 'force-dynamic';
 export const GET = withRouteHandler(async () => {
   const supabase = createClient();
 
-  // Fetch vote aggregation
-  const { data: votes, error } = await supabase.from('cc_votes').select('cc_hot_id, vote');
+  // Parallel fetches: votes, health summary, and member verdicts
+  const [{ data: votes, error }, health, verdicts] = await Promise.all([
+    supabase.from('cc_votes').select('cc_hot_id, vote'),
+    getCCHealthSummary(),
+    getCCMemberVerdicts(),
+  ]);
 
   if (error) {
     logger.error('Supabase error', { context: 'governance/committee', error: error?.message });
-    return NextResponse.json({ members: [] });
+    return NextResponse.json({ members: [], health });
   }
 
   if (!votes?.length) {
-    return NextResponse.json({ members: [] });
+    return NextResponse.json({ members: [], health });
   }
 
   const memberMap = new Map<string, { yes: number; no: number; abstain: number }>();
@@ -48,10 +53,14 @@ export const GET = withRouteHandler(async () => {
     });
   }
 
+  // Build verdict lookup
+  const verdictMap = new Map(verdicts.map((v) => [v.ccHotId, v]));
+
   const members = Array.from(memberMap.entries())
     .map(([ccHotId, counts]) => {
       const total = counts.yes + counts.no + counts.abstain;
       const meta = metaMap.get(ccHotId);
+      const verdict = verdictMap.get(ccHotId);
       return {
         ccHotId,
         name: meta?.name ?? null,
@@ -62,6 +71,8 @@ export const GET = withRouteHandler(async () => {
         noCount: counts.no,
         abstainCount: counts.abstain,
         approvalRate: total > 0 ? Math.round((counts.yes / total) * 100) : 0,
+        rank: verdict?.rank ?? null,
+        narrativeVerdict: verdict?.narrative ?? null,
       };
     })
     .sort((a, b) => {
@@ -73,7 +84,7 @@ export const GET = withRouteHandler(async () => {
     });
 
   return NextResponse.json(
-    { members },
+    { members, health },
     {
       headers: {
         'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',

--- a/components/cc/CCHealthVerdict.tsx
+++ b/components/cc/CCHealthVerdict.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import {
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Zap,
+} from 'lucide-react';
+import { spring, fadeInUp, staggerContainer } from '@/lib/animations';
+import type { CCHealthSummaryResponse } from '@/hooks/queries';
+
+// ---------------------------------------------------------------------------
+// Types & Config
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG = {
+  healthy: {
+    label: 'Healthy',
+    icon: ShieldCheck,
+    gradient: 'from-emerald-500/20 via-emerald-500/5 to-transparent',
+    ringColor: 'text-emerald-500',
+    glowColor: 'shadow-emerald-500/20',
+    accentBorder: 'border-emerald-500/30',
+    badgeBg: 'bg-emerald-500/15 text-emerald-400',
+    arcColor: '#10b981',
+    arcTrack: 'rgba(16, 185, 129, 0.12)',
+  },
+  attention: {
+    label: 'Needs Attention',
+    icon: ShieldAlert,
+    gradient: 'from-amber-500/20 via-amber-500/5 to-transparent',
+    ringColor: 'text-amber-500',
+    glowColor: 'shadow-amber-500/20',
+    accentBorder: 'border-amber-500/30',
+    badgeBg: 'bg-amber-500/15 text-amber-400',
+    arcColor: '#f59e0b',
+    arcTrack: 'rgba(245, 158, 11, 0.12)',
+  },
+  critical: {
+    label: 'Critical',
+    icon: ShieldX,
+    gradient: 'from-rose-500/20 via-rose-500/5 to-transparent',
+    ringColor: 'text-rose-500',
+    glowColor: 'shadow-rose-500/20',
+    accentBorder: 'border-rose-500/30',
+    badgeBg: 'bg-rose-500/15 text-rose-400',
+    arcColor: '#ef4444',
+    arcTrack: 'rgba(239, 68, 68, 0.12)',
+  },
+} as const;
+
+const TREND_ICON = {
+  improving: TrendingUp,
+  stable: Minus,
+  declining: TrendingDown,
+} as const;
+
+const TREND_LABEL = {
+  improving: 'Improving',
+  stable: 'Stable',
+  declining: 'Declining',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Arc SVG — the distinctive visual element
+// ---------------------------------------------------------------------------
+
+function HealthArc({
+  score,
+  color,
+  trackColor,
+}: {
+  score: number | null;
+  color: string;
+  trackColor: string;
+}) {
+  const size = 120;
+  const strokeWidth = 8;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = Math.PI * radius; // half-circle
+  const normalizedScore = Math.min(100, Math.max(0, score ?? 0));
+  const strokeDashoffset = circumference - (normalizedScore / 100) * circumference;
+
+  return (
+    <svg
+      width={size}
+      height={size / 2 + strokeWidth}
+      viewBox={`0 0 ${size} ${size / 2 + strokeWidth}`}
+      className="overflow-visible"
+    >
+      {/* Track */}
+      <path
+        d={`M ${strokeWidth / 2} ${size / 2} A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2}`}
+        fill="none"
+        stroke={trackColor}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+      />
+      {/* Filled arc */}
+      <motion.path
+        d={`M ${strokeWidth / 2} ${size / 2} A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2}`}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        initial={{ strokeDashoffset: circumference }}
+        animate={{ strokeDashoffset }}
+        transition={{ ...spring.smooth, duration: 1.2, delay: 0.3 }}
+      />
+      {/* Score text */}
+      <text
+        x={size / 2}
+        y={size / 2 - 4}
+        textAnchor="middle"
+        className="fill-foreground font-mono text-2xl font-bold"
+        style={{ fontSize: 28 }}
+      >
+        {score ?? '—'}
+      </text>
+      <text
+        x={size / 2}
+        y={size / 2 + 14}
+        textAnchor="middle"
+        className="fill-muted-foreground text-[10px]"
+      >
+        / 100
+      </text>
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+interface CCHealthVerdictProps {
+  health: CCHealthSummaryResponse;
+}
+
+export function CCHealthVerdict({ health }: CCHealthVerdictProps) {
+  const config = STATUS_CONFIG[health.status];
+  const StatusIcon = config.icon;
+  const TrendIcon = TREND_ICON[health.trend];
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className={`relative overflow-hidden rounded-2xl border ${config.accentBorder} bg-card p-6 sm:p-8 ${config.glowColor} shadow-lg`}
+    >
+      {/* Background gradient wash */}
+      <div
+        className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${config.gradient}`}
+      />
+
+      <div className="relative z-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:gap-8">
+        {/* Left: Arc + Score */}
+        <motion.div
+          variants={fadeInUp}
+          className="flex flex-col items-center gap-1 sm:min-w-[140px]"
+        >
+          <HealthArc
+            score={health.avgTransparency}
+            color={config.arcColor}
+            trackColor={config.arcTrack}
+          />
+          <div
+            className={`mt-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium ${config.badgeBg}`}
+          >
+            <StatusIcon className="h-3.5 w-3.5" />
+            {config.label}
+          </div>
+        </motion.div>
+
+        {/* Right: Narrative */}
+        <motion.div variants={fadeInUp} className="flex min-w-0 flex-1 flex-col gap-3">
+          <h2 className="text-lg font-semibold tracking-tight sm:text-xl">
+            Constitutional Committee
+          </h2>
+
+          <p className="text-sm leading-relaxed text-muted-foreground sm:text-base">
+            {health.narrative}
+          </p>
+
+          {/* Meta row */}
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
+            {/* Trend */}
+            <span className="inline-flex items-center gap-1">
+              <TrendIcon className="h-3.5 w-3.5" />
+              {TREND_LABEL[health.trend]}
+            </span>
+
+            {/* Member count */}
+            <span className="inline-flex items-center gap-1">
+              <span className="font-mono font-medium text-foreground">
+                {health.activeMembers}/{health.totalMembers}
+              </span>{' '}
+              active members
+            </span>
+
+            {/* Tension indicator */}
+            {health.tensionCount > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <Zap className="h-3.5 w-3.5 text-amber-500" />
+                <span className="font-mono font-medium text-foreground">
+                  {health.tensionCount}
+                </span>{' '}
+                CC–DRep tension{health.tensionCount !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -8,6 +8,16 @@ async function fetchJson<T>(url: string): Promise<T> {
   return res.json();
 }
 
+export interface CCHealthSummaryResponse {
+  status: 'healthy' | 'attention' | 'critical';
+  narrative: string;
+  trend: 'improving' | 'stable' | 'declining';
+  activeMembers: number;
+  totalMembers: number;
+  avgTransparency: number | null;
+  tensionCount: number;
+}
+
 export interface CommitteeMemberQuickView {
   ccHotId: string;
   name: string | null;
@@ -18,10 +28,12 @@ export interface CommitteeMemberQuickView {
   noCount: number;
   abstainCount: number;
   approvalRate: number;
+  rank: number | null;
+  narrativeVerdict: string | null;
 }
 
 export function useCommitteeMembers() {
-  return useQuery<{ members: CommitteeMemberQuickView[] }>({
+  return useQuery<{ members: CommitteeMemberQuickView[]; health: CCHealthSummaryResponse }>({
     queryKey: ['cc-members'],
     queryFn: () => fetchJson('/api/governance/committee'),
     staleTime: 120_000,

--- a/lib/cc/interpretations.ts
+++ b/lib/cc/interpretations.ts
@@ -1,0 +1,279 @@
+/**
+ * CC Narrative Interpretation Helpers
+ *
+ * Deterministic template functions that translate raw metrics into
+ * one-line human-readable stories. Every metric displayed on the
+ * committee pages should pass through one of these functions.
+ *
+ * Rules:
+ *  - Always include specific numbers
+ *  - Always include contextual framing (good/bad/neutral)
+ *  - Never return just a number
+ *  - Never call an AI model — these are pure template functions
+ */
+
+// ---------------------------------------------------------------------------
+// Transparency Score
+// ---------------------------------------------------------------------------
+
+export function interpretTransparencyScore(
+  score: number | null,
+  rank: number,
+  total: number,
+): string {
+  if (score == null) return 'No transparency data available yet.';
+  const label =
+    score >= 85
+      ? 'Excellent'
+      : score >= 70
+        ? 'Strong'
+        : score >= 55
+          ? 'Moderate'
+          : score >= 40
+            ? 'Weak'
+            : 'Poor';
+  return `${label} transparency (${score}/100) — ranked ${ordinal(rank)} of ${total} members`;
+}
+
+// ---------------------------------------------------------------------------
+// Participation
+// ---------------------------------------------------------------------------
+
+export function interpretParticipation(votesCast: number, eligible: number): string {
+  if (eligible === 0) return 'No proposals eligible for CC vote yet.';
+  const rate = Math.round((votesCast / eligible) * 100);
+  const missed = eligible - votesCast;
+  if (rate === 100) return `Voted on all ${eligible} proposals — perfect participation`;
+  if (rate >= 90)
+    return `Voted on ${votesCast} of ${eligible} proposals (${rate}%) — only missed ${missed}`;
+  if (rate >= 70)
+    return `Voted on ${votesCast} of ${eligible} proposals (${rate}%) — missed ${missed}`;
+  return `Voted on only ${votesCast} of ${eligible} proposals (${rate}%) — significant gaps in participation`;
+}
+
+// ---------------------------------------------------------------------------
+// Unanimous Rate
+// ---------------------------------------------------------------------------
+
+export function interpretUnanimousRate(
+  rate: number,
+  unanimousCount: number,
+  totalProposals: number,
+): string {
+  if (totalProposals === 0) return 'No proposals voted on yet.';
+  const dissentCount = totalProposals - unanimousCount;
+  if (rate >= 95)
+    return `${rate}% unanimous — very high consensus, ${dissentCount === 0 ? 'no' : `only ${dissentCount}`} proposals with dissent`;
+  if (rate >= 75)
+    return `${rate}% unanimous — healthy consensus with ${dissentCount} proposals showing independent judgment`;
+  if (rate >= 50)
+    return `${rate}% unanimous — moderate disagreement on ${dissentCount} proposals, suggesting active deliberation`;
+  return `${rate}% unanimous — significant disagreement on ${dissentCount} proposals`;
+}
+
+// ---------------------------------------------------------------------------
+// Alignment Tension
+// ---------------------------------------------------------------------------
+
+export interface TensionSummary {
+  proposalKey: string;
+  title: string | null;
+  drepMajority: string;
+  ccVote: string;
+}
+
+export function interpretAlignmentTension(tensions: TensionSummary[]): string {
+  if (tensions.length === 0)
+    return 'No tension — the CC and DRep majority have aligned on all proposals';
+  if (tensions.length === 1)
+    return 'The CC diverged from the DRep majority on 1 proposal — a sign of independent constitutional review';
+  return `The CC diverged from the DRep majority on ${tensions.length} proposals — exercising independent constitutional judgment`;
+}
+
+// ---------------------------------------------------------------------------
+// Rationale Quality
+// ---------------------------------------------------------------------------
+
+export function interpretRationaleQuality(
+  qualityScore: number | null,
+  provisionRate: number | null,
+): string {
+  if (provisionRate == null || provisionRate === 0) return 'No rationales provided yet.';
+  const pctStr = `${Math.round(provisionRate)}%`;
+  if (qualityScore == null || qualityScore === 0)
+    return `Provides rationales on ${pctStr} of votes`;
+  if (qualityScore >= 80)
+    return `Provides rationales on ${pctStr} of votes with strong constitutional article citations`;
+  if (qualityScore >= 60)
+    return `Provides rationales on ${pctStr} of votes with good article coverage`;
+  return `Provides rationales on ${pctStr} of votes — article citation depth could improve`;
+}
+
+// ---------------------------------------------------------------------------
+// Independence
+// ---------------------------------------------------------------------------
+
+export function interpretIndependence(score: number | null, unanimousRate: number | null): string {
+  if (score == null) return 'Independence data not yet available.';
+  if (score >= 80)
+    return 'High independence — regularly exercises independent judgment on proposals';
+  if (score >= 60) {
+    const ctx =
+      unanimousRate != null && unanimousRate >= 90 ? ' despite high overall CC consensus' : '';
+    return `Moderate independence${ctx} — balanced between consensus and independent judgment`;
+  }
+  if (score >= 40) return 'Low independence — tends to vote with the CC majority on most proposals';
+  return 'Very low independence — rarely diverges from the CC majority';
+}
+
+// ---------------------------------------------------------------------------
+// Trend
+// ---------------------------------------------------------------------------
+
+export function interpretTrend(
+  current: number | null,
+  previous: number | null,
+  epochSpan: number,
+): string {
+  if (current == null || previous == null) return 'Not enough data for trend analysis.';
+  const delta = current - previous;
+  const periodLabel = epochSpan === 1 ? 'the last epoch' : `the last ${epochSpan} epochs`;
+  if (Math.abs(delta) <= 2) return `Stable — holding steady over ${periodLabel}`;
+  if (delta > 0) return `Improving — up ${delta} points over ${periodLabel}`;
+  return `Declining — down ${Math.abs(delta)} points over ${periodLabel}`;
+}
+
+// ---------------------------------------------------------------------------
+// Pillar Strength/Weakness
+// ---------------------------------------------------------------------------
+
+interface PillarScores {
+  participation: number | null;
+  rationaleQuality: number | null;
+  responsiveness: number | null;
+  independence: number | null;
+}
+
+const PILLAR_LABELS: Record<keyof PillarScores, string> = {
+  participation: 'Participation',
+  rationaleQuality: 'Rationale Quality',
+  responsiveness: 'Responsiveness',
+  independence: 'Independence',
+};
+
+export function interpretPillarStrengthWeakness(pillars: PillarScores): string {
+  const entries = (Object.entries(pillars) as [keyof PillarScores, number | null][]).filter(
+    ([, v]) => v != null,
+  ) as [keyof PillarScores, number][];
+
+  if (entries.length === 0) return 'No pillar data available.';
+
+  const sorted = entries.sort((a, b) => b[1] - a[1]);
+  const strongest = sorted[0];
+  const weakest = sorted[sorted.length - 1];
+
+  if (strongest[1] === weakest[1]) return `Balanced across all pillars at ${strongest[1]}/100`;
+
+  return `Strongest: ${PILLAR_LABELS[strongest[0]]} (${strongest[1]}/100). Weakest: ${PILLAR_LABELS[weakest[0]]} (${weakest[1]}/100)`;
+}
+
+// ---------------------------------------------------------------------------
+// CC Health Narrative (for the health verdict component)
+// ---------------------------------------------------------------------------
+
+export type HealthStatus = 'healthy' | 'attention' | 'critical';
+export type TrendDirection = 'improving' | 'stable' | 'declining';
+
+export interface CCHealthData {
+  activeMembers: number;
+  totalMembers: number;
+  avgTransparency: number | null;
+  tensionCount: number;
+  trend: TrendDirection;
+}
+
+export function interpretHealthStatus(data: CCHealthData): HealthStatus {
+  const { avgTransparency, activeMembers, totalMembers } = data;
+  if (avgTransparency == null) return 'attention';
+  const activeRate = totalMembers > 0 ? activeMembers / totalMembers : 0;
+  if (avgTransparency >= 65 && activeRate >= 0.8) return 'healthy';
+  if (avgTransparency >= 45 && activeRate >= 0.5) return 'attention';
+  return 'critical';
+}
+
+export function generateCCHealthNarrative(data: CCHealthData): string {
+  const { activeMembers, totalMembers, avgTransparency, tensionCount } = data;
+  const status = interpretHealthStatus(data);
+
+  const memberStr =
+    activeMembers === totalMembers
+      ? `All ${totalMembers} members are actively voting`
+      : `${activeMembers} of ${totalMembers} members are actively voting`;
+
+  const scoreStr =
+    avgTransparency != null
+      ? `Average transparency is ${avgTransparency >= 70 ? 'strong' : avgTransparency >= 55 ? 'moderate' : 'weak'} at ${avgTransparency}/100`
+      : 'Transparency scores are not yet available';
+
+  if (status === 'critical')
+    return `${memberStr}. ${scoreStr}. Accountability gaps need attention.`;
+
+  const tensionStr =
+    tensionCount > 0
+      ? ` ${tensionCount} proposal${tensionCount > 1 ? 's' : ''} with CC-DRep tension this epoch.`
+      : '';
+
+  return `${memberStr}. ${scoreStr}.${tensionStr}`;
+}
+
+// ---------------------------------------------------------------------------
+// Member Verdict (one-line summary for member cards)
+// ---------------------------------------------------------------------------
+
+export interface MemberVerdictInput {
+  rank: number;
+  total: number;
+  transparencyScore: number | null;
+  trend: TrendDirection;
+  strongestPillar: string | null;
+  weakestPillar: string | null;
+  participationRate: number | null;
+}
+
+export function generateMemberVerdict(input: MemberVerdictInput): string {
+  const { rank, total, transparencyScore, trend, strongestPillar, weakestPillar } = input;
+
+  if (transparencyScore == null) return 'Transparency data not yet available.';
+
+  const positionStr =
+    rank <= Math.ceil(total / 3)
+      ? 'Above average'
+      : rank <= Math.ceil((total * 2) / 3)
+        ? 'Average'
+        : 'Below average';
+
+  const parts: string[] = [positionStr];
+
+  if (strongestPillar && weakestPillar && strongestPillar !== weakestPillar) {
+    parts.push(`strong ${strongestPillar.toLowerCase()}`);
+    if (trend === 'declining') {
+      parts.push(`declining ${weakestPillar.toLowerCase()}`);
+    } else {
+      parts.push(`${weakestPillar.toLowerCase()} could improve`);
+    }
+  } else if (trend !== 'stable') {
+    parts.push(trend === 'improving' ? 'trending upward' : 'trending downward');
+  }
+
+  return parts.join('. ').replace(/\.\./g, '.') + '.';
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1088,6 +1088,215 @@ export async function getCCMembersTransparency(): Promise<CCMemberTransparency[]
 }
 
 // ============================================================================
+// CC HEALTH SUMMARY & MEMBER VERDICTS
+// ============================================================================
+
+export interface CCHealthSummary {
+  status: 'healthy' | 'attention' | 'critical';
+  narrative: string;
+  trend: 'improving' | 'stable' | 'declining';
+  activeMembers: number;
+  totalMembers: number;
+  avgTransparency: number | null;
+  tensionCount: number;
+}
+
+export interface CCMemberVerdict {
+  ccHotId: string;
+  rank: number;
+  total: number;
+  narrative: string;
+  strongestPillar: string | null;
+  weakestPillar: string | null;
+  trend: 'improving' | 'stable' | 'declining';
+}
+
+export async function getCCHealthSummary(): Promise<CCHealthSummary> {
+  const { interpretHealthStatus, generateCCHealthNarrative } =
+    await import('@/lib/cc/interpretations');
+
+  try {
+    const supabase = createClient();
+
+    // Parallel fetches: members, tension data, and latest snapshots for trend
+    const [members, { data: alignmentRows }, { data: votes }, { data: stats }] = await Promise.all([
+      getCCMembersTransparency(),
+      supabase
+        .from('inter_body_alignment')
+        .select('proposal_tx_hash, proposal_index, drep_yes_pct, drep_no_pct'),
+      supabase.from('cc_votes').select('cc_hot_id, proposal_tx_hash, proposal_index, vote'),
+      supabase.from('governance_stats').select('current_epoch').eq('id', 1).single(),
+    ]);
+
+    const currentEpoch = stats?.current_epoch ?? 0;
+    const activeMembers = members.filter((m) => m.status === 'authorized').length;
+    const totalMembers = members.length;
+    const scoredMembers = members.filter((m) => m.transparencyIndex != null);
+    const avgTransparency =
+      scoredMembers.length > 0
+        ? Math.round(
+            scoredMembers.reduce((sum, m) => sum + (m.transparencyIndex ?? 0), 0) /
+              scoredMembers.length,
+          )
+        : null;
+
+    // Count tension proposals (where CC unanimous vote diverges from DRep majority)
+    const safeVotes = votes ?? [];
+    const alignmentMap = new Map<string, string>();
+    for (const row of alignmentRows ?? []) {
+      const key = `${row.proposal_tx_hash}-${row.proposal_index}`;
+      const drepMaj =
+        row.drep_yes_pct > row.drep_no_pct
+          ? 'Yes'
+          : row.drep_no_pct > row.drep_yes_pct
+            ? 'No'
+            : 'Abstain';
+      alignmentMap.set(key, drepMaj);
+    }
+
+    const proposalVotes = new Map<string, Map<string, string>>();
+    for (const v of safeVotes) {
+      const key = `${v.proposal_tx_hash}-${v.proposal_index}`;
+      const voteMap = proposalVotes.get(key) ?? new Map<string, string>();
+      voteMap.set(v.cc_hot_id, v.vote);
+      proposalVotes.set(key, voteMap);
+    }
+
+    let tensionCount = 0;
+    for (const [key, voteMap] of proposalVotes) {
+      const allVotes = Array.from(voteMap.values());
+      if (allVotes.length < totalMembers || totalMembers === 0) continue;
+      const first = allVotes[0];
+      const isUnanimous = allVotes.every((v) => v === first);
+      if (isUnanimous) {
+        const drepMaj = alignmentMap.get(key);
+        if (drepMaj && drepMaj !== 'Abstain' && first !== drepMaj) tensionCount++;
+      }
+    }
+
+    // Trend: compare current epoch avg vs 3 epochs ago
+    let trend: 'improving' | 'stable' | 'declining' = 'stable';
+    if (currentEpoch > 3 && scoredMembers.length > 0) {
+      const { data: oldSnapshots } = await supabase
+        .from('cc_transparency_snapshots')
+        .select('transparency_index')
+        .eq('epoch_no', currentEpoch - 3);
+
+      if (oldSnapshots && oldSnapshots.length > 0) {
+        const oldAvg = Math.round(
+          oldSnapshots.reduce((s, r) => s + (r.transparency_index ?? 0), 0) / oldSnapshots.length,
+        );
+        const delta = (avgTransparency ?? 0) - oldAvg;
+        if (delta > 2) trend = 'improving';
+        else if (delta < -2) trend = 'declining';
+      }
+    }
+
+    const healthData = { activeMembers, totalMembers, avgTransparency, tensionCount, trend };
+    const status = interpretHealthStatus(healthData);
+    const narrative = generateCCHealthNarrative(healthData);
+
+    return { status, narrative, trend, activeMembers, totalMembers, avgTransparency, tensionCount };
+  } catch {
+    return {
+      status: 'attention',
+      narrative: 'Unable to compute CC health summary.',
+      trend: 'stable',
+      activeMembers: 0,
+      totalMembers: 0,
+      avgTransparency: null,
+      tensionCount: 0,
+    };
+  }
+}
+
+export async function getCCMemberVerdicts(): Promise<CCMemberVerdict[]> {
+  const { generateMemberVerdict, interpretTrend } = await import('@/lib/cc/interpretations');
+
+  try {
+    const supabase = createClient();
+    const members = await getCCMembersTransparency();
+    if (members.length === 0) return [];
+
+    // Get latest 2 snapshots per member for trend
+    const { data: snapshots } = await supabase
+      .from('cc_transparency_snapshots')
+      .select('cc_hot_id, epoch_no, transparency_index')
+      .order('epoch_no', { ascending: false })
+      .limit(members.length * 5);
+
+    const snapshotsByMember = new Map<string, { epoch: number; index: number }[]>();
+    for (const s of snapshots ?? []) {
+      const list = snapshotsByMember.get(s.cc_hot_id) ?? [];
+      list.push({ epoch: s.epoch_no, index: s.transparency_index ?? 0 });
+      snapshotsByMember.set(s.cc_hot_id, list);
+    }
+
+    const PILLAR_LABELS: Record<string, string> = {
+      participation: 'Participation',
+      rationaleQuality: 'Rationale Quality',
+      responsiveness: 'Responsiveness',
+      independence: 'Independence',
+    };
+
+    return members.map((m, i) => {
+      const rank = i + 1;
+      const total = members.length;
+
+      // Find strongest/weakest pillar
+      const pillars: [string, number | null][] = [
+        ['participation', m.participationScore],
+        ['rationaleQuality', m.rationaleQualityScore],
+        ['responsiveness', m.responsivenessScore],
+        ['independence', m.independenceScore],
+      ];
+      const validPillars = pillars.filter(([, v]) => v != null) as [string, number][];
+      const sorted = [...validPillars].sort((a, b) => b[1] - a[1]);
+      const strongest = sorted.length > 0 ? PILLAR_LABELS[sorted[0][0]] : null;
+      const weakest = sorted.length > 1 ? PILLAR_LABELS[sorted[sorted.length - 1][0]] : null;
+
+      // Compute trend
+      const memberSnaps = snapshotsByMember.get(m.ccHotId) ?? [];
+      let trend: 'improving' | 'stable' | 'declining' = 'stable';
+      if (memberSnaps.length >= 2) {
+        const current = memberSnaps[0].index;
+        const previous = memberSnaps[Math.min(2, memberSnaps.length - 1)].index;
+        const epochSpan =
+          memberSnaps[0].epoch - memberSnaps[Math.min(2, memberSnaps.length - 1)].epoch;
+        const trendStr = interpretTrend(current, previous, epochSpan);
+        if (trendStr.startsWith('Improving')) trend = 'improving';
+        else if (trendStr.startsWith('Declining')) trend = 'declining';
+      }
+
+      const narrative = generateMemberVerdict({
+        rank,
+        total,
+        transparencyScore: m.transparencyIndex,
+        trend,
+        strongestPillar: strongest,
+        weakestPillar: weakest,
+        participationRate:
+          m.votesCast != null && m.eligibleProposals != null && m.eligibleProposals > 0
+            ? Math.round((m.votesCast / m.eligibleProposals) * 100)
+            : null,
+      });
+
+      return {
+        ccHotId: m.ccHotId,
+        rank,
+        total,
+        narrative,
+        strongestPillar: strongest,
+        weakestPillar: weakest,
+        trend,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================================
 // GOVERNANCE INBOX
 // ============================================================================
 

--- a/lib/scoring/ccTransparency.ts
+++ b/lib/scoring/ccTransparency.ts
@@ -42,12 +42,18 @@ export interface TransparencyResult {
 // Weights — per persona doc spec
 // ---------------------------------------------------------------------------
 
+// Weights — redistributed after removing Community Engagement (Pillar 5).
+// Pillar 5 data sources (questionsAnswered, endorsementCount) don't exist yet,
+// so the pillar was contributing 0 to every member's score, artificially deflating
+// all transparency indices by up to 10 points. Weights below redistribute the
+// original 10% proportionally across the 4 active pillars.
+// When engagement data becomes available, re-enable with its own weight slice.
 const WEIGHTS = {
-  participation: 0.35,
-  rationaleQuality: 0.3,
-  responsiveness: 0.15,
-  independence: 0.1,
-  communityEngagement: 0.1,
+  participation: 0.39,
+  rationaleQuality: 0.33,
+  responsiveness: 0.17,
+  independence: 0.11,
+  communityEngagement: 0,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Redistribute CC transparency pillar weights after zeroing Community Engagement (Pillar 5), fixing score deflation across all members
- Add health summary API endpoint, deterministic narrative interpretation helpers, and animated HealthVerdict arc component
- Foundation layer (Wave 1) for the committee page redesign — no UI integration yet

## Impact
- **What changed**: CC transparency scores will increase ~5-10pts across the board (dead pillar weight redistributed). New `/api/governance/committee` response includes `health` summary and per-member `rank`/`narrativeVerdict`. New `CCHealthVerdict` component and `lib/cc/interpretations.ts` narrative engine ready for Wave 2 integration.
- **User-facing**: No — scoring fix improves stored scores but the committee page UI hasn't changed yet. Wave 2 will integrate these components.
- **Risk**: Low — scoring weight change is additive (scores go up, not down). New API fields are additive. New component is unused until Wave 2.
- **Scope**: `lib/scoring/ccTransparency.ts`, `lib/data.ts`, `hooks/queries.ts`, `app/api/governance/committee/route.ts`, new `components/cc/CCHealthVerdict.tsx`, new `lib/cc/interpretations.ts`

## Test plan
- [x] Preflight passes (format, lint, types, tests)
- [x] Weight redistribution sums to 1.0 (verified)
- [x] All 163 tests pass
- [ ] Verify `/api/governance/committee` returns `health` object and per-member verdicts in production
- [ ] Verify CC member scores increased after next sync cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)