### PR TITLE
feat: cockpit phase 2 — intelligence + inline action layer

### DIFF
--- a/app/api/workspace/cockpit/route.ts
+++ b/app/api/workspace/cockpit/route.ts
@@ -3,6 +3,9 @@
  *
  * Merges data from urgent, competitive, delegator-trends, and score-change
  * into one response to eliminate the waterfall of 4+ client requests.
+ *
+ * Phase 2: adds per-proposal intelligence (AI summary, citizen sentiment,
+ * DRep vote tally) and per-pillar Score Story data.
  */
 
 import { NextResponse } from 'next/server';
@@ -125,10 +128,48 @@ export const GET = withRouteHandler(async (request) => {
     scoreTrendDate = weekAgo.snapshot_date;
   }
 
-  // ── Action Feed: Pending proposals ─────────────────────────────────
+  // ── Citizen sentiment for open proposals (batch) ──────────────────
+  let sentimentMap = new Map<
+    string,
+    { support: number; oppose: number; abstain: number; total: number }
+  >();
+  try {
+    const openTxHashes = pendingProposals.map((p) => p.txHash);
+    if (openTxHashes.length > 0) {
+      const { data: sentiments } = await supabase
+        .from('citizen_sentiment')
+        .select('proposal_tx_hash, proposal_index, sentiment')
+        .in('proposal_tx_hash', openTxHashes);
+
+      if (sentiments) {
+        for (const s of sentiments) {
+          const key = `${s.proposal_tx_hash}-${s.proposal_index}`;
+          const entry = sentimentMap.get(key) ?? {
+            support: 0,
+            oppose: 0,
+            abstain: 0,
+            total: 0,
+          };
+          const val = (s.sentiment ?? '').toLowerCase();
+          if (val === 'support' || val === 'yes') entry.support++;
+          else if (val === 'oppose' || val === 'no') entry.oppose++;
+          else entry.abstain++;
+          entry.total++;
+          sentimentMap.set(key, entry);
+        }
+      }
+    }
+  } catch (err) {
+    logger.error('Cockpit: citizen sentiment fetch failed', { error: err });
+    sentimentMap = new Map();
+  }
+
+  // ── Action Feed: Pending proposals (with intelligence) ────────────
   const pendingList = pendingProposals
     .map((p) => {
       const expiryEpoch = p.expirationEpoch ?? 0;
+      const sentimentKey = `${p.txHash}-${p.proposalIndex}`;
+      const sentiment = sentimentMap.get(sentimentKey) ?? null;
       return {
         txHash: p.txHash,
         index: p.proposalIndex,
@@ -136,6 +177,10 @@ export const GET = withRouteHandler(async (request) => {
         proposalType: p.proposalType || 'Proposal',
         epochsRemaining: expiryEpoch > 0 ? Math.max(0, expiryEpoch - currentEpoch) : null,
         isUrgent: expiryEpoch > 0 && expiryEpoch - currentEpoch <= 2,
+        aiSummary: p.aiSummary ?? null,
+        abstract: p.abstract ?? null,
+        drepVoteTally: { yes: p.yesCount, no: p.noCount, abstain: p.abstainCount },
+        citizenSentiment: sentiment,
       };
     })
     .sort((a, b) => (a.epochsRemaining ?? 999) - (b.epochsRemaining ?? 999));
@@ -226,6 +271,72 @@ export const GET = withRouteHandler(async (request) => {
     }
   }
 
+  // ── Score Story: per-pillar breakdown with specific actions ────────
+  const pillarMeta = [
+    {
+      key: 'engagementQuality' as const,
+      label: 'Engagement Quality',
+      weight: 0.35,
+      action: (v: number) =>
+        v >= 80
+          ? 'Strong — keep explaining your votes'
+          : `Submit rationales with your next ${Math.max(1, Math.ceil((70 - v) / 15))} votes`,
+    },
+    {
+      key: 'effectiveParticipation' as const,
+      label: 'Effective Participation',
+      weight: 0.3,
+      action: (v: number) =>
+        v >= 80
+          ? 'Strong — stay active on new proposals'
+          : `Vote on ${Math.max(1, Math.min(pendingProposals.length, Math.ceil((70 - v) / 10)))} open proposals`,
+    },
+    {
+      key: 'reliability' as const,
+      label: 'Reliability',
+      weight: 0.2,
+      action: (v: number) =>
+        v >= 80
+          ? 'Strong — maintain your voting streak'
+          : `Vote this epoch to ${streak > 0 ? 'extend' : 'start'} your streak`,
+    },
+    {
+      key: 'governanceIdentity' as const,
+      label: 'Governance Identity',
+      weight: 0.15,
+      action: (v: number) =>
+        v >= 80
+          ? 'Strong — profile is well-established'
+          : 'Complete your profile bio and add social links',
+    },
+  ];
+
+  const pillarValues: Record<string, number> = {
+    engagementQuality: drep.rationale_rate ?? 0,
+    effectiveParticipation: drep.effective_participation ?? 0,
+    reliability: drep.reliability_score ?? 0,
+    governanceIdentity: drep.profile_completeness ?? 0,
+  };
+
+  let lowestWeighted = Infinity;
+  let biggestWin = 'engagementQuality';
+  const scoreStoryPillars = pillarMeta.map((m) => {
+    const value = Math.round(pillarValues[m.key] ?? 0);
+    const weighted = value * m.weight;
+    if (weighted < lowestWeighted) {
+      lowestWeighted = weighted;
+      biggestWin = m.key;
+    }
+    return {
+      key: m.key,
+      label: m.label,
+      value,
+      weight: m.weight,
+      scoreImpact: Math.round((100 - value) * m.weight * 0.5),
+      action: m.action(value),
+    };
+  });
+
   // ── Assemble response ──────────────────────────────────────────────
   return NextResponse.json({
     score: {
@@ -267,6 +378,10 @@ export const GET = withRouteHandler(async (request) => {
     activityHeatmap: {
       epochs: activityEpochs,
       streak,
+    },
+    scoreStory: {
+      pillars: scoreStoryPillars,
+      biggestWin,
     },
   });
 });

--- a/components/workspace/ActionFeed.tsx
+++ b/components/workspace/ActionFeed.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import {
   AlertTriangle,
@@ -8,79 +9,229 @@ import {
   FileText,
   MessageCircle,
   TrendingDown,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+  Users,
   ArrowRight,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import type { CockpitData } from '@/hooks/queries';
+import { VoteRationaleFlow } from '@/components/civica/proposals/VoteRationaleFlow';
+import type { CockpitData, CockpitProposal } from '@/hooks/queries';
+
+// ── Intelligence overlays ─────────────────────────────────────────────
+
+function SentimentBar({
+  sentiment,
+}: {
+  sentiment: NonNullable<CockpitProposal['citizenSentiment']>;
+}) {
+  if (sentiment.total === 0) return null;
+  const supportPct = Math.round((sentiment.support / sentiment.total) * 100);
+  const opposePct = Math.round((sentiment.oppose / sentiment.total) * 100);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+        <Users className="h-3 w-3" />
+        <span>
+          Citizen sentiment ({sentiment.total} response{sentiment.total !== 1 ? 's' : ''})
+        </span>
+      </div>
+      <div className="flex h-1.5 rounded-full overflow-hidden bg-muted">
+        {supportPct > 0 && (
+          <div
+            className="h-full bg-emerald-500 transition-all"
+            style={{ width: `${supportPct}%` }}
+          />
+        )}
+        {opposePct > 0 && (
+          <div className="h-full bg-rose-500 transition-all" style={{ width: `${opposePct}%` }} />
+        )}
+      </div>
+      <div className="flex justify-between text-[10px] tabular-nums">
+        <span className="text-emerald-600 dark:text-emerald-400">{supportPct}% support</span>
+        <span className="text-rose-600 dark:text-rose-400">{opposePct}% oppose</span>
+      </div>
+    </div>
+  );
+}
+
+function DRepVoteTally({ tally }: { tally: CockpitProposal['drepVoteTally'] }) {
+  const total = tally.yes + tally.no + tally.abstain;
+  if (total === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+      <span>
+        DRep votes: <span className="text-emerald-600 dark:text-emerald-400">{tally.yes} Yes</span>{' '}
+        / <span className="text-rose-600 dark:text-rose-400">{tally.no} No</span> /{' '}
+        <span>{tally.abstain} Abstain</span>
+      </span>
+    </div>
+  );
+}
 
 // ── Card types ───────────────────────────────────────────────────────
 
-function ProposalCard({
-  proposal,
-}: {
-  proposal: CockpitData['actionFeed']['pendingProposals'][number];
-}) {
+function ProposalCard({ proposal }: { proposal: CockpitProposal }) {
+  const [expanded, setExpanded] = useState(false);
   const isUrgent = proposal.isUrgent;
+  const summary = proposal.aiSummary || proposal.abstract;
+
   return (
-    <Link
-      href={`/proposal/${proposal.txHash}/${proposal.index}`}
-      className="group flex items-start gap-3 rounded-xl border border-border bg-card p-3.5 transition-colors hover:border-primary/40"
+    <div
+      className={cn(
+        'rounded-xl border bg-card transition-colors',
+        expanded ? 'border-primary/40 shadow-sm' : 'border-border hover:border-primary/30',
+      )}
     >
-      <div
-        className={cn(
-          'mt-0.5 rounded-full p-1.5',
-          isUrgent ? 'bg-red-100 dark:bg-red-900/30' : 'bg-amber-100 dark:bg-amber-900/30',
-        )}
+      {/* Card header — click to expand */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-start gap-3 p-3.5 text-left"
       >
-        {isUrgent ? (
-          <AlertTriangle className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />
-        ) : (
-          <Clock className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
-        )}
-      </div>
-      <div className="flex-1 min-w-0 space-y-0.5">
-        <p className="text-sm font-medium text-foreground truncate">{proposal.title}</p>
-        <div className="flex items-center gap-2 flex-wrap">
-          <Badge variant="secondary" className="text-[10px]">
-            {proposal.proposalType}
-          </Badge>
-          {proposal.epochsRemaining !== null && (
-            <span
-              className={cn(
-                'text-[10px] font-medium',
-                isUrgent ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400',
-              )}
-            >
-              {proposal.epochsRemaining === 0
-                ? 'Expires this epoch'
-                : `${proposal.epochsRemaining} epoch${proposal.epochsRemaining !== 1 ? 's' : ''} left`}
-            </span>
+        <div
+          className={cn(
+            'mt-0.5 shrink-0 rounded-full p-1.5',
+            isUrgent ? 'bg-red-100 dark:bg-red-900/30' : 'bg-amber-100 dark:bg-amber-900/30',
+          )}
+        >
+          {isUrgent ? (
+            <AlertTriangle className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />
+          ) : (
+            <Clock className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
           )}
         </div>
-      </div>
-      <ArrowRight className="mt-1.5 h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-    </Link>
+        <div className="flex-1 min-w-0 space-y-1">
+          <p className="text-sm font-medium text-foreground truncate">{proposal.title}</p>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="secondary" className="text-[10px]">
+              {proposal.proposalType}
+            </Badge>
+            {proposal.epochsRemaining !== null && (
+              <span
+                className={cn(
+                  'text-[10px] font-medium',
+                  isUrgent
+                    ? 'text-red-600 dark:text-red-400'
+                    : 'text-amber-600 dark:text-amber-400',
+                )}
+              >
+                {proposal.epochsRemaining === 0
+                  ? 'Expires this epoch'
+                  : `${proposal.epochsRemaining} epoch${proposal.epochsRemaining !== 1 ? 's' : ''} left`}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="mt-1 shrink-0">
+          {expanded ? (
+            <ChevronUp className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded: intelligence + inline voting */}
+      {expanded && (
+        <div className="border-t border-border px-3.5 pb-3.5 pt-3 space-y-3 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+          {/* AI Summary */}
+          {summary && (
+            <div className="rounded-lg bg-muted/50 p-2.5 space-y-1">
+              <div className="flex items-center gap-1.5 text-[10px] font-medium text-muted-foreground">
+                <Sparkles className="h-3 w-3" />
+                AI Analysis
+              </div>
+              <p className="text-xs text-foreground/80 leading-relaxed line-clamp-3">{summary}</p>
+            </div>
+          )}
+
+          {/* Intelligence row: citizen sentiment + DRep vote tally */}
+          <div className="space-y-2">
+            {proposal.citizenSentiment && proposal.citizenSentiment.total > 0 && (
+              <SentimentBar sentiment={proposal.citizenSentiment} />
+            )}
+            <DRepVoteTally tally={proposal.drepVoteTally} />
+          </div>
+
+          {/* Inline voting flow */}
+          <VoteRationaleFlow
+            txHash={proposal.txHash}
+            proposalIndex={proposal.index}
+            title={proposal.title}
+            isOpen={true}
+            proposalAbstract={proposal.abstract}
+            proposalType={proposal.proposalType}
+            aiSummary={proposal.aiSummary}
+          />
+
+          {/* Link to full proposal detail */}
+          <Link
+            href={`/proposal/${proposal.txHash}/${proposal.index}`}
+            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-primary transition-colors"
+          >
+            View full proposal details
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+      )}
+    </div>
   );
 }
 
 function RationaleCard({ vote }: { vote: { txHash: string; index: number; title: string } }) {
+  const [expanded, setExpanded] = useState(false);
+
   return (
-    <Link
-      href={`/proposal/${vote.txHash}/${vote.index}`}
-      className="group flex items-start gap-3 rounded-xl border border-border bg-card p-3.5 transition-colors hover:border-primary/40"
+    <div
+      className={cn(
+        'rounded-xl border bg-card transition-colors',
+        expanded ? 'border-primary/40 shadow-sm' : 'border-border hover:border-primary/30',
+      )}
     >
-      <div className="mt-0.5 rounded-full p-1.5 bg-blue-100 dark:bg-blue-900/30">
-        <FileText className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
-      </div>
-      <div className="flex-1 min-w-0 space-y-0.5">
-        <p className="text-sm font-medium text-foreground truncate">{vote.title}</p>
-        <p className="text-[10px] text-blue-600 dark:text-blue-400 font-medium">
-          Add rationale to build trust
-        </p>
-      </div>
-      <ArrowRight className="mt-1.5 h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-    </Link>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-start gap-3 p-3.5 text-left"
+      >
+        <div className="mt-0.5 shrink-0 rounded-full p-1.5 bg-blue-100 dark:bg-blue-900/30">
+          <FileText className="h-3.5 w-3.5 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div className="flex-1 min-w-0 space-y-0.5">
+          <p className="text-sm font-medium text-foreground truncate">{vote.title}</p>
+          <p className="text-[10px] text-blue-600 dark:text-blue-400 font-medium">
+            Add rationale to build trust
+          </p>
+        </div>
+        <div className="mt-1 shrink-0">
+          {expanded ? (
+            <ChevronUp className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border px-3.5 pb-3.5 pt-3 space-y-3 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+          <VoteRationaleFlow
+            txHash={vote.txHash}
+            proposalIndex={vote.index}
+            title={vote.title}
+            isOpen={true}
+          />
+          <Link
+            href={`/proposal/${vote.txHash}/${vote.index}`}
+            className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-primary transition-colors"
+          >
+            View full proposal details
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/components/workspace/CockpitScoreHero.tsx
+++ b/components/workspace/CockpitScoreHero.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { TrendingUp, TrendingDown, Minus, Trophy } from 'lucide-react';
+import { useState } from 'react';
+import { TrendingUp, TrendingDown, Minus, Trophy, ChevronDown, ChevronUp, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { CockpitData } from '@/hooks/queries';
+import type { CockpitData, ScoreStoryPillar } from '@/hooks/queries';
 
 const TIER_ACCENT: Record<string, string> = {
   Emerging: 'text-zinc-400',
@@ -22,11 +23,52 @@ const TIER_BG: Record<string, string> = {
   Legendary: 'bg-purple-400/10',
 };
 
-interface CockpitScoreHeroProps {
-  score: CockpitData['score'];
+// ── Score Story Pillar Row ──────────────────────────────────────────
+
+function PillarRow({ pillar, isBiggestWin }: { pillar: ScoreStoryPillar; isBiggestWin: boolean }) {
+  const barColor =
+    pillar.value >= 70 ? 'bg-emerald-500' : pillar.value >= 40 ? 'bg-amber-500' : 'bg-rose-500';
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg p-2.5 space-y-1.5 transition-colors',
+        isBiggestWin ? 'bg-primary/5 ring-1 ring-primary/20' : 'bg-muted/30',
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          {isBiggestWin && <Zap className="h-3 w-3 text-primary" />}
+          <span className="text-xs font-medium text-foreground">{pillar.label}</span>
+        </div>
+        <span className="text-xs font-bold tabular-nums text-foreground">{pillar.value}</span>
+      </div>
+      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn('h-full rounded-full transition-all duration-500', barColor)}
+          style={{ width: `${Math.min(100, pillar.value)}%` }}
+        />
+      </div>
+      <p className="text-[10px] text-muted-foreground leading-tight">
+        {isBiggestWin && <span className="text-primary font-medium">Biggest win: </span>}
+        {pillar.action}
+        {pillar.scoreImpact > 0 && (
+          <span className="text-muted-foreground/70"> (+{pillar.scoreImpact} pts potential)</span>
+        )}
+      </p>
+    </div>
+  );
 }
 
-export function CockpitScoreHero({ score }: CockpitScoreHeroProps) {
+// ── Main Component ──────────────────────────────────────────────────
+
+interface CockpitScoreHeroProps {
+  score: CockpitData['score'];
+  scoreStory?: CockpitData['scoreStory'];
+}
+
+export function CockpitScoreHero({ score, scoreStory }: CockpitScoreHeroProps) {
+  const [storyOpen, setStoryOpen] = useState(false);
   const trend = score.trend;
   const TrendIcon = trend > 0 ? TrendingUp : trend < 0 ? TrendingDown : Minus;
   const trendColor =
@@ -80,7 +122,7 @@ export function CockpitScoreHero({ score }: CockpitScoreHeroProps) {
         </div>
       </div>
 
-      {/* 4-Pillar Mini Bars */}
+      {/* 4-Pillar Mini Bars (always visible) */}
       <div className="grid grid-cols-4 gap-2">
         {pillars.map((p) => (
           <div key={p.key} className="space-y-1">
@@ -116,6 +158,36 @@ export function CockpitScoreHero({ score }: CockpitScoreHeroProps) {
             {score.tierProgress.pointsToNext} pts to {score.tierProgress.nextTier}
           </span>
         </div>
+      )}
+
+      {/* Score Story toggle */}
+      {scoreStory && (
+        <>
+          <button
+            onClick={() => setStoryOpen(!storyOpen)}
+            className="w-full flex items-center justify-center gap-1.5 text-xs text-primary hover:text-primary/80 transition-colors pt-1"
+          >
+            {storyOpen ? (
+              <>
+                Hide score breakdown
+                <ChevronUp className="h-3.5 w-3.5" />
+              </>
+            ) : (
+              <>
+                What&apos;s driving your score?
+                <ChevronDown className="h-3.5 w-3.5" />
+              </>
+            )}
+          </button>
+
+          {storyOpen && (
+            <div className="space-y-2 animate-in fade-in-0 slide-in-from-top-1 duration-200">
+              {scoreStory.pillars.map((p) => (
+                <PillarRow key={p.key} pillar={p} isBiggestWin={p.key === scoreStory.biggestWin} />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/workspace/DRepCockpit.tsx
+++ b/components/workspace/DRepCockpit.tsx
@@ -40,7 +40,7 @@ export function DRepCockpit() {
   return (
     <div className="space-y-4 animate-in fade-in-0 duration-300">
       {/* Score Hero */}
-      <CockpitScoreHero score={data.score} />
+      <CockpitScoreHero score={data.score} scoreStory={data.scoreStory} />
 
       {/* Governance Readiness */}
       <GovernanceReadiness data={data} />

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -686,6 +686,33 @@ export function useAccountInfo(stakeAddress: string | null | undefined) {
 
 // ── Workspace Cockpit (aggregate) ────────────────────────────────────
 
+export interface CockpitProposal {
+  txHash: string;
+  index: number;
+  title: string;
+  proposalType: string;
+  epochsRemaining: number | null;
+  isUrgent: boolean;
+  aiSummary: string | null;
+  abstract: string | null;
+  drepVoteTally: { yes: number; no: number; abstain: number };
+  citizenSentiment: {
+    support: number;
+    oppose: number;
+    abstain: number;
+    total: number;
+  } | null;
+}
+
+export interface ScoreStoryPillar {
+  key: string;
+  label: string;
+  value: number;
+  weight: number;
+  scoreImpact: number;
+  action: string;
+}
+
 export interface CockpitData {
   score: {
     current: number;
@@ -712,14 +739,7 @@ export interface CockpitData {
     };
   };
   actionFeed: {
-    pendingProposals: {
-      txHash: string;
-      index: number;
-      title: string;
-      proposalType: string;
-      epochsRemaining: number | null;
-      isUrgent: boolean;
-    }[];
+    pendingProposals: CockpitProposal[];
     pendingCount: number;
     unexplainedVotes: { txHash: string; index: number; title: string }[];
     unansweredQuestions: number;
@@ -734,6 +754,10 @@ export interface CockpitData {
   activityHeatmap: {
     epochs: { epoch: number; votes: number }[];
     streak: number;
+  };
+  scoreStory: {
+    pillars: ScoreStoryPillar[];
+    biggestWin: string;
   };
 }
 


### PR DESCRIPTION
## Summary

- **Inline voting** in proposal cards — DReps can vote Yes/No/Abstain + write rationale + use AI drafting without leaving the cockpit (wires existing `VoteRationaleFlow`)
- **AI proposal summaries** on each action feed card (2-sentence analysis from `proposals.ai_summary`)
- **Citizen sentiment bars** per proposal ("65% support / 35% oppose") from `citizen_sentiment` table
- **DRep vote tally** per proposal (Yes/No/Abstain counts from other DReps)
- **Score Story Panel** — Credit Karma-style factor breakdown in `CockpitScoreHero` with per-pillar recommended actions and "biggest win" highlight

## Impact

- **User-facing**: Yes — DReps get a command center with inline governance actions
- **Risk**: Medium — new UI interactions with on-chain voting, but `VoteRationaleFlow` is existing battle-tested code
- **Scope**: 5 files changed, no migrations, no new env vars, no Inngest changes
- **Files**: `route.ts` (API), `ActionFeed.tsx`, `CockpitScoreHero.tsx`, `DRepCockpit.tsx`, `queries.ts`

## Test plan

- [ ] Cockpit loads without errors for a DRep with pending proposals
- [ ] Expanding a proposal card shows AI summary, sentiment bar, vote tally, and inline voting flow
- [ ] Voting flow completes end-to-end (select → rationale → review → submit)
- [ ] Score Story section expands/collapses and highlights the biggest win pillar
- [ ] Empty states render correctly (no pending proposals, no sentiment data)
- [ ] Mobile layout remains single-column and usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)