### PR TITLE
feat: committee redesign Wave 3+4 — mobile, persona, craft

### DIFF
--- a/app/governance/committee/[ccHotId]/loading.tsx
+++ b/app/governance/committee/[ccHotId]/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function MemberProfileLoading() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      {/* Hero skeleton */}
+      <div className="flex flex-col sm:flex-row gap-5">
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-72" />
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-40 rounded-full" />
+            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+          </div>
+          <Skeleton className="h-12 w-full" />
+        </div>
+        <Skeleton className="w-full sm:w-48 h-32 rounded-xl" />
+      </div>
+
+      {/* Key stats skeleton */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-28 rounded-xl" />
+        ))}
+      </div>
+
+      {/* Tabs skeleton */}
+      <div className="space-y-4">
+        <div className="flex gap-4 border-b pb-2">
+          <Skeleton className="h-8 w-24" />
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+        <Skeleton className="h-64 rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/app/governance/committee/loading.tsx
+++ b/app/governance/committee/loading.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CommitteeLoading() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      {/* Health Verdict skeleton */}
+      <Skeleton className="h-40 rounded-2xl" />
+
+      {/* Insight card skeleton */}
+      <Skeleton className="h-20 rounded-xl" />
+
+      {/* Member rankings skeleton */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-8 w-48" />
+        </div>
+        <div className="rounded-xl border divide-y">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 px-4 py-3.5">
+              <Skeleton className="h-4 w-7" />
+              <Skeleton className="h-8 w-8 rounded-lg" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              <Skeleton className="hidden sm:block h-1.5 w-36 rounded-full" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -12,6 +12,7 @@ import type { CommitteeMemberQuickView } from '@/hooks/queries';
 import { CCHealthVerdict } from '@/components/cc/CCHealthVerdict';
 import { CCInsightCard } from '@/components/cc/CCInsightCard';
 import { PageViewTracker } from '@/components/PageViewTracker';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { staggerContainer, fadeInUp } from '@/lib/animations';
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,73 @@ function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
       <span className="hidden md:block w-16 shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
         {member.voteCount} votes
       </span>
+    </Link>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Member Card (mobile)
+// ---------------------------------------------------------------------------
+
+function MemberCard({ member }: { member: CommitteeMemberQuickView }) {
+  const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
+  const gradeStyle = member.transparencyGrade ? (GRADE_COLORS[member.transparencyGrade] ?? '') : '';
+
+  return (
+    <Link
+      href={`/governance/committee/${encodeURIComponent(member.ccHotId)}`}
+      className="group block rounded-xl border border-border/60 p-4 transition-colors hover:bg-muted/40 active:bg-muted/60"
+    >
+      <div className="flex items-start gap-3">
+        {/* Grade badge */}
+        {member.transparencyGrade ? (
+          <span
+            className={cn(
+              'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border text-sm font-bold',
+              gradeStyle,
+            )}
+          >
+            {member.transparencyGrade}
+          </span>
+        ) : (
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted text-sm text-muted-foreground">
+            —
+          </span>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium truncate group-hover:text-primary transition-colors">
+              {displayName}
+            </span>
+            {member.rank != null && (
+              <span className="shrink-0 text-xs font-mono tabular-nums text-muted-foreground">
+                #{member.rank}
+              </span>
+            )}
+          </div>
+
+          {/* Transparency bar */}
+          <div className="flex items-center gap-2 mt-2">
+            <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+              <div
+                className={`h-full rounded-full ${transparencyBarColor(member.transparencyIndex)}`}
+                style={{ width: `${member.transparencyIndex ?? 0}%` }}
+              />
+            </div>
+            <span className="font-mono text-xs tabular-nums text-muted-foreground">
+              {member.transparencyIndex ?? '—'}
+            </span>
+          </div>
+
+          {/* Narrative verdict */}
+          {member.narrativeVerdict && (
+            <p className="text-xs text-muted-foreground mt-1.5 line-clamp-2">
+              {member.narrativeVerdict}
+            </p>
+          )}
+        </div>
+      </div>
     </Link>
   );
 }
@@ -196,6 +264,7 @@ function CommitteePageSkeleton() {
 
 export default function CommitteePage() {
   const { data, isLoading } = useCommitteeMembers();
+  const { segment } = useSegment();
   const [search, setSearch] = useState('');
 
   const members = useMemo(() => data?.members ?? [], [data]);
@@ -239,8 +308,8 @@ export default function CommitteePage() {
             <CCHealthVerdict health={health} />
           </motion.div>
 
-          {/* Section 2: Key Insight */}
-          <CCInsightCard health={health} members={members} />
+          {/* Section 2: Key Insight (persona-adapted) */}
+          <CCInsightCard health={health} members={members} segment={segment} />
 
           {/* Section 3: Member Rankings */}
           <motion.div variants={fadeInUp} className="space-y-3">
@@ -264,11 +333,20 @@ export default function CommitteePage() {
                 {search ? 'No members match your search.' : 'No CC member data available yet.'}
               </div>
             ) : (
-              <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
-                {sorted.map((member) => (
-                  <MemberRow key={member.ccHotId} member={member} />
-                ))}
-              </div>
+              <>
+                {/* Desktop: compact rows */}
+                <div className="hidden sm:block rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+                  {sorted.map((member) => (
+                    <MemberRow key={member.ccHotId} member={member} />
+                  ))}
+                </div>
+                {/* Mobile: touch-friendly cards */}
+                <div className="grid gap-3 sm:hidden">
+                  {sorted.map((member) => (
+                    <MemberCard key={member.ccHotId} member={member} />
+                  ))}
+                </div>
+              </>
             )}
           </motion.div>
 

--- a/components/cc/CCInsightCard.tsx
+++ b/components/cc/CCInsightCard.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Lightbulb, Zap, TrendingUp, ShieldCheck } from 'lucide-react';
+import { Lightbulb, Zap, TrendingUp, ShieldCheck, Users } from 'lucide-react';
 import { fadeInUp } from '@/lib/animations';
 import type { CCHealthSummaryResponse, CommitteeMemberQuickView } from '@/hooks/queries';
 
 interface CCInsightCardProps {
   health: CCHealthSummaryResponse;
   members: CommitteeMemberQuickView[];
+  segment?: string;
 }
 
 interface Insight {
@@ -20,8 +21,40 @@ interface Insight {
 function selectInsight(
   health: CCHealthSummaryResponse,
   members: CommitteeMemberQuickView[],
+  segment?: string,
 ): Insight {
-  // Priority 1: Alignment tensions
+  // Persona-aware: DRep sees CC-DRep tension elevated
+  if (segment === 'drep' && health.tensionCount > 0) {
+    return {
+      icon: Zap,
+      title: 'CC–DRep Alignment',
+      body: `The committee diverged from DRep majority on ${health.tensionCount} proposal${health.tensionCount > 1 ? 's' : ''}. Review member profiles to see where your votes differed from the CC.`,
+      accent: 'text-amber-500',
+    };
+  }
+
+  // Persona-aware: SPO sees CC-SPO alignment
+  if (segment === 'spo') {
+    return {
+      icon: Users,
+      title: 'CC–SPO Alignment',
+      body: "See how each committee member's constitutional votes align with SPO consensus on their individual profiles.",
+      accent: 'text-violet-500',
+    };
+  }
+
+  // Persona-aware: CC member sees standing
+  if (segment === 'cc') {
+    const scored = members.filter((m) => m.transparencyIndex != null);
+    return {
+      icon: ShieldCheck,
+      title: 'Your Committee Standing',
+      body: `${scored.length} member${scored.length !== 1 ? 's' : ''} scored on the Transparency Index. Check your profile to see your rank and pillar breakdown.`,
+      accent: 'text-emerald-500',
+    };
+  }
+
+  // Priority 1: Alignment tensions (citizen/anonymous default)
   if (health.tensionCount > 0) {
     return {
       icon: Zap,
@@ -78,8 +111,8 @@ function selectInsight(
   };
 }
 
-export function CCInsightCard({ health, members }: CCInsightCardProps) {
-  const insight = selectInsight(health, members);
+export function CCInsightCard({ health, members, segment }: CCInsightCardProps) {
+  const insight = selectInsight(health, members, segment);
   const Icon = insight.icon;
 
   return (

--- a/components/cc/CCMemberProfileClient.tsx
+++ b/components/cc/CCMemberProfileClient.tsx
@@ -262,11 +262,13 @@ function PillarBar({
   label,
   weight,
   score,
+  delay = 0,
 }: {
   icon: React.ReactNode;
   label: string;
   weight: string;
   score: number | null;
+  delay?: number;
 }) {
   const displayScore = score != null ? Math.round(score) : null;
   return (
@@ -279,9 +281,11 @@ function PillarBar({
         <span className="text-[10px] text-muted-foreground">{weight}</span>
       </div>
       <div className="h-2 rounded-full bg-muted overflow-hidden">
-        <div
-          className={cn('h-full rounded-full transition-all', pillarBarColor(score))}
-          style={{ width: `${displayScore ?? 0}%` }}
+        <motion.div
+          className={cn('h-full rounded-full', pillarBarColor(score))}
+          initial={{ width: 0 }}
+          animate={{ width: `${displayScore ?? 0}%` }}
+          transition={{ duration: 0.7, ease: [0.4, 0, 0.2, 1], delay: 0.3 + delay }}
         />
       </div>
       <p className="text-xs tabular-nums text-right text-muted-foreground">
@@ -311,24 +315,28 @@ function OverviewTab({ data }: { data: ProfileData }) {
               label="Participation"
               weight="39%"
               score={data.pillarScores.participation}
+              delay={0}
             />
             <PillarBar
               icon={<BookOpen className="h-3.5 w-3.5" />}
               label="Rationale Quality"
               weight="33%"
               score={data.pillarScores.rationaleQuality}
+              delay={0.1}
             />
             <PillarBar
               icon={<Clock className="h-3.5 w-3.5" />}
               label="Responsiveness"
               weight="17%"
               score={data.pillarScores.responsiveness}
+              delay={0.2}
             />
             <PillarBar
               icon={<Sparkles className="h-3.5 w-3.5" />}
               label="Independence"
               weight="11%"
               score={data.pillarScores.independence}
+              delay={0.3}
             />
           </div>
         </div>

--- a/components/cc/CCTransparencyTrend.tsx
+++ b/components/cc/CCTransparencyTrend.tsx
@@ -73,6 +73,13 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
     return gen(chartData) ?? '';
   }, [chartData, xScale, yScale]);
 
+  const areaPath = useMemo(() => {
+    if (!linePath || chartData.length < 2) return '';
+    const firstX = xScale(chartData[0].label) ?? 0;
+    const lastX = xScale(chartData[chartData.length - 1].label) ?? 0;
+    return `${linePath} L ${lastX},${innerHeight} L ${firstX},${innerHeight} Z`;
+  }, [linePath, chartData, xScale, innerHeight]);
+
   const pillarPaths = useMemo(() => {
     if (!showPillars) return [];
     return PILLAR_KEYS.map((key) => {
@@ -182,6 +189,10 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
             <svg width={width} height={250}>
               <defs>
                 <GlowFilter id="ti-glow" stdDeviation={3} />
+                <linearGradient id="ti-area-gradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="oklch(0.72 0.14 200)" stopOpacity={0.15} />
+                  <stop offset="100%" stopColor="oklch(0.72 0.14 200)" stopOpacity={0} />
+                </linearGradient>
               </defs>
               <g transform={`translate(${margin.left},${margin.top})`}>
                 {/* Grid lines */}
@@ -227,6 +238,9 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
                     {d.label}
                   </text>
                 ))}
+
+                {/* Area gradient fill */}
+                {areaPath && <path d={areaPath} fill="url(#ti-area-gradient)" />}
 
                 {/* Score line glow */}
                 <path

--- a/docs/strategy/context/ux-constraints.md
+++ b/docs/strategy/context/ux-constraints.md
@@ -65,6 +65,29 @@ World-class products (Linear, Stripe, Robinhood, Apple Health) share one trait: 
 | **Supporting elements** | Pending governance actions (if any), pool governance activity summary                             |
 | **NOT on this page**    | Detailed analytics, delegator deep dives, competitive comparisons — those are workspace features. |
 
+### `/governance/committee` — CC Accountability
+
+| Attribute               | Constraint                                                              |
+| ----------------------- | ----------------------------------------------------------------------- |
+| **Core JTBD**           | Judge if my constitutional guardians are trustworthy                    |
+| **5-second answer**     | "The CC is [healthy/needs attention] — here's the story"                |
+| **Dominant element**    | CC Health Verdict — interpreted status with trend                       |
+| **Supporting elements** | Key insight card (persona-adapted), member accountability rankings      |
+| **NOT on this page**    | Raw stat cards, full methodology, unbounded tables, individual profiles |
+| **Persona adaptation**  | DRep: CC-DRep tension elevated. SPO: CC-SPO alignment. CC: your rank    |
+| **Benchmark**           | Apple Health cardio fitness: one number, one trend, one insight         |
+
+### `/governance/committee/[id]` — CC Member Profile
+
+| Attribute               | Constraint                                                             |
+| ----------------------- | ---------------------------------------------------------------------- |
+| **Core JTBD**           | Evaluate this CC member's accountability                               |
+| **5-second answer**     | "This member is [above/below average] because [reason]"                |
+| **Dominant element**    | Verdict hero — name, score, grade, one-line narrative                  |
+| **Supporting elements** | 3 key stats (participation, rationale quality, independence)           |
+| **NOT in the hero**     | Full pillar breakdown, voting record, alignment data (tabs below fold) |
+| **Benchmark**           | LinkedIn profile: name, headline, key stats above fold. Details scroll |
+
 ### `/discover`
 
 | Attribute               | Constraint                                                                                                                                                             |
@@ -141,6 +164,19 @@ World-class products (Linear, Stripe, Robinhood, Apple Health) share one trait: 
 | **Dominant element**    | Proposal summary: title, plain-English description, amount, deadline                                                                      |
 | **Supporting elements** | Vote status (% yes/no/abstain), citizen sentiment, your DRep's vote (if applicable)                                                       |
 | **NOT above the fold**  | Full voter lists, detailed treasury analysis, constitutional alignment deep dive, similar proposals comparison. Those are depth sections. |
+
+### `/governance/treasury`
+
+| Attribute                  | Constraint                                                                                                       |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Core JTBD**              | See where treasury money goes and whether it works                                                               |
+| **5-second answer**        | "Budget [X]% used. [Y]% of spending delivered. [N] proposals pending."                                           |
+| **Dominant element**       | Narrative hero — one glanceable paragraph synthesizing balance, NCL utilization, effectiveness, pending activity |
+| **Supporting elements**    | NCL budget bar (enacted/pending/remaining segments), epoch flow, pending proposals                               |
+| **NOT on this page**       | Raw simulator controls above the fold, standalone health bar, four competing section headers                     |
+| **Progressive disclosure** | Accountability behind accordion. Simulator behind accordion. Health score components behind tooltip.             |
+| **Persona adaptation**     | Citizens: narrative + proportional share. DReps: vote queue + track record + NCL impact per vote.                |
+| **Benchmark**              | USAspending.gov summary: headline, budget context, drill-down. Government budget thermometers.                   |
 
 ### `/methodology`
 


### PR DESCRIPTION
## Summary
- **Mobile-first responsive layout**: Touch-friendly member cards on mobile (`sm:hidden`), compact rows on desktop (`hidden sm:block`)
- **Persona-gated CCInsightCard**: DRep sees CC-DRep tension count, SPO sees alignment note, CC sees committee standing, citizen/anon get default insight
- **Craft & delight**: Animated pillar bar fills (Framer Motion staggered), gradient fill under transparency trend chart (SVG linearGradient), loading skeletons for both committee routes
- **UX constraints doc**: Added `/governance/committee` and `/governance/committee/[id]` page constraint entries

## Impact
- **What changed**: Committee pages now adapt to mobile screens and user personas, with animation polish and proper loading states
- **User-facing**: Yes — mobile users see card layout instead of cramped rows; DReps/SPOs/CC members see persona-relevant insights; pillar bars animate on profile load
- **Risk**: Low — styling and progressive enhancement only, no data/API changes
- **Scope**: 5 modified files + 2 new loading.tsx files in `app/governance/committee/`

## Test plan
- [ ] Mobile viewport: verify card layout renders below 640px breakpoint
- [ ] Desktop: verify row layout renders above 640px
- [ ] Persona switching via View As: confirm DRep/SPO/CC/citizen see different insight cards
- [ ] Member profile: pillar bars animate on page load
- [ ] Trend chart: gradient fill visible under line
- [ ] Loading states: skeleton shows during data fetch on both routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)