### PR TITLE
fix: committee page post-release — active-only members, UX cleanup

### DIFF
--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -9,63 +9,64 @@ export const dynamic = 'force-dynamic';
 export const GET = withRouteHandler(async () => {
   const supabase = createClient();
 
-  // Parallel fetches: votes, health summary, and member verdicts
-  const [{ data: votes, error }, health, verdicts] = await Promise.all([
+  // Parallel fetches: active members, votes, rationale names, health, verdicts
+  const [
+    { data: activeMembers, error: membersError },
+    { data: votes, error: votesError },
+    { data: rationaleNames },
+    health,
+    verdicts,
+  ] = await Promise.all([
+    supabase
+      .from('cc_members')
+      .select('cc_hot_id, author_name, transparency_grade, transparency_index, status')
+      .eq('status', 'authorized'),
     supabase.from('cc_votes').select('cc_hot_id, vote'),
+    supabase.from('cc_rationales').select('cc_hot_id, author_name').not('author_name', 'is', null),
     getCCHealthSummary(),
     getCCMemberVerdicts(),
   ]);
 
-  if (error) {
-    logger.error('Supabase error', { context: 'governance/committee', error: error?.message });
+  if (membersError) {
+    logger.error('Supabase error', {
+      context: 'governance/committee',
+      error: membersError?.message,
+    });
     return NextResponse.json({ members: [], health });
   }
 
-  if (!votes?.length) {
-    return NextResponse.json({ members: [], health });
+  // Build rationale name fallback map (first name found per cc_hot_id)
+  const rationaleNameMap = new Map<string, string>();
+  for (const r of rationaleNames ?? []) {
+    if (r.author_name && !rationaleNameMap.has(r.cc_hot_id)) {
+      rationaleNameMap.set(r.cc_hot_id, r.author_name);
+    }
   }
 
-  const memberMap = new Map<string, { yes: number; no: number; abstain: number }>();
-  for (const v of votes) {
-    const existing = memberMap.get(v.cc_hot_id) || { yes: 0, no: 0, abstain: 0 };
+  // Build vote counts per member
+  const voteMap = new Map<string, { yes: number; no: number; abstain: number }>();
+  for (const v of votes ?? []) {
+    const existing = voteMap.get(v.cc_hot_id) || { yes: 0, no: 0, abstain: 0 };
     if (v.vote === 'Yes') existing.yes++;
     else if (v.vote === 'No') existing.no++;
     else existing.abstain++;
-    memberMap.set(v.cc_hot_id, existing);
-  }
-
-  // Fetch CC member metadata (names + transparency grades)
-  const ccIds = Array.from(memberMap.keys());
-  const { data: memberMeta } = await supabase
-    .from('cc_members')
-    .select('cc_hot_id, author_name, transparency_grade, transparency_index')
-    .in('cc_hot_id', ccIds);
-
-  const metaMap = new Map<
-    string,
-    { name: string | null; grade: string | null; index: number | null }
-  >();
-  for (const m of memberMeta || []) {
-    metaMap.set(m.cc_hot_id, {
-      name: m.author_name,
-      grade: m.transparency_grade,
-      index: m.transparency_index,
-    });
+    voteMap.set(v.cc_hot_id, existing);
   }
 
   // Build verdict lookup
   const verdictMap = new Map(verdicts.map((v) => [v.ccHotId, v]));
 
-  const members = Array.from(memberMap.entries())
-    .map(([ccHotId, counts]) => {
+  // Start from active members (not from votes) — ensures all 7 active CC members appear
+  const members = (activeMembers ?? [])
+    .map((m) => {
+      const counts = voteMap.get(m.cc_hot_id) || { yes: 0, no: 0, abstain: 0 };
       const total = counts.yes + counts.no + counts.abstain;
-      const meta = metaMap.get(ccHotId);
-      const verdict = verdictMap.get(ccHotId);
+      const verdict = verdictMap.get(m.cc_hot_id);
       return {
-        ccHotId,
-        name: meta?.name ?? null,
-        transparencyGrade: meta?.grade ?? null,
-        transparencyIndex: meta?.index ?? null,
+        ccHotId: m.cc_hot_id,
+        name: m.author_name ?? rationaleNameMap.get(m.cc_hot_id) ?? null,
+        transparencyGrade: m.transparency_grade ?? null,
+        transparencyIndex: m.transparency_index ?? null,
         voteCount: total,
         yesCount: counts.yes,
         noCount: counts.no,

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -3,10 +3,9 @@
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Search, ChevronDown, ChevronUp, Vote, BookOpen, Clock, Sparkles } from 'lucide-react';
+import { ChevronDown, ChevronUp, Vote, BookOpen, Clock, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Input } from '@/components/ui/input';
 import { useCommitteeMembers } from '@/hooks/queries';
 import type { CommitteeMemberQuickView } from '@/hooks/queries';
 import { CCHealthVerdict } from '@/components/cc/CCHealthVerdict';
@@ -265,29 +264,20 @@ function CommitteePageSkeleton() {
 export default function CommitteePage() {
   const { data, isLoading } = useCommitteeMembers();
   const { segment } = useSegment();
-  const [search, setSearch] = useState('');
 
   const members = useMemo(() => data?.members ?? [], [data]);
   const health = data?.health;
 
-  const filtered = useMemo(() => {
-    if (!search.trim()) return members;
-    const q = search.toLowerCase();
-    return members.filter(
-      (m) => m.name?.toLowerCase().includes(q) || m.ccHotId.toLowerCase().includes(q),
-    );
-  }, [members, search]);
-
   const sorted = useMemo(
     () =>
-      [...filtered].sort((a, b) => {
+      [...members].sort((a, b) => {
         if (a.transparencyIndex != null && b.transparencyIndex != null)
           return b.transparencyIndex - a.transparencyIndex;
         if (a.transparencyIndex != null) return -1;
         if (b.transparencyIndex != null) return 1;
         return b.voteCount - a.voteCount;
       }),
-    [filtered],
+    [members],
   );
 
   return (
@@ -313,24 +303,11 @@ export default function CommitteePage() {
 
           {/* Section 3: Member Rankings */}
           <motion.div variants={fadeInUp} className="space-y-3">
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="text-base font-semibold">Member Rankings</h2>
-              {members.length > 5 && (
-                <div className="relative w-48">
-                  <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    placeholder="Search members…"
-                    className="h-8 pl-8 text-xs"
-                  />
-                </div>
-              )}
-            </div>
+            <h2 className="text-base font-semibold">Member Rankings</h2>
 
             {sorted.length === 0 ? (
               <div className="py-12 text-center text-sm text-muted-foreground">
-                {search ? 'No members match your search.' : 'No CC member data available yet.'}
+                No CC member data available yet.
               </div>
             ) : (
               <>

--- a/components/cc/CCHealthVerdict.tsx
+++ b/components/cc/CCHealthVerdict.tsx
@@ -198,9 +198,7 @@ export function CCHealthVerdict({ health }: CCHealthVerdictProps) {
 
             {/* Member count */}
             <span className="inline-flex items-center gap-1">
-              <span className="font-mono font-medium text-foreground">
-                {health.activeMembers}/{health.totalMembers}
-              </span>{' '}
+              <span className="font-mono font-medium text-foreground">{health.activeMembers}</span>{' '}
               active members
             </span>
 

--- a/components/cc/CCMemberProfileClient.tsx
+++ b/components/cc/CCMemberProfileClient.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { CCTransparencyTrend } from '@/components/cc/CCTransparencyTrend';
+import { CopyableAddress } from '@/components/CopyableAddress';
 import {
   interpretTransparencyScore,
   interpretParticipation,
@@ -128,7 +129,7 @@ function ProfileHero({ data }: { data: ProfileData }) {
           {data.authorName ? (
             <>
               <h1 className="text-2xl sm:text-3xl font-bold truncate">{data.authorName}</h1>
-              <p className="font-mono text-xs text-muted-foreground truncate">{data.ccHotId}</p>
+              <CopyableAddress address={data.ccHotId} truncate className="text-xs" />
             </>
           ) : (
             <h1 className="text-xl sm:text-2xl font-bold font-mono break-all">{displayName}</h1>
@@ -210,11 +211,11 @@ function KeyStats({ data }: { data: ProfileData }) {
     {
       label: 'Participation',
       value:
-        data.eligibleProposals != null
+        data.eligibleProposals != null && data.eligibleProposals > 0
           ? `${data.votesCast}/${data.eligibleProposals}`
           : `${data.totalVotes}`,
       sub:
-        data.eligibleProposals != null
+        data.eligibleProposals != null && data.eligibleProposals > 0
           ? `${Math.round((data.votesCast / data.eligibleProposals) * 100)}% vote rate`
           : 'proposals voted on',
       narrative: participationNarrative,

--- a/lib/cc/interpretations.ts
+++ b/lib/cc/interpretations.ts
@@ -172,7 +172,12 @@ export function interpretPillarStrengthWeakness(pillars: PillarScores): string {
   const strongest = sorted[0];
   const weakest = sorted[sorted.length - 1];
 
-  if (strongest[1] === weakest[1]) return `Balanced across all pillars at ${strongest[1]}/100`;
+  if (strongest[1] === weakest[1]) {
+    if (strongest[1] >= 70) return `Consistently strong across all pillars (${strongest[1]}/100)`;
+    if (strongest[1] >= 40)
+      return `Even across all pillars (${strongest[1]}/100) — room to improve`;
+    return `Low across all pillars (${strongest[1]}/100) — significant improvement needed`;
+  }
 
   return `Strongest: ${PILLAR_LABELS[strongest[0]]} (${strongest[1]}/100). Weakest: ${PILLAR_LABELS[weakest[0]]} (${weakest[1]}/100)`;
 }
@@ -193,11 +198,11 @@ export interface CCHealthData {
 }
 
 export function interpretHealthStatus(data: CCHealthData): HealthStatus {
-  const { avgTransparency, activeMembers, totalMembers } = data;
+  const { avgTransparency, activeMembers } = data;
   if (avgTransparency == null) return 'attention';
-  const activeRate = totalMembers > 0 ? activeMembers / totalMembers : 0;
-  if (avgTransparency >= 65 && activeRate >= 0.8) return 'healthy';
-  if (avgTransparency >= 45 && activeRate >= 0.5) return 'attention';
+  if (activeMembers === 0) return 'critical';
+  if (avgTransparency >= 65) return 'healthy';
+  if (avgTransparency >= 45) return 'attention';
   return 'critical';
 }
 
@@ -205,10 +210,7 @@ export function generateCCHealthNarrative(data: CCHealthData): string {
   const { activeMembers, totalMembers, avgTransparency, tensionCount } = data;
   const status = interpretHealthStatus(data);
 
-  const memberStr =
-    activeMembers === totalMembers
-      ? `All ${totalMembers} members are actively voting`
-      : `${activeMembers} of ${totalMembers} members are actively voting`;
+  const memberStr = `${activeMembers} active committee member${activeMembers !== 1 ? 's' : ''}`;
 
   const scoreStr =
     avgTransparency != null

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1130,7 +1130,7 @@ export async function getCCHealthSummary(): Promise<CCHealthSummary> {
 
     const currentEpoch = stats?.current_epoch ?? 0;
     const activeMembers = members.filter((m) => m.status === 'authorized').length;
-    const totalMembers = members.length;
+    const totalMembers = activeMembers; // Only count active members — expired ones are historical
     const scoredMembers = members.filter((m) => m.transparencyIndex != null);
     const avgTransparency =
       scoredMembers.length > 0


### PR DESCRIPTION
## Summary
- Filter API to only return authorized CC members (was including expired, showing "7/12")
- Add `cc_rationales` name fallback for members missing `author_name`
- Fix participation "0/0" display when `eligible_proposals` is 0
- Add click-to-copy for CC ID on member profiles (`CopyableAddress`)
- Remove search bar (only 7 active members)
- Fix confusing "Balanced across all pillars at 10/100" — now score-aware tiers
- Simplify health status logic and member count display

## Impact
- **What changed**: Committee list now shows only active CC members with better name resolution and clearer metrics
- **User-facing**: Yes — fixes misleading "7/12 active" stat, shows names instead of IDs where available, removes unnecessary search, clearer pillar messaging
- **Risk**: Low — pure display/query fixes, no schema changes
- **Scope**: 6 files (API route, page, 2 components, interpretations, data)

## Test plan
- [ ] Committee list shows only 7 active members
- [ ] Members display names from rationale fallback where available
- [ ] Health verdict shows "7 active members" (not "7/12")
- [ ] Participation shows vote count (not "0/0") when eligible_proposals is 0
- [ ] CC ID on profile page is click-to-copy
- [ ] No search bar on committee list
- [ ] Pillar summary shows score-appropriate language at low scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)