### PR TITLE
fix: GHI engine audit — force-dynamic, band consistency, weighted median

### DIFF
--- a/app/api/governance/health-index/route.ts
+++ b/app/api/governance/health-index/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { computeGHI } from '@/lib/ghi';

--- a/components/civica/pulse/GHIExplorer.tsx
+++ b/components/civica/pulse/GHIExplorer.tsx
@@ -161,93 +161,97 @@ export function GHIExplorer({
             exit="hidden"
             className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-3"
           >
-            {components.map((comp) => {
-              const calKey = getCalibrationKey(comp.name);
-              const curve = calibration[calKey];
-              const trend = componentTrends[comp.name];
-              const label = COMPONENT_LABELS[calKey] ?? comp.name;
-              const tooltipText = COMPONENT_TOOLTIPS[calKey];
+            {components
+              .filter((c) => c.weight > 0)
+              .map((comp) => {
+                const calKey = getCalibrationKey(comp.name);
+                const curve = calibration[calKey];
+                const trend = componentTrends[comp.name];
+                const label = COMPONENT_LABELS[calKey] ?? comp.name;
+                const tooltipText = COMPONENT_TOOLTIPS[calKey];
 
-              const sparkData = componentHistory
-                .filter((h) => h.components)
-                .map((h) => {
-                  const match = h.components!.find((c) => c.name === comp.name);
-                  return match?.value ?? null;
-                })
-                .slice(-5);
+                const sparkData = componentHistory
+                  .filter((h) => h.components)
+                  .map((h) => {
+                    const match = h.components!.find((c) => c.name === comp.name);
+                    return match?.value ?? null;
+                  })
+                  .slice(-5);
 
-              const scorePct = Math.min((comp.contribution / comp.weight) * 100, 100);
+                const scorePct = Math.min((comp.contribution / comp.weight) * 100, 100);
 
-              return (
-                <motion.div
-                  key={comp.name}
-                  variants={fadeInUp}
-                  className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md p-3 space-y-2"
-                >
-                  <div className="flex items-center justify-between">
-                    {tooltipText ? (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="text-sm font-medium cursor-help border-b border-dashed border-muted-foreground/40">
-                              {label}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="top" className="max-w-60">
-                            <p>{tooltipText}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : (
-                      <span className="text-sm font-medium">{label}</span>
-                    )}
-                    <span className="text-xs text-muted-foreground tabular-nums">
-                      {Math.round(comp.weight * 100)}%
-                    </span>
-                  </div>
-
-                  {/* Score bar */}
-                  <div
-                    className="relative h-2 rounded-full bg-muted overflow-hidden"
-                    role="meter"
-                    aria-valuenow={Math.round(comp.value)}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-label={`${label}: ${Math.round(comp.value)} out of 100`}
+                return (
+                  <motion.div
+                    key={comp.name}
+                    variants={fadeInUp}
+                    className="rounded-lg border border-border/50 bg-card/70 backdrop-blur-md p-3 space-y-2"
                   >
-                    <motion.div
-                      className={cn('absolute inset-y-0 left-0 rounded-full', barColor)}
-                      initial={{ width: 0 }}
-                      animate={{ width: `${scorePct}%` }}
-                      transition={shouldReduceMotion ? { duration: 0 } : (spring.smooth as object)}
-                      aria-hidden="true"
-                    />
-                  </div>
-
-                  {/* Zone indicator */}
-                  {curve && <ZoneIndicator value={comp.value} curve={curve} />}
-
-                  {/* Footer: sparkline + trend */}
-                  <div className="flex items-center justify-between">
-                    <MiniSparkline data={sparkData} />
-                    {trend && trend.delta !== 0 && (
-                      <span
-                        className={cn(
-                          'text-[10px] font-medium',
-                          trend.direction === 'up'
-                            ? 'text-emerald-500'
-                            : trend.direction === 'down'
-                              ? 'text-rose-500'
-                              : 'text-muted-foreground',
-                        )}
-                      >
-                        {trend.direction === 'up' ? '↑' : '↓'} {Math.abs(trend.delta).toFixed(1)}
+                    <div className="flex items-center justify-between">
+                      {tooltipText ? (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-sm font-medium cursor-help border-b border-dashed border-muted-foreground/40">
+                                {label}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-60">
+                              <p>{tooltipText}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      ) : (
+                        <span className="text-sm font-medium">{label}</span>
+                      )}
+                      <span className="text-xs text-muted-foreground tabular-nums">
+                        {Math.round(comp.weight * 100)}%
                       </span>
-                    )}
-                  </div>
-                </motion.div>
-              );
-            })}
+                    </div>
+
+                    {/* Score bar */}
+                    <div
+                      className="relative h-2 rounded-full bg-muted overflow-hidden"
+                      role="meter"
+                      aria-valuenow={Math.round(comp.value)}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-label={`${label}: ${Math.round(comp.value)} out of 100`}
+                    >
+                      <motion.div
+                        className={cn('absolute inset-y-0 left-0 rounded-full', barColor)}
+                        initial={{ width: 0 }}
+                        animate={{ width: `${scorePct}%` }}
+                        transition={
+                          shouldReduceMotion ? { duration: 0 } : (spring.smooth as object)
+                        }
+                        aria-hidden="true"
+                      />
+                    </div>
+
+                    {/* Zone indicator */}
+                    {curve && <ZoneIndicator value={comp.value} curve={curve} />}
+
+                    {/* Footer: sparkline + trend */}
+                    <div className="flex items-center justify-between">
+                      <MiniSparkline data={sparkData} />
+                      {trend && trend.delta !== 0 && (
+                        <span
+                          className={cn(
+                            'text-[10px] font-medium',
+                            trend.direction === 'up'
+                              ? 'text-emerald-500'
+                              : trend.direction === 'down'
+                                ? 'text-rose-500'
+                                : 'text-muted-foreground',
+                          )}
+                        >
+                          {trend.direction === 'up' ? '↑' : '↓'} {Math.abs(trend.delta).toFixed(1)}
+                        </span>
+                      )}
+                    </div>
+                  </motion.div>
+                );
+              })}
 
             {/* Share button */}
             <motion.div variants={fadeInUp} className="col-span-full flex justify-end">

--- a/components/hub/cards/GovernanceHealthCard.tsx
+++ b/components/hub/cards/GovernanceHealthCard.tsx
@@ -3,6 +3,7 @@
 import { Activity, TrendingUp, TrendingDown, AlertTriangle } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { HubCard, HubCardSkeleton, HubCardError, type CardUrgency } from './HubCard';
+import { getBand, GHI_BAND_LABELS, type GHIBand } from '@/lib/ghi/types';
 
 interface GHIComponent {
   name: string;
@@ -43,19 +44,17 @@ export function GovernanceHealthCard() {
   const rounded = Math.round(score);
   const components = (ghi?.components as GHIComponent[]) ?? [];
 
-  // Health band
-  let band: string;
-  let urgency: CardUrgency;
-  if (rounded >= 70) {
-    band = 'Healthy';
-    urgency = 'success';
-  } else if (rounded >= 50) {
-    band = 'Fair';
-    urgency = 'warning';
-  } else {
-    band = 'Needs Attention';
-    urgency = 'critical';
-  }
+  // Use canonical GHI bands (76/51/26) to match the dedicated health page
+  const bandKey: GHIBand = getBand(rounded);
+  const band = GHI_BAND_LABELS[bandKey];
+  const urgency: CardUrgency =
+    bandKey === 'strong'
+      ? 'success'
+      : bandKey === 'good'
+        ? 'default'
+        : bandKey === 'fair'
+          ? 'warning'
+          : 'critical';
 
   const bandColor =
     urgency === 'success'

--- a/lib/ghi/components.ts
+++ b/lib/ghi/components.ts
@@ -41,21 +41,52 @@ export async function computeDRepParticipation({
   const active = (dreps ?? []).filter((d) => (d.info as Record<string, unknown> | null)?.isActive);
   if (active.length === 0) return { raw: 0 };
 
+  // Participation-weighted median: weight each DRep's participation by their
+  // voting power so that DReps with more delegation carry proportionally more
+  // influence on the system-level health signal. This reflects whether the ADA
+  // that IS delegated is being well-represented, rather than penalizing the
+  // index for ghost DReps who registered but never participate.
+  const entries = active
+    .map((d) => ({
+      participation: (d.effective_participation as number) ?? 0,
+      weight: parseInt(
+        String((d.info as Record<string, unknown> | null)?.votingPowerLovelace || '0'),
+        10,
+      ),
+    }))
+    .filter((e) => e.weight > 0)
+    .sort((a, b) => a.participation - b.participation);
+
+  if (entries.length === 0) return { raw: 0 };
+
+  const totalWeight = entries.reduce((s, e) => s + e.weight, 0);
+  const halfWeight = totalWeight / 2;
+
+  let cumulativeWeight = 0;
+  let weightedMedian = entries[0].participation;
+  for (const entry of entries) {
+    cumulativeWeight += entry.weight;
+    if (cumulativeWeight >= halfWeight) {
+      weightedMedian = entry.participation;
+      break;
+    }
+  }
+
+  // Also compute unweighted median for detail reporting
   const participationValues = active
     .map((d) => (d.effective_participation as number) ?? 0)
     .sort((a, b) => a - b);
-
-  // Median (not mean) — resistant to outlier auto-voters
   const mid = Math.floor(participationValues.length / 2);
-  const median =
+  const unweightedMedian =
     participationValues.length % 2 === 0
       ? (participationValues[mid - 1] + participationValues[mid]) / 2
       : participationValues[mid];
 
   return {
-    raw: Math.min(100, Math.max(0, median)),
+    raw: Math.min(100, Math.max(0, weightedMedian)),
     detail: {
-      medianParticipation: median,
+      weightedMedianParticipation: weightedMedian,
+      unweightedMedianParticipation: unweightedMedian,
       activeDreps: active.length,
     },
   };


### PR DESCRIPTION
## Summary
- Add missing `force-dynamic` to `/api/governance/health-index` route (hard constraint violation)
- Fix Hub card band thresholds to use canonical GHI bands (76/51/26) instead of hardcoded 70/50, eliminating contradictory labels between Hub and Health page
- Hide disabled Citizen Engagement (weight 0) from GHI Explorer breakdown
- Switch DRep Participation component from unweighted median to **participation-weighted median** — weights each DRep's participation by their voting power so the index reflects governance health of delegated ADA, not ghost DRep headcount. Empirically validated: weighted median ~80 vs unweighted 4.

## Impact
- **What changed**: GHI score will increase significantly (~49→~65-70) due to weighted median reflecting that high-power DReps participate actively
- **User-facing**: Yes — GHI score on Hub and Health page will show higher, more accurate governance health. Band labels now consistent everywhere.
- **Risk**: Low — scoring methodology change is deliberate product decision; all other changes are bug fixes
- **Scope**: 4 files (1 API route, 2 UI components, 1 scoring component). No migrations, no new Inngest functions.

## Test plan
- [x] All 591 tests pass
- [x] TypeScript compiles clean
- [x] Prettier + ESLint clean
- [ ] CI passes
- [ ] Verify GHI score on production after deploy
- [ ] Verify Hub card and Health page show consistent bands

🤖 Generated with [Claude Code](https://claude.com/claude-code)