### PR TITLE
feat: treasury NCL intelligence — narrative hero, budget bar, persona adaptation

### DIFF
--- a/app/api/treasury/ncl/route.ts
+++ b/app/api/treasury/ncl/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getNclUtilization } from '@/lib/treasury';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(
+  async () => {
+    const ncl = await getNclUtilization();
+
+    if (!ncl) {
+      return NextResponse.json(
+        { error: 'No active NCL period', ncl: null },
+        { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } },
+      );
+    }
+
+    return NextResponse.json(
+      { ncl },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } },
+    );
+  },
+  { rateLimit: { max: 60, window: 60 } },
+);

--- a/app/governance/treasury/TreasuryOverview.tsx
+++ b/app/governance/treasury/TreasuryOverview.tsx
@@ -1,61 +1,177 @@
 'use client';
 
-import { CivicaTreasury } from '@/components/civica/pulse/CivicaTreasury';
+import { TreasuryNarrativeHero } from '@/components/treasury/TreasuryNarrativeHero';
+import { NclBudgetBar } from '@/components/treasury/NclBudgetBar';
+import { TreasuryKeyMetrics } from '@/components/treasury/TreasuryKeyMetrics';
+import { TreasuryEpochFlow } from '@/components/treasury/TreasuryEpochFlow';
 import { TreasuryPendingProposals } from '@/components/TreasuryPendingProposals';
 import { TreasuryAccountabilitySection } from '@/components/TreasuryAccountabilitySection';
 import { TreasurySimulator } from '@/components/TreasurySimulator';
-import { useTreasuryCurrent } from '@/hooks/queries';
+import { DRepTreasuryTrackRecord } from '@/components/treasury/DRepTreasuryTrackRecord';
+import { SegmentGate } from '@/components/shared/SegmentGate';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { useTreasuryCurrent, useTreasuryNcl, useTreasuryHistory } from '@/hooks/queries';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import type { NclUtilization, IncomeVsOutflow } from '@/lib/treasury';
+import { useQuery } from '@tanstack/react-query';
+
+interface TreasuryCurrentData {
+  balance: number;
+  epoch: number;
+  snapshotAt: string;
+  runwayMonths: number;
+  burnRatePerEpoch: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  healthScore: number | null;
+  healthComponents: Record<string, number> | null;
+  pendingCount: number;
+  pendingTotalAda: number;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
 
 /**
- * Client-side treasury overview that composes existing treasury components
- * into a cohesive spending transparency page.
+ * Narrative-first treasury overview with NCL budget bar as visual anchor.
  *
- * Data is fetched via TanStack Query hooks inside each child component.
- * We also fetch treasury current here to pass required (but unused) props
- * to components that have them in their interface.
+ * Layout:
+ * 1. Narrative hero — contextual paragraph
+ * 2. NCL budget bar — horizontal segmented bar
+ * 3. Key metrics — 3-stat row
+ * 4. Epoch flow — income vs outflow last 6 epochs
+ * 5. Pending proposals — with per-proposal NCL impact
+ * 6. [DRep only] Track record
+ * 7. Accordion: Spending Accountability
+ * 8. Accordion: Runway Projections
  */
 export function TreasuryOverview() {
+  const { drepId } = useSegment();
   const { data: rawCurrent } = useTreasuryCurrent();
-  const treasury = rawCurrent as
-    | {
-        balance?: number;
-        balanceAda?: number;
-        runwayMonths?: number;
-        burnRatePerEpoch?: number;
-        currentEpoch?: number;
-        [key: string]: unknown;
-      }
-    | undefined;
+  const treasury = rawCurrent as TreasuryCurrentData | undefined;
 
-  const balance = treasury?.balance ?? treasury?.balanceAda ?? 0;
+  const { data: rawNcl } = useTreasuryNcl();
+  const ncl = (rawNcl as { ncl: NclUtilization | null } | undefined)?.ncl ?? null;
+
+  const { data: rawHistory } = useTreasuryHistory(30);
+  const incomeVsOutflow =
+    (rawHistory as { incomeVsOutflow: IncomeVsOutflow[] } | undefined)?.incomeVsOutflow ?? [];
+
+  // Effectiveness rate for narrative + metrics
+  const { data: rawEffectiveness } = useQuery({
+    queryKey: ['treasury-effectiveness'],
+    queryFn: () => fetchJson<{ effectivenessRate: number | null }>('/api/treasury/effectiveness'),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const balance = treasury?.balance ?? 0;
   const burnRate = treasury?.burnRatePerEpoch ?? 0;
   const runway = treasury?.runwayMonths ?? 0;
-  const epoch = treasury?.currentEpoch ?? 0;
+  const epoch = treasury?.epoch ?? 0;
+  const trend = treasury?.trend ?? 'stable';
+  const pendingCount = treasury?.pendingCount ?? 0;
+  const pendingTotalAda = treasury?.pendingTotalAda ?? 0;
+  const effectivenessRate = rawEffectiveness?.effectivenessRate ?? null;
+
+  const epochFlow = incomeVsOutflow;
+
+  const nclImpact = ncl
+    ? {
+        utilizationPct: ncl.utilizationPct,
+        remainingAda: ncl.remainingAda,
+        nclAda: ncl.period.nclAda,
+      }
+    : null;
 
   return (
-    <div className="space-y-8">
-      {/* Balance, sparkline, runway, and quick pending list */}
-      <section>
-        <CivicaTreasury />
-      </section>
+    <div className="space-y-6">
+      {/* 1. Narrative hero */}
+      <TreasuryNarrativeHero
+        balanceAda={balance}
+        trend={trend}
+        effectivenessRate={effectivenessRate}
+        pendingCount={pendingCount}
+        pendingTotalAda={pendingTotalAda}
+        runwayMonths={runway}
+        ncl={ncl}
+      />
 
-      {/* Detailed pending treasury proposals */}
+      {/* 2. NCL Budget Bar */}
+      {ncl && <NclBudgetBar ncl={ncl} />}
+      {!ncl && treasury && (
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 text-sm text-muted-foreground">
+          No active NCL period. The community has not yet set a spending limit for the current epoch
+          range.
+        </div>
+      )}
+
+      {/* 3. Key metrics */}
+      <TreasuryKeyMetrics
+        ncl={ncl}
+        pendingCount={pendingCount}
+        effectivenessRate={effectivenessRate}
+      />
+
+      {/* 4. Epoch flow */}
+      {epochFlow.length > 0 && <TreasuryEpochFlow data={epochFlow} />}
+
+      {/* 5. Pending proposals with NCL impact */}
       <section>
         <h2 className="text-lg font-semibold mb-3">Pending Proposals</h2>
-        <TreasuryPendingProposals treasuryBalanceAda={balance} runwayMonths={runway} />
+        <TreasuryPendingProposals
+          treasuryBalanceAda={balance}
+          runwayMonths={runway}
+          nclImpact={nclImpact}
+        />
       </section>
 
-      {/* Spending effectiveness and accountability ratings */}
-      <section>
-        <h2 className="text-lg font-semibold mb-3">Spending Accountability</h2>
-        <TreasuryAccountabilitySection />
-      </section>
+      {/* 6. DRep track record (segment-gated) */}
+      <SegmentGate show={['drep']}>
+        {drepId && (
+          <section>
+            <DRepTreasuryTrackRecord drepId={drepId} />
+          </section>
+        )}
+      </SegmentGate>
 
-      {/* Runway scenario projections */}
-      <section>
-        <h2 className="text-lg font-semibold mb-3">Runway Projections</h2>
-        <TreasurySimulator currentBalance={balance} burnRate={burnRate} currentEpoch={epoch} />
-      </section>
+      {/* 7 & 8. Depth sections behind accordion */}
+      <Accordion type="multiple" className="space-y-2">
+        <AccordionItem
+          value="accountability"
+          className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
+        >
+          <AccordionTrigger className="text-sm font-semibold hover:no-underline">
+            Spending Accountability
+            {effectivenessRate !== null && (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                {effectivenessRate}% delivered
+              </span>
+            )}
+          </AccordionTrigger>
+          <AccordionContent>
+            <TreasuryAccountabilitySection />
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem
+          value="simulator"
+          className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
+        >
+          <AccordionTrigger className="text-sm font-semibold hover:no-underline">
+            Explore Runway Scenarios
+          </AccordionTrigger>
+          <AccordionContent>
+            <TreasurySimulator currentBalance={balance} burnRate={burnRate} currentEpoch={epoch} />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 }

--- a/app/governance/treasury/page.tsx
+++ b/app/governance/treasury/page.tsx
@@ -26,22 +26,35 @@ export const metadata: Metadata = {
 function TreasuryFallback() {
   return (
     <div className="space-y-6">
-      {/* Balance card skeleton */}
-      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
-        <Skeleton className="h-3 w-24" />
-        <Skeleton className="h-10 w-36" />
-        <Skeleton className="h-16 w-full" />
+      {/* Narrative hero skeleton */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
       </div>
-      {/* Stats row skeleton */}
-      <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
-          <Skeleton className="h-3 w-16" />
-          <Skeleton className="h-8 w-20" />
+      {/* NCL budget bar skeleton */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">
+        <div className="flex justify-between">
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="h-3 w-32" />
         </div>
-        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
-          <Skeleton className="h-3 w-20" />
-          <Skeleton className="h-8 w-12" />
+        <Skeleton className="h-5 w-full rounded-full" />
+        <div className="flex gap-5">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-24" />
         </div>
+      </div>
+      {/* Key metrics skeleton */}
+      <div className="grid grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2"
+          >
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-6 w-12" />
+          </div>
+        ))}
       </div>
       {/* Pending proposals skeleton */}
       <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-3">

--- a/components/TreasuryPendingProposals.tsx
+++ b/components/TreasuryPendingProposals.tsx
@@ -25,9 +25,17 @@ interface PendingData {
   treasuryBalanceAda: number;
 }
 
+interface NclImpact {
+  utilizationPct: number;
+  remainingAda: number;
+  nclAda: number;
+}
+
 interface Props {
   treasuryBalanceAda: number;
   runwayMonths: number;
+  /** NCL data for per-proposal impact indicators */
+  nclImpact?: NclImpact | null;
 }
 
 const tierColors: Record<string, string> = {
@@ -36,7 +44,7 @@ const tierColors: Record<string, string> = {
   major: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
 };
 
-export function TreasuryPendingProposals({}: Props) {
+export function TreasuryPendingProposals({ nclImpact }: Props) {
   const { data: raw, isLoading: loading } = useTreasuryPending();
   const data = raw as PendingData | undefined;
 
@@ -101,10 +109,34 @@ export function TreasuryPendingProposals({}: Props) {
                 <span>{p.pctOfBalance.toFixed(2)}% of treasury</span>
                 <span>Epoch {p.proposedEpoch}</span>
               </div>
+              {nclImpact && p.withdrawalAda != null && p.withdrawalAda > 0 && (
+                <div className="text-[10px] text-muted-foreground mt-0.5">
+                  If enacted: NCL {Math.round(nclImpact.utilizationPct)}% →{' '}
+                  {Math.round(
+                    ((nclImpact.nclAda - nclImpact.remainingAda + p.withdrawalAda) /
+                      nclImpact.nclAda) *
+                      100,
+                  )}
+                  % · {formatAda(p.withdrawalAda)} of ₳{formatAda(nclImpact.remainingAda)} remaining
+                </div>
+              )}
             </div>
             <ExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           </Link>
         ))}
+
+        {nclImpact && data.totalAda > 0 && (
+          <div className="text-xs text-muted-foreground mt-2 p-2 rounded bg-muted/30">
+            If all {data.proposals.length} pending proposals pass: NCL utilization{' '}
+            {Math.round(nclImpact.utilizationPct)}% →{' '}
+            {Math.round(
+              ((nclImpact.nclAda - nclImpact.remainingAda + data.totalAda) / nclImpact.nclAda) *
+                100,
+            )}
+            % (₳{formatAda(nclImpact.nclAda - nclImpact.remainingAda + data.totalAda)} of ₳
+            {formatAda(nclImpact.nclAda)})
+          </div>
+        )}
 
         {parseFloat(data.pctOfTreasury) > 5 && (
           <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400 text-xs mt-2 p-2 rounded bg-amber-50 dark:bg-amber-950/20">

--- a/components/treasury/DRepTreasuryTrackRecord.tsx
+++ b/components/treasury/DRepTreasuryTrackRecord.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { formatAda } from '@/lib/treasury';
+import type { DRepTreasuryRecord } from '@/lib/treasury';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface DRepTreasuryTrackRecordProps {
+  drepId: string;
+}
+
+export function DRepTreasuryTrackRecord({ drepId }: DRepTreasuryTrackRecordProps) {
+  const { data, isLoading } = useQuery<{ record: DRepTreasuryRecord }>({
+    queryKey: ['treasury-drep-record', drepId],
+    queryFn: async () => {
+      const res = await fetch(`/api/treasury/drep-record?drepId=${encodeURIComponent(drepId)}`);
+      if (!res.ok) throw new Error('Failed to fetch DRep treasury record');
+      return res.json();
+    },
+    enabled: !!drepId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-4 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-6 w-24" />
+          <Skeleton className="h-4 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const record = data?.record;
+  if (!record || record.totalProposals === 0) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center text-muted-foreground">
+          <p className="text-sm">
+            You haven&apos;t voted on any treasury proposals yet. Your track record will appear here
+            once you do.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">Your Treasury Track Record</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p className="text-lg font-semibold text-emerald-400">{record.approvedCount}</p>
+            <p className="text-xs text-muted-foreground">Approved</p>
+            <p className="text-[10px] text-muted-foreground">₳{formatAda(record.approvedAda)}</p>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-red-400">{record.opposedCount}</p>
+            <p className="text-xs text-muted-foreground">Opposed</p>
+            <p className="text-[10px] text-muted-foreground">₳{formatAda(record.opposedAda)}</p>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-muted-foreground">{record.abstainedCount}</p>
+            <p className="text-xs text-muted-foreground">Abstained</p>
+          </div>
+        </div>
+
+        {record.judgmentScore !== null && (
+          <div className="mt-3 pt-3 border-t border-border/50">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">Judgment Score</span>
+              <span className="text-sm font-semibold">{record.judgmentScore}%</span>
+            </div>
+            <p className="text-[10px] text-muted-foreground mt-0.5">
+              Based on accountability outcomes of proposals you approved
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/treasury/NclBudgetBar.tsx
+++ b/components/treasury/NclBudgetBar.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { formatAda } from '@/lib/treasury';
+import type { NclUtilization } from '@/lib/treasury';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface NclBudgetBarProps {
+  ncl: NclUtilization;
+}
+
+const STATUS_COLORS = {
+  healthy: {
+    enacted: 'bg-emerald-500',
+    pending: 'bg-emerald-500/40',
+    label: 'text-emerald-400',
+    border: 'border-emerald-500/30',
+  },
+  elevated: {
+    enacted: 'bg-amber-500',
+    pending: 'bg-amber-500/40',
+    label: 'text-amber-400',
+    border: 'border-amber-500/30',
+  },
+  critical: {
+    enacted: 'bg-red-500',
+    pending: 'bg-red-500/40',
+    label: 'text-red-400',
+    border: 'border-red-500/30',
+  },
+} as const;
+
+const STATUS_LABELS = {
+  healthy: 'Healthy budget headroom',
+  elevated: 'Budget moderately utilized',
+  critical: 'Budget nearing limit — scrutiny recommended',
+} as const;
+
+export function NclBudgetBar({ ncl }: NclBudgetBarProps) {
+  const colors = STATUS_COLORS[ncl.status];
+  const enactedPct = Math.min(100, ncl.utilizationPct);
+  const pendingPct = Math.min(100 - enactedPct, ncl.projectedUtilizationPct - ncl.utilizationPct);
+
+  return (
+    <div className={cn('rounded-xl border bg-card/70 backdrop-blur-md p-5', colors.border)}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-sm font-medium text-muted-foreground">
+          NCL Budget: ₳{formatAda(ncl.period.nclAda)}{' '}
+          <span className="text-xs">
+            (Epochs {ncl.period.startEpoch}–{ncl.period.endEpoch})
+          </span>
+        </div>
+        <span className={cn('text-xs font-medium', colors.label)}>{STATUS_LABELS[ncl.status]}</span>
+      </div>
+
+      {/* Segmented bar */}
+      <TooltipProvider>
+        <div className="relative h-5 w-full rounded-full bg-muted/30 overflow-hidden">
+          {/* Enacted segment */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  'absolute inset-y-0 left-0 rounded-l-full transition-all',
+                  colors.enacted,
+                )}
+                style={{ width: `${enactedPct}%` }}
+              />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                Enacted: ₳{formatAda(ncl.enactedWithdrawalsAda)} ({Math.round(ncl.utilizationPct)}%)
+              </p>
+            </TooltipContent>
+          </Tooltip>
+
+          {/* Pending segment (hatched appearance via striped gradient) */}
+          {pendingPct > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  className={cn('absolute inset-y-0 transition-all', colors.pending)}
+                  style={{
+                    left: `${enactedPct}%`,
+                    width: `${pendingPct}%`,
+                    backgroundImage:
+                      'repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,0.1) 3px, rgba(255,255,255,0.1) 6px)',
+                  }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>
+                  Pending: ₳{formatAda(ncl.pendingWithdrawalsAda)} ({Math.round(pendingPct)}%)
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {/* Remaining (implicit via background) */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="absolute inset-y-0 rounded-r-full"
+                style={{
+                  left: `${enactedPct + pendingPct}%`,
+                  width: `${Math.max(0, 100 - enactedPct - pendingPct)}%`,
+                }}
+              />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Remaining: ₳{formatAda(ncl.headroomAfterPendingAda)}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 mt-3 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className={cn('inline-block h-2.5 w-2.5 rounded-sm', colors.enacted)} />
+          Enacted: ₳{formatAda(ncl.enactedWithdrawalsAda)}
+        </span>
+        {ncl.pendingWithdrawalsAda > 0 && (
+          <span className="flex items-center gap-1.5">
+            <span className={cn('inline-block h-2.5 w-2.5 rounded-sm', colors.pending)} />
+            Pending: ₳{formatAda(ncl.pendingWithdrawalsAda)}
+          </span>
+        )}
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-muted/30" />
+          Remaining: ₳{formatAda(ncl.headroomAfterPendingAda)}
+        </span>
+      </div>
+
+      {/* Context row */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-1 mt-2 text-xs text-muted-foreground">
+        <span>
+          Epoch {ncl.epochsElapsed} of {ncl.period.endEpoch - ncl.period.startEpoch} in this budget
+          period ({Math.round(ncl.periodProgressPct)}%)
+        </span>
+        <span>
+          {ncl.sustainabilityRatio >= 1
+            ? `Annual income ≈ ₳${formatAda(ncl.period.nclAda * ncl.sustainabilityRatio)} vs NCL ₳${formatAda(ncl.period.nclAda)} — sustainable`
+            : `⚠ NCL exceeds projected annual income (ratio: ${ncl.sustainabilityRatio}x)`}
+        </span>
+      </div>
+
+      {/* Alerts */}
+      {ncl.epochsRemaining < 10 && ncl.epochsRemaining > 0 && (
+        <div className="mt-3 text-xs text-amber-400 bg-amber-500/10 rounded-md px-3 py-2">
+          Budget period ends in {ncl.epochsRemaining} epochs. A new NCL Info Action will need to be
+          voted on.
+        </div>
+      )}
+      {ncl.enactedWithdrawalsAda > ncl.period.nclAda && (
+        <div className="mt-3 text-xs text-red-400 bg-red-500/10 rounded-md px-3 py-2">
+          ⚠ Enacted withdrawals (₳{formatAda(ncl.enactedWithdrawalsAda)}) exceed the NCL (₳
+          {formatAda(ncl.period.nclAda)}). This may indicate a constitutional compliance issue.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/treasury/TreasuryEpochFlow.tsx
+++ b/components/treasury/TreasuryEpochFlow.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useMemo } from 'react';
+import { formatAda } from '@/lib/treasury';
+import type { IncomeVsOutflow } from '@/lib/treasury';
+
+interface TreasuryEpochFlowProps {
+  data: IncomeVsOutflow[];
+}
+
+export function TreasuryEpochFlow({ data }: TreasuryEpochFlowProps) {
+  const recent = useMemo(() => data.slice(-6), [data]);
+
+  if (recent.length === 0) return null;
+
+  const maxValue = Math.max(...recent.flatMap((d) => [d.incomeAda, d.outflowAda]), 1);
+  const latestNet = recent[recent.length - 1]?.netAda ?? 0;
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-muted-foreground">Epoch Flow (last 6)</h3>
+        <span className="text-xs text-muted-foreground">
+          Latest net:{' '}
+          <span className={latestNet >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+            {latestNet >= 0 ? '+' : ''}₳{formatAda(Math.abs(latestNet))}
+          </span>
+        </span>
+      </div>
+
+      <div className="flex items-end gap-1.5 h-20">
+        {recent.map((epoch) => {
+          const inHeight = (epoch.incomeAda / maxValue) * 100;
+          const outHeight = (epoch.outflowAda / maxValue) * 100;
+
+          return (
+            <div
+              key={epoch.epoch}
+              className="flex-1 flex items-end gap-0.5"
+              title={`Epoch ${epoch.epoch}`}
+            >
+              {/* Income bar */}
+              <div
+                className="flex-1 bg-emerald-500/60 rounded-t-sm transition-all"
+                style={{ height: `${Math.max(2, inHeight)}%` }}
+              />
+              {/* Outflow bar */}
+              <div
+                className="flex-1 bg-red-400/50 rounded-t-sm transition-all"
+                style={{ height: `${Math.max(2, outHeight)}%` }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Epoch labels */}
+      <div className="flex gap-1.5 mt-1">
+        {recent.map((epoch) => (
+          <div key={epoch.epoch} className="flex-1 text-center text-[10px] text-muted-foreground">
+            {epoch.epoch}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-2 text-[10px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-sm bg-emerald-500/60" />
+          Income
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-sm bg-red-400/50" />
+          Outflow
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/treasury/TreasuryKeyMetrics.tsx
+++ b/components/treasury/TreasuryKeyMetrics.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { formatAda } from '@/lib/treasury';
+import type { NclUtilization } from '@/lib/treasury';
+
+interface TreasuryKeyMetricsProps {
+  ncl: NclUtilization | null;
+  pendingCount: number;
+  effectivenessRate: number | null;
+}
+
+function MetricCard({
+  label,
+  value,
+  subtext,
+  className,
+}: {
+  label: string;
+  value: string;
+  subtext?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4',
+        className,
+      )}
+    >
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-xl font-semibold mt-0.5">{value}</p>
+      {subtext && <p className="text-xs text-muted-foreground mt-0.5">{subtext}</p>}
+    </div>
+  );
+}
+
+export function TreasuryKeyMetrics({
+  ncl,
+  pendingCount,
+  effectivenessRate,
+}: TreasuryKeyMetricsProps) {
+  const nclValue = ncl ? `${Math.round(ncl.utilizationPct)}%` : '—';
+  const nclSubtext = ncl ? `₳${formatAda(ncl.remainingAda)} remaining` : 'No active NCL period';
+
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <MetricCard label="NCL Utilization" value={nclValue} subtext={nclSubtext} />
+      <MetricCard
+        label="Pending Proposals"
+        value={String(pendingCount)}
+        subtext={pendingCount === 0 ? 'None active' : undefined}
+      />
+      <MetricCard
+        label="Effectiveness"
+        value={effectivenessRate !== null ? `${effectivenessRate}%` : '—'}
+        subtext={effectivenessRate !== null ? 'of funded projects delivered' : 'Awaiting data'}
+      />
+    </div>
+  );
+}

--- a/components/treasury/TreasuryNarrativeHero.tsx
+++ b/components/treasury/TreasuryNarrativeHero.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect } from 'react';
+import { posthog } from '@/lib/posthog';
+import { generateTreasuryNarrative, formatAda } from '@/lib/treasury';
+import type { NclUtilization, TreasuryNarrativeData } from '@/lib/treasury';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+interface TreasuryNarrativeHeroProps {
+  balanceAda: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  effectivenessRate: number | null;
+  pendingCount: number;
+  pendingTotalAda: number;
+  runwayMonths: number;
+  ncl: NclUtilization | null;
+  /** Citizen's proportional share (ADA), if available */
+  proportionalShareAda?: number | null;
+}
+
+export function TreasuryNarrativeHero({
+  balanceAda,
+  trend,
+  effectivenessRate,
+  pendingCount,
+  pendingTotalAda,
+  runwayMonths,
+  ncl,
+  proportionalShareAda,
+}: TreasuryNarrativeHeroProps) {
+  const { segment } = useSegment();
+
+  const narrativeData: TreasuryNarrativeData = {
+    balanceAda,
+    trend,
+    effectivenessRate,
+    pendingCount,
+    pendingTotalAda,
+    runwayMonths,
+    ncl,
+  };
+
+  const narrative = generateTreasuryNarrative(narrativeData);
+
+  useEffect(() => {
+    posthog.capture('treasury_narrative_viewed', {
+      ncl_available: !!ncl,
+      ncl_status: ncl?.status ?? null,
+      ncl_utilization_pct: ncl?.utilizationPct ?? null,
+    });
+  }, [ncl]);
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
+      <p className="text-sm sm:text-base leading-relaxed text-foreground/90">{narrative}</p>
+
+      {/* Citizen proportional share */}
+      {segment === 'citizen' && proportionalShareAda != null && proportionalShareAda > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Your proportional share: ₳{formatAda(proportionalShareAda)}
+        </p>
+      )}
+
+      {/* DRep contextual note */}
+      {segment === 'drep' && ncl && pendingCount > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Your votes on pending proposals directly affect NCL utilization. See the pending proposals
+          section below for per-proposal impact.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -238,6 +238,14 @@ export function useTreasurySimilar(txHash: string, index: number) {
   });
 }
 
+export function useTreasuryNcl() {
+  return useQuery({
+    queryKey: ['treasury-ncl'],
+    queryFn: () => fetchJson('/api/treasury/ncl'),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
 export function useDashboardUrgent(drepId: string | null | undefined) {
   return useQuery({
     queryKey: ['dashboard-urgent', drepId],

--- a/lib/treasury.ts
+++ b/lib/treasury.ts
@@ -691,4 +691,197 @@ export function getNextCycleEpoch(
   return currentClosesEpoch + ACCOUNTABILITY_CYCLE_INTERVAL;
 }
 
+// ---------------------------------------------------------------------------
+// NCL (Net Change Limit) Utilization
+// ---------------------------------------------------------------------------
+
+export interface NclPeriod {
+  id: number;
+  nclAda: number;
+  startEpoch: number;
+  endEpoch: number;
+  infoActionTxHash: string | null;
+  infoActionIndex: number | null;
+  status: 'active' | 'expired' | 'superseded';
+}
+
+export interface NclUtilization {
+  period: NclPeriod;
+  enactedWithdrawalsAda: number;
+  pendingWithdrawalsAda: number;
+  utilizationPct: number;
+  projectedUtilizationPct: number;
+  remainingAda: number;
+  headroomAfterPendingAda: number;
+  epochsRemaining: number;
+  epochsElapsed: number;
+  periodProgressPct: number;
+  sustainabilityRatio: number;
+  status: 'healthy' | 'elevated' | 'critical';
+}
+
+export async function getActiveNclPeriod(): Promise<NclPeriod | null> {
+  const supabase = createClient();
+  const { data } = await supabase
+    .from('ncl_periods')
+    .select('*')
+    .eq('status', 'active')
+    .order('start_epoch', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!data) return null;
+  return {
+    id: data.id,
+    nclAda: Number(data.ncl_ada),
+    startEpoch: data.start_epoch,
+    endEpoch: data.end_epoch,
+    infoActionTxHash: data.info_action_tx_hash,
+    infoActionIndex: data.info_action_index,
+    status: data.status as NclPeriod['status'],
+  };
+}
+
+export async function getNclUtilization(): Promise<NclUtilization | null> {
+  const period = await getActiveNclPeriod();
+  if (!period) return null;
+
+  const supabase = createClient();
+
+  // Enacted treasury withdrawals within this NCL period
+  const { data: enacted } = await supabase
+    .from('proposals')
+    .select('withdrawal_amount')
+    .eq('proposal_type', 'TreasuryWithdrawals')
+    .not('enacted_epoch', 'is', null)
+    .gte('enacted_epoch', period.startEpoch)
+    .lte('enacted_epoch', period.endEpoch);
+
+  const enactedWithdrawalsAda = (enacted || []).reduce(
+    (sum, p) => sum + (p.withdrawal_amount || 0),
+    0,
+  );
+
+  // Pending proposals (not yet enacted, not expired/dropped)
+  const { data: pending } = await supabase
+    .from('proposals')
+    .select('withdrawal_amount')
+    .eq('proposal_type', 'TreasuryWithdrawals')
+    .is('ratified_epoch', null)
+    .is('enacted_epoch', null)
+    .is('expired_epoch', null)
+    .is('dropped_epoch', null);
+
+  const pendingWithdrawalsAda = (pending || []).reduce(
+    (sum, p) => sum + (p.withdrawal_amount || 0),
+    0,
+  );
+
+  // Current epoch from latest treasury snapshot
+  const balance = await getTreasuryBalance();
+  const currentEpoch = balance?.epoch ?? period.startEpoch;
+
+  // Estimate annualized income for sustainability ratio
+  const snapshots = await getTreasuryTrend(73); // ~1 year of epochs
+  const totalIncome = snapshots.reduce((sum, s) => sum + s.reservesIncomeAda, 0);
+  const epochsCovered = snapshots.length || 1;
+  const annualizedIncome = (totalIncome / epochsCovered) * (365.25 / EPOCH_DAYS);
+
+  const totalEpochs = period.endEpoch - period.startEpoch;
+  const epochsElapsed = Math.max(0, currentEpoch - period.startEpoch);
+  const epochsRemaining = Math.max(0, period.endEpoch - currentEpoch);
+  const utilizationPct = period.nclAda > 0 ? (enactedWithdrawalsAda / period.nclAda) * 100 : 0;
+  const projectedUtilizationPct =
+    period.nclAda > 0 ? ((enactedWithdrawalsAda + pendingWithdrawalsAda) / period.nclAda) * 100 : 0;
+  const remainingAda = Math.max(0, period.nclAda - enactedWithdrawalsAda);
+  const headroomAfterPendingAda = Math.max(
+    0,
+    period.nclAda - enactedWithdrawalsAda - pendingWithdrawalsAda,
+  );
+  const periodProgressPct = totalEpochs > 0 ? (epochsElapsed / totalEpochs) * 100 : 0;
+  const sustainabilityRatio = period.nclAda > 0 ? annualizedIncome / period.nclAda : 1;
+
+  const status: NclUtilization['status'] =
+    utilizationPct >= 80 ? 'critical' : utilizationPct >= 50 ? 'elevated' : 'healthy';
+
+  return {
+    period,
+    enactedWithdrawalsAda,
+    pendingWithdrawalsAda,
+    utilizationPct: Math.round(utilizationPct * 10) / 10,
+    projectedUtilizationPct: Math.round(projectedUtilizationPct * 10) / 10,
+    remainingAda,
+    headroomAfterPendingAda,
+    epochsRemaining,
+    epochsElapsed,
+    periodProgressPct: Math.round(periodProgressPct * 10) / 10,
+    sustainabilityRatio: Math.round(sustainabilityRatio * 100) / 100,
+    status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Treasury Narrative Generation
+// ---------------------------------------------------------------------------
+
+export interface TreasuryNarrativeData {
+  balanceAda: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  effectivenessRate: number | null;
+  pendingCount: number;
+  pendingTotalAda: number;
+  runwayMonths: number;
+  ncl: NclUtilization | null;
+}
+
+export function generateTreasuryNarrative(data: TreasuryNarrativeData): string {
+  const { balanceAda, trend, effectivenessRate, pendingCount, pendingTotalAda, runwayMonths, ncl } =
+    data;
+
+  const parts: string[] = [];
+
+  // Balance + trend
+  const trendWord =
+    trend === 'growing' ? 'growing' : trend === 'shrinking' ? 'declining' : 'stable';
+  parts.push(`₳${formatAda(balanceAda)} treasury, ${trendWord}.`);
+
+  // NCL utilization (cornerstone)
+  if (ncl) {
+    const utilizationStr = `${Math.round(ncl.utilizationPct)}% of the ₳${formatAda(ncl.period.nclAda)} budget period limit has been used`;
+    const epochStr = `with ${ncl.epochsRemaining} epochs remaining`;
+
+    if (ncl.status === 'critical') {
+      parts.push(`⚠ ${utilizationStr} ${epochStr}.`);
+    } else {
+      parts.push(`${utilizationStr} ${epochStr}.`);
+    }
+  }
+
+  // Effectiveness
+  if (effectivenessRate !== null) {
+    parts.push(`${effectivenessRate}% of funded projects delivered.`);
+  }
+
+  // Pending proposals
+  if (pendingCount > 0) {
+    const pendingStr =
+      pendingCount === 1
+        ? `1 proposal pending totaling ₳${formatAda(pendingTotalAda)}`
+        : `${pendingCount} proposals pending totaling ₳${formatAda(pendingTotalAda)}`;
+    parts.push(`${pendingStr}.`);
+  } else {
+    parts.push('No proposals currently pending.');
+  }
+
+  // Runway
+  if (runwayMonths < 240) {
+    const years = Math.floor(runwayMonths / 12);
+    parts.push(`Runway: ${years > 0 ? `${years}+ years` : `${runwayMonths} months`}.`);
+  } else {
+    parts.push('Runway: 10+ years.');
+  }
+
+  return parts.join(' ');
+}
+
 export { ACCOUNTABILITY_POLL_DURATION, ACCOUNTABILITY_CYCLE_INTERVAL };

--- a/types/database.ts
+++ b/types/database.ts
@@ -2424,6 +2424,39 @@ export type Database = {
         };
         Relationships: [];
       };
+      ncl_periods: {
+        Row: {
+          created_at: string;
+          end_epoch: number;
+          id: number;
+          info_action_index: number | null;
+          info_action_tx_hash: string | null;
+          ncl_ada: number;
+          start_epoch: number;
+          status: string;
+        };
+        Insert: {
+          created_at?: string;
+          end_epoch: number;
+          id?: number;
+          info_action_index?: number | null;
+          info_action_tx_hash?: string | null;
+          ncl_ada: number;
+          start_epoch: number;
+          status?: string;
+        };
+        Update: {
+          created_at?: string;
+          end_epoch?: number;
+          id?: number;
+          info_action_index?: number | null;
+          info_action_tx_hash?: string | null;
+          ncl_ada?: number;
+          start_epoch?: number;
+          status?: string;
+        };
+        Relationships: [];
+      };
       notification_log: {
         Row: {
           channel: string;


### PR DESCRIPTION
## Summary
- Transform treasury page from raw dashboard to narrative-first intelligence surface with NCL (Net Change Limit) utilization as the cornerstone feature
- Add 5 new components: NclBudgetBar, TreasuryNarrativeHero, TreasuryKeyMetrics, TreasuryEpochFlow, DRepTreasuryTrackRecord
- Restructure page layout: narrative hero → NCL budget bar → key metrics → epoch flow → pending proposals (with per-proposal NCL impact) → DRep track record (gated) → accordions (accountability, simulator)

## Impact
- **What changed**: Treasury page redesigned from 4-section flat dashboard to narrative-first intelligence surface. NCL budget utilization tracking added — first in the Cardano ecosystem.
- **User-facing**: Yes — citizens see contextual narrative instead of raw numbers; DReps see treasury voting track record; all users see NCL budget bar showing enacted/pending/remaining spending against constitutional limit
- **Risk**: Low-Medium — new components are additive, page composition restructured but all existing components preserved. Migration already applied (ncl_periods table).
- **Scope**: 5 new components, 1 new API route, lib/treasury.ts (+193 lines), hooks/queries.ts, TreasuryOverview.tsx rewrite, TreasuryPendingProposals.tsx (NCL impact), page.tsx skeleton update, types/database.ts regenerated

## Test plan
- [ ] Treasury page loads with narrative hero paragraph
- [ ] NCL budget bar shows correct utilization % with enacted/pending/remaining segments
- [ ] Tooltips on bar segments show ADA amounts
- [ ] Key metrics row shows NCL %, pending count, effectiveness %
- [ ] Epoch flow chart renders last 6 epochs income vs outflow
- [ ] Pending proposals show per-proposal NCL impact ("If enacted: X% → Y%")
- [ ] Cumulative NCL footer appears when multiple proposals pending
- [ ] DRep track record card appears only for DRep segment
- [ ] Accountability and simulator sections are in collapsed accordions
- [ ] No NCL period: graceful fallback message shown
- [ ] Mobile: all sections stack correctly, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)