### PR TITLE
feat: citizen Hub consequence story — epoch narrative replaces abstract cards

### DIFF
--- a/app/api/citizen/epoch-consequence/route.ts
+++ b/app/api/citizen/epoch-consequence/route.ts
@@ -1,0 +1,295 @@
+/**
+ * GET /api/citizen/epoch-consequence
+ *
+ * Returns consequence-oriented data for the citizen Hub:
+ * - Decided proposals this epoch with DRep votes + community sentiment
+ * - Active proposals with DRep votes + community sentiment
+ * - Voting power fraction (DRep's power / total active voting power)
+ * - Total ADA decided this epoch
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ConsequenceProposal {
+  txHash: string;
+  index: number;
+  title: string | null;
+  proposalType: string;
+  outcome: 'ratified' | 'dropped' | 'expired' | null;
+  outcomeEpoch: number | null;
+  withdrawalAda: number | null;
+  aiSummary: string | null;
+  drepVote: string | null;
+  communitySignal: {
+    support: number;
+    oppose: number;
+    unsure: number;
+    total: number;
+  } | null;
+  userSignal: string | null;
+}
+
+interface EpochConsequenceResponse {
+  epoch: number;
+
+  /** Total ADA in decided proposals this epoch */
+  adaDecided: number;
+
+  /** Citizen's DRep voting power as fraction (0-1) of total active voting power */
+  votingPowerFraction: number | null;
+
+  /** DRep's voting power in ADA */
+  votingPowerAda: number | null;
+
+  /** Proposals decided this epoch (ratified/dropped/expired) with DRep votes */
+  decidedProposals: ConsequenceProposal[];
+
+  /** Active proposals with DRep votes + community sentiment */
+  activeProposals: ConsequenceProposal[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function proposalOutcome(p: {
+  ratified_epoch: number | null;
+  dropped_epoch: number | null;
+  expired_epoch: number | null;
+}): { outcome: 'ratified' | 'dropped' | 'expired' | null; epoch: number | null } {
+  if (p.ratified_epoch) return { outcome: 'ratified', epoch: p.ratified_epoch };
+  if (p.dropped_epoch) return { outcome: 'dropped', epoch: p.dropped_epoch };
+  if (p.expired_epoch) return { outcome: 'expired', epoch: p.expired_epoch };
+  return { outcome: null, epoch: null };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, ctx: RouteContext) => {
+    const supabase = createClient();
+
+    // 1. Current epoch
+    const { data: stats } = await supabase
+      .from('governance_stats')
+      .select('current_epoch')
+      .eq('id', 1)
+      .single();
+
+    const currentEpoch = stats?.current_epoch ?? 0;
+
+    // 2. Resolve DRep ID
+    let drepId: string | null = null;
+
+    if (ctx.wallet) {
+      const { data: walletRow } = await supabase
+        .from('user_wallets')
+        .select('drep_id')
+        .eq('payment_address', ctx.wallet)
+        .maybeSingle();
+
+      if (walletRow?.drep_id) {
+        drepId = walletRow.drep_id;
+      } else if (ctx.userId) {
+        const { data: user } = await supabase
+          .from('users')
+          .select('claimed_drep_id, delegation_history')
+          .eq('id', ctx.userId)
+          .single();
+
+        if (user?.claimed_drep_id) {
+          drepId = user.claimed_drep_id;
+        } else if (Array.isArray(user?.delegation_history) && user.delegation_history.length > 0) {
+          const last = user.delegation_history[user.delegation_history.length - 1] as {
+            drepId?: string;
+          };
+          drepId = last?.drepId ?? null;
+        }
+      }
+    }
+
+    // 3. Fetch decided + active proposals in parallel
+    const lookbackEpoch = Math.max(0, currentEpoch - 1);
+
+    const [decidedResult, activeResult] = await Promise.all([
+      supabase
+        .from('proposals')
+        .select(
+          'tx_hash, proposal_index, title, proposal_type, ai_summary, withdrawal_amount, ratified_epoch, dropped_epoch, expired_epoch, enacted_epoch',
+        )
+        .or(
+          `ratified_epoch.gte.${lookbackEpoch},dropped_epoch.gte.${lookbackEpoch},expired_epoch.gte.${lookbackEpoch}`,
+        )
+        .order('block_time', { ascending: false })
+        .limit(20),
+
+      supabase
+        .from('proposals')
+        .select(
+          'tx_hash, proposal_index, title, proposal_type, ai_summary, withdrawal_amount, ratified_epoch, dropped_epoch, expired_epoch',
+        )
+        .is('ratified_epoch', null)
+        .is('expired_epoch', null)
+        .is('dropped_epoch', null)
+        .order('block_time', { ascending: false })
+        .limit(10),
+    ]);
+
+    const decidedRows = decidedResult.data ?? [];
+    const activeRows = activeResult.data ?? [];
+    const allRows = [...decidedRows, ...activeRows];
+
+    // 4. Fetch DRep votes for all relevant proposals
+    const allTxHashes = [...new Set(allRows.map((p) => p.tx_hash))];
+    const drepVotesMap = new Map<string, string>();
+
+    if (drepId && allTxHashes.length > 0) {
+      const { data: votes } = await supabase
+        .from('drep_votes')
+        .select('proposal_tx_hash, proposal_index, vote')
+        .eq('drep_id', drepId)
+        .in('proposal_tx_hash', allTxHashes);
+
+      if (votes) {
+        for (const v of votes) {
+          drepVotesMap.set(`${v.proposal_tx_hash}:${v.proposal_index}`, v.vote);
+        }
+      }
+    }
+
+    // 5. Fetch community sentiment for all proposals
+    const proposalKeys = allRows.map((p) => `${p.tx_hash}:${p.proposal_index}`);
+    const sentimentMap = new Map<
+      string,
+      { support: number; oppose: number; unsure: number; total: number }
+    >();
+
+    if (proposalKeys.length > 0) {
+      const { data: aggs } = await supabase
+        .from('engagement_signal_aggregations')
+        .select('entity_id, data')
+        .eq('entity_type', 'proposal')
+        .eq('signal_type', 'sentiment')
+        .in('entity_id', proposalKeys);
+
+      if (aggs) {
+        for (const a of aggs) {
+          const d = a.data as {
+            support?: number;
+            oppose?: number;
+            unsure?: number;
+            total?: number;
+          } | null;
+          if (d) {
+            sentimentMap.set(a.entity_id, {
+              support: d.support ?? 0,
+              oppose: d.oppose ?? 0,
+              unsure: d.unsure ?? 0,
+              total: d.total ?? 0,
+            });
+          }
+        }
+      }
+    }
+
+    // 6. Fetch user's own sentiment signals
+    const userSignalMap = new Map<string, string>();
+
+    if (ctx.userId && allTxHashes.length > 0) {
+      const { data: userSentiments } = await supabase
+        .from('citizen_sentiment')
+        .select('proposal_tx_hash, proposal_index, sentiment')
+        .eq('user_id', ctx.userId)
+        .in('proposal_tx_hash', allTxHashes);
+
+      if (userSentiments) {
+        for (const s of userSentiments) {
+          userSignalMap.set(`${s.proposal_tx_hash}:${s.proposal_index}`, s.sentiment);
+        }
+      }
+    }
+
+    // 7. Compute voting power fraction
+    let votingPowerFraction: number | null = null;
+    let votingPowerAda: number | null = null;
+
+    if (drepId) {
+      const { data: powerRow } = await supabase
+        .from('drep_power_snapshots')
+        .select('amount_lovelace, epoch_no')
+        .eq('drep_id', drepId)
+        .order('epoch_no', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (powerRow) {
+        const drepPower = powerRow.amount_lovelace ?? 0;
+        votingPowerAda = Math.round(drepPower / 1_000_000);
+
+        // Sum total active voting power from the same epoch's snapshot
+        const { data: totalRows } = await supabase
+          .from('drep_power_snapshots')
+          .select('amount_lovelace')
+          .eq('epoch_no', powerRow.epoch_no);
+
+        if (totalRows && totalRows.length > 0) {
+          const totalPower = totalRows.reduce((sum, r) => sum + (r.amount_lovelace ?? 0), 0);
+          if (totalPower > 0 && drepPower > 0) {
+            votingPowerFraction = drepPower / totalPower;
+          }
+        }
+      }
+    }
+
+    // 8. Build response
+    function buildProposal(row: (typeof allRows)[number]): ConsequenceProposal {
+      const key = `${row.tx_hash}:${row.proposal_index}`;
+      const { outcome, epoch: outcomeEpoch } = proposalOutcome(row);
+
+      return {
+        txHash: row.tx_hash,
+        index: row.proposal_index,
+        title: row.title,
+        proposalType: row.proposal_type,
+        outcome,
+        outcomeEpoch,
+        withdrawalAda: row.withdrawal_amount ? Math.round(row.withdrawal_amount / 1_000_000) : null,
+        aiSummary: row.ai_summary,
+        drepVote: drepVotesMap.get(key) ?? null,
+        communitySignal: sentimentMap.get(key) ?? null,
+        userSignal: userSignalMap.get(key) ?? null,
+      };
+    }
+
+    const adaDecided = decidedRows.reduce((sum, p) => {
+      if (p.withdrawal_amount && p.ratified_epoch) {
+        return sum + Math.round(p.withdrawal_amount / 1_000_000);
+      }
+      return sum;
+    }, 0);
+
+    const response: EpochConsequenceResponse = {
+      epoch: currentEpoch,
+      adaDecided,
+      votingPowerFraction,
+      votingPowerAda,
+      decidedProposals: decidedRows.map(buildProposal),
+      activeProposals: activeRows.map(buildProposal),
+    };
+
+    return NextResponse.json(response, {
+      headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
+    });
+  },
+  { auth: 'optional' },
+);

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -1,0 +1,550 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import {
+  ArrowRight,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Vote,
+  Coins,
+  Flame,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  ThumbsUp,
+  ThumbsDown,
+  HelpCircle,
+  ExternalLink,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { briefingContainer, briefingItem } from '@/lib/animations';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import {
+  useEpochConsequence,
+  useGovernanceHolder,
+  type ConsequenceProposal,
+} from '@/hooks/queries';
+import { computeTier } from '@/lib/scoring/tiers';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/* ── Helpers ─────────────────────────────────────────────────── */
+
+function formatAda(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toLocaleString();
+}
+
+function formatPowerFraction(fraction: number): string {
+  if (fraction >= 0.01) return `${(fraction * 100).toFixed(1)}%`;
+  if (fraction >= 0.001) return `${(fraction * 100).toFixed(2)}%`;
+  return `${(fraction * 100).toFixed(3)}%`;
+}
+
+const OUTCOME_CONFIG = {
+  ratified: {
+    icon: CheckCircle2,
+    label: 'Ratified',
+    color: 'text-emerald-500',
+    bg: 'bg-emerald-500/10 border-emerald-500/20',
+  },
+  dropped: {
+    icon: XCircle,
+    label: 'Dropped',
+    color: 'text-red-500',
+    bg: 'bg-red-500/10 border-red-500/20',
+  },
+  expired: {
+    icon: Clock,
+    label: 'Expired',
+    color: 'text-amber-500',
+    bg: 'bg-amber-500/10 border-amber-500/20',
+  },
+} as const;
+
+const VOTE_LABELS: Record<string, { label: string; color: string }> = {
+  Yes: { label: 'Voted Yes', color: 'text-emerald-400' },
+  No: { label: 'Voted No', color: 'text-red-400' },
+  Abstain: { label: 'Abstained', color: 'text-amber-400' },
+};
+
+const PROPOSAL_TYPE_LABELS: Record<string, string> = {
+  TreasuryWithdrawals: 'Treasury',
+  ParameterChange: 'Parameter Change',
+  HardForkInitiation: 'Hard Fork',
+  InfoAction: 'Info Action',
+  NoConfidence: 'No Confidence',
+  NewConstitution: 'Constitution',
+  UpdateCommittee: 'Committee Update',
+};
+
+/* ── Section wrapper (glassmorphic) ──────────────────────────── */
+
+function Section({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <motion.section
+      variants={briefingItem}
+      className={cn(
+        'rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5',
+        className,
+      )}
+    >
+      {children}
+    </motion.section>
+  );
+}
+
+/* ── Consequence card for a decided proposal ─────────────────── */
+
+function ConsequenceCard({ proposal }: { proposal: ConsequenceProposal }) {
+  const outcome = proposal.outcome ? OUTCOME_CONFIG[proposal.outcome] : null;
+  const OutcomeIcon = outcome?.icon ?? Clock;
+  const voteInfo = proposal.drepVote ? VOTE_LABELS[proposal.drepVote] : null;
+  const typeLabel = PROPOSAL_TYPE_LABELS[proposal.proposalType] ?? proposal.proposalType;
+
+  return (
+    <Link
+      href={`/governance/proposals/${proposal.txHash}/${proposal.index}`}
+      className="group block rounded-xl border border-white/[0.06] bg-white/[0.03] p-3.5 transition-all hover:border-primary/40 hover:bg-white/[0.05]"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0 space-y-1.5">
+          {/* Outcome badge + type */}
+          <div className="flex items-center gap-2 flex-wrap">
+            {outcome && (
+              <span
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+                  outcome.bg,
+                  outcome.color,
+                )}
+              >
+                <OutcomeIcon className="h-3 w-3" />
+                {outcome.label}
+              </span>
+            )}
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {typeLabel}
+            </span>
+          </div>
+
+          {/* Title */}
+          <p className="text-sm font-medium text-foreground line-clamp-2 leading-snug">
+            {proposal.title ?? 'Untitled Proposal'}
+          </p>
+
+          {/* DRep vote + community signal row */}
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {voteInfo && (
+              <span className={cn('font-medium', voteInfo.color)}>{voteInfo.label}</span>
+            )}
+            {!voteInfo && proposal.drepVote === null && (
+              <span className="text-muted-foreground/60">DRep didn&apos;t vote</span>
+            )}
+            {proposal.communitySignal && proposal.communitySignal.total > 0 && (
+              <CommunitySignalInline signal={proposal.communitySignal} />
+            )}
+            {proposal.withdrawalAda && proposal.withdrawalAda > 0 && (
+              <span className="tabular-nums">{formatAda(proposal.withdrawalAda)} ADA</span>
+            )}
+          </div>
+        </div>
+
+        <ArrowRight className="mt-1 h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-all group-hover:text-primary group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  );
+}
+
+/* ── Inline community signal bar ─────────────────────────────── */
+
+function CommunitySignalInline({
+  signal,
+}: {
+  signal: { support: number; oppose: number; total: number };
+}) {
+  const supportPct = Math.round((signal.support / signal.total) * 100);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-flex h-1.5 w-8 rounded-full bg-muted overflow-hidden">
+        <span className="h-full bg-emerald-500 rounded-full" style={{ width: `${supportPct}%` }} />
+      </span>
+      <span className="tabular-nums text-[10px]">{supportPct}% support</span>
+    </span>
+  );
+}
+
+/* ── Active proposal card with signal buttons ────────────────── */
+
+function ActiveProposalCard({ proposal }: { proposal: ConsequenceProposal }) {
+  const voteInfo = proposal.drepVote ? VOTE_LABELS[proposal.drepVote] : null;
+  const typeLabel = PROPOSAL_TYPE_LABELS[proposal.proposalType] ?? proposal.proposalType;
+
+  return (
+    <Link
+      href={`/governance/proposals/${proposal.txHash}/${proposal.index}`}
+      className="group block rounded-xl border border-white/[0.06] bg-white/[0.03] p-3.5 transition-all hover:border-primary/40 hover:bg-white/[0.05]"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded-full border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-blue-400">
+              <Vote className="h-3 w-3" />
+              Active
+            </span>
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              {typeLabel}
+            </span>
+          </div>
+
+          <p className="text-sm font-medium text-foreground line-clamp-2 leading-snug">
+            {proposal.title ?? 'Untitled Proposal'}
+          </p>
+
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {voteInfo && (
+              <span className={cn('font-medium', voteInfo.color)}>
+                DRep {voteInfo.label.toLowerCase()}
+              </span>
+            )}
+            {!voteInfo && <span className="text-amber-400/80">DRep hasn&apos;t voted yet</span>}
+            {proposal.communitySignal && proposal.communitySignal.total > 0 && (
+              <CommunitySignalInline signal={proposal.communitySignal} />
+            )}
+            {proposal.userSignal && (
+              <span className="flex items-center gap-1">
+                {proposal.userSignal === 'support' && (
+                  <ThumbsUp className="h-3 w-3 text-emerald-400" />
+                )}
+                {proposal.userSignal === 'oppose' && (
+                  <ThumbsDown className="h-3 w-3 text-red-400" />
+                )}
+                {proposal.userSignal === 'unsure' && (
+                  <HelpCircle className="h-3 w-3 text-amber-400" />
+                )}
+                <span className="text-[10px]">You: {proposal.userSignal}</span>
+              </span>
+            )}
+            {!proposal.userSignal && (
+              <span className="text-primary/70 text-[10px] font-medium">
+                Share your opinion &rarr;
+              </span>
+            )}
+          </div>
+        </div>
+
+        <ArrowRight className="mt-1 h-3.5 w-3.5 shrink-0 text-muted-foreground/40 transition-all group-hover:text-primary group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  );
+}
+
+/* ── Footprint stat ──────────────────────────────────────────── */
+
+function FootprintStat({
+  icon: Icon,
+  value,
+  label,
+}: {
+  icon: typeof Vote;
+  value: string | number;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1 rounded-xl bg-white/[0.04] p-3 text-center">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <p className="text-lg font-bold tabular-nums text-foreground">{value}</p>
+      <p className="text-[10px] font-medium text-muted-foreground leading-tight">{label}</p>
+    </div>
+  );
+}
+
+/* ── Loading skeleton ────────────────────────────────────────── */
+
+function CitizenHubSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-4 px-4 py-6">
+      {/* Headline skeleton */}
+      <div className="space-y-2 py-2">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="h-7 w-64" />
+        <Skeleton className="h-4 w-48" />
+      </div>
+      {/* Cards skeleton */}
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 space-y-3"
+        >
+          <Skeleton className="h-4 w-32" />
+          <div className="space-y-2">
+            <Skeleton className="h-12 w-full rounded-xl" />
+            <Skeleton className="h-12 w-full rounded-xl" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Main component ──────────────────────────────────────────── */
+
+export function CitizenHub() {
+  const { stakeAddress, delegatedDrep } = useSegment();
+
+  const {
+    data: consequence,
+    isLoading: consequenceLoading,
+    isError: consequenceError,
+  } = useEpochConsequence(stakeAddress);
+
+  const { data: holderRaw, isLoading: holderLoading } = useGovernanceHolder(stakeAddress);
+
+  const isLoading = consequenceLoading || holderLoading;
+
+  if (isLoading) return <CitizenHubSkeleton />;
+
+  // Extract DRep data from holder
+  const holder = holderRaw as Record<string, unknown> | undefined;
+  const drep = holder?.drep as Record<string, unknown> | undefined;
+  const drepName = (drep?.name as string) || (drep?.ticker as string) || 'Your DRep';
+  const drepScore = (drep?.score as number) ?? 0;
+  const drepIsActive = (drep?.isActive as boolean) ?? true;
+  const participationRate = (drep?.participationRate as number) ?? 0;
+  const footprint = holder?.footprint as Record<string, unknown> | undefined;
+
+  // Consequence data
+  const epoch = consequence?.epoch ?? 0;
+  const adaDecided = consequence?.adaDecided ?? 0;
+  const decidedProposals = consequence?.decidedProposals ?? [];
+  const activeProposals = consequence?.activeProposals ?? [];
+  const votingPowerFraction = consequence?.votingPowerFraction;
+  const votingPowerAda = consequence?.votingPowerAda;
+
+  // Footprint stats from holder or consequence
+  const proposalsInfluenced = (footprint?.proposalsInfluenced as number) ?? decidedProposals.length;
+  const delegationStreak = (footprint?.delegationStreak as number) ?? 0;
+  const adaGoverned = votingPowerAda ?? 0;
+
+  // Build headline
+  const headlineText =
+    adaDecided > 0
+      ? `Your delegation helped decide ${formatAda(adaDecided)} ADA`
+      : decidedProposals.length > 0
+        ? `${decidedProposals.length} governance decision${decidedProposals.length !== 1 ? 's' : ''} this epoch`
+        : 'No governance decisions yet this epoch';
+
+  return (
+    <motion.div
+      variants={briefingContainer}
+      initial="hidden"
+      animate="visible"
+      className="mx-auto w-full max-w-2xl space-y-4 px-4 py-6"
+    >
+      {/* ── Epoch headline ─────────────────────────────────── */}
+      <motion.header variants={briefingItem} className="space-y-1 pb-1">
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Epoch {epoch}
+        </p>
+        <h1 className="text-xl sm:text-2xl font-bold text-foreground leading-tight">
+          {headlineText}
+        </h1>
+        {votingPowerFraction != null && votingPowerFraction > 0 && (
+          <p className="text-sm text-muted-foreground">
+            Your voice represents {formatPowerFraction(votingPowerFraction)} of total voting power
+            {votingPowerAda ? ` (${formatAda(votingPowerAda)} ADA)` : ''}
+          </p>
+        )}
+      </motion.header>
+
+      {/* ── Decided proposals ──────────────────────────────── */}
+      {decidedProposals.length > 0 && (
+        <Section>
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+            What was decided
+          </h2>
+          <div className="space-y-2">
+            {decidedProposals.map((p) => (
+              <ConsequenceCard key={`${p.txHash}:${p.index}`} proposal={p} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* ── Active proposals ───────────────────────────────── */}
+      {activeProposals.length > 0 && (
+        <Section>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Being decided now
+            </h2>
+            <Link
+              href="/governance/proposals"
+              className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+            >
+              View all
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </div>
+          <div className="space-y-2">
+            {activeProposals.map((p) => (
+              <ActiveProposalCard key={`${p.txHash}:${p.index}`} proposal={p} />
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* ── Empty state ────────────────────────────────────── */}
+      {consequenceError && (
+        <Section className="text-center py-8">
+          <p className="text-sm text-muted-foreground">
+            Couldn&apos;t load governance activity. Try refreshing.
+          </p>
+        </Section>
+      )}
+
+      {!consequenceError && decidedProposals.length === 0 && activeProposals.length === 0 && (
+        <Section className="text-center py-8">
+          <p className="text-sm text-muted-foreground">
+            No governance proposals this epoch yet. Check back soon.
+          </p>
+          <Link
+            href="/governance"
+            className="inline-flex items-center gap-1 mt-3 text-sm text-primary hover:underline"
+          >
+            Explore governance
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </Section>
+      )}
+
+      {/* ── Governance footprint ───────────────────────────── */}
+      <Section>
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+          Your governance footprint
+        </h2>
+        <div className="grid grid-cols-3 gap-2">
+          <FootprintStat icon={Vote} value={proposalsInfluenced} label="Proposals Influenced" />
+          <FootprintStat
+            icon={Coins}
+            value={adaGoverned > 0 ? formatAda(adaGoverned) : '--'}
+            label="ADA Governed"
+          />
+          <FootprintStat icon={Flame} value={delegationStreak} label="Epoch Streak" />
+        </div>
+      </Section>
+
+      {/* ── Representation quality ─────────────────────────── */}
+      <Section>
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+          Your representation
+        </h2>
+
+        {!delegatedDrep && (
+          <Link href="/match" className="flex items-center justify-between gap-3 group">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <ShieldAlert className="h-4 w-4 text-amber-500" />
+                <span className="text-sm font-semibold text-foreground">Unrepresented</span>
+              </div>
+              <p className="text-xs text-muted-foreground">Find a DRep who shares your values</p>
+            </div>
+            <ArrowRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
+          </Link>
+        )}
+
+        {delegatedDrep &&
+          delegatedDrep !== 'drep_always_abstain' &&
+          delegatedDrep !== 'drep_always_no_confidence' &&
+          drep && (
+            <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+              <div className="space-y-1.5">
+                <div className="flex items-center gap-2">
+                  {drepIsActive ? (
+                    <ShieldCheck className="h-4 w-4 text-emerald-500" />
+                  ) : (
+                    <ShieldX className="h-4 w-4 text-red-500" />
+                  )}
+                  <span className="text-sm font-semibold text-foreground">{drepName}</span>
+                  <span
+                    className={cn(
+                      'text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full',
+                      drepIsActive
+                        ? 'bg-emerald-500/10 text-emerald-400'
+                        : 'bg-red-500/10 text-red-400',
+                    )}
+                  >
+                    {drepIsActive ? 'Active' : 'Inactive'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span className="tabular-nums">
+                    Score: {Math.round(drepScore)} &middot; {computeTier(drepScore)}
+                  </span>
+                  <span className="text-muted-foreground/40">&middot;</span>
+                  <span className="tabular-nums">
+                    {Math.round(participationRate)}% participation
+                  </span>
+                </div>
+              </div>
+              <ArrowRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
+            </Link>
+          )}
+
+        {delegatedDrep === 'drep_always_abstain' && (
+          <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">Always Abstain</p>
+              <p className="text-xs text-muted-foreground">
+                Your ADA abstains on all governance actions but counts toward quorum.
+              </p>
+            </div>
+            <ArrowRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
+          </Link>
+        )}
+
+        {delegatedDrep === 'drep_always_no_confidence' && (
+          <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">No Confidence</p>
+              <p className="text-xs text-muted-foreground">
+                Your vote weight counts against all proposals.
+              </p>
+            </div>
+            <ArrowRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
+          </Link>
+        )}
+      </Section>
+
+      {/* ── Quick links ────────────────────────────────────── */}
+      <motion.div
+        variants={briefingItem}
+        className="flex items-center justify-center gap-4 pt-2 pb-4"
+      >
+        <Link
+          href="/governance"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Governance overview
+        </Link>
+        <span className="text-muted-foreground/30">&middot;</span>
+        <Link
+          href="/match"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Find a DRep
+        </Link>
+        <span className="text-muted-foreground/30">&middot;</span>
+        <Link
+          href="/delegation"
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          My delegation
+        </Link>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -3,6 +3,7 @@
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { HubCardRenderer } from './HubCardRenderer';
 import { AnonymousLanding } from './AnonymousLanding';
+import { CitizenHub } from './CitizenHub';
 import { HubCardSkeleton } from './cards/HubCard';
 
 interface PulseData {
@@ -45,6 +46,11 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     return <AnonymousLanding pulseData={pulseData} />;
   }
 
-  // Authenticated homepage — globe provided by CivicaShell, cards float on glass
+  // Citizens get the consequence story Hub
+  if (segment === 'citizen') {
+    return <CitizenHub />;
+  }
+
+  // Other authenticated personas — globe provided by CivicaShell, cards float on glass
   return <HubCardRenderer persona={segment} />;
 }

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -358,6 +358,44 @@ export function useGovernanceForYou() {
   });
 }
 
+// -- Citizen consequence story --
+
+export interface ConsequenceProposal {
+  txHash: string;
+  index: number;
+  title: string | null;
+  proposalType: string;
+  outcome: 'ratified' | 'dropped' | 'expired' | null;
+  outcomeEpoch: number | null;
+  withdrawalAda: number | null;
+  aiSummary: string | null;
+  drepVote: string | null;
+  communitySignal: {
+    support: number;
+    oppose: number;
+    unsure: number;
+    total: number;
+  } | null;
+  userSignal: string | null;
+}
+
+export interface EpochConsequenceData {
+  epoch: number;
+  adaDecided: number;
+  votingPowerFraction: number | null;
+  votingPowerAda: number | null;
+  decidedProposals: ConsequenceProposal[];
+  activeProposals: ConsequenceProposal[];
+}
+
+export function useEpochConsequence(wallet: string | null | undefined) {
+  return useQuery<EpochConsequenceData>({
+    queryKey: ['epoch-consequence', wallet ?? 'anon'],
+    queryFn: () => fetchJson('/api/citizen/epoch-consequence'),
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
 export function useSpoVotes(txHash: string, index: number) {
   return useQuery({
     queryKey: ['spo-votes', txHash, index],


### PR DESCRIPTION
## Summary
- Redesign citizen home from 6 abstract status cards to a scrollable epoch consequence story showing what delegation PRODUCED
- New API endpoint `/api/citizen/epoch-consequence` returning decided/active proposals with DRep votes, community sentiment, voting power fraction
- New `CitizenHub` component with epoch headline, consequence cards, active proposal affordances, governance footprint, and representation gauge

## Impact
- **What changed**: Citizens now see a narrative-first Hub showing governance outcomes and their delegation's impact, replacing abstract card widgets
- **User-facing**: Yes — citizen homepage completely redesigned with consequence story layout
- **Risk**: Medium — new citizen-only Hub path, other personas unaffected. Fallback: revert citizen routing in HubHomePage
- **Scope**: 4 files (1 new API route, 1 new component, 1 modified dispatcher, 1 modified hooks file). No migrations.

## Test plan
- [ ] Verify citizen segment routes to new CitizenHub
- [ ] Verify DRep/SPO/CC segments still route to HubCardRenderer
- [ ] Verify anonymous users still see AnonymousLanding
- [ ] Check consequence cards render with decided proposals
- [ ] Check active proposals show DRep vote status and signal affordance
- [ ] Check footprint stats display correctly
- [ ] Check representation section handles all delegation states (normal, abstain, no-confidence, undelegated)
- [ ] Verify mobile responsiveness of scrollable layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)