### PR TITLE
feat: share engine — milestone cards, profile sharing, governance stats cards

### DIFF
--- a/app/api/og/citizen-milestone/[stakeAddress]/[milestoneKey]/route.tsx
+++ b/app/api/og/citizen-milestone/[stakeAddress]/[milestoneKey]/route.tsx
@@ -1,0 +1,218 @@
+import { ImageResponse } from 'next/og';
+import { CITIZEN_MILESTONES } from '@/lib/citizenMilestones';
+import { OGBackground, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+const CATEGORY_COLORS: Record<string, string> = {
+  delegation: OG.blue,
+  influence: OG.indigo,
+  engagement: OG.amber,
+  identity: OG.green,
+};
+
+const MILESTONE_EMOJIS: Record<string, string> = {
+  'first-delegation': '\u{1F91D}',
+  'delegation-streak-10': '\u{1F525}',
+  'delegation-streak-25': '\u{1F525}',
+  'delegation-streak-50': '\u{1F525}',
+  'delegation-streak-100': '\u{1F525}',
+  'influenced-10': '\u{1F5F3}',
+  'influenced-50': '\u{1F5F3}',
+  'influenced-100': '\u{1F5F3}',
+  'first-engagement': '\u{1F4E3}',
+  'engagement-10': '\u{1F4E3}',
+  'ada-governed-100k': '\u{1FA99}',
+  'ada-governed-1m': '\u{1FA99}',
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ stakeAddress: string; milestoneKey: string }> },
+) {
+  try {
+    const { stakeAddress, milestoneKey } = await params;
+
+    const milestone = CITIZEN_MILESTONES.find((m) => m.key === milestoneKey);
+    if (!milestone) {
+      return new ImageResponse(<OGFallback message="Milestone not found" />, {
+        width: 1200,
+        height: 630,
+      });
+    }
+
+    const supabase = createClient();
+
+    // Look up citizen tenure (first delegation epoch)
+    const { data: wallet } = await supabase
+      .from('user_wallets')
+      .select('delegation_streak_epochs, created_at')
+      .eq('stake_address', stakeAddress)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    const streakEpochs = (wallet as { delegation_streak_epochs?: number } | null)
+      ?.delegation_streak_epochs;
+
+    const emoji = MILESTONE_EMOJIS[milestoneKey] || '\u{1F3C5}';
+    const accentColor = CATEGORY_COLORS[milestone.category] || OG.brand;
+
+    return new ImageResponse(
+      <OGBackground glow={accentColor}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '64px',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {/* Header badge */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '20px',
+              color: accentColor,
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase' as const,
+              marginBottom: '24px',
+            }}
+          >
+            Citizen Achievement Unlocked
+          </div>
+
+          {/* Icon */}
+          <div style={{ display: 'flex', fontSize: '72px', marginBottom: '20px' }}>{emoji}</div>
+
+          {/* Milestone name */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '44px',
+              fontWeight: 700,
+              color: OG.text,
+              textAlign: 'center',
+              lineHeight: 1.2,
+            }}
+          >
+            {milestone.label}
+          </div>
+
+          {/* Description */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '22px',
+              color: OG.textMuted,
+              marginTop: '12px',
+              textAlign: 'center',
+              maxWidth: '700px',
+            }}
+          >
+            {milestone.description}
+          </div>
+
+          {/* Stats row */}
+          <div
+            style={{
+              display: 'flex',
+              gap: '24px',
+              marginTop: '40px',
+            }}
+          >
+            {/* Category badge */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                padding: '16px 28px',
+                borderRadius: '12px',
+                backgroundColor: OG.bgCard,
+                border: `1px solid ${OG.border}`,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '22px',
+                  fontWeight: 700,
+                  color: accentColor,
+                  textTransform: 'capitalize' as const,
+                }}
+              >
+                {milestone.category}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '13px',
+                  color: OG.textMuted,
+                  marginTop: '4px',
+                }}
+              >
+                Category
+              </div>
+            </div>
+
+            {/* Tenure / streak */}
+            {streakEpochs != null && streakEpochs > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  padding: '16px 28px',
+                  borderRadius: '12px',
+                  backgroundColor: OG.bgCard,
+                  border: `1px solid ${OG.border}`,
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '22px',
+                    fontWeight: 700,
+                    color: OG.text,
+                  }}
+                >
+                  {streakEpochs} Epochs
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '13px',
+                    color: OG.textMuted,
+                    marginTop: '4px',
+                  }}
+                >
+                  Delegation Streak
+                </div>
+              </div>
+            )}
+          </div>
+
+          <OGFooter left="$governada" right="governada.io" />
+        </div>
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG Citizen Milestone] Error:', error);
+    return new ImageResponse(<OGFallback message="Citizen Achievement" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/app/api/og/coverage-gap/[stakeAddress]/route.tsx
+++ b/app/api/og/coverage-gap/[stakeAddress]/route.tsx
@@ -1,0 +1,175 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGFooter, OGFallback, OG, tierColor } from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ stakeAddress: string }> },
+) {
+  try {
+    const { stakeAddress } = await params;
+    const supabase = createClient();
+
+    // Find the user's DRep
+    const { data: wallet } = await supabase
+      .from('user_wallets')
+      .select('drep_id')
+      .eq('stake_address', stakeAddress)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const drepId = (wallet as { drep_id?: string } | null)?.drep_id ?? null;
+
+    let coveragePct = 0;
+    let votesCount = 0;
+    let totalProposals = 0;
+    let missedCount = 0;
+    let drepName: string | null = null;
+
+    if (drepId) {
+      const [votesResult, proposalsResult, drepResult] = await Promise.all([
+        supabase
+          .from('drep_votes')
+          .select('vote_tx_hash', { count: 'exact', head: true })
+          .eq('drep_id', drepId),
+        supabase.from('proposals').select('proposal_tx_hash', { count: 'exact', head: true }),
+        supabase.from('dreps').select('info').eq('id', drepId).single(),
+      ]);
+
+      votesCount = votesResult.count ?? 0;
+      totalProposals = proposalsResult.count ?? 0;
+      coveragePct = totalProposals > 0 ? Math.round((votesCount / totalProposals) * 100) : 0;
+      missedCount = totalProposals - votesCount;
+
+      // Try to extract DRep name from info
+      const info = drepResult.data?.info;
+      if (info && typeof info === 'object') {
+        const infoObj = info as Record<string, unknown>;
+        drepName = (infoObj.givenName as string) ?? (infoObj.name as string) ?? null;
+      }
+    }
+
+    const color = tierColor(coveragePct);
+    const isGood = coveragePct >= 80;
+
+    return new ImageResponse(
+      <OGBackground glow={color}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '64px',
+            justifyContent: 'center',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '20px',
+              color: OG.textMuted,
+              fontWeight: 500,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase' as const,
+              marginBottom: '12px',
+            }}
+          >
+            Representation Coverage
+          </div>
+
+          {/* Main stat */}
+          <div
+            style={{ display: 'flex', alignItems: 'baseline', gap: '16px', marginBottom: '8px' }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '100px',
+                fontWeight: 700,
+                color,
+                lineHeight: 1,
+              }}
+            >
+              {coveragePct}%
+            </div>
+            <div style={{ display: 'flex', fontSize: '28px', color: OG.textMuted }}>coverage</div>
+          </div>
+
+          {/* Headline */}
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '28px',
+              fontWeight: 600,
+              color: OG.text,
+              marginBottom: '28px',
+            }}
+          >
+            {isGood
+              ? `${drepName ? drepName : 'Your DRep'} voted on ${votesCount} of ${totalProposals} proposals`
+              : `${drepName ? drepName : 'Your DRep'} missed ${missedCount} of ${totalProposals} proposals`}
+          </div>
+
+          {/* Coverage bar */}
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              height: '32px',
+              backgroundColor: OG.barBg,
+              borderRadius: '16px',
+              overflow: 'hidden',
+              marginBottom: '32px',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                width: `${coveragePct}%`,
+                height: '100%',
+                backgroundColor: color,
+                borderRadius: '16px',
+              }}
+            />
+          </div>
+
+          {/* CTA */}
+          <div
+            style={{
+              display: 'flex',
+              padding: '12px 28px',
+              borderRadius: '12px',
+              backgroundColor: `${OG.brand}20`,
+              border: `1px solid ${OG.brand}40`,
+              fontSize: '20px',
+              fontWeight: 600,
+              color: OG.brand,
+              alignSelf: 'flex-start',
+            }}
+          >
+            Check your representation at governada.io
+          </div>
+
+          <OGFooter left="$governada" right="governada.io" />
+        </div>
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG Coverage Gap] Error:', error);
+    return new ImageResponse(<OGFallback message="Check Your Representation" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/app/api/og/divergence/route.tsx
+++ b/app/api/og/divergence/route.tsx
@@ -1,0 +1,196 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const supabase = createClient();
+
+    // Get latest inter-body alignment data
+    const { data: alignments } = await supabase
+      .from('inter_body_alignment')
+      .select('alignment_score, proposal_tx_hash')
+      .order('created_at', { ascending: false })
+      .limit(100);
+
+    // Get current epoch from latest GHI snapshot
+    const { data: ghiSnapshot } = await supabase
+      .from('ghi_snapshots')
+      .select('epoch_no')
+      .order('epoch_no', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const currentEpoch = ghiSnapshot?.epoch_no ?? null;
+
+    // Compute average alignment across recent proposals
+    let avgAlignment = 0;
+    if (alignments && alignments.length > 0) {
+      const total = alignments.reduce((sum, a) => sum + (Number(a.alignment_score) || 0), 0);
+      avgAlignment = Math.round(total / alignments.length);
+    }
+
+    const agreementPct = Math.min(100, Math.max(0, avgAlignment));
+    const disagreementPct = 100 - agreementPct;
+
+    // Color based on agreement level
+    const barColor = agreementPct >= 70 ? OG.green : agreementPct >= 40 ? OG.amber : OG.red;
+    const statusLabel =
+      agreementPct >= 70
+        ? 'Strong Alignment'
+        : agreementPct >= 40
+          ? 'Moderate Divergence'
+          : 'Significant Divergence';
+
+    return new ImageResponse(
+      <OGBackground glow={barColor}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '64px',
+            justifyContent: 'center',
+          }}
+        >
+          {/* Header */}
+          <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '40px' }}>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '20px',
+                color: OG.textMuted,
+                fontWeight: 500,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase' as const,
+                marginBottom: '8px',
+              }}
+            >
+              {currentEpoch ? `Epoch ${currentEpoch}` : 'Current Epoch'} \u2014 Inter-Body Alignment
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '42px',
+                fontWeight: 700,
+                color: OG.text,
+                lineHeight: 1.2,
+              }}
+            >
+              DReps, SPOs &amp; CC: {agreementPct}% Agreement
+            </div>
+          </div>
+
+          {/* Alignment bar */}
+          <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '32px' }}>
+            <div
+              style={{
+                display: 'flex',
+                width: '100%',
+                height: '48px',
+                borderRadius: '24px',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  width: `${agreementPct}%`,
+                  height: '100%',
+                  backgroundColor: barColor,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {agreementPct >= 20 && (
+                  <div
+                    style={{ display: 'flex', fontSize: '18px', fontWeight: 600, color: '#fff' }}
+                  >
+                    Agree {agreementPct}%
+                  </div>
+                )}
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  width: `${disagreementPct}%`,
+                  height: '100%',
+                  backgroundColor: OG.barBg,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {disagreementPct >= 20 && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      fontSize: '18px',
+                      fontWeight: 600,
+                      color: OG.textMuted,
+                    }}
+                  >
+                    Diverge {disagreementPct}%
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Status + stats row */}
+          <div style={{ display: 'flex', gap: '24px', alignItems: 'center' }}>
+            <div
+              style={{
+                display: 'flex',
+                padding: '10px 24px',
+                borderRadius: '20px',
+                backgroundColor: `${barColor}20`,
+                border: `1px solid ${barColor}40`,
+                fontSize: '20px',
+                fontWeight: 600,
+                color: barColor,
+              }}
+            >
+              {statusLabel}
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                padding: '12px 24px',
+                borderRadius: '12px',
+                backgroundColor: OG.bgCard,
+                border: `1px solid ${OG.border}`,
+              }}
+            >
+              <div style={{ display: 'flex', fontSize: '24px', fontWeight: 700, color: OG.text }}>
+                {alignments?.length ?? 0}
+              </div>
+              <div
+                style={{ display: 'flex', fontSize: '13px', color: OG.textMuted, marginTop: '2px' }}
+              >
+                Proposals Analyzed
+              </div>
+            </div>
+          </div>
+
+          <OGFooter left="$governada" right="governada.io/governance/health" />
+        </div>
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG Divergence] Error:', error);
+    return new ImageResponse(<OGFallback message="Governance Alignment" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/app/api/og/governance-stats/[stakeAddress]/route.tsx
+++ b/app/api/og/governance-stats/[stakeAddress]/route.tsx
@@ -1,0 +1,212 @@
+import { ImageResponse } from 'next/og';
+import { OGBackground, OGFooter, OGFallback, OG } from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ stakeAddress: string }> },
+) {
+  try {
+    const { stakeAddress } = await params;
+    const supabase = createClient();
+
+    // Fetch wallet + linked DRep
+    const { data: wallet } = await supabase
+      .from('user_wallets')
+      .select('user_id, delegation_streak_epochs, drep_id')
+      .eq('stake_address', stakeAddress)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const drepId = (wallet as { drep_id?: string } | null)?.drep_id ?? null;
+    const streak =
+      (wallet as { delegation_streak_epochs?: number } | null)?.delegation_streak_epochs ?? 0;
+
+    // Coverage: votes cast by user's DRep / total proposals
+    let coveragePct = 0;
+    let votesCount = 0;
+    let totalProposals = 0;
+
+    if (drepId) {
+      const [votesResult, proposalsResult] = await Promise.all([
+        supabase
+          .from('drep_votes')
+          .select('vote_tx_hash', { count: 'exact', head: true })
+          .eq('drep_id', drepId),
+        supabase.from('proposals').select('proposal_tx_hash', { count: 'exact', head: true }),
+      ]);
+      votesCount = votesResult.count ?? 0;
+      totalProposals = proposalsResult.count ?? 0;
+      coveragePct = totalProposals > 0 ? Math.round((votesCount / totalProposals) * 100) : 0;
+    }
+
+    // Milestones earned
+    const userId = (wallet as { user_id?: string } | null)?.user_id;
+    let milestonesEarned = 0;
+    if (userId) {
+      const { count } = await supabase
+        .from('citizen_milestones')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId);
+      milestonesEarned = count ?? 0;
+    }
+
+    // Coverage bar color
+    const coverageColor = coveragePct >= 80 ? OG.green : coveragePct >= 50 ? OG.amber : OG.red;
+
+    const stats = [
+      { label: 'Coverage', value: `${coveragePct}%`, color: coverageColor },
+      { label: 'Proposals Influenced', value: `${votesCount}`, color: OG.blue },
+      { label: 'Delegation Streak', value: `${streak} epochs`, color: OG.indigo },
+      { label: 'Milestones', value: `${milestonesEarned}`, color: OG.amber },
+    ];
+
+    return new ImageResponse(
+      <OGBackground glow={OG.brand}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: '100%',
+            height: '100%',
+            padding: '64px',
+          }}
+        >
+          {/* Header */}
+          <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '40px' }}>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '20px',
+                color: OG.textMuted,
+                fontWeight: 500,
+                letterSpacing: '0.06em',
+                textTransform: 'uppercase' as const,
+                marginBottom: '8px',
+              }}
+            >
+              My Governance Footprint
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '42px',
+                fontWeight: 700,
+                color: OG.text,
+                lineHeight: 1.2,
+              }}
+            >
+              Cardano Citizen
+            </div>
+          </div>
+
+          {/* Stats grid */}
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '20px',
+              flex: 1,
+              alignContent: 'center',
+            }}
+          >
+            {stats.map((s) => (
+              <div
+                key={s.label}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  padding: '24px 32px',
+                  borderRadius: '16px',
+                  backgroundColor: OG.bgCard,
+                  border: `1px solid ${OG.border}`,
+                  minWidth: '220px',
+                  flex: '1 1 40%',
+                }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '40px',
+                    fontWeight: 700,
+                    color: s.color,
+                    lineHeight: 1,
+                  }}
+                >
+                  {s.value}
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: '16px',
+                    color: OG.textMuted,
+                    marginTop: '8px',
+                  }}
+                >
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Coverage bar */}
+          <div style={{ display: 'flex', flexDirection: 'column', marginTop: '20px' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginBottom: '8px',
+              }}
+            >
+              <div style={{ display: 'flex', fontSize: '16px', color: OG.textMuted }}>
+                Representation Coverage
+              </div>
+              <div
+                style={{ display: 'flex', fontSize: '16px', color: coverageColor, fontWeight: 600 }}
+              >
+                {coveragePct}%
+              </div>
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                width: '100%',
+                height: '16px',
+                backgroundColor: OG.barBg,
+                borderRadius: '8px',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  width: `${coveragePct}%`,
+                  height: '100%',
+                  backgroundColor: coverageColor,
+                  borderRadius: '8px',
+                }}
+              />
+            </div>
+          </div>
+
+          <OGFooter left="$governada" right="governada.io" />
+        </div>
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG Governance Stats] Error:', error);
+    return new ImageResponse(<OGFallback message="My Governance Footprint" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/app/api/og/pool/[poolId]/route.tsx
+++ b/app/api/og/pool/[poolId]/route.tsx
@@ -1,0 +1,188 @@
+import { ImageResponse } from 'next/og';
+import {
+  OGBackground,
+  OGScoreRing,
+  OGFooter,
+  OGFallback,
+  OG,
+  tierColor,
+  tierLabel,
+  formatAdaCompact,
+} from '@/lib/og-utils';
+import { createClient } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ poolId: string }> }) {
+  try {
+    const { poolId } = await params;
+    const supabase = createClient();
+
+    const { data: pool } = await supabase
+      .from('pools')
+      .select(
+        'pool_id, pool_name, ticker, governance_score, delegator_count, live_stake_lovelace, governance_participation_rate',
+      )
+      .eq('pool_id', poolId)
+      .single();
+
+    if (!pool) {
+      return new ImageResponse(<OGFallback message="Pool not found" />, {
+        width: 1200,
+        height: 630,
+      });
+    }
+
+    const score = Number(pool.governance_score ?? 0);
+    const color = tierColor(score);
+    const tier = tierLabel(score);
+    const poolName = (pool.pool_name as string | null) ?? poolId;
+    const ticker = (pool.ticker as string | null) ?? '';
+    const delegatorCount = Number(pool.delegator_count ?? 0);
+    const stakeLovelace = Number(pool.live_stake_lovelace ?? 0);
+    const participationRate = Number(
+      (pool as Record<string, unknown>).governance_participation_rate ?? 0,
+    );
+
+    const displayName = ticker
+      ? `[${ticker}] ${poolName.length > 20 ? poolName.slice(0, 18) + '\u2026' : poolName}`
+      : poolName.length > 28
+        ? poolName.slice(0, 26) + '\u2026'
+        : poolName;
+
+    const stats = [
+      { label: 'Governance Score', value: `${score}/100` },
+      { label: 'Delegators', value: delegatorCount.toLocaleString() },
+      { label: 'Live Stake', value: `${formatAdaCompact(stakeLovelace)} ADA` },
+      ...(participationRate > 0
+        ? [{ label: 'Participation', value: `${Math.round(participationRate)}%` }]
+        : []),
+    ];
+
+    return new ImageResponse(
+      <OGBackground glow={color}>
+        <div style={{ display: 'flex', width: '100%', height: '100%', padding: '48px 64px' }}>
+          {/* Left: Score ring + tier badge */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: '300px',
+              marginRight: '48px',
+            }}
+          >
+            <OGScoreRing score={score} size={200} />
+            <div
+              style={{
+                display: 'flex',
+                marginTop: '16px',
+                padding: '6px 20px',
+                borderRadius: '20px',
+                backgroundColor: `${color}20`,
+                border: `1px solid ${color}40`,
+                fontSize: '18px',
+                fontWeight: 600,
+                color,
+              }}
+            >
+              {tier}
+            </div>
+          </div>
+
+          {/* Right: Pool info + stats grid */}
+          <div
+            style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center' }}
+          >
+            {/* Header */}
+            <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '32px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '18px',
+                  color: OG.textMuted,
+                  fontWeight: 500,
+                  letterSpacing: '0.05em',
+                  textTransform: 'uppercase' as const,
+                  marginBottom: '8px',
+                }}
+              >
+                Stake Pool Governance
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: '38px',
+                  fontWeight: 700,
+                  color: OG.text,
+                  lineHeight: 1.2,
+                }}
+              >
+                {displayName}
+              </div>
+            </div>
+
+            {/* Stats grid */}
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: '16px',
+              }}
+            >
+              {stats.map((s) => (
+                <div
+                  key={s.label}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    padding: '16px 24px',
+                    borderRadius: '12px',
+                    backgroundColor: OG.bgCard,
+                    border: `1px solid ${OG.border}`,
+                    minWidth: '160px',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      fontSize: '26px',
+                      fontWeight: 700,
+                      color: OG.text,
+                    }}
+                  >
+                    {s.value}
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      fontSize: '14px',
+                      color: OG.textMuted,
+                      marginTop: '4px',
+                    }}
+                  >
+                    {s.label}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <OGFooter />
+      </OGBackground>,
+      {
+        width: 1200,
+        height: 630,
+        headers: { 'Cache-Control': 'public, s-maxage=1800, stale-while-revalidate=3600' },
+      },
+    );
+  } catch (error) {
+    console.error('[OG Pool] Error:', error);
+    return new ImageResponse(<OGFallback message="Stake Pool Governance" />, {
+      width: 1200,
+      height: 630,
+    });
+  }
+}

--- a/components/share/MilestoneShareButton.tsx
+++ b/components/share/MilestoneShareButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Share2 } from 'lucide-react';
+import { CITIZEN_MILESTONES } from '@/lib/citizenMilestones';
+import { buildCitizenMilestoneUrl, buildCitizenMilestoneOgUrl, trackShare } from '@/lib/share';
+import { ProfileShareCard } from './ProfileShareCard';
+
+interface MilestoneShareButtonProps {
+  stakeAddress: string;
+  milestoneKey: string;
+  /** Button variant */
+  variant?: 'default' | 'outline' | 'ghost' | 'secondary';
+  /** Button size */
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  className?: string;
+}
+
+/**
+ * Share button for citizen milestones.
+ * Shows a preview of the milestone OG image with share options.
+ */
+export function MilestoneShareButton({
+  stakeAddress,
+  milestoneKey,
+  variant = 'outline',
+  size = 'sm',
+  className,
+}: MilestoneShareButtonProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const milestone = CITIZEN_MILESTONES.find((m) => m.key === milestoneKey);
+
+  const handleOpen = useCallback(() => {
+    trackShare('milestone-card', 'dialog-open', { milestoneKey }, 'initiated');
+    setDialogOpen(true);
+  }, [milestoneKey]);
+
+  if (!milestone) return null;
+
+  const shareUrl = buildCitizenMilestoneUrl(stakeAddress, milestoneKey);
+  const ogImageUrl = buildCitizenMilestoneOgUrl(stakeAddress, milestoneKey);
+  const shareText = `${milestone.shareText} #Cardano #Governance @governada_io`;
+
+  return (
+    <>
+      <Button
+        variant={variant}
+        size={size}
+        className={className}
+        onClick={handleOpen}
+        aria-label={`Share ${milestone.label} milestone`}
+      >
+        <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" />
+        Share
+      </Button>
+
+      <ProfileShareCard
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        ogImageUrl={ogImageUrl}
+        shareText={shareText}
+        shareUrl={shareUrl}
+        title={`Share: ${milestone.label}`}
+        surface="milestone-card"
+        downloadFilename={`governada-milestone-${milestoneKey}`}
+      />
+    </>
+  );
+}

--- a/components/share/ProfileShareCard.tsx
+++ b/components/share/ProfileShareCard.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Check, Copy, Download, Share2, Code, Link } from 'lucide-react';
+import {
+  shareToX,
+  copyToClipboard,
+  downloadImage,
+  canWebShare,
+  webShare,
+  trackShare,
+} from '@/lib/share';
+
+interface ProfileShareCardProps {
+  open: boolean;
+  onClose: () => void;
+  ogImageUrl: string;
+  shareText: string;
+  shareUrl: string;
+  title: string;
+  /** Analytics surface identifier */
+  surface: string;
+  /** Filename for image download (without extension) */
+  downloadFilename?: string;
+  /** Enable embed snippet */
+  showEmbed?: boolean;
+}
+
+/**
+ * Reusable share dialog with OG image preview.
+ * Supports: Share to X, copy link, native share, download image, embed snippet.
+ */
+export function ProfileShareCard({
+  open,
+  onClose,
+  ogImageUrl,
+  shareText,
+  shareUrl,
+  title,
+  surface,
+  downloadFilename = 'governada-card',
+  showEmbed = false,
+}: ProfileShareCardProps) {
+  const [copied, setCopied] = useState(false);
+  const [embedCopied, setEmbedCopied] = useState(false);
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  const embedSnippet = `<iframe src="${shareUrl}" width="600" height="315" frameborder="0" style="border-radius:12px;border:1px solid rgba(255,255,255,0.08)"></iframe>`;
+
+  const handleShareX = useCallback(() => {
+    trackShare(surface, 'twitter', { url: shareUrl }, 'initiated');
+    shareToX(shareText, shareUrl);
+    trackShare(surface, 'twitter', { url: shareUrl }, 'success');
+  }, [shareText, shareUrl, surface]);
+
+  const handleNativeShare = useCallback(async () => {
+    trackShare(surface, 'native', { url: shareUrl }, 'initiated');
+    const success = await webShare({ title, text: shareText, url: shareUrl });
+    trackShare(surface, 'native', { url: shareUrl }, success ? 'success' : 'failed');
+  }, [title, shareText, shareUrl, surface]);
+
+  const handleCopyLink = useCallback(async () => {
+    trackShare(surface, 'clipboard', { url: shareUrl }, 'initiated');
+    const success = await copyToClipboard(shareUrl);
+    trackShare(surface, 'clipboard', { url: shareUrl }, success ? 'success' : 'failed');
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [shareUrl, surface]);
+
+  const handleDownload = useCallback(async () => {
+    trackShare(surface, 'download', { url: shareUrl }, 'initiated');
+    try {
+      await downloadImage(ogImageUrl, `${downloadFilename}.png`);
+      trackShare(surface, 'download', { url: shareUrl }, 'success');
+    } catch {
+      trackShare(surface, 'download', { url: shareUrl }, 'failed');
+    }
+  }, [ogImageUrl, downloadFilename, shareUrl, surface]);
+
+  const handleCopyEmbed = useCallback(async () => {
+    trackShare(surface, 'embed', { url: shareUrl }, 'initiated');
+    const success = await copyToClipboard(embedSnippet);
+    trackShare(surface, 'embed', { url: shareUrl }, success ? 'success' : 'failed');
+    if (success) {
+      setEmbedCopied(true);
+      setTimeout(() => setEmbedCopied(false), 2000);
+    }
+  }, [embedSnippet, shareUrl, surface]);
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* OG card preview */}
+          <div className="relative aspect-[1200/630] w-full overflow-hidden rounded-lg border border-border bg-muted">
+            {!imgLoaded && <div className="absolute inset-0 animate-pulse rounded-lg bg-muted" />}
+            {/* eslint-disable-next-line @next/next/no-img-element -- OG image preview */}
+            <img
+              src={ogImageUrl}
+              alt="Share preview"
+              className="w-full rounded-lg"
+              onLoad={() => setImgLoaded(true)}
+            />
+          </div>
+
+          {/* Share text preview */}
+          <div className="rounded-md border border-border bg-muted/50 p-3">
+            <p className="text-sm text-muted-foreground">{shareText}</p>
+          </div>
+
+          {/* Primary actions */}
+          <div className="flex gap-2">
+            <Button
+              variant="default"
+              className="flex-1 gap-2"
+              onClick={handleShareX}
+              aria-label="Share on X (Twitter)"
+            >
+              <Share2 className="h-4 w-4" aria-hidden="true" />
+              Share on X
+            </Button>
+
+            {canWebShare() && (
+              <Button
+                variant="secondary"
+                className="flex-1 gap-2"
+                onClick={handleNativeShare}
+                aria-label="Share via native share"
+              >
+                <Share2 className="h-4 w-4" aria-hidden="true" />
+                Share
+              </Button>
+            )}
+          </div>
+
+          {/* Secondary actions */}
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1 gap-2"
+              onClick={handleCopyLink}
+              aria-label={copied ? 'Link copied' : 'Copy share link'}
+            >
+              {copied ? (
+                <>
+                  <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Link className="h-4 w-4" aria-hidden="true" />
+                  Copy Link
+                </>
+              )}
+            </Button>
+
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={handleDownload}
+              aria-label="Download share image"
+            >
+              <Download className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+
+          {/* Embed snippet */}
+          {showEmbed && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Code className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                <span className="text-xs font-medium text-muted-foreground">Embed</span>
+              </div>
+              <div className="relative">
+                <pre className="overflow-x-auto rounded-md border border-border bg-muted/50 p-3 text-xs text-muted-foreground">
+                  {embedSnippet}
+                </pre>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="absolute right-1 top-1"
+                  onClick={handleCopyEmbed}
+                  aria-label={embedCopied ? 'Embed code copied' : 'Copy embed code'}
+                >
+                  {embedCopied ? (
+                    <Check className="h-3 w-3 text-green-500" aria-hidden="true" />
+                  ) : (
+                    <Copy className="h-3 w-3" aria-hidden="true" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <p className="text-center text-xs text-muted-foreground">
+            via Governada &mdash; governance intelligence for Cardano
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/share/ShareButton.tsx
+++ b/components/share/ShareButton.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Check, Share2 } from 'lucide-react';
+import { canWebShare, webShare, copyToClipboard, trackShare } from '@/lib/share';
+
+interface ShareButtonProps {
+  title: string;
+  text: string;
+  url: string;
+  ogImageUrl?: string;
+  /** Analytics surface identifier */
+  surface: string;
+  /** Button variant */
+  variant?: 'default' | 'outline' | 'ghost' | 'secondary';
+  /** Button size */
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  /** Custom class name */
+  className?: string;
+  /** Optional onClick callback (fires after share action) */
+  onShare?: () => void;
+  /** Label text override (default: "Share") */
+  label?: string;
+}
+
+/**
+ * Reusable one-tap share button.
+ * - Mobile: uses navigator.share() (native share sheet)
+ * - Desktop: copies link to clipboard with check animation
+ * - All actions fire PostHog analytics via trackShare()
+ */
+export function ShareButton({
+  title,
+  text,
+  url,
+  surface,
+  variant = 'outline',
+  size = 'default',
+  className,
+  onShare,
+  label = 'Share',
+}: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    trackShare(surface, 'native', { url }, 'initiated');
+
+    // Mobile: native share
+    if (canWebShare()) {
+      const success = await webShare({ title, text, url });
+      trackShare(surface, 'native', { url }, success ? 'success' : 'failed');
+      onShare?.();
+      return;
+    }
+
+    // Desktop: copy to clipboard
+    const success = await copyToClipboard(url);
+    trackShare(surface, 'clipboard', { url }, success ? 'success' : 'failed');
+
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+    onShare?.();
+  }, [title, text, url, surface, onShare]);
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={className}
+      onClick={handleShare}
+      aria-label={copied ? 'Link copied' : `Share ${title}`}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-1.5 h-4 w-4 text-green-500" aria-hidden="true" />
+          {size !== 'icon' && 'Copied!'}
+        </>
+      ) : (
+        <>
+          <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          {size !== 'icon' && label}
+        </>
+      )}
+    </Button>
+  );
+}

--- a/components/share/index.ts
+++ b/components/share/index.ts
@@ -1,0 +1,3 @@
+export { ShareButton } from './ShareButton';
+export { ProfileShareCard } from './ProfileShareCard';
+export { MilestoneShareButton } from './MilestoneShareButton';

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -79,6 +79,46 @@ export function buildMatchResultUrl(encodedProfile: string): string {
   return `${SITE_URL}/match/result?profile=${encodeURIComponent(encodedProfile)}`;
 }
 
+export function buildCitizenMilestoneUrl(stakeAddress: string, milestoneKey: string): string {
+  return `${SITE_URL}/you?milestone=${encodeURIComponent(milestoneKey)}&stake=${encodeURIComponent(stakeAddress)}`;
+}
+
+export function buildCitizenMilestoneOgUrl(stakeAddress: string, milestoneKey: string): string {
+  return `${SITE_URL}/api/og/citizen-milestone/${encodeURIComponent(stakeAddress)}/${encodeURIComponent(milestoneKey)}`;
+}
+
+export function buildPoolOgUrl(poolId: string): string {
+  return `${SITE_URL}/api/og/pool/${encodeURIComponent(poolId)}`;
+}
+
+export function buildGovernanceStatsUrl(stakeAddress: string): string {
+  return `${SITE_URL}/you?stake=${encodeURIComponent(stakeAddress)}`;
+}
+
+export function buildGovernanceStatsOgUrl(stakeAddress: string): string {
+  return `${SITE_URL}/api/og/governance-stats/${encodeURIComponent(stakeAddress)}`;
+}
+
+export function buildDivergenceUrl(): string {
+  return `${SITE_URL}/governance/health`;
+}
+
+export function buildDivergenceOgUrl(): string {
+  return `${SITE_URL}/api/og/divergence`;
+}
+
+export function buildCoverageGapUrl(stakeAddress: string): string {
+  return `${SITE_URL}/you?stake=${encodeURIComponent(stakeAddress)}`;
+}
+
+export function buildCoverageGapOgUrl(stakeAddress: string): string {
+  return `${SITE_URL}/api/og/coverage-gap/${encodeURIComponent(stakeAddress)}`;
+}
+
+export function buildDRepOgUrl(drepId: string): string {
+  return `${SITE_URL}/api/og/drep/${encodeURIComponent(drepId)}`;
+}
+
 export function trackShare(
   surface: string,
   platform: string,


### PR DESCRIPTION
## Summary
- **5 new OG image routes**: citizen milestone, pool governance, personal governance stats, inter-body divergence, coverage gap — all 1200x630px branded cards with Governada design system
- **3 new share components**: `ShareButton` (one-tap native/clipboard), `ProfileShareCard` (full dialog with X/clipboard/download/embed), `MilestoneShareButton` (milestone-specific trigger)
- **11 new URL builder functions** in `lib/share.ts` for all shareable surfaces (page URLs + OG image URLs)
- All share actions fire PostHog analytics via `trackShare()` with surface, platform, and outcome tracking
- Mobile-first: uses `navigator.share()` on mobile, dialog/clipboard on desktop

## New Routes
| Route | Purpose |
|-------|---------|
| `/api/og/citizen-milestone/[stakeAddress]/[milestoneKey]` | Citizen achievement card |
| `/api/og/pool/[poolId]` | Stake pool governance card |
| `/api/og/governance-stats/[stakeAddress]` | Personal governance footprint |
| `/api/og/divergence` | Inter-body alignment visualization |
| `/api/og/coverage-gap/[stakeAddress]` | DRep coverage with CTA |

## Test plan
- [ ] Verify OG images render correctly at each route (curl/browser)
- [ ] Test ShareButton on mobile (native share sheet) and desktop (clipboard)
- [ ] Test ProfileShareCard dialog: X share, copy link, download image, embed snippet
- [ ] Test MilestoneShareButton with various milestone keys
- [ ] Verify PostHog events fire for all share actions
- [ ] Check OG images display correctly when shared to X/social platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)