### PR TITLE
fix: governance identity audit — percentages, pillar detail, citizen gating

### DIFF
--- a/components/ScoreDeepDive.tsx
+++ b/components/ScoreDeepDive.tsx
@@ -224,14 +224,31 @@ export function ScoreDeepDive(props: ScoreDeepDiveProps) {
                       )}
                       {pillar.key === 'identity' && (
                         <>
+                          <p className="text-xs font-medium text-foreground/80 mb-1">
+                            Profile Quality (60%) + Community Presence (40%)
+                          </p>
                           <p className="tabular-nums">
                             Profile completeness: {props.profileCompleteness}%
                           </p>
                           <p className="tabular-nums">Delegators: {props.delegatorCount}</p>
-                          <p className="text-primary/80 mt-1">
-                            {props.profileCompleteness < 70
-                              ? 'To improve: complete your DRep profile — add a bio, references, and motivation statement.'
-                              : 'Profile is well-filled. Growing your delegator base further strengthens this pillar.'}
+                          <div className="mt-2 space-y-0.5 text-[11px] text-muted-foreground/80">
+                            <p className="font-medium text-muted-foreground mb-0.5">
+                              Profile point breakdown (max 100):
+                            </p>
+                            <p>
+                              Name (15 pts) · Objectives (up to 20 pts) · Motivations (up to 15 pts)
+                            </p>
+                            <p>
+                              Qualifications (up to 10 pts) · Bio (up to 10 pts) · Social links (up
+                              to 30 pts)
+                            </p>
+                          </div>
+                          <p className="text-primary/80 mt-2">
+                            {props.profileCompleteness < 40
+                              ? 'To improve: add objectives (200+ chars for max points), motivations, and 2+ social links — these fields carry the most weight.'
+                              : props.profileCompleteness < 70
+                                ? 'Good start. Add longer objectives/motivations (200+ chars) and a second social link to unlock more points.'
+                                : 'Profile is well-filled. Growing your delegator count (by number, not ADA) strengthens Community Presence.'}
                           </p>
                         </>
                       )}

--- a/components/civica/mygov/CivicaProfile.tsx
+++ b/components/civica/mygov/CivicaProfile.tsx
@@ -246,8 +246,9 @@ export function CivicaProfile() {
               <span
                 className={cn(
                   'text-[11px] font-bold px-2 py-0.5 rounded-full',
-                  TIER_BADGE_BG[tKey],
-                  TIER_SCORE_COLOR[tKey],
+                  segment === 'drep' || segment === 'spo'
+                    ? cn(TIER_BADGE_BG[tKey], TIER_SCORE_COLOR[tKey])
+                    : 'bg-primary/10 text-primary',
                 )}
               >
                 {segmentLabel}

--- a/components/ui/ScoreExplainer.tsx
+++ b/components/ui/ScoreExplainer.tsx
@@ -9,7 +9,7 @@ type ScoreType = 'drep' | 'spo';
 const EXPLAINERS: Record<ScoreType, { pillars: string; summary: string }> = {
   drep: {
     pillars:
-      'Engagement Quality (35%) · Participation (30%) · Reliability (20%) · Governance Identity (15%)',
+      'Engagement Quality (35%) · Participation (25%) · Reliability (25%) · Governance Identity (15%)',
     summary:
       'Higher scores mean this DRep votes consistently, explains their reasoning, and maintains an active governance presence.',
   },


### PR DESCRIPTION
## Summary
- Fix ScoreExplainer displaying wrong pillar weight percentages (Participation showed 30% instead of 25%, Reliability showed 20% instead of 25%)
- Enrich Governance Identity pillar expansion in ScoreDeepDive with sub-component breakdown (Profile Quality 60% + Community Presence 40%), per-field point values, and tiered actionable guidance
- Fix citizen badge on CivicaProfile applying tier-derived colors (Emerging tier styling) instead of neutral styling — citizens aren't scored, so tier colors are misleading

## Impact
- **What changed**: Corrected data display + enriched scoring transparency + fixed persona gating leak
- **User-facing**: Yes — DReps see accurate pillar weights and actionable identity breakdown; citizens no longer see confusing tier-colored badge
- **Risk**: Low — styling and string changes only, no data/logic changes
- **Scope**: `components/ui/ScoreExplainer.tsx`, `components/ScoreDeepDive.tsx`, `components/civica/mygov/CivicaProfile.tsx`

## Test plan
- [x] Preflight passes (format, lint, types, 591 tests)
- [ ] View as DRep: ScoreExplainer tooltip shows correct 35/25/25/15 weights
- [ ] View as DRep: Identity pillar expansion shows sub-component breakdown and point values
- [ ] View as Citizen: Profile badge shows neutral "Delegator" styling (no tier colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)