### PR TITLE
fix: show wallet-gated features in View As preview mode

### DIFF
--- a/components/GovernanceCitizenSection.tsx
+++ b/components/GovernanceCitizenSection.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useWallet } from '@/utils/wallet';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { Shield } from 'lucide-react';
 import { GovernanceTimeline } from '@/components/GovernanceTimeline';
 import { GovernanceImpactHero } from '@/components/GovernanceImpactHero';
 import { GovernanceCitizenPanels } from '@/components/GovernanceCitizenPanels';
@@ -99,6 +101,19 @@ export function GovernanceCitizenSection() {
 
     return init;
   }, [holderData, timelineData, isAuthenticated, address, delegatedDrepId]);
+
+  const { isViewingAs, segment } = useSegment();
+
+  if (isViewingAs && (!connected || !isAuthenticated || !state)) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+          <Shield className="h-3.5 w-3.5 shrink-0" />
+          Preview mode — viewing as {segment}. Connect a wallet to see real citizen governance data.
+        </div>
+      </div>
+    );
+  }
 
   if (!connected || !isAuthenticated || !state) return null;
 

--- a/components/civica/discover/DiscoverHero.tsx
+++ b/components/civica/discover/DiscoverHero.tsx
@@ -50,12 +50,12 @@ function StatPill({
 
 /* -- Segment-aware contextual banner ----------------------------- */
 function SegmentBanner({ totalDreps }: { totalDreps: number }) {
-  const { segment, delegatedDrep, isLoading } = useSegment();
+  const { segment, delegatedDrep, isLoading, isViewingAs } = useSegment();
   const { connected } = useWallet();
 
   if (isLoading) return null;
 
-  if (!connected || segment === 'anonymous') {
+  if (!isViewingAs && (!connected || segment === 'anonymous')) {
     return (
       <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 rounded-lg border border-primary/20 bg-card/80 backdrop-blur-sm p-4">
         <div className="flex items-center gap-3 shrink-0">

--- a/components/civica/proposals/VoteCastingPanel.tsx
+++ b/components/civica/proposals/VoteCastingPanel.tsx
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Sparkles,
   FileText,
+  Shield,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -138,7 +139,7 @@ export function VoteCastingPanel({
   aiSummary,
 }: VoteCastingPanelProps) {
   const { connected, ownDRepId } = useWallet();
-  const { segment, poolId } = useSegment();
+  const { segment, poolId, isViewingAs, drepId: overrideDrepId } = useSegment();
   const { phase, startVote, confirmVote, reset, isProcessing } = useVote();
   const [selectedVote, setSelectedVote] = useState<VoteChoice | null>(null);
   const [rationaleText, setRationaleText] = useState('');
@@ -147,14 +148,16 @@ export function VoteCastingPanel({
   const [isPublishing, setIsPublishing] = useState(false);
   // Determine voter role and credential from segment
   const voterRole: VoterRole = segment === 'spo' ? 'spo' : 'drep';
-  const voterId = segment === 'spo' ? poolId : ownDRepId;
-  const canVote = connected && !!voterId;
+  const voterId = segment === 'spo' ? poolId : ownDRepId || (isViewingAs ? overrideDrepId : null);
+  const previewMode = isViewingAs && !connected;
+  const canVote = connected && !!voterId && !previewMode;
 
   // Don't show for closed proposals
   if (!isOpen) return null;
 
-  // Don't show if not a DRep or SPO
-  if (!connected || !voterId) return null;
+  // Don't show if not a DRep or SPO (allow View As mode)
+  if (!connected && !isViewingAs) return null;
+  if (!voterId) return null;
 
   const isConfirming = phase.status === 'confirming';
   const isDone = phase.status === 'success';
@@ -167,7 +170,7 @@ export function VoteCastingPanel({
       : 'DReps who explain votes score higher on Engagement (25% weight)';
 
   const handleVoteSelect = (vote: VoteChoice) => {
-    if (isProcessing || isDone) return;
+    if (previewMode || isProcessing || isDone) return;
     setSelectedVote(vote);
 
     if (hasError) reset();
@@ -252,6 +255,13 @@ export function VoteCastingPanel({
           )}
         </div>
 
+        {previewMode && (
+          <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+            <Shield className="h-3.5 w-3.5 shrink-0" />
+            Preview mode — voting disabled while viewing as another user
+          </div>
+        )}
+
         {/* Vote buttons */}
         {!isDone && (
           <div
@@ -265,7 +275,7 @@ export function VoteCastingPanel({
                 <button
                   key={value}
                   onClick={() => handleVoteSelect(value)}
-                  disabled={isProcessing || isPublishing}
+                  disabled={previewMode || isProcessing || isPublishing}
                   role="radio"
                   aria-checked={isSelected}
                   className={cn(

--- a/components/civica/proposals/VoteRationaleFlow.tsx
+++ b/components/civica/proposals/VoteRationaleFlow.tsx
@@ -220,7 +220,7 @@ export function VoteRationaleFlow({
   aiSummary,
 }: VoteRationaleFlowProps) {
   const { connected, ownDRepId } = useWallet();
-  const { segment, poolId } = useSegment();
+  const { segment, poolId, isViewingAs, drepId: overrideDrepId } = useSegment();
   const { phase, startVote, confirmVote, reset, isProcessing, canVote } = useVote();
   const [flowStep, setFlowStep] = useState<FlowStep>('select');
   const [selectedVote, setSelectedVote] = useState<VoteChoice | null>(null);
@@ -231,8 +231,9 @@ export function VoteRationaleFlow({
 
   // Determine voter role and credential based on segment
   const voterRole: VoterRole = segment === 'spo' ? 'spo' : 'drep';
-  const voterId = segment === 'spo' ? poolId : ownDRepId;
+  const voterId = segment === 'spo' ? poolId : ownDRepId || (isViewingAs ? overrideDrepId : null);
   const roleLabel = voterRole === 'spo' ? 'SPO' : 'DRep';
+  const previewMode = isViewingAs && !connected;
 
   // Detect success — transition flow step when vote succeeds
   useEffect(() => {
@@ -255,8 +256,8 @@ export function VoteRationaleFlow({
     );
   }
 
-  // Wallet not connected — show connect CTA
-  if (!connected) {
+  // Wallet not connected — show connect CTA (skip in View As mode)
+  if (!connected && !isViewingAs) {
     return (
       <Card className="border-primary/20">
         <CardContent className="pt-6 space-y-3">
@@ -274,7 +275,7 @@ export function VoteRationaleFlow({
   if (!voterId) return null;
 
   const handleVoteSelect = (vote: VoteChoice) => {
-    if (isProcessing) return;
+    if (previewMode || isProcessing) return;
     setSelectedVote(vote);
 
     if (phase.status === 'error') reset();
@@ -436,6 +437,12 @@ export function VoteRationaleFlow({
         {/* ------------------------------------------------------------------ */}
         {flowStep === 'select' && (
           <div className="space-y-3">
+            {previewMode && (
+              <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                <Shield className="h-3.5 w-3.5 shrink-0" />
+                Preview mode — voting disabled while viewing as another user
+              </div>
+            )}
             {/* Vote buttons */}
             <div className="grid grid-cols-3 gap-2">
               {VOTE_OPTIONS.map(({ value, label, icon: Icon, color, selectedColor, bgColor }) => {
@@ -444,13 +451,13 @@ export function VoteRationaleFlow({
                   <button
                     key={value}
                     onClick={() => handleVoteSelect(value)}
-                    disabled={isProcessing}
+                    disabled={previewMode || isProcessing}
                     className={cn(
                       'flex flex-col items-center gap-1.5 rounded-lg border p-3 transition-all',
                       isSelected
                         ? `${bgColor} ring-2 ring-offset-1 ring-offset-background ${selectedColor}`
                         : 'border-border hover:bg-muted/30',
-                      isProcessing && 'opacity-50 cursor-not-allowed',
+                      (previewMode || isProcessing) && 'opacity-50 cursor-not-allowed',
                     )}
                   >
                     <Icon className={cn('h-5 w-5', isSelected ? color : 'text-muted-foreground')} />
@@ -751,7 +758,7 @@ function PostVoteRationale({
   aiSummary?: string | null;
 }) {
   const { connected, ownDRepId } = useWallet();
-  const { segment, poolId } = useSegment();
+  const { segment, poolId, isViewingAs, drepId: overrideDrepId } = useSegment();
   const { phase, startVote, confirmVote, canVote } = useVote();
 
   const [expanded, setExpanded] = useState(false);
@@ -762,7 +769,8 @@ function PostVoteRationale({
 
   // Determine voter role and credential based on segment
   const postVoterRole: VoterRole = segment === 'spo' ? 'spo' : 'drep';
-  const postVoterId = segment === 'spo' ? poolId : ownDRepId;
+  const postVoterId =
+    segment === 'spo' ? poolId : ownDRepId || (isViewingAs ? overrideDrepId : null);
 
   // Pending anchor data: when set, we auto-confirm after preflight completes
   const pendingAnchorRef = useRef<{ url: string; hash: string } | null>(null);
@@ -784,7 +792,7 @@ function PostVoteRationale({
     }
   }, [phase.status, vote, confirmVote, isSubmitting]);
 
-  if (!connected || !postVoterId) return null;
+  if ((!connected && !isViewingAs) || !postVoterId) return null;
   if (submitted) {
     return (
       <div className="flex items-center gap-2 text-xs text-emerald-500 mt-2 justify-center">

--- a/components/civica/pulse/GovernanceImpactCard.tsx
+++ b/components/civica/pulse/GovernanceImpactCard.tsx
@@ -49,7 +49,7 @@ export function GovernanceImpactCard({
   treasuryBalanceAda,
 }: GovernanceImpactCardProps) {
   const { connected, delegatedDrepId } = useWallet();
-  const { stakeAddress, delegatedDrep } = useSegment();
+  const { stakeAddress, delegatedDrep, isViewingAs } = useSegment();
 
   // The wallet may provide delegatedDrepId before segment resolves
   const effectiveDrepId = delegatedDrepId || delegatedDrep;
@@ -59,8 +59,8 @@ export function GovernanceImpactCard({
   const walletAddress = stakeAddress ?? undefined;
   const { data: epochSummary } = useEpochSummary(walletAddress);
 
-  // No-wallet preview: blurred mock stats create FOMO
-  if (!connected) {
+  // No-wallet preview: blurred mock stats create FOMO (skip in View As mode)
+  if (!connected && !isViewingAs) {
     return (
       <div className="relative rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 overflow-hidden">
         <div className="absolute inset-0 backdrop-blur-sm bg-card/60 z-10 flex flex-col items-center justify-center gap-2">

--- a/components/engagement/AskYourDRep.tsx
+++ b/components/engagement/AskYourDRep.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from 'react';
 import { useWallet } from '@/utils/wallet';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { getStoredSession } from '@/lib/supabaseAuth';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { MessageSquare, Send, Info, CheckCircle2 } from 'lucide-react';
+import { MessageSquare, Send, Info, CheckCircle2, Shield } from 'lucide-react';
 import { hapticLight } from '@/lib/haptics';
 
 interface AskYourDRepProps {
@@ -18,15 +19,21 @@ interface AskYourDRepProps {
 
 export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRepProps) {
   const { connected, isAuthenticated, delegatedDrepId, authenticate } = useWallet();
+  const { isViewingAs, delegatedDrep } = useSegment();
   const [question, setQuestion] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Only show if user has a delegated DRep
-  if (!connected || !delegatedDrepId) return null;
+  const previewMode = isViewingAs && !connected;
+  const effectiveDrepId = delegatedDrepId || (isViewingAs ? delegatedDrep : null);
+
+  // Only show if user has a delegated DRep (real or overridden)
+  if (!effectiveDrepId) return null;
+  if (!connected && !isViewingAs) return null;
 
   const submit = async () => {
+    if (previewMode) return;
     if (!question.trim() || question.length > 500) return;
     hapticLight();
 
@@ -50,7 +57,7 @@ export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRe
         },
         body: JSON.stringify({
           sessionToken: token,
-          drepId: delegatedDrepId,
+          drepId: effectiveDrepId,
           questionText: question.trim(),
           proposalTxHash: txHash,
           proposalIndex,
@@ -70,7 +77,7 @@ export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRe
           posthog.capture('citizen_question_asked', {
             proposal_tx_hash: txHash,
             proposal_index: proposalIndex,
-            drep_id: delegatedDrepId,
+            drep_id: effectiveDrepId,
           });
         })
         .catch(() => {});
@@ -130,6 +137,12 @@ export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRe
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        {previewMode && (
+          <div className="flex items-center gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+            <Shield className="h-3.5 w-3.5 shrink-0" />
+            Preview mode — questions disabled while viewing as another user
+          </div>
+        )}
         <p className="text-xs text-muted-foreground">
           Ask your DRep about &ldquo;{proposalTitle.slice(0, 80)}
           {proposalTitle.length > 80 ? '...' : ''}&rdquo;
@@ -140,13 +153,14 @@ export function AskYourDRep({ txHash, proposalIndex, proposalTitle }: AskYourDRe
           placeholder="What's your position on this proposal?"
           className="min-h-[80px] text-sm resize-none"
           maxLength={500}
+          disabled={previewMode}
         />
         <div className="flex items-center justify-between">
           <span className="text-xs text-muted-foreground">{question.length}/500</span>
           <Button
             size="sm"
             onClick={submit}
-            disabled={submitting || !question.trim()}
+            disabled={previewMode || submitting || !question.trim()}
             className="gap-1.5"
           >
             <Send className="h-3.5 w-3.5" />

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -36,6 +36,8 @@ export interface SegmentState {
   getEngagementLevelOverride: () => EngagementLevel | null;
   getCredibilityTierOverride: () => CredibilityTier | null;
   getGovernanceLevelOverride: () => GovernanceLevel | null;
+  /** True when admin "View As" override is active — components should show preview mode */
+  isViewingAs: boolean;
 }
 
 const STORAGE_KEY = 'civica_segment';
@@ -59,6 +61,7 @@ const DEFAULT_STATE: SegmentState = {
   getEngagementLevelOverride: () => null,
   getCredibilityTierOverride: () => null,
   getGovernanceLevelOverride: () => null,
+  isViewingAs: false,
 };
 
 const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
@@ -106,6 +109,7 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
       | 'getEngagementLevelOverride'
       | 'getCredibilityTierOverride'
       | 'getGovernanceLevelOverride'
+      | 'isViewingAs'
     >
   >({
     isLoading: false,
@@ -203,6 +207,7 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
     getEngagementLevelOverride: () => dimensionOverrides.engagementLevel ?? null,
     getCredibilityTierOverride: () => dimensionOverrides.credibilityTier ?? null,
     getGovernanceLevelOverride: () => dimensionOverrides.governanceLevel ?? null,
+    isViewingAs: override !== null,
   };
 
   return <SegmentContext.Provider value={value}>{children}</SegmentContext.Provider>;


### PR DESCRIPTION
## Summary
- Adds `isViewingAs` flag to `SegmentProvider` (computed from `override !== null`)
- Implements read-only preview mode across 7 wallet-gated components: VoteRationaleFlow, VoteCastingPanel, AskYourDRep, DiscoverHero, GovernanceCitizenSection, GovernanceImpactCard
- UI renders fully in View As mode but interactive elements (vote buttons, submit) are disabled with amber preview banners
- Two-layer safety: transaction hooks (`useVote`, `useDelegation`) remain gated on real wallet — no accidental on-chain actions

## Impact
- **What changed**: Admin View As now shows all wallet-gated features in preview mode instead of hiding them
- **User-facing**: Yes — admins using View As persona simulation see the full UI for any persona
- **Risk**: Low — only adds a new boolean flag and UI guards; no data or transaction logic changed
- **Scope**: SegmentProvider + 6 components (voting, engagement, discovery, citizen section)

## Test plan
- [ ] View As DRep profile → VoteRationaleFlow + VoteCastingPanel visible with preview banner
- [ ] View As citizen with delegation → AskYourDRep card visible, submit disabled
- [ ] View As citizen → DiscoverHero shows segment-specific banner, not generic CTA
- [ ] View As citizen → GovernanceCitizenSection shows preview placeholder
- [ ] View As citizen → GovernanceImpactCard shows real data, not blurred FOMO card
- [ ] Real wallet connected → all features work normally (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)