### PR TITLE
feat: governance health world-class redesign — narrative-first info architecture

### DIFF
--- a/app/api/og/governance-snapshot/route.tsx
+++ b/app/api/og/governance-snapshot/route.tsx
@@ -1,0 +1,310 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { OGBackground, OGFooter, OG } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+const BAND_COLORS: Record<string, string> = {
+  strong: '#10b981',
+  good: '#22c55e',
+  fair: '#f59e0b',
+  critical: '#f43f5e',
+};
+
+function bandColor(band: string): string {
+  return BAND_COLORS[band.toLowerCase()] ?? BAND_COLORS.fair;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const score = Number(searchParams.get('score') || '0');
+  const band = searchParams.get('band') || 'fair';
+  const epoch = searchParams.get('epoch');
+  const drep = searchParams.get('drep');
+  const tier = searchParams.get('tier');
+  const participation = searchParams.get('participation');
+  const ada = searchParams.get('ada');
+
+  const color = bandColor(band);
+  const hasPersonalData = !!drep;
+
+  const jsx = (
+    <OGBackground glow={color}>
+      {/* Radial glow behind the score */}
+      <div
+        style={{
+          display: 'flex',
+          position: 'absolute',
+          top: hasPersonalData ? '120px' : '80px',
+          left: hasPersonalData ? '80px' : '350px',
+          width: '400px',
+          height: '400px',
+          borderRadius: '50%',
+          background: `radial-gradient(circle, ${color}1a 0%, transparent 70%)`,
+        }}
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          height: '100%',
+          padding: '48px 64px',
+        }}
+      >
+        {/* Top-left: Brand */}
+        <div
+          style={{
+            display: 'flex',
+            fontSize: '16px',
+            fontWeight: 600,
+            letterSpacing: '0.15em',
+            textTransform: 'uppercase' as const,
+            color: '#818cf8',
+          }}
+        >
+          GOVERNADA
+        </div>
+
+        {/* Main content area */}
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            alignItems: 'center',
+            gap: '80px',
+            marginTop: '16px',
+          }}
+        >
+          {/* Left: GHI Score with ring */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minWidth: '280px',
+            }}
+          >
+            <ScoreRing score={score} color={color} />
+            <div
+              style={{
+                display: 'flex',
+                marginTop: '16px',
+                padding: '6px 24px',
+                borderRadius: '20px',
+                backgroundColor: `${color}20`,
+                border: `1px solid ${color}40`,
+                fontSize: '20px',
+                fontWeight: 600,
+                color,
+                textTransform: 'capitalize' as const,
+              }}
+            >
+              {band}
+            </div>
+            {!hasPersonalData && (
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '18px',
+                  color: OG.textMuted,
+                  marginTop: '12px',
+                }}
+              >
+                Cardano Governance Health
+              </div>
+            )}
+          </div>
+
+          {/* Right: Personal data or nothing */}
+          {hasPersonalData && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                flex: 1,
+                justifyContent: 'center',
+                gap: '24px',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  letterSpacing: '0.1em',
+                  textTransform: 'uppercase' as const,
+                  color: OG.textMuted,
+                }}
+              >
+                Your Governance
+              </div>
+
+              {/* DRep name + tier */}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '36px',
+                    fontWeight: 700,
+                    color: OG.text,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {drep.length > 22 ? drep.slice(0, 20) + '...' : drep}
+                </div>
+                {tier && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        padding: '4px 14px',
+                        borderRadius: '12px',
+                        backgroundColor: `${OG.indigo}20`,
+                        border: `1px solid ${OG.indigo}40`,
+                        fontSize: '14px',
+                        fontWeight: 500,
+                        color: OG.indigo,
+                      }}
+                    >
+                      {tier}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Stats row */}
+              <div style={{ display: 'flex', gap: '40px', marginTop: '8px' }}>
+                {participation && (
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <div style={{ display: 'flex', fontSize: '14px', color: OG.textDim }}>
+                      Participation
+                    </div>
+                    <div
+                      style={{
+                        display: 'flex',
+                        fontSize: '28px',
+                        fontWeight: 700,
+                        color: OG.text,
+                      }}
+                    >
+                      {participation}
+                    </div>
+                  </div>
+                )}
+                {ada && (
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <div style={{ display: 'flex', fontSize: '14px', color: OG.textDim }}>ADA</div>
+                    <div
+                      style={{
+                        display: 'flex',
+                        fontSize: '28px',
+                        fontWeight: 700,
+                        color: OG.text,
+                      }}
+                    >
+                      {ada}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <OGFooter left={epoch ? `Epoch ${epoch}` : undefined} right="governada.io" />
+      </div>
+    </OGBackground>
+  );
+
+  return new ImageResponse(jsx, {
+    width: 1200,
+    height: 630,
+    headers: {
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}
+
+function ScoreRing({ score, color }: { score: number; color: string }) {
+  const size = 220;
+  const strokeWidth = 14;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = Math.min(100, Math.max(0, score)) / 100;
+  const dashOffset = circumference * (1 - progress);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        position: 'relative',
+        width: size,
+        height: size,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)', position: 'absolute' }}>
+        {/* Background track */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={OG.barBg}
+          strokeWidth={strokeWidth}
+        />
+        {/* Progress arc */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+        />
+        {/* Glow arc */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth * 2}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          opacity={0.15}
+        />
+      </svg>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            fontSize: '72px',
+            fontWeight: 700,
+            color: OG.text,
+            lineHeight: 1,
+          }}
+        >
+          {score}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -2,21 +2,8 @@
 
 import { useCallback } from 'react';
 import { useSearchParams, usePathname } from 'next/navigation';
-import Link from 'next/link';
-import {
-  Activity,
-  AlertTriangle,
-  TrendingUp,
-  TrendingDown,
-  Users,
-  Vote,
-  DollarSign,
-  BarChart3,
-  ChevronRight,
-} from 'lucide-react';
+import { Activity } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { formatAda } from '@/lib/treasury';
-import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorCard } from '@/components/ui/ErrorCard';
 import { useGovernancePulse } from '@/hooks/queries';
 import { useTreasuryCurrent } from '@/hooks/queries';
@@ -25,22 +12,21 @@ import { CivicaEpochReport } from './CivicaEpochReport';
 import { CivicaGovernanceTrends } from './CivicaGovernanceTrends';
 import { CivicaObservatory } from './CivicaObservatory';
 import { CivicaGovernanceCalendar } from './CivicaGovernanceCalendar';
-import { StateOfGovernance } from './StateOfGovernance';
 import { GHIHero } from './GHIHero';
 import { GHIExplorer } from './GHIExplorer';
 import { GovernanceImpactCard } from './GovernanceImpactCard';
+import { GovernanceBriefing } from './GovernanceBriefing';
+import { GovernanceAlerts } from './GovernanceAlerts';
 import { ActivityTicker } from '@/components/ActivityTicker';
 import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { EmptyState } from './EmptyState';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type {
   TreasuryData,
   LeaderboardData,
   LeaderboardEntry,
   CommunityGapItem,
-  TreasuryHealthComponent,
 } from '@/types/api';
 
 interface PulseDataLocal {
@@ -94,86 +80,6 @@ function resolvePulseTab(param: string | null): PulseTab {
   if (VALID_PULSE_TABS.has(lower as PulseTab)) return lower as PulseTab;
   if (lower in TAB_ALIASES) return TAB_ALIASES[lower];
   return 'now';
-}
-
-function StatCard({
-  label,
-  value,
-  sub,
-  icon: Icon,
-  accent,
-  href,
-  trend,
-  delta,
-}: {
-  label: string;
-  value: React.ReactNode;
-  sub?: string;
-  icon: React.FC<{ className?: string }>;
-  accent?: 'default' | 'warning' | 'success' | 'danger';
-  href?: string;
-  trend?: 'up' | 'down' | 'flat' | null;
-  delta?: string | null;
-}) {
-  const accentClass = {
-    default: 'text-primary',
-    warning: 'text-amber-400',
-    success: 'text-emerald-400',
-    danger: 'text-rose-400',
-  }[accent ?? 'default'];
-
-  const Wrap = href ? Link : 'div';
-  return (
-    <Wrap
-      href={href as string}
-      className={cn(
-        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2 transition-colors',
-        href &&
-          'hover:border-primary/30 cursor-pointer group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-      )}
-      {...(href ? { 'aria-label': `${label}: ${value}${sub ? `, ${sub}` : ''}` } : {})}
-    >
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-muted-foreground font-medium uppercase tracking-wider">
-          {label}
-        </p>
-        <Icon className={cn('h-4 w-4', accentClass)} aria-hidden="true" />
-      </div>
-      <div className="flex items-baseline gap-2">
-        <div
-          className={cn('font-display text-3xl font-bold leading-none tabular-nums', accentClass)}
-        >
-          {value}
-        </div>
-        {delta && trend && trend !== 'flat' && (
-          <span
-            className={cn(
-              'text-[10px] font-medium whitespace-nowrap',
-              trend === 'up' ? 'text-emerald-500' : 'text-rose-500',
-            )}
-          >
-            {trend === 'up' ? '↑' : '↓'} {delta}
-          </span>
-        )}
-      </div>
-      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
-      {href && (
-        <div className="flex items-center gap-1 text-[10px] text-muted-foreground/70 group-hover:text-primary transition-colors">
-          View details <ChevronRight className="h-3 w-3" />
-        </div>
-      )}
-    </Wrap>
-  );
-}
-
-function StatCardSkeleton() {
-  return (
-    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
-      <Skeleton className="h-3 w-24" />
-      <Skeleton className="h-8 w-16" />
-      <Skeleton className="h-2.5 w-32" />
-    </div>
-  );
 }
 
 export function CivicaPulseOverview() {
@@ -267,7 +173,7 @@ export function CivicaPulseOverview() {
         message="The big picture. How healthy is Cardano governance right now? Track participation, treasury, and trends over time."
       />
       <AnonymousNudge variant="health" />
-      {/* ── Tab bar ─────────────────────────────────────────── */}
+      {/* ── Tab bar ───────────── */}
       <div
         className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 flex gap-1 border-b border-border/30 -mb-2 overflow-x-auto bg-card/60 backdrop-blur-xl"
         role="tablist"
@@ -299,7 +205,7 @@ export function CivicaPulseOverview() {
         </div>
       )}
 
-      {/* ── History tab: epoch report + trends + calendar ───── */}
+      {/* ── History tab ───── */}
       {activeTab === 'history' && (
         <div className="space-y-8" role="tabpanel" id="pulse-tabpanel-history" aria-label="History">
           <CivicaEpochReport />
@@ -308,13 +214,34 @@ export function CivicaPulseOverview() {
         </div>
       )}
 
-      {/* ── Now tab ─────────────────────────────────────────── */}
+      {/* ── Now tab ──────── */}
       {activeTab === 'now' && (
         <div className="space-y-8" role="tabpanel" id="pulse-tabpanel-now" aria-label="Now">
-          {/* ── GHI Hero ─────────────────────────────────────────── */}
+          {/* 1. GHI Verdict */}
           <GHIHero />
 
-          {/* ── GHI Explorer (click-to-expand breakdown) ──────── */}
+          {/* 2. Personal governance footprint */}
+          <GovernanceImpactCard
+            totalAdaGovernedLovelace={
+              (pulse as PulseDataLocal & { totalAdaGovernedRaw?: number })?.totalAdaGovernedRaw ?? 0
+            }
+            treasuryBalanceAda={treasury?.balance ?? treasury?.balanceAda ?? 0}
+          />
+
+          {/* 3. Narrative briefing + headline metric pills */}
+          <GovernanceBriefing />
+
+          {/* 4. Consolidated governance alerts */}
+          <GovernanceAlerts
+            communityGap={pulse?.communityGap}
+            spotlightProposal={pulse?.spotlightProposal}
+            gainers={gainers}
+            losers={losers}
+            criticalProposals={pulse?.criticalProposals}
+            loading={loading}
+          />
+
+          {/* 5. GHI Explorer (click-to-expand breakdown) */}
           {ghiData?.current && (
             <GHIExplorer
               components={ghiData.current.components}
@@ -333,460 +260,7 @@ export function CivicaPulseOverview() {
             />
           )}
 
-          {/* ── State of Governance narrative ───────────────────── */}
-          <StateOfGovernance />
-
-          {/* ── Personalized governance impact card ────────────── */}
-          <GovernanceImpactCard
-            totalAdaGovernedLovelace={
-              (pulse as PulseDataLocal & { totalAdaGovernedRaw?: number })?.totalAdaGovernedRaw ?? 0
-            }
-            treasuryBalanceAda={treasury?.balance ?? treasury?.balanceAda ?? 0}
-          />
-
-          {/* ── Epoch context ────────────────────────────────────── */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              {pulse?.currentEpoch
-                ? `Epoch ${pulse.currentEpoch} · live data`
-                : 'Live Cardano governance data'}
-            </p>
-            <div className="flex items-center gap-1.5">
-              <span className="relative flex h-2 w-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-400" />
-              </span>
-              <span className="text-xs text-muted-foreground">Live</span>
-            </div>
-          </div>
-
-          {/* ── Stats grid ──────────────────────────────────────── */}
-          {loading ? (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <StatCardSkeleton key={i} />
-              ))}
-            </div>
-          ) : (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-              <StatCard
-                label="Current Epoch"
-                value={pulse?.currentEpoch ?? '—'}
-                sub="Cardano consensus layer"
-                icon={Activity}
-              />
-              <StatCard
-                label="Active Proposals"
-                value={pulse?.activeProposals ?? 0}
-                sub={
-                  (pulse?.criticalProposals ?? 0) > 0
-                    ? `${pulse!.criticalProposals} critical`
-                    : 'No critical proposals'
-                }
-                icon={Vote}
-                accent={(pulse?.criticalProposals ?? 0) > 0 ? 'warning' : 'success'}
-                href="/governance/proposals"
-              />
-              <StatCard
-                label="Active DReps"
-                value={pulse?.activeDReps ?? 0}
-                sub={pulse?.totalDReps ? `of ${pulse.totalDReps} total` : undefined}
-                icon={Users}
-                accent="default"
-                href="/governance/representatives"
-                trend={
-                  pulse?.deltas?.activeDRepsDelta != null
-                    ? pulse.deltas.activeDRepsDelta > 0
-                      ? 'up'
-                      : pulse.deltas.activeDRepsDelta < 0
-                        ? 'down'
-                        : 'flat'
-                    : null
-                }
-                delta={
-                  pulse?.deltas?.activeDRepsDelta != null && pulse.deltas.activeDRepsDelta !== 0
-                    ? `${Math.abs(pulse.deltas.activeDRepsDelta)} from last epoch`
-                    : null
-                }
-              />
-              <StatCard
-                label="Votes This Week"
-                value={pulse?.votesThisWeek?.toLocaleString() ?? 0}
-                sub="On-chain DRep votes"
-                icon={BarChart3}
-                accent={(pulse?.votesThisWeek ?? 0) > 100 ? 'success' : 'default'}
-              />
-              <StatCard
-                label="Avg Participation"
-                value={`${pulse?.avgParticipationRate ?? 0}%`}
-                sub="Across all DReps"
-                icon={Activity}
-                accent={
-                  ((pulse?.avgParticipationRate as number | undefined) ?? 0) >= 70
-                    ? 'success'
-                    : ((pulse?.avgParticipationRate as number | undefined) ?? 0) >= 40
-                      ? 'warning'
-                      : 'danger'
-                }
-                trend={
-                  pulse?.deltas?.participationDelta != null
-                    ? pulse.deltas.participationDelta > 0
-                      ? 'up'
-                      : pulse.deltas.participationDelta < 0
-                        ? 'down'
-                        : 'flat'
-                    : null
-                }
-                delta={
-                  pulse?.deltas?.participationDelta != null && pulse.deltas.participationDelta !== 0
-                    ? `${Math.abs(pulse.deltas.participationDelta)}% from last epoch`
-                    : null
-                }
-              />
-              <StatCard
-                label="Avg Rationale Rate"
-                value={`${pulse?.avgRationaleRate ?? 0}%`}
-                sub="DReps providing rationale"
-                icon={BarChart3}
-                accent={
-                  ((pulse?.avgRationaleRate as number | undefined) ?? 0) >= 60
-                    ? 'success'
-                    : ((pulse?.avgRationaleRate as number | undefined) ?? 0) >= 30
-                      ? 'warning'
-                      : 'danger'
-                }
-                trend={
-                  pulse?.deltas?.rationaleDelta != null
-                    ? pulse.deltas.rationaleDelta > 0
-                      ? 'up'
-                      : pulse.deltas.rationaleDelta < 0
-                        ? 'down'
-                        : 'flat'
-                    : null
-                }
-                delta={
-                  pulse?.deltas?.rationaleDelta != null && pulse.deltas.rationaleDelta !== 0
-                    ? `${Math.abs(pulse.deltas.rationaleDelta)}% from last epoch`
-                    : null
-                }
-              />
-              {treasury && (
-                <>
-                  <StatCard
-                    label="Treasury Balance"
-                    value={formatAda(treasury.balance ?? treasury.balanceAda ?? 0)}
-                    sub={
-                      treasury.trend === 'growing'
-                        ? '↑ Growing'
-                        : treasury.trend === 'shrinking'
-                          ? '↓ Shrinking'
-                          : 'Stable'
-                    }
-                    icon={DollarSign}
-                    accent={
-                      treasury.trend === 'growing'
-                        ? 'success'
-                        : treasury.trend === 'shrinking'
-                          ? 'danger'
-                          : 'default'
-                    }
-                  />
-                  <StatCard
-                    label="Treasury Runway"
-                    value={
-                      (treasury.runwayMonths ?? 0) >= 999 ? '∞' : `${treasury.runwayMonths ?? 0}mo`
-                    }
-                    sub={
-                      (treasury.pendingCount ?? 0) > 0
-                        ? `${treasury.pendingCount} withdrawal${(treasury.pendingCount ?? 0) > 1 ? 's' : ''} pending`
-                        : 'No pending withdrawals'
-                    }
-                    icon={TrendingUp}
-                    accent={(treasury.runwayMonths ?? 0) > 24 ? 'success' : 'warning'}
-                  />
-                </>
-              )}
-            </div>
-          )}
-
-          {/* ── Spotlight Proposal ──────────────────────────────── */}
-          {pulse?.spotlightProposal && (
-            <div className="rounded-xl border border-amber-800/30 bg-amber-950/10 p-4 space-y-2">
-              <div className="flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0" />
-                <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider">
-                  Spotlight Proposal
-                </p>
-              </div>
-              <Link
-                href={`/proposal/${pulse.spotlightProposal.txHash}/${pulse.spotlightProposal.index}`}
-                className="block text-sm font-medium text-foreground hover:text-primary transition-colors"
-              >
-                {pulse.spotlightProposal.title}
-              </Link>
-              <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                <span className="capitalize">
-                  {pulse.spotlightProposal.proposalType?.replace(/([A-Z])/g, ' $1').trim()}
-                </span>
-                {pulse.spotlightProposal.voteCoverage != null && (
-                  <span>
-                    <strong className="text-foreground">
-                      {pulse.spotlightProposal.voteCoverage}%
-                    </strong>{' '}
-                    DRep vote coverage
-                  </span>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* ── Community vs DRep Sentiment Gap ─────────────────── */}
-          {(pulse?.communityGap?.length ?? 0) > 0 && (
-            <div className="rounded-xl border-l-2 border-l-primary border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <h3 className="text-sm font-semibold">Where Citizens & DReps Diverge</h3>
-                <span className="text-[10px] text-muted-foreground px-1.5 py-0.5 rounded bg-muted">
-                  Unique to Governada
-                </span>
-              </div>
-              <div className="divide-y divide-border">
-                {(pulse!.communityGap as CommunityGapItem[]).slice(0, 3).map((g) => {
-                  const pollTotal = g.pollTotal || 1;
-                  const yesPct = Math.round(((g.pollYes ?? 0) / pollTotal) * 100);
-                  const noPct = Math.round(((g.pollNo ?? 0) / pollTotal) * 100);
-                  return (
-                    <Link
-                      key={`${g.txHash}-${g.index}`}
-                      href={`/proposal/${g.txHash}/${g.index}`}
-                      className="block py-3 first:pt-0 last:pb-0 hover:bg-muted/20 transition-colors"
-                    >
-                      <p className="text-sm truncate mb-1.5">{g.title}</p>
-                      <div className="flex items-center gap-3 text-[11px]">
-                        <span className="text-muted-foreground">
-                          Community: <strong className="text-emerald-400">{yesPct}% Yes</strong>
-                          {' / '}
-                          <strong className="text-rose-400">{noPct}% No</strong>
-                          <span className="text-muted-foreground/60"> ({pollTotal} votes)</span>
-                        </span>
-                        <span className="text-muted-foreground">
-                          DReps: <strong className="text-foreground">{g.drepVotePct}%</strong> voted
-                        </span>
-                      </div>
-                    </Link>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-          {(pulse?.communityGap?.length ?? 0) === 0 && !loading && (
-            <EmptyState
-              icon={<Users className="h-8 w-8" />}
-              title="Community sentiment polls coming soon"
-              description="Be the first to participate"
-            />
-          )}
-
-          {/* ── Weekly movers ───────────────────────────────────── */}
-          {(gainers.length > 0 || losers.length > 0) && (
-            <div className="grid gap-3 sm:grid-cols-2">
-              {gainers.length > 0 && (
-                <div className="rounded-xl border border-emerald-900/30 bg-emerald-950/10 p-4 space-y-3">
-                  <div className="flex items-center gap-1.5">
-                    <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
-                    <p className="text-xs font-semibold text-emerald-400 uppercase tracking-wider">
-                      Rising this week
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    {gainers.map((m) => {
-                      const prevScore =
-                        m.currentScore != null && m.delta != null
-                          ? (m.currentScore as number) - (m.delta as number)
-                          : null;
-                      return (
-                        <TooltipProvider key={m.drepId}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Link
-                                href={`/drep/${m.drepId}`}
-                                className="flex items-center justify-between group"
-                              >
-                                <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
-                                  {m.name}
-                                </span>
-                                <div className="flex items-center gap-1 shrink-0">
-                                  <span className="text-xs font-bold text-emerald-400 tabular-nums">
-                                    +{m.delta}
-                                  </span>
-                                  <span className="text-[10px] text-muted-foreground">
-                                    → {m.currentScore}
-                                  </span>
-                                </div>
-                              </Link>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" className="max-w-64">
-                              <p>
-                                Score changed from {prevScore ?? '?'} to {m.currentScore} this week.
-                                Visit their profile for detailed breakdown.
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-              {losers.length > 0 && (
-                <div className="rounded-xl border border-rose-900/30 bg-rose-950/10 p-4 space-y-3">
-                  <div className="flex items-center gap-1.5">
-                    <TrendingDown className="h-3.5 w-3.5 text-rose-400" />
-                    <p className="text-xs font-semibold text-rose-400 uppercase tracking-wider">
-                      Falling this week
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    {losers.map((m) => {
-                      const prevScore =
-                        m.currentScore != null && m.delta != null
-                          ? (m.currentScore as number) - (m.delta as number)
-                          : null;
-                      return (
-                        <TooltipProvider key={m.drepId}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Link
-                                href={`/drep/${m.drepId}`}
-                                className="flex items-center justify-between group"
-                              >
-                                <span className="text-sm text-foreground/80 truncate max-w-[200px] group-hover:text-foreground transition-colors">
-                                  {m.name}
-                                </span>
-                                <div className="flex items-center gap-1 shrink-0">
-                                  <span className="text-xs font-bold text-rose-400 tabular-nums">
-                                    {m.delta}
-                                  </span>
-                                  <span className="text-[10px] text-muted-foreground">
-                                    → {m.currentScore}
-                                  </span>
-                                </div>
-                              </Link>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" className="max-w-64">
-                              <p>
-                                Score changed from {prevScore ?? '?'} to {m.currentScore} this week.
-                                Visit their profile for detailed breakdown.
-                              </p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-          {gainers.length === 0 && losers.length === 0 && !loading && (
-            <EmptyState
-              icon={<TrendingUp className="h-8 w-8" />}
-              title="No significant DRep score changes this week"
-              description="Score changes are tracked weekly across all active DReps"
-            />
-          )}
-
-          {/* ── Treasury Health Components ─────────────────────── */}
-          {treasury?.healthComponents &&
-            typeof treasury.healthComponents === 'object' &&
-            (() => {
-              const components = Array.isArray(treasury.healthComponents)
-                ? (treasury.healthComponents as TreasuryHealthComponent[])
-                : Object.entries(treasury.healthComponents as Record<string, number>).map(
-                    ([key, value]) => ({
-                      name: key
-                        .replace(/([A-Z])/g, ' $1')
-                        .replace(/^./, (s: string) => s.toUpperCase()),
-                      score: value,
-                    }),
-                  );
-              if (components.length === 0) return null;
-              return (
-                <div className="space-y-2">
-                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                    Treasury Health Breakdown
-                  </p>
-                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                    {components.map((c: TreasuryHealthComponent) => (
-                      <div
-                        key={c.name ?? c.label}
-                        className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-4 py-3 space-y-1.5"
-                      >
-                        <div className="flex items-center justify-between">
-                          <p className="text-[11px] text-muted-foreground uppercase tracking-wider font-medium truncate">
-                            {c.name ?? c.label}
-                          </p>
-                          <span
-                            className={cn(
-                              'text-sm font-bold tabular-nums',
-                              (c.score ?? c.value ?? 0) >= 70
-                                ? 'text-emerald-400'
-                                : (c.score ?? c.value ?? 0) >= 40
-                                  ? 'text-amber-400'
-                                  : 'text-rose-400',
-                            )}
-                          >
-                            {Math.round(c.score ?? c.value ?? 0)}
-                          </span>
-                        </div>
-                        <div
-                          className="w-full h-1.5 bg-border rounded-full overflow-hidden"
-                          role="meter"
-                          aria-valuenow={Math.round(c.score ?? c.value ?? 0)}
-                          aria-valuemin={0}
-                          aria-valuemax={100}
-                          aria-label={`${c.name ?? c.label}: ${Math.round(c.score ?? c.value ?? 0)} out of 100`}
-                        >
-                          <div
-                            className={cn(
-                              'h-full rounded-full',
-                              (c.score ?? c.value ?? 0) >= 70
-                                ? 'bg-emerald-500'
-                                : (c.score ?? c.value ?? 0) >= 40
-                                  ? 'bg-amber-500'
-                                  : 'bg-rose-500',
-                            )}
-                            style={{ width: `${Math.min(100, c.score ?? c.value ?? 0)}%` }}
-                            aria-hidden="true"
-                          />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              );
-            })()}
-
-          {/* ── ADA governed ────────────────────────────────────── */}
-          {pulse?.totalAdaGoverned && (
-            <div className="rounded-xl border border-border bg-muted/10 px-5 py-4 flex items-center justify-between">
-              <div>
-                <p className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-                  Total ADA under DRep governance
-                </p>
-                <p className="font-display text-2xl font-bold text-foreground mt-0.5">
-                  ₳{String(pulse.totalAdaGoverned)}
-                </p>
-              </div>
-              <Link
-                href="/governance/representatives"
-                className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-0.5"
-              >
-                Browse DReps <ChevronRight className="h-3.5 w-3.5" />
-              </Link>
-            </div>
-          )}
-
-          {/* ── Live Activity Ticker (inline) ────────────────────── */}
+          {/* 6. Live Activity Ticker */}
           <ActivityTicker variant="inline" />
         </div>
       )}

--- a/components/civica/pulse/GHIHero.tsx
+++ b/components/civica/pulse/GHIHero.tsx
@@ -4,6 +4,7 @@ import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { useGovernanceHealthIndex } from '@/hooks/queries';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorCard } from '@/components/ui/ErrorCard';
 import { spring } from '@/lib/animations';
@@ -24,50 +25,114 @@ interface GHIData {
   trend: GHITrend;
 }
 
-const BAND_STYLES: Record<
-  string,
-  { text: string; ring: string; bg: string; label: string; description: string }
-> = {
+const BAND_STYLES: Record<string, { text: string; ring: string; bg: string; label: string }> = {
   strong: {
     text: 'text-emerald-500',
     ring: 'var(--color-emerald-500)',
     bg: 'bg-emerald-500/10',
     label: 'Strong',
-    description: 'Cardano governance is highly active with broad participation.',
   },
   good: {
     text: 'text-green-500',
     ring: 'var(--color-green-500)',
     bg: 'bg-green-500/10',
     label: 'Good',
-    description: 'Governance is healthy with solid participation across most areas.',
   },
   fair: {
     text: 'text-amber-500',
     ring: 'var(--color-amber-500)',
     bg: 'bg-amber-500/10',
     label: 'Fair',
-    description: 'Governance participation is moderate, with room for improvement.',
   },
   critical: {
     text: 'text-rose-500',
     ring: 'var(--color-rose-500)',
     bg: 'bg-rose-500/10',
     label: 'Critical',
-    description: 'Governance participation is low. Key areas need attention.',
   },
 };
 
 const CIRCUMFERENCE = 2 * Math.PI * 15.5;
 
+function buildVerdict(
+  band: string,
+  direction: 'up' | 'down' | 'flat',
+  _delta: number,
+  streakEpochs: number,
+): string {
+  const hasStreak = streakEpochs > 1;
+
+  if (band === 'strong') {
+    if (direction === 'up')
+      return hasStreak
+        ? `Governance is thriving \u2014 health has climbed for ${streakEpochs} consecutive epochs.`
+        : 'Governance is thriving with broad participation and accountability.';
+    if (direction === 'down')
+      return 'Still strong, but the trend is cooling. Worth watching this epoch.';
+    return 'Governance is in excellent shape across all dimensions.';
+  }
+
+  if (band === 'good') {
+    if (direction === 'up')
+      return hasStreak
+        ? `Healthy and improving \u2014 ${streakEpochs} epochs of steady gains.`
+        : 'Governance is healthy and trending upward.';
+    if (direction === 'down')
+      return 'Governance is solid but losing momentum. A few areas need attention.';
+    return 'Governance is performing well with room for further growth.';
+  }
+
+  if (band === 'fair') {
+    if (direction === 'up')
+      return 'Governance is recovering. Participation and accountability are on the rise.';
+    if (direction === 'down')
+      return hasStreak
+        ? `Governance has declined for ${streakEpochs} epochs. Key areas need intervention.`
+        : 'Governance health is moderate and slipping. Action is needed.';
+    return 'Governance participation is moderate, with clear room for improvement.';
+  }
+
+  // critical
+  if (direction === 'up')
+    return 'Signs of recovery are emerging, but governance needs urgent attention.';
+  if (direction === 'down')
+    return hasStreak
+      ? `Governance has been declining for ${streakEpochs} epochs. Immediate action is critical.`
+      : 'Governance health is critical and worsening.';
+  return 'Governance participation is dangerously low. The ecosystem needs to mobilize.';
+}
+
+function buildPersonaAddendum(segment: string, band: string): string | null {
+  if (segment === 'drep') {
+    if (band === 'critical' || band === 'fair')
+      return 'Your votes and rationales directly move this score. Every action counts.';
+    return 'Your consistent participation is helping maintain governance health.';
+  }
+  if (segment === 'spo') {
+    if (band === 'critical' || band === 'fair')
+      return 'SPO governance participation can help reverse this trend.';
+    return null;
+  }
+  if (segment === 'citizen') {
+    if (band === 'critical' || band === 'fair')
+      return 'Delegating to an active DRep is the most impactful action you can take.';
+    return null;
+  }
+  if (segment === 'cc') {
+    return 'Constitutional Committee oversight shapes the governance environment.';
+  }
+  return null;
+}
+
 export function GHIHero() {
   const { data: rawGhi, isLoading, isError, refetch } = useGovernanceHealthIndex(1);
   const shouldReduceMotion = useReducedMotion();
+  const { segment } = useSegment();
 
   if (isLoading) {
     return (
       <div className="flex items-center gap-5 p-5 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md">
-        <Skeleton className="h-20 w-20 rounded-full shrink-0" />
+        <Skeleton className="h-[120px] w-[120px] rounded-full shrink-0" />
         <div className="space-y-2 flex-1">
           <Skeleton className="h-5 w-40" />
           <Skeleton className="h-3 w-64" />
@@ -106,6 +171,9 @@ export function GHIHero() {
       ? `${streakEpochs}-epoch ${direction === 'up' ? 'climb' : direction === 'down' ? 'slide' : 'streak'}`
       : null;
 
+  const verdict = buildVerdict(band, direction, delta, streakEpochs);
+  const personaAddendum = buildPersonaAddendum(segment, band);
+
   return (
     <div
       className={cn(
@@ -116,14 +184,14 @@ export function GHIHero() {
     >
       {/* Score ring */}
       <div
-        className="relative h-20 w-20 shrink-0"
+        className="relative h-[120px] w-[120px] shrink-0"
         role="meter"
         aria-valuenow={Math.round(score)}
         aria-valuemin={0}
         aria-valuemax={100}
         aria-label={`Governance Health Index: ${Math.round(score)} out of 100`}
       >
-        <svg viewBox="0 0 36 36" className="h-20 w-20 -rotate-90" aria-hidden="true">
+        <svg viewBox="0 0 36 36" className="h-[120px] w-[120px] -rotate-90" aria-hidden="true">
           <circle
             cx="18"
             cy="18"
@@ -133,6 +201,22 @@ export function GHIHero() {
             strokeWidth="2.5"
             className="text-muted/30"
           />
+          {/* Glow circle */}
+          {!shouldReduceMotion && (
+            <circle
+              cx="18"
+              cy="18"
+              r="15.5"
+              fill="none"
+              stroke={style.ring}
+              strokeWidth="3.5"
+              strokeDasharray={CIRCUMFERENCE}
+              strokeDashoffset={strokeOffset}
+              strokeLinecap="round"
+              className="animate-[ghi-pulse_3s_ease-in-out_infinite]"
+              style={{ filter: 'blur(3px)' }}
+            />
+          )}
           <motion.circle
             cx="18"
             cy="18"
@@ -153,8 +237,8 @@ export function GHIHero() {
         </svg>
         <div className="absolute inset-0 flex items-center justify-center" aria-hidden="true">
           <div className="text-center leading-none">
-            <span className="text-2xl font-bold tabular-nums">{Math.round(score)}</span>
-            <span className="text-[9px] text-muted-foreground font-medium">/100</span>
+            <span className="text-3xl font-bold tabular-nums">{Math.round(score)}</span>
+            <span className="text-[10px] text-muted-foreground font-medium">/100</span>
           </div>
         </div>
       </div>
@@ -180,8 +264,17 @@ export function GHIHero() {
           )}
         </div>
         {streakLabel && <p className="text-xs text-muted-foreground">{streakLabel}</p>}
-        <p className="text-sm text-muted-foreground">{style.description}</p>
+        <p className="text-sm text-muted-foreground">{verdict}</p>
+        {personaAddendum && <p className="text-xs text-primary/80 mt-1">{personaAddendum}</p>}
       </div>
+
+      {/* Pulse animation keyframes */}
+      <style>{`
+        @keyframes ghi-pulse {
+          0%, 100% { opacity: 0.3; }
+          50% { opacity: 0.7; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/components/civica/pulse/GovernanceAlerts.tsx
+++ b/components/civica/pulse/GovernanceAlerts.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Users,
+  TrendingUp,
+  TrendingDown,
+  ChevronRight,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { CommunityGapItem, LeaderboardEntry } from '@/types/api';
+
+interface GovernanceAlertsProps {
+  communityGap?: CommunityGapItem[];
+  spotlightProposal?: {
+    txHash: string;
+    index: number;
+    title: string;
+    proposalType?: string;
+    voteCoverage?: number;
+  } | null;
+  gainers?: LeaderboardEntry[];
+  losers?: LeaderboardEntry[];
+  criticalProposals?: number;
+  loading?: boolean;
+}
+
+interface Alert {
+  priority: number;
+  icon: React.ReactNode;
+  headline: string;
+  detail: string;
+  href: string;
+}
+
+function buildAlerts(props: GovernanceAlertsProps): Alert[] {
+  const { communityGap, spotlightProposal, gainers, losers, criticalProposals } = props;
+
+  const alerts: Alert[] = [];
+
+  // --- Critical proposals alert (priority 0) ---
+  if (criticalProposals && criticalProposals > 0) {
+    alerts.push({
+      priority: 0,
+      icon: <AlertTriangle className="h-4 w-4 text-amber-500" aria-hidden />,
+      headline: `${criticalProposals} critical proposal${criticalProposals > 1 ? 's' : ''} need${criticalProposals === 1 ? 's' : ''} DRep attention`,
+      detail: spotlightProposal
+        ? `${spotlightProposal.title} has ${spotlightProposal.voteCoverage ?? 0}% DRep coverage`
+        : 'Review active proposals before the voting deadline',
+      href: '/governance/proposals',
+    });
+  } else if (spotlightProposal?.voteCoverage != null) {
+    const coverage = spotlightProposal.voteCoverage;
+    if (coverage < 30) {
+      alerts.push({
+        priority: 0,
+        icon: <AlertTriangle className="h-4 w-4 text-amber-500" aria-hidden />,
+        headline: 'Low engagement on active proposal',
+        detail: `${spotlightProposal.title} has only ${coverage}% DRep coverage`,
+        href: `/proposal/${spotlightProposal.txHash}/${spotlightProposal.index}`,
+      });
+    } else if (coverage > 80) {
+      alerts.push({
+        priority: 0,
+        icon: <AlertTriangle className="h-4 w-4 text-amber-500" aria-hidden />,
+        headline: 'High engagement on active proposal',
+        detail: `${spotlightProposal.title} has ${coverage}% DRep coverage`,
+        href: `/proposal/${spotlightProposal.txHash}/${spotlightProposal.index}`,
+      });
+    }
+  }
+
+  // --- Sentiment divergence alert (priority 1) ---
+  if (communityGap?.length) {
+    for (const g of communityGap) {
+      const yesPct = Math.round(((g.pollYes ?? 0) / (g.pollTotal || 1)) * 100);
+      const drepPct = g.drepVotePct ?? 0;
+      const diff = Math.abs(yesPct - drepPct);
+
+      if (diff > 20) {
+        alerts.push({
+          priority: 1,
+          icon: <Users className="h-4 w-4 text-blue-500" aria-hidden />,
+          headline: `Sentiment divergence on "${g.title}"`,
+          detail: `Community polls ${yesPct}% in favor vs ${drepPct}% DRep support — ${diff}pp gap`,
+          href: `/proposal/${g.txHash}/${g.index}`,
+        });
+      }
+    }
+  }
+
+  // --- DRep movement alerts (priority 2) ---
+  if (gainers?.length) {
+    for (const g of gainers) {
+      if (g.delta != null && Math.abs(g.delta) >= 5) {
+        alerts.push({
+          priority: 2,
+          icon: <TrendingUp className="h-4 w-4 text-emerald-500" aria-hidden />,
+          headline: `${g.name ?? g.drepId ?? 'A DRep'} surged +${g.delta.toFixed(1)} points`,
+          detail:
+            g.currentScore != null
+              ? `Now at ${g.currentScore.toFixed(1)} — one of this epoch's biggest movers`
+              : "One of this epoch's biggest movers",
+          href: g.drepId ? `/drep/${g.drepId}` : '/governance/representatives',
+        });
+      }
+    }
+  }
+
+  if (losers?.length) {
+    for (const l of losers) {
+      if (l.delta != null && Math.abs(l.delta) >= 5) {
+        alerts.push({
+          priority: 2,
+          icon: <TrendingDown className="h-4 w-4 text-rose-500" aria-hidden />,
+          headline: `${l.name ?? l.drepId ?? 'A DRep'} dropped ${l.delta.toFixed(1)} points`,
+          detail:
+            l.currentScore != null
+              ? `Now at ${l.currentScore.toFixed(1)} — significant score decline this epoch`
+              : 'Significant score decline this epoch',
+          href: l.drepId ? `/drep/${l.drepId}` : '/governance/representatives',
+        });
+      }
+    }
+  }
+
+  // Sort by priority, then take at most 4
+  alerts.sort((a, b) => a.priority - b.priority);
+  return alerts.slice(0, 4);
+}
+
+export function GovernanceAlerts(props: GovernanceAlertsProps) {
+  const { loading } = props;
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+        <Skeleton className="h-5 w-48" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  const alerts = buildAlerts(props);
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+      {alerts.length === 0 ? (
+        <div className="flex items-center gap-3 py-2">
+          <CheckCircle2 className="h-5 w-5 text-emerald-500 shrink-0" aria-hidden />
+          <div>
+            <p className="text-sm font-medium text-foreground">No governance alerts this epoch</p>
+            <p className="text-xs text-muted-foreground">
+              Participation, proposals, and representation all look healthy.
+            </p>
+          </div>
+        </div>
+      ) : (
+        alerts.map((alert, i) => (
+          <Link
+            key={i}
+            href={alert.href}
+            className={cn(
+              'flex items-start gap-3 py-2 border-b border-border/30 last:border-0',
+              'group hover:bg-muted/30 rounded-md -mx-1 px-1 transition-colors',
+            )}
+          >
+            <span className="shrink-0 mt-0.5">{alert.icon}</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-foreground">{alert.headline}</p>
+              <p className="text-xs text-muted-foreground truncate">{alert.detail}</p>
+            </div>
+            <ChevronRight
+              className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+              aria-hidden
+            />
+          </Link>
+        ))
+      )}
+    </div>
+  );
+}

--- a/components/civica/pulse/GovernanceBriefing.tsx
+++ b/components/civica/pulse/GovernanceBriefing.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import Link from 'next/link';
+import { TrendingUp, TrendingDown, Minus, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatAda } from '@/lib/treasury';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useGovernancePulse, useTreasuryCurrent, useGovernanceHealthIndex } from '@/hooks/queries';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PulseData {
+  activeProposals?: number;
+  criticalProposals?: number;
+  currentEpoch?: number;
+  activeDReps?: number;
+  totalDReps?: number;
+  votesThisWeek?: number;
+  avgParticipationRate?: number;
+  avgRationaleRate?: number;
+  totalAdaGoverned?: string;
+  deltas?: {
+    participationDelta?: number | null;
+    rationaleDelta?: number | null;
+    activeDRepsDelta?: number | null;
+  };
+}
+
+interface TreasuryData {
+  balance?: number;
+  balanceAda?: number;
+  trend?: string;
+  runwayMonths?: number;
+  pendingCount?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Band = 'healthy' | 'moderate' | 'concerning';
+
+function participationBand(rate: number): Band {
+  if (rate >= 70) return 'healthy';
+  if (rate >= 40) return 'moderate';
+  return 'concerning';
+}
+
+function rationaleBand(rate: number): Band {
+  if (rate >= 60) return 'healthy';
+  if (rate >= 30) return 'moderate';
+  return 'concerning';
+}
+
+function runwayBand(months: number): Band {
+  if (months > 24) return 'healthy';
+  if (months > 12) return 'moderate';
+  return 'concerning';
+}
+
+function bandColor(band: Band): string {
+  switch (band) {
+    case 'healthy':
+      return 'text-emerald-600 dark:text-emerald-400';
+    case 'moderate':
+      return 'text-amber-600 dark:text-amber-400';
+    case 'concerning':
+      return 'text-rose-600 dark:text-rose-400';
+  }
+}
+
+function bandLabel(band: Band): string {
+  switch (band) {
+    case 'healthy':
+      return 'healthy';
+    case 'moderate':
+      return 'moderate';
+    case 'concerning':
+      return 'concerning';
+  }
+}
+
+function formatDelta(value: number | null | undefined): string {
+  if (value == null) return '';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value}`;
+}
+
+function DeltaArrow({ value }: { value: number | null | undefined }) {
+  if (value == null || value === 0)
+    return <Minus className="inline h-3 w-3 text-muted-foreground" />;
+  if (value > 0) return <TrendingUp className="inline h-3 w-3 text-emerald-500" />;
+  return <TrendingDown className="inline h-3 w-3 text-rose-500" />;
+}
+
+function TrendArrow({ trend }: { trend: string | undefined }) {
+  if (!trend || trend === 'stable')
+    return <Minus className="inline h-3 w-3 text-muted-foreground" />;
+  if (trend === 'up') return <TrendingUp className="inline h-3 w-3 text-emerald-500" />;
+  return <TrendingDown className="inline h-3 w-3 text-rose-500" />;
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function BriefingSkeleton() {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-4">
+      {/* Narrative lines */}
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-[92%]" />
+        <Skeleton className="h-4 w-[85%]" />
+      </div>
+      {/* Headline pills */}
+      <div className="flex gap-3">
+        <Skeleton className="h-14 flex-1 rounded-lg" />
+        <Skeleton className="h-14 flex-1 rounded-lg" />
+        <Skeleton className="h-14 flex-1 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function GovernanceBriefing() {
+  const segment = useSegment();
+  const { data: pulseRaw, isLoading: pulseLoading, isError: pulseError } = useGovernancePulse();
+  const {
+    data: treasuryRaw,
+    isLoading: treasuryLoading,
+    isError: treasuryError,
+  } = useTreasuryCurrent();
+  const { isLoading: ghiLoading, isError: ghiError } = useGovernanceHealthIndex();
+
+  const isLoading = pulseLoading || treasuryLoading || ghiLoading;
+  const isError = pulseError || treasuryError || ghiError;
+
+  if (isLoading) return <BriefingSkeleton />;
+  if (isError) return null;
+
+  const pulse = (pulseRaw ?? {}) as PulseData;
+  const treasury = (treasuryRaw ?? {}) as TreasuryData;
+
+  const activeDReps = pulse.activeDReps ?? 0;
+  const drepDelta = pulse.deltas?.activeDRepsDelta;
+  const votesThisWeek = pulse.votesThisWeek ?? 0;
+  const activeProposals = pulse.activeProposals ?? 0;
+  const criticalProposals = pulse.criticalProposals ?? 0;
+  const avgParticipation = pulse.avgParticipationRate ?? 0;
+  const avgRationale = pulse.avgRationaleRate ?? 0;
+  const participationDelta = pulse.deltas?.participationDelta;
+
+  const treasuryBalance = treasury.balanceAda ?? treasury.balance ?? 0;
+  const runway = treasury.runwayMonths ?? 0;
+  const treasuryTrend = treasury.trend;
+
+  const pBand = participationBand(avgParticipation);
+  const rBand = rationaleBand(avgRationale);
+  const tBand = runwayBand(runway);
+
+  const criticalMention =
+    criticalProposals > 0 ? `, including ${criticalProposals} marked critical` : '';
+
+  const runwayLabel =
+    runway >= 12 ? `${Math.round(runway / 12)}+ years` : `${Math.round(runway)} months`;
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-4">
+      {/* Narrative paragraph */}
+      <p className="text-sm text-foreground leading-relaxed">
+        <Link
+          href="/governance/representatives"
+          className="underline decoration-dotted underline-offset-2 hover:decoration-solid"
+        >
+          <strong className={bandColor(pBand)}>{activeDReps.toLocaleString()}</strong> DReps
+        </Link>{' '}
+        are actively participating this epoch
+        {drepDelta != null ? (
+          <>
+            {' '}
+            &mdash;{' '}
+            <strong
+              className={cn(
+                drepDelta > 0
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : drepDelta < 0
+                    ? 'text-rose-600 dark:text-rose-400'
+                    : 'text-muted-foreground',
+              )}
+            >
+              {formatDelta(drepDelta)}
+            </strong>{' '}
+            from last.
+          </>
+        ) : (
+          '.'
+        )}{' '}
+        They&rsquo;ve cast{' '}
+        <strong className={bandColor(pBand)}>{votesThisWeek.toLocaleString()}</strong> votes across{' '}
+        <Link
+          href="/governance/proposals"
+          className="underline decoration-dotted underline-offset-2 hover:decoration-solid"
+        >
+          <strong className={bandColor(pBand)}>{activeProposals.toLocaleString()}</strong> active
+          proposals
+        </Link>
+        {criticalMention ? (
+          <>
+            , including{' '}
+            <strong className="text-rose-600 dark:text-rose-400">{criticalProposals}</strong> marked
+            critical
+          </>
+        ) : (
+          ''
+        )}
+        . Participation rate is{' '}
+        <strong className={bandColor(pBand)}>{avgParticipation.toFixed(1)}%</strong> (
+        {bandLabel(pBand)}), while{' '}
+        <strong className={bandColor(rBand)}>{avgRationale.toFixed(1)}%</strong> are providing
+        rationales. The treasury holds{' '}
+        <strong className={bandColor(tBand)}>&#8371;{formatAda(treasuryBalance)}</strong> with{' '}
+        <strong className={bandColor(tBand)}>{runwayLabel}</strong> runway.
+      </p>
+
+      {/* Headline metrics row */}
+      <div className="flex flex-wrap gap-3">
+        {/* Participation Rate */}
+        <div className="flex-1 min-w-[120px] rounded-lg bg-muted/30 px-3 py-2">
+          <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            Participation
+          </div>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className={cn('text-sm font-semibold', bandColor(pBand))}>
+              {avgParticipation.toFixed(1)}%
+            </span>
+            <DeltaArrow value={participationDelta} />
+            {participationDelta != null && participationDelta !== 0 && (
+              <span className="text-[11px] text-muted-foreground">
+                {formatDelta(participationDelta)}pp
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Active Proposals */}
+        <div className="flex-1 min-w-[120px] rounded-lg bg-muted/30 px-3 py-2">
+          <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            Active Proposals
+          </div>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className="text-sm font-semibold text-foreground">{activeProposals}</span>
+            {criticalProposals > 0 && (
+              <span className="inline-flex items-center gap-0.5 text-[11px] text-rose-600 dark:text-rose-400">
+                <AlertTriangle className="h-3 w-3" />
+                {criticalProposals} critical
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Treasury Balance */}
+        <div className="flex-1 min-w-[120px] rounded-lg bg-muted/30 px-3 py-2">
+          <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+            Treasury
+          </div>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className={cn('text-sm font-semibold', bandColor(tBand))}>
+              &#8371;{formatAda(treasuryBalance)}
+            </span>
+            <TrendArrow trend={treasuryTrend} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace 8-card stats grid with narrative briefing (GovernanceBriefing) + 3 headline metric pills
- Consolidate spotlight proposal, community gap, weekly movers into filtered alert system (GovernanceAlerts)
- GHI Hero: contextual verdicts (12 sentences based on band/direction/streak), persona-adaptive addendums, living score pulse animation
- CivicaPulseOverview shrinks from 795 → 270 lines with clean 6-section Now tab: GHI Verdict → Impact Card → Briefing → Alerts → Explorer → Ticker
- Add OG image route for governance health social sharing

## Impact
- **What changed**: Governance Health "Now" tab completely redesigned from data-dump to narrative-first intelligence
- **User-facing**: Yes — all users see a dramatically different, story-driven health page with contextual verdicts and persona-specific guidance
- **Risk**: Medium — significant frontend restructure but no backend/data changes, all existing tests pass
- **Scope**: 5 files (2 modified, 3 new). No migrations, no env vars, no Inngest changes

## Test plan
- [ ] Verify /governance/health loads with all 6 sections visible
- [ ] Check GHI verdict text changes based on band (strong/good/fair/critical)
- [ ] Verify persona addendum appears for DRep/SPO/Citizen/CC segments
- [ ] Confirm pulse animation on GHI ring (disabled with prefers-reduced-motion)
- [ ] Check GovernanceAlerts shows/hides correctly based on data
- [ ] Verify GovernanceBriefing narrative paragraph renders with correct metrics
- [ ] Test History and Observatory tabs still work unchanged
- [ ] Mobile responsive check

🤖 Generated with [Claude Code](https://claude.com/claude-code)