### PR TITLE
refactor: scoring system overhaul — fidelity, calibration, timeliness

### DIFF
--- a/__tests__/scoring/drepScore.test.ts
+++ b/__tests__/scoring/drepScore.test.ts
@@ -37,7 +37,7 @@ function makePillarMaps(
 // ── Tests ──
 
 describe('computeDRepScores', () => {
-  it('computes composite from 4 percentile-normalized pillars', () => {
+  it('computes composite from 4 calibrated pillars', () => {
     const { rawEngagement, rawParticipation, rawReliability, rawIdentity } = makePillarMaps({
       d1: { eq: 80, ep: 70, rl: 60, gi: 50 },
       d2: { eq: 40, ep: 50, rl: 60, gi: 70 },
@@ -79,7 +79,7 @@ describe('computeDRepScores', () => {
     expect(result.governanceIdentityRaw).toBe(50);
   });
 
-  it('single DRep gets 50 percentile on all pillars', () => {
+  it('single DRep gets calibrated scores based on raw inputs', () => {
     const results = computeDRepScores(
       new Map([['solo', 75]]),
       new Map([['solo', 60]]),
@@ -89,12 +89,12 @@ describe('computeDRepScores', () => {
     );
 
     const result = results.get('solo')!;
-    expect(result.engagementQualityPercentile).toBe(50);
-    expect(result.effectiveParticipationPercentile).toBe(50);
-    expect(result.reliabilityPercentile).toBe(50);
-    expect(result.governanceIdentityPercentile).toBe(50);
-    // Composite = 50 for all pillars
-    expect(result.composite).toBe(50);
+    // Calibrated via piecewise linear curves (absolute, not percentile)
+    expect(result.engagementQualityCalibrated).toBe(89);
+    expect(result.effectiveParticipationCalibrated).toBe(76);
+    expect(result.reliabilityCalibrated).toBe(91);
+    expect(result.governanceIdentityCalibrated).toBe(65);
+    expect(result.composite).toBe(83);
   });
 
   // ── Pillar weight verification ──
@@ -109,9 +109,9 @@ describe('computeDRepScores', () => {
     expect(total).toBeCloseTo(1.0, 10);
   });
 
-  // ── Percentile distribution ──
+  // ── Score distribution ──
 
-  it('produces valid percentile distribution with many DReps', () => {
+  it('produces valid score distribution with many DReps', () => {
     const rawEngagement = new Map<string, number>();
     const rawParticipation = new Map<string, number>();
     const rawReliability = new Map<string, number>();
@@ -228,7 +228,7 @@ describe('computeDRepScores', () => {
       new Map(),
     );
 
-    // Both should have results, missing pillars default to 0 percentile
+    // Both should have results, missing pillars default to 0 raw → calibrated 0
     expect(results.has('d1')).toBe(true);
     expect(results.has('d2')).toBe(true);
   });
@@ -260,14 +260,13 @@ describe('computeDRepScores', () => {
       new Map(),
     );
 
-    // With 3 DReps, all having distinct ordered scores and full confidence (default 100):
-    // Weighted percentile normalization (midpoint formula):
-    //   a is top in all pillars -> percentile ~83 each
-    //   b is middle -> percentile 50
-    //   c is bottom -> percentile ~17 each
-    expect(results.get('a')!.composite).toBe(83);
-    expect(results.get('b')!.composite).toBe(50);
-    expect(results.get('c')!.composite).toBe(17);
+    // With absolute calibration (not percentile), scores are determined solely by raw values:
+    //   a (90/85/80/75): high raws → high calibrated → composite ~93
+    //   b (60/55/50/45): mid raws → mid calibrated → composite ~72
+    //   c (30/25/20/15): low raws → low calibrated → composite ~43
+    expect(results.get('a')!.composite).toBe(93);
+    expect(results.get('b')!.composite).toBe(72);
+    expect(results.get('c')!.composite).toBe(43);
   });
 
   // ── Confidence field ──
@@ -317,10 +316,10 @@ describe('computeDRepScores', () => {
 
   // ── Zero-activity override ──
 
-  it('caps zero-activity DReps to GI-only composite (~15% of GI percentile)', () => {
+  it('caps zero-activity DReps to GI-only composite (~15% of GI calibrated)', () => {
     // DRep with zero activity on all 3 activity pillars but high GI
-    // should NOT score 50+ from dampened-to-median activity percentiles.
-    // Instead, activity percentiles should be forced to 0.
+    // should NOT score from dampened-to-median activity scores.
+    // Instead, activity calibrated scores should be forced to 0.
     const { rawEngagement, rawParticipation, rawReliability, rawIdentity } = makePillarMaps({
       active1: { eq: 80, ep: 70, rl: 60, gi: 50 },
       active2: { eq: 40, ep: 50, rl: 60, gi: 70 },
@@ -336,13 +335,13 @@ describe('computeDRepScores', () => {
     );
 
     const inactive = results.get('inactive')!;
-    // All activity percentiles should be 0
-    expect(inactive.engagementQualityPercentile).toBe(0);
-    expect(inactive.effectiveParticipationPercentile).toBe(0);
-    expect(inactive.reliabilityPercentile).toBe(0);
-    // GI percentile should NOT be 0 (profile is real data)
-    expect(inactive.governanceIdentityPercentile).toBeGreaterThan(0);
-    // Composite should be at most GI weight (15%) * 100 = 15
+    // All activity calibrated scores should be 0
+    expect(inactive.engagementQualityCalibrated).toBe(0);
+    expect(inactive.effectiveParticipationCalibrated).toBe(0);
+    expect(inactive.reliabilityCalibrated).toBe(0);
+    // GI calibrated should NOT be 0 (profile is real data)
+    expect(inactive.governanceIdentityCalibrated).toBeGreaterThan(0);
+    // Composite should be at most GI weight (15%) * 95 (calibration cap) ≈ 14
     expect(inactive.composite).toBeLessThanOrEqual(15);
     // Active DReps should still score normally (much higher than inactive)
     const active1 = results.get('active1')!;
@@ -366,14 +365,15 @@ describe('computeDRepScores', () => {
 
     const partial = results.get('partial')!;
     // With EP>0, zero-activity override should NOT apply
-    // EQ and RL percentiles should be dampened to median (not forced to 0)
-    // since the DRep has SOME activity (EP=30)
-    expect(partial.engagementQualityPercentile).toBeGreaterThan(0);
+    // EP should get a positive calibrated score from raw=30
+    expect(partial.effectiveParticipationCalibrated).toBeGreaterThan(0);
+    // Composite should be higher than a fully inactive DRep
+    expect(partial.composite).toBeGreaterThan(0);
   });
 
   // ── Confidence dampening ──
 
-  it('dampens low-confidence DRep percentiles toward median', () => {
+  it('dampens low-confidence DRep calibrated scores toward median', () => {
     // Three DReps: d1 (top, low confidence) should be pulled toward median.
     // d3 (top, full confidence) should NOT be pulled toward median.
     const confidences = new Map([

--- a/__tests__/scoring/governanceIdentity.test.ts
+++ b/__tests__/scoring/governanceIdentity.test.ts
@@ -20,10 +20,10 @@ describe('computeGovernanceIdentity', () => {
 
   it('scores low for a DRep with null metadata and 0 delegators', () => {
     const profiles = new Map([['drep_empty', makeEmptyProfile('drep_empty')]]);
-    const scores = computeGovernanceIdentity(profiles, [0]);
-    // Profile quality = 0 (null metadata), community presence = 50 (single entry default)
-    // Total = 0 * 0.6 + 50 * 0.4 = 20
-    expect(scores.get('drep_empty')).toBe(20);
+    const scores = computeGovernanceIdentity(profiles);
+    // Profile quality = 0 (null metadata), community presence = 0 (0 delegators → tier 0)
+    // Total = 0 * 0.6 + 0 * 0.4 = 0
+    expect(scores.get('drep_empty')).toBe(0);
   });
 
   // ── Fully complete profile ──
@@ -35,10 +35,7 @@ describe('computeGovernanceIdentity', () => {
       metadataHashVerified: true,
     });
 
-    const scores = computeGovernanceIdentity(
-      new Map([['drep_full', profile]]),
-      [1, 5, 10, 50, 100, 200],
-    );
+    const scores = computeGovernanceIdentity(new Map([['drep_full', profile]]));
     // Complete profile + top delegator count → high score
     expect(scores.get('drep_full')!).toBeGreaterThan(70);
   });
@@ -62,7 +59,6 @@ describe('computeGovernanceIdentity', () => {
         ['a', withName],
         ['b', noName],
       ]),
-      [0, 0],
     );
     expect(scores.get('a')!).toBeGreaterThan(scores.get('b')!);
   });
@@ -90,7 +86,6 @@ describe('computeGovernanceIdentity', () => {
         ['medium', medium],
         ['short', short],
       ]),
-      [0, 0, 0],
     );
     expect(scores.get('long')!).toBeGreaterThan(scores.get('medium')!);
     expect(scores.get('medium')!).toBeGreaterThan(scores.get('short')!);
@@ -128,7 +123,6 @@ describe('computeGovernanceIdentity', () => {
         ['one', oneLink],
         ['none', noLinks],
       ]),
-      [0, 0, 0],
     );
     expect(scores.get('two')!).toBeGreaterThan(scores.get('one')!);
     expect(scores.get('one')!).toBeGreaterThan(scores.get('none')!);
@@ -146,7 +140,7 @@ describe('computeGovernanceIdentity', () => {
       delegatorCount: 0,
     });
 
-    const scores = computeGovernanceIdentity(new Map([['dupes', dupes]]), [0]);
+    const scores = computeGovernanceIdentity(new Map([['dupes', dupes]]));
     // Only 1 unique link → 25 points for social (not 30)
     // Just verify it's less than a profile with 2 unique links
     const twoUnique = makeProfile({
@@ -165,7 +159,6 @@ describe('computeGovernanceIdentity', () => {
         ['dupes', dupes],
         ['unique2', twoUnique],
       ]),
-      [0, 0],
     );
     expect(scores2.get('unique2')!).toBeGreaterThan(scores2.get('dupes')!);
   });
@@ -183,7 +176,7 @@ describe('computeGovernanceIdentity', () => {
       brokenUris: new Set(['https://twitter.com/drep']),
     });
 
-    const scores = computeGovernanceIdentity(new Map([['broken', brokenProfile]]), [0]);
+    const scores = computeGovernanceIdentity(new Map([['broken', brokenProfile]]));
     // Only 1 valid link (github, twitter is broken) → 25 pts not 30
     expect(scores.get('broken')!).toBeGreaterThan(0);
   });
@@ -209,7 +202,6 @@ describe('computeGovernanceIdentity', () => {
         ['verified', verified],
         ['unverified', unverified],
       ]),
-      [0, 0],
     );
     // Profile quality diff should be exactly 5 (hash bonus)
     // Community presence is same (both 0 delegators)
@@ -219,7 +211,7 @@ describe('computeGovernanceIdentity', () => {
     expect(diff).toBeLessThanOrEqual(4);
   });
 
-  // ── Community presence (delegator percentile) ──
+  // ── Community presence (absolute delegator tiers) ──
 
   it('scores higher for top delegator count', () => {
     const top = makeProfile({ drepId: 'top', metadata: { givenName: 'Top' }, delegatorCount: 500 });
@@ -229,28 +221,26 @@ describe('computeGovernanceIdentity', () => {
       delegatorCount: 1,
     });
 
-    const allCounts = [1, 5, 10, 50, 100, 500];
     const scores = computeGovernanceIdentity(
       new Map([
         ['top', top],
         ['bottom', bottom],
       ]),
-      allCounts,
     );
     expect(scores.get('top')!).toBeGreaterThan(scores.get('bottom')!);
   });
 
-  it('returns 50 percentile when only one delegator count exists', () => {
+  it('uses absolute delegator tiers for community presence', () => {
     const profile = makeProfile({
       drepId: 'solo',
       metadata: { givenName: 'Solo' },
       delegatorCount: 100,
     });
 
-    const scores = computeGovernanceIdentity(new Map([['solo', profile]]), [100]);
-    // Community presence = 50 (single entry), Profile = name(15) × 0.6 = 9
-    // Total ≈ 9 + 50*0.4 = 29
-    expect(scores.get('solo')!).toBeGreaterThan(20);
+    const scores = computeGovernanceIdentity(new Map([['solo', profile]]));
+    // Community presence = 95 (100 delegators → tier 95), Profile = name(15) × 0.6 = 9
+    // Total ≈ 9 + 95*0.4 = 47
+    expect(scores.get('solo')!).toBeGreaterThan(40);
   });
 
   // ── @value wrapper handling ──
@@ -265,7 +255,7 @@ describe('computeGovernanceIdentity', () => {
       delegatorCount: 0,
     });
 
-    const scores = computeGovernanceIdentity(new Map([['cip119', profile]]), [0]);
+    const scores = computeGovernanceIdentity(new Map([['cip119', profile]]));
     // Should extract string from @value wrapper
     expect(scores.get('cip119')!).toBeGreaterThan(0);
   });
@@ -291,7 +281,7 @@ describe('computeGovernanceIdentity', () => {
       delegatorCount: 1000,
     });
 
-    const scores = computeGovernanceIdentity(new Map([['max', maxProfile]]), [0, 100, 500, 1000]);
+    const scores = computeGovernanceIdentity(new Map([['max', maxProfile]]));
     expect(scores.get('max')!).toBeLessThanOrEqual(100);
     expect(scores.get('max')!).toBeGreaterThanOrEqual(0);
   });

--- a/__tests__/scoring/reliability.test.ts
+++ b/__tests__/scoring/reliability.test.ts
@@ -191,9 +191,9 @@ describe('computeReliability', () => {
     expect(scores.get('active')!).toBeGreaterThan(scores.get('stale')!);
   });
 
-  // ── Responsiveness ──
+  // ── Responsiveness removed (directive 1: no timeliness factors) ──
 
-  it('rewards fast response time (voting soon after proposal)', () => {
+  it('scores fast and slow responders equally (timeliness removed)', () => {
     const proposalEpochs = makeProposalEpochs([518, 519, 520]);
 
     // Fast responder: votes within 1 day of proposal
@@ -201,7 +201,7 @@ describe('computeReliability', () => {
       makeVoteData({
         drepId: 'fast',
         proposalKey: `tx_f${i}-0`,
-        blockTime: NOW - (3 - i) * ONE_EPOCH + ONE_DAY, // 1 day after proposal
+        blockTime: NOW - (3 - i) * ONE_EPOCH + ONE_DAY,
         proposalBlockTime: NOW - (3 - i) * ONE_EPOCH,
       }),
     );
@@ -229,7 +229,8 @@ describe('computeReliability', () => {
       ]),
     );
 
-    expect(scores.get('fast')!).toBeGreaterThan(scores.get('slow')!);
+    // With timeliness removed, response speed no longer affects score
+    expect(scores.get('fast')!).toBe(scores.get('slow')!);
   });
 
   // ── Scores bounded ──

--- a/__tests__/spo-score-v3.test.ts
+++ b/__tests__/spo-score-v3.test.ts
@@ -340,7 +340,7 @@ describe('SPO Score V3', () => {
         ['pool2', sparse],
       ]);
 
-      const scores = computeSpoGovernanceIdentity(profiles, [100, 5]);
+      const scores = computeSpoGovernanceIdentity(profiles);
       expect(scores.get('pool1')!).toBeGreaterThan(scores.get('pool2')!);
     });
   });

--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -19,7 +19,7 @@ export const GET = withRouteHandler(async () => {
   ] = await Promise.all([
     supabase
       .from('cc_members')
-      .select('cc_hot_id, author_name, transparency_grade, transparency_index, status')
+      .select('cc_hot_id, author_name, transparency_grade, fidelity_score, status')
       .eq('status', 'authorized'),
     supabase.from('cc_votes').select('cc_hot_id, vote'),
     supabase.from('cc_rationales').select('cc_hot_id, author_name').not('author_name', 'is', null),
@@ -65,8 +65,8 @@ export const GET = withRouteHandler(async () => {
       return {
         ccHotId: m.cc_hot_id,
         name: m.author_name ?? rationaleNameMap.get(m.cc_hot_id) ?? null,
-        transparencyGrade: m.transparency_grade ?? null,
-        transparencyIndex: m.transparency_index ?? null,
+        fidelityGrade: m.transparency_grade ?? null, // column rename pending migration
+        fidelityScore: m.fidelity_score ?? null,
         voteCount: total,
         yesCount: counts.yes,
         noCount: counts.no,
@@ -77,9 +77,9 @@ export const GET = withRouteHandler(async () => {
       };
     })
     .sort((a, b) => {
-      // Sort by transparency index (descending) if available, then by vote count
-      if (a.transparencyIndex != null && b.transparencyIndex != null) {
-        return b.transparencyIndex - a.transparencyIndex;
+      // Sort by fidelity score (descending) if available, then by vote count
+      if (a.fidelityScore != null && b.fidelityScore != null) {
+        return b.fidelityScore - a.fidelityScore;
       }
       return b.voteCount - a.voteCount;
     });

--- a/app/governance/committee/[ccHotId]/page.tsx
+++ b/app/governance/committee/[ccHotId]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase';
-import { getCCTransparencyHistory, getCCMembersTransparency } from '@/lib/data';
+import { getCCFidelityHistory, getCCMembersFidelity } from '@/lib/data';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { CCMemberProfileClient } from '@/components/cc/CCMemberProfileClient';
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const name = member?.author_name ?? `CC Member ${ccHotId.slice(0, 12)}...`;
   return {
     title: `${name} — Constitutional Committee — Governada`,
-    description: `Transparency score, voting record, and accountability metrics for ${name}.`,
+    description: `Constitutional fidelity score, voting record, and accountability metrics for ${name}.`,
   };
 }
 
@@ -38,7 +38,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     { data: votes },
     { data: rationales },
     { data: alignmentRows },
-    transparencyHistory,
+    fidelityHistory,
     allMembers,
     { data: proposals },
   ] = await Promise.all([
@@ -59,8 +59,8 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
       .select(
         'proposal_tx_hash, proposal_index, drep_yes_pct, drep_no_pct, spo_yes_pct, spo_no_pct',
       ),
-    getCCTransparencyHistory(decodedId),
-    getCCMembersTransparency(),
+    getCCFidelityHistory(decodedId),
+    getCCMembersFidelity(),
     supabase.from('proposals').select('tx_hash, proposal_index, title, proposal_type'),
   ]);
 
@@ -129,10 +129,10 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
   }
 
   const authorName = member?.author_name ?? rationales?.[0]?.author_name ?? null;
-  const transparencyIndex = member?.transparency_index ?? null;
+  const fidelityScore = member?.fidelity_score ?? null;
 
   // Peer rank
-  const scoredMembers = allMembers.filter((m) => m.transparencyIndex != null);
+  const scoredMembers = allMembers.filter((m) => m.fidelityScore != null);
   const rank = scoredMembers.findIndex((m) => m.ccHotId === decodedId) + 1;
   const totalScored = scoredMembers.length;
 
@@ -157,21 +157,20 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     };
   });
 
-  // Pillar scores for the breakdown
+  // Pillar scores for the breakdown (3-pillar Constitutional Fidelity model)
   const pillarScores = member
     ? {
         participation: member.participation_score,
-        rationaleQuality: member.rationale_quality_score,
-        responsiveness: member.responsiveness_score,
-        independence: member.independence_score,
+        constitutionalGrounding: member.independence_score, // repurposed column
+        reasoningQuality: member.rationale_quality_score,
       }
     : null;
 
   const profileData = {
     ccHotId: decodedId,
     authorName,
-    transparencyIndex,
-    transparencyGrade: member?.transparency_grade ?? null,
+    fidelityScore,
+    fidelityGrade: member?.transparency_grade ?? null, // column rename pending migration
     status: member?.status ?? null,
     expirationEpoch: member?.expiration_epoch ?? null,
     rank: rank > 0 ? rank : null,
@@ -184,14 +183,14 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     votesCast: member?.votes_cast ?? totalVotes,
     eligibleProposals: member?.eligible_proposals ?? null,
     rationaleProvisionRate: member?.rationale_provision_rate ?? null,
-    independenceScore: member?.independence_score ?? null,
+    constitutionalGroundingScore: member?.independence_score ?? null, // repurposed column
     drepAgree,
     drepCompare,
     spoAgree,
     spoCompare,
     pillarScores,
     enrichedVotes,
-    transparencyHistory,
+    fidelityHistory,
   };
 
   return (

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { ChevronDown, ChevronUp, Vote, BookOpen, Clock, Sparkles } from 'lucide-react';
+import { ChevronDown, ChevronUp, Vote, BookOpen, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCommitteeMembers } from '@/hooks/queries';
@@ -26,7 +26,7 @@ const GRADE_COLORS: Record<string, string> = {
   F: 'bg-rose-500/15 text-rose-500 border-rose-500/30',
 };
 
-function transparencyBarColor(score: number | null): string {
+function fidelityBarColor(score: number | null): string {
   if (score == null) return 'bg-muted';
   if (score >= 85) return 'bg-emerald-500/80';
   if (score >= 70) return 'bg-sky-500/80';
@@ -41,7 +41,7 @@ function transparencyBarColor(score: number | null): string {
 
 function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
   const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
-  const gradeStyle = member.transparencyGrade ? (GRADE_COLORS[member.transparencyGrade] ?? '') : '';
+  const gradeStyle = member.fidelityGrade ? (GRADE_COLORS[member.fidelityGrade] ?? '') : '';
 
   return (
     <Link
@@ -54,14 +54,14 @@ function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
       </span>
 
       {/* Grade badge */}
-      {member.transparencyGrade ? (
+      {member.fidelityGrade ? (
         <span
           className={cn(
             'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border text-xs font-bold',
             gradeStyle,
           )}
         >
-          {member.transparencyGrade}
+          {member.fidelityGrade}
         </span>
       ) : (
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-xs text-muted-foreground">
@@ -81,16 +81,16 @@ function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
         )}
       </div>
 
-      {/* Transparency bar (hidden on mobile) */}
+      {/* Fidelity bar (hidden on mobile) */}
       <div className="hidden sm:flex items-center gap-2 w-36 shrink-0">
         <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
           <div
-            className={`h-full rounded-full ${transparencyBarColor(member.transparencyIndex)}`}
-            style={{ width: `${member.transparencyIndex ?? 0}%` }}
+            className={`h-full rounded-full ${fidelityBarColor(member.fidelityScore)}`}
+            style={{ width: `${member.fidelityScore ?? 0}%` }}
           />
         </div>
         <span className="font-mono text-xs tabular-nums text-muted-foreground w-7 text-right">
-          {member.transparencyIndex ?? '—'}
+          {member.fidelityScore ?? '—'}
         </span>
       </div>
 
@@ -108,7 +108,7 @@ function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
 
 function MemberCard({ member }: { member: CommitteeMemberQuickView }) {
   const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
-  const gradeStyle = member.transparencyGrade ? (GRADE_COLORS[member.transparencyGrade] ?? '') : '';
+  const gradeStyle = member.fidelityGrade ? (GRADE_COLORS[member.fidelityGrade] ?? '') : '';
 
   return (
     <Link
@@ -117,14 +117,14 @@ function MemberCard({ member }: { member: CommitteeMemberQuickView }) {
     >
       <div className="flex items-start gap-3">
         {/* Grade badge */}
-        {member.transparencyGrade ? (
+        {member.fidelityGrade ? (
           <span
             className={cn(
               'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border text-sm font-bold',
               gradeStyle,
             )}
           >
-            {member.transparencyGrade}
+            {member.fidelityGrade}
           </span>
         ) : (
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted text-sm text-muted-foreground">
@@ -144,16 +144,16 @@ function MemberCard({ member }: { member: CommitteeMemberQuickView }) {
             )}
           </div>
 
-          {/* Transparency bar */}
+          {/* Fidelity bar */}
           <div className="flex items-center gap-2 mt-2">
             <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
               <div
-                className={`h-full rounded-full ${transparencyBarColor(member.transparencyIndex)}`}
-                style={{ width: `${member.transparencyIndex ?? 0}%` }}
+                className={`h-full rounded-full ${fidelityBarColor(member.fidelityScore)}`}
+                style={{ width: `${member.fidelityScore ?? 0}%` }}
               />
             </div>
             <span className="font-mono text-xs tabular-nums text-muted-foreground">
-              {member.transparencyIndex ?? '—'}
+              {member.fidelityScore ?? '—'}
             </span>
           </div>
 
@@ -177,24 +177,18 @@ function Methodology() {
   const [open, setOpen] = useState(false);
 
   const pillars = [
-    { icon: Vote, label: 'Participation', weight: '39%', desc: 'Vote rate on eligible proposals' },
+    { icon: Vote, label: 'Participation', weight: '30%', desc: 'Vote rate on eligible proposals' },
     {
       icon: BookOpen,
-      label: 'Rationale Quality',
-      weight: '33%',
-      desc: 'Constitutional article citations in vote rationales',
-    },
-    {
-      icon: Clock,
-      label: 'Responsiveness',
-      weight: '17%',
-      desc: 'Timeliness of voting relative to deadlines',
+      label: 'Constitutional Grounding',
+      weight: '40%',
+      desc: 'Depth of constitutional article citations in vote rationales',
     },
     {
       icon: Sparkles,
-      label: 'Independence',
-      weight: '11%',
-      desc: 'Independent judgment vs. always voting with the majority',
+      label: 'Reasoning Quality',
+      weight: '30%',
+      desc: 'Quality and completeness of rationale explanations',
     },
   ];
 
@@ -204,16 +198,16 @@ function Methodology() {
         onClick={() => setOpen(!open)}
         className="flex w-full items-center justify-between px-5 py-3.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
-        <span>How is the Transparency Index calculated?</span>
+        <span>How is the Constitutional Fidelity Score calculated?</span>
         {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
       </button>
       {open && (
         <div className="border-t px-5 py-4 space-y-3">
           <p className="text-sm text-muted-foreground">
-            Each CC member is scored on 4 pillars of accountability. The weighted average produces
-            the Transparency Index (0-100).
+            Each CC member is scored on 3 pillars of constitutional accountability. The weighted
+            average produces the Constitutional Fidelity Score (0-100).
           </p>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-3 sm:grid-cols-3">
             {pillars.map((p) => (
               <div key={p.label} className="space-y-1">
                 <div className="flex items-center gap-1.5 text-xs font-medium">
@@ -271,10 +265,10 @@ export default function CommitteePage() {
   const sorted = useMemo(
     () =>
       [...members].sort((a, b) => {
-        if (a.transparencyIndex != null && b.transparencyIndex != null)
-          return b.transparencyIndex - a.transparencyIndex;
-        if (a.transparencyIndex != null) return -1;
-        if (b.transparencyIndex != null) return 1;
+        if (a.fidelityScore != null && b.fidelityScore != null)
+          return b.fidelityScore - a.fidelityScore;
+        if (a.fidelityScore != null) return -1;
+        if (b.fidelityScore != null) return 1;
         return b.voteCount - a.voteCount;
       }),
     [members],

--- a/components/CommitteeDiscovery.tsx
+++ b/components/CommitteeDiscovery.tsx
@@ -34,22 +34,22 @@ function VoteBar({ yes, no, abstain }: { yes: number; no: number; abstain: numbe
 
 function MemberRow({ member }: { member: CommitteeMemberQuickView }) {
   const displayName = member.name || `${member.ccHotId.slice(0, 12)}…${member.ccHotId.slice(-6)}`;
-  const gradeStyle = member.transparencyGrade ? GRADE_COLORS[member.transparencyGrade] || '' : '';
+  const gradeStyle = member.fidelityGrade ? GRADE_COLORS[member.fidelityGrade] || '' : '';
 
   return (
     <Link
       href={`/committee#${member.ccHotId.slice(0, 12)}`}
       className="flex items-center gap-3 px-4 py-3 hover:bg-muted/30 transition-colors group"
     >
-      {/* Transparency grade badge */}
-      {member.transparencyGrade ? (
+      {/* Fidelity grade badge */}
+      {member.fidelityGrade ? (
         <span
           className={cn(
             'text-[10px] font-bold w-6 h-6 rounded flex items-center justify-center border shrink-0',
             gradeStyle,
           )}
         >
-          {member.transparencyGrade}
+          {member.fidelityGrade}
         </span>
       ) : (
         <span className="w-6 h-6 rounded flex items-center justify-center bg-muted text-muted-foreground text-[10px] font-medium shrink-0">
@@ -135,10 +135,10 @@ export function CommitteeDiscovery() {
         onReset={resetFilters}
       />
 
-      {/* Link to full transparency page */}
+      {/* Link to full fidelity page */}
       <div className="flex items-center justify-end">
         <Link href="/governance/committee" className="text-xs text-primary hover:underline">
-          View full Transparency Index →
+          View full Constitutional Fidelity Index →
         </Link>
       </div>
 

--- a/components/cc/CCHealthVerdict.tsx
+++ b/components/cc/CCHealthVerdict.tsx
@@ -166,7 +166,7 @@ export function CCHealthVerdict({ health }: CCHealthVerdictProps) {
           className="flex flex-col items-center gap-1 sm:min-w-[140px]"
         >
           <HealthArc
-            score={health.avgTransparency}
+            score={health.avgFidelity}
             color={config.arcColor}
             trackColor={config.arcTrack}
           />

--- a/components/cc/CCInsightCard.tsx
+++ b/components/cc/CCInsightCard.tsx
@@ -45,11 +45,11 @@ function selectInsight(
 
   // Persona-aware: CC member sees standing
   if (segment === 'cc') {
-    const scored = members.filter((m) => m.transparencyIndex != null);
+    const scored = members.filter((m) => m.fidelityScore != null);
     return {
       icon: ShieldCheck,
       title: 'Your Committee Standing',
-      body: `${scored.length} member${scored.length !== 1 ? 's' : ''} scored on the Transparency Index. Check your profile to see your rank and pillar breakdown.`,
+      body: `${scored.length} member${scored.length !== 1 ? 's' : ''} scored on Constitutional Fidelity. Check your profile to see your rank and pillar breakdown.`,
       accent: 'text-emerald-500',
     };
   }
@@ -69,7 +69,7 @@ function selectInsight(
     return {
       icon: TrendingUp,
       title: 'Accountability Improving',
-      body: `Average transparency scores are trending upward across the committee, signaling stronger governance practices.`,
+      body: `Average fidelity scores are trending upward across the committee, signaling stronger governance practices.`,
       accent: 'text-emerald-500',
     };
   }
@@ -78,35 +78,34 @@ function selectInsight(
     return {
       icon: TrendingUp,
       title: 'Accountability Declining',
-      body: `Average transparency scores have dropped — some members may need to improve participation or rationale quality.`,
+      body: `Average fidelity scores have dropped — some members may need to improve participation or rationale quality.`,
       accent: 'text-rose-500',
     };
   }
 
   // Priority 3: All members graded well
-  const graded = members.filter((m) => m.transparencyGrade != null);
+  const graded = members.filter((m) => m.fidelityGrade != null);
   const allStrong =
-    graded.length > 0 &&
-    graded.every((m) => m.transparencyGrade === 'A' || m.transparencyGrade === 'B');
+    graded.length > 0 && graded.every((m) => m.fidelityGrade === 'A' || m.fidelityGrade === 'B');
   if (allStrong) {
     return {
       icon: ShieldCheck,
       title: 'Strong Accountability',
-      body: `All scored members are maintaining a B grade or above — healthy transparency across the committee.`,
+      body: `All scored members are maintaining a B grade or above — strong constitutional fidelity across the committee.`,
       accent: 'text-emerald-500',
     };
   }
 
   // Fallback: general insight
-  const scored = members.filter((m) => m.transparencyIndex != null);
+  const scored = members.filter((m) => m.fidelityScore != null);
   const active = health.activeMembers;
   return {
     icon: Lightbulb,
     title: 'Committee Overview',
     body:
       scored.length > 0
-        ? `${active} active member${active !== 1 ? 's' : ''} with ${scored.length} scored on the Transparency Index. Review individual profiles to see pillar breakdowns.`
-        : `${active} active committee member${active !== 1 ? 's' : ''} participating in governance. Transparency scores will appear after the next scoring cycle.`,
+        ? `${active} active member${active !== 1 ? 's' : ''} with ${scored.length} scored on Constitutional Fidelity. Review individual profiles to see pillar breakdowns.`
+        : `${active} active committee member${active !== 1 ? 's' : ''} participating in governance. Fidelity scores will appear after the next scoring cycle.`,
     accent: 'text-blue-500',
   };
 }

--- a/components/cc/CCMemberProfileClient.tsx
+++ b/components/cc/CCMemberProfileClient.tsx
@@ -6,7 +6,6 @@ import { motion } from 'framer-motion';
 import {
   Vote,
   BookOpen,
-  Clock,
   Sparkles,
   ShieldCheck,
   Users,
@@ -20,14 +19,14 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { CCTransparencyTrend } from '@/components/cc/CCTransparencyTrend';
 import { CopyableAddress } from '@/components/CopyableAddress';
 import {
-  interpretTransparencyScore,
+  interpretFidelityScore,
   interpretParticipation,
   interpretRationaleQuality,
-  interpretIndependence,
+  interpretConstitutionalGrounding,
   interpretPillarStrengthWeakness,
 } from '@/lib/cc/interpretations';
 import { staggerContainer, fadeInUp } from '@/lib/animations';
-import type { CCTransparencySnapshot } from '@/lib/data';
+import type { CCFidelitySnapshot } from '@/lib/data';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,16 +48,15 @@ interface EnrichedVote {
 
 interface PillarScores {
   participation: number | null;
-  rationaleQuality: number | null;
-  responsiveness: number | null;
-  independence: number | null;
+  constitutionalGrounding: number | null;
+  reasoningQuality: number | null;
 }
 
 interface ProfileData {
   ccHotId: string;
   authorName: string | null;
-  transparencyIndex: number | null;
-  transparencyGrade: string | null;
+  fidelityScore: number | null;
+  fidelityGrade: string | null;
   status: string | null;
   expirationEpoch: number | null;
   rank: number | null;
@@ -71,14 +69,14 @@ interface ProfileData {
   votesCast: number;
   eligibleProposals: number | null;
   rationaleProvisionRate: number | null;
-  independenceScore: number | null;
+  constitutionalGroundingScore: number | null;
   drepAgree: number;
   drepCompare: number;
   spoAgree: number;
   spoCompare: number;
   pillarScores: PillarScores | null;
   enrichedVotes: EnrichedVote[];
-  transparencyHistory: CCTransparencySnapshot[];
+  fidelityHistory: CCFidelitySnapshot[];
 }
 
 // ---------------------------------------------------------------------------
@@ -110,11 +108,11 @@ const VOTES_PER_PAGE = 10;
 function ProfileHero({ data }: { data: ProfileData }) {
   const displayName =
     data.authorName ?? `${data.ccHotId.slice(0, 12)}\u2026${data.ccHotId.slice(-6)}`;
-  const grade = data.transparencyGrade ? GRADE_COLORS[data.transparencyGrade] : null;
+  const grade = data.fidelityGrade ? GRADE_COLORS[data.fidelityGrade] : null;
 
   const verdict =
-    data.transparencyIndex != null && data.rank != null
-      ? interpretTransparencyScore(data.transparencyIndex, data.rank, data.totalScored)
+    data.fidelityScore != null && data.rank != null
+      ? interpretFidelityScore(data.fidelityScore, data.rank, data.totalScored)
       : null;
 
   const pillarSummary = data.pillarScores
@@ -171,7 +169,7 @@ function ProfileHero({ data }: { data: ProfileData }) {
       </div>
 
       {/* Right: Score card */}
-      {data.transparencyIndex != null && grade && data.transparencyGrade && (
+      {data.fidelityScore != null && grade && data.fidelityGrade && (
         <div
           className={cn(
             'shrink-0 w-full sm:w-48 rounded-xl border px-6 py-5 text-center',
@@ -179,11 +177,9 @@ function ProfileHero({ data }: { data: ProfileData }) {
             grade.border,
           )}
         >
-          <p className="text-xs text-muted-foreground mb-1">Transparency Index</p>
-          <p className={cn('text-4xl font-bold tabular-nums', grade.text)}>
-            {data.transparencyIndex}
-          </p>
-          <p className={cn('text-lg font-bold', grade.text)}>Grade {data.transparencyGrade}</p>
+          <p className="text-xs text-muted-foreground mb-1">Constitutional Fidelity</p>
+          <p className={cn('text-4xl font-bold tabular-nums', grade.text)}>{data.fidelityScore}</p>
+          <p className={cn('text-lg font-bold', grade.text)}>Grade {data.fidelityGrade}</p>
         </div>
       )}
     </div>
@@ -201,11 +197,11 @@ function KeyStats({ data }: { data: ProfileData }) {
       : `${data.totalVotes} votes cast`;
 
   const rationaleNarrative = interpretRationaleQuality(
-    data.pillarScores?.rationaleQuality ?? null,
+    data.pillarScores?.reasoningQuality ?? null,
     data.rationaleProvisionRate,
   );
 
-  const independenceNarrative = interpretIndependence(data.independenceScore, null);
+  const groundingNarrative = interpretConstitutionalGrounding(data.constitutionalGroundingScore);
 
   const stats = [
     {
@@ -221,16 +217,19 @@ function KeyStats({ data }: { data: ProfileData }) {
       narrative: participationNarrative,
     },
     {
-      label: 'Rationale Quality',
+      label: 'Constitutional Grounding',
+      value:
+        data.constitutionalGroundingScore != null
+          ? `${Math.round(data.constitutionalGroundingScore)}`
+          : '\u2014',
+      sub: data.constitutionalGroundingScore != null ? '/100 score' : 'Not available',
+      narrative: groundingNarrative,
+    },
+    {
+      label: 'Reasoning Quality',
       value: `${data.withRationale}/${data.totalVotes}`,
       sub: `${data.totalVotes > 0 ? Math.round((data.withRationale / data.totalVotes) * 100) : 0}% provision rate`,
       narrative: rationaleNarrative,
-    },
-    {
-      label: 'Independence',
-      value: data.independenceScore != null ? `${Math.round(data.independenceScore)}` : '\u2014',
-      sub: data.independenceScore != null ? '/100 score' : 'Not available',
-      narrative: independenceNarrative,
     },
   ];
 
@@ -304,47 +303,40 @@ function OverviewTab({ data }: { data: ProfileData }) {
   return (
     <div className="space-y-6">
       {/* Pillar breakdown */}
-      {data.pillarScores && data.transparencyIndex != null && (
+      {data.pillarScores && data.fidelityScore != null && (
         <div className="space-y-3">
           <h3 className="text-sm font-semibold flex items-center gap-2">
             <Scale className="h-4 w-4" />
-            Transparency Index Breakdown
+            Constitutional Fidelity Breakdown
           </h3>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-4 sm:grid-cols-3">
             <PillarBar
               icon={<Vote className="h-3.5 w-3.5" />}
               label="Participation"
-              weight="39%"
+              weight="30%"
               score={data.pillarScores.participation}
               delay={0}
             />
             <PillarBar
               icon={<BookOpen className="h-3.5 w-3.5" />}
-              label="Rationale Quality"
-              weight="33%"
-              score={data.pillarScores.rationaleQuality}
+              label="Constitutional Grounding"
+              weight="40%"
+              score={data.pillarScores.constitutionalGrounding}
               delay={0.1}
             />
             <PillarBar
-              icon={<Clock className="h-3.5 w-3.5" />}
-              label="Responsiveness"
-              weight="17%"
-              score={data.pillarScores.responsiveness}
-              delay={0.2}
-            />
-            <PillarBar
               icon={<Sparkles className="h-3.5 w-3.5" />}
-              label="Independence"
-              weight="11%"
-              score={data.pillarScores.independence}
-              delay={0.3}
+              label="Reasoning Quality"
+              weight="30%"
+              score={data.pillarScores.reasoningQuality}
+              delay={0.2}
             />
           </div>
         </div>
       )}
 
-      {/* Transparency trend */}
-      <CCTransparencyTrend history={data.transparencyHistory} />
+      {/* Fidelity trend */}
+      <CCTransparencyTrend history={data.fidelityHistory} />
     </div>
   );
 }

--- a/components/cc/CCTransparencyTrend.tsx
+++ b/components/cc/CCTransparencyTrend.tsx
@@ -9,25 +9,17 @@ import { TrendingUp } from 'lucide-react';
 import { useChartDimensions } from '@/lib/charts/useChartDimensions';
 import { GlowFilter } from '@/lib/charts/GlowDefs';
 import { chartTheme } from '@/lib/charts/theme';
-import type { CCTransparencySnapshot } from '@/lib/data';
+import type { CCFidelitySnapshot } from '@/lib/data';
 
-const PILLAR_KEYS = [
-  'Participation',
-  'Rationale',
-  'Responsiveness',
-  'Independence',
-  'Engagement',
-] as const;
+const PILLAR_KEYS = ['Participation', 'Grounding', 'Reasoning'] as const;
 const PILLAR_COLORS = [
   'oklch(0.68 0.16 160)', // green
   'oklch(0.60 0.18 290)', // purple
   'oklch(0.75 0.14 80)', // amber
-  'oklch(0.65 0.16 30)', // orange
-  'oklch(0.60 0.18 230)', // blue
 ];
 
 interface CCTransparencyTrendProps {
-  history: CCTransparencySnapshot[];
+  history: CCFidelitySnapshot[];
 }
 
 export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
@@ -41,12 +33,10 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
       history.map((s) => ({
         label: `E${s.epochNo}`,
         epochNo: s.epochNo,
-        Index: s.transparencyIndex,
+        Index: s.fidelityScore,
         Participation: s.participationScore,
-        Rationale: s.rationaleQualityScore,
-        Responsiveness: s.responsivenessScore,
-        Independence: s.independenceScore,
-        Engagement: s.communityEngagementScore,
+        Grounding: s.constitutionalGroundingScore,
+        Reasoning: s.reasoningQualityScore,
       })),
     [history],
   );
@@ -110,12 +100,12 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <TrendingUp className="h-4 w-4" />
-            Transparency Trend
+            Constitutional Fidelity Trend
           </CardTitle>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            Transparency tracking started recently. Check back after the next epoch to see how this
+            Fidelity tracking started recently. Check back after the next epoch to see how this
             member&apos;s score changes over time.
           </p>
         </CardContent>
@@ -130,12 +120,12 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-base">
             <TrendingUp className="h-4 w-4" />
-            Transparency Trend
+            Constitutional Fidelity Trend
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-center py-6">
-            <p className="text-3xl font-bold tabular-nums">{s.transparencyIndex}</p>
+            <p className="text-3xl font-bold tabular-nums">{s.fidelityScore}</p>
             <p className="text-sm text-muted-foreground mt-1">
               First snapshot at epoch {s.epochNo}. Trend data will appear as more epochs pass.
             </p>
@@ -147,7 +137,7 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
 
   const latest = history[history.length - 1];
   const first = history[0];
-  const change = latest.transparencyIndex - first.transparencyIndex;
+  const change = latest.fidelityScore - first.fidelityScore;
   const hovered = hoveredIndex !== null ? chartData[hoveredIndex] : null;
   const ticks = yScale.ticks(5);
   const xTicks =
@@ -161,7 +151,7 @@ export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
         <div className="flex items-center justify-between flex-wrap gap-2">
           <CardTitle className="flex items-center gap-2 text-base">
             <TrendingUp className="h-4 w-4" />
-            Transparency Trend
+            Constitutional Fidelity Trend
           </CardTitle>
           <div className="flex items-center gap-3">
             {history.length > 1 && (

--- a/components/civica/AdminViewAsPicker.tsx
+++ b/components/civica/AdminViewAsPicker.tsx
@@ -42,7 +42,7 @@ interface PoolItem {
 interface CCMemberItem {
   ccHotId: string;
   name?: string | null;
-  transparencyGrade?: string | null;
+  fidelityGrade?: string | null;
   voteCount?: number;
 }
 
@@ -297,9 +297,9 @@ export function AdminViewAsPicker({
                       </div>
                     )}
                   </div>
-                  {m.transparencyGrade && (
+                  {m.fidelityGrade && (
                     <span className="text-xs font-semibold text-muted-foreground">
-                      {m.transparencyGrade}
+                      {m.fidelityGrade}
                     </span>
                   )}
                 </button>

--- a/docs/strategy/context/build-manifest.md
+++ b/docs/strategy/context/build-manifest.md
@@ -1,7 +1,7 @@
 # Build Manifest (derived from ultimate-vision.md V3.0)
 
 > **Purpose:** Machine-readable audit checklist. Agents verify `[x]` items exist, report `[ ]` items as gaps.
-> **Last synced with vision:** 2026-03-10
+> **Last synced with vision:** 2026-03-12 (V3.1)
 > **Usage:** `Phase 1 audit` = read this file, verify files/routes/tables. `Phase 2 audit` = read ultimate-vision.md for qualitative alignment.
 > **Scoring:** After each `/audit`, record dimension scores in the Audit Score History section at the bottom.
 
@@ -174,56 +174,103 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 
 ---
 
-## Phase 2: Engagement Flywheel Activation [NOT STARTED]
+## Phase 2: The Living Platform [NOT STARTED — LAUNCH PHASE 1 of 2]
 
-- [ ] Hub engagement cards — active sentiment polls, priority signals, assemblies
-- [ ] Anonymous glass window — see engagement results, can't participate, conversion CTA
+### 2a: Engagement Activation (The Voice Layer)
+
+- [ ] Hub feed engagement items — active sentiment polls, priority signals, assemblies
 - [ ] Contextual prompts on proposal pages — inline sentiment voting
 - [ ] Contextual prompts on DRep profiles — endorsement prompt
 - [ ] Contextual prompts on funded projects — impact tags
 - [ ] Concern flags inline on proposal pages
-- [ ] Citizen sentiment visible in DRep Workspace
-- [ ] Engagement metrics in Hub briefings
-- [ ] Endorsement counts on discovery cards
+- [ ] Anonymous glass window — see engagement results, can't participate, conversion CTA
+- [ ] Engagement → intelligence feedback — citizen sentiment visible in DRep Workspace
+- [ ] Endorsement counts on governance browse cards
+- [ ] Community Consensus visualization (feature-flagged until data volume threshold)
 
-### Flywheel activated: Engagement
+### 2b: Civic Identity & Milestones (The Investment Layer)
 
-- verify: engagement actions possible from Hub without visiting separate page
+- [ ] Governance Impact Score calculation + display on Hub and `/you`
+- [ ] Milestone achievement system — first delegation, first sentiment vote, streaks, coverage milestones
+- [ ] Enhanced civic identity surface on `/you` — governance resume
+- [ ] "Governance Since" epoch tenure display
+- [ ] `citizen_impact_scores` table
+
+### 2c: Share Engine (The Viral Layer)
+
+- [ ] Milestone share cards with branded OG images
+- [ ] DRep/SPO profile share cards (score tier, key stats, endorsements)
+- [ ] Governance stats shareable card (coverage, tenure, engagement depth)
+- [ ] Sentiment divergence shareable insights
+- [ ] Coverage gap shareable card
+- [ ] Pre-formatted share text + deep links for X/Twitter
+- [ ] One-tap share with `navigator.share()` + clipboard fallback
+
+### 2d: Representative Activation (The Supply-Side Engine)
+
+- [ ] "Claim Your Profile" flow — DRep connects wallet, enhances profile
+- [ ] "Claim Your Profile" flow — SPO connects wallet, governance statement
+- [ ] Delegator intelligence dashboard — "Your delegators care about..."
+- [ ] Competitive context — rank, percentile, peer comparison
+- [ ] Profile sharing toolkit — pre-formatted post, OG image, embed snippet
+- [ ] Governance leaderboards — by score, rationale quality, endorsements
+
+### Flywheels activated: Engagement, Viral/Identity, Accountability (accelerated), Content (accelerated)
+
+- verify: engagement actions possible from Hub and entity pages
 - verify: anonymous users see engagement results but cannot participate
-
----
-
-## Phase 3: Anonymous Funnel + Coverage Polish [NOT STARTED]
-
-- [ ] Two-path anonymous landing optimized (Match + Governance)
-- [ ] Match flow expanded: DRep matching + Pool matching ("governance team")
-- [ ] Inline education (tooltips, contextual explainers)
-- [ ] Wallet connect at moment of intent
-- [ ] PostHog funnel measurement + iteration
-- [ ] Governance Coverage prominent on Hub and Delegation
-- [ ] "Complete your governance team" CTA
-- [ ] Coverage trend over time
-- [ ] Shareable coverage card
-
-- verify: anonymous -> citizen conversion measurable via PostHog funnel
-
----
-
-## Phase 4: Viral/Identity Flywheel Activation [NOT STARTED]
-
-- [ ] GovernanceImpactScore calculation + display
-- [ ] CivicMilestoneShare cards (first delegation, DRep milestones, coverage streaks)
-- [ ] Enhanced Wrapped (multi-role, engagement stats, coverage)
-- [ ] Animated share preview generation
-- [ ] citizen_impact_scores table
-
-### Flywheel activated: Viral/Identity
-
 - verify: milestone share cards generate shareable OG images
+- verify: DReps/SPOs can claim and share profiles
 
 ---
 
-## Phase 5: Monetization Layer [NOT STARTED]
+## Phase 3: The Growth Engine [NOT STARTED — LAUNCH PHASE 2 of 2]
+
+### 3a: Conversion Funnel (The Door)
+
+- [ ] Anonymous landing optimization — live social proof numbers, two clear paths
+- [ ] Match flow reframed as "Build Your Governance Team" (DRep + Pool)
+- [ ] Wallet connect at moment of intent (not on arrival)
+- [ ] Progressive onboarding — reveal features as users are ready
+- [ ] PostHog funnel instrumentation — full conversion pipeline measured
+- [ ] SEO foundation — meta tags, structured data, sitemap for public-facing pages
+
+### 3b: Return Loop (The Hook)
+
+- [ ] Epoch-boundary digest — opt-in email with personalized briefing
+- [ ] Email collection opt-in flow (web3-first, no email for auth)
+- [ ] Alert system — DRep voted, coverage changed, score shifted, milestones
+- [ ] Notification pipeline wired to `/you/inbox` with real governance events
+- [ ] "What changed" summary on return visit
+- [ ] Engagement result follow-ups — "87% agreed with your vote"
+
+### 3c: Community Intelligence (The Conversation Starter) — all feature-flagged
+
+- [ ] Citizen Mandate dashboard — aggregate priority signals visualized
+- [ ] Sentiment Divergence Index — citizen vs. DRep agreement analysis
+- [ ] "State of Governance" auto-generated epoch report
+- [ ] Governance Temperature — single-number aggregate sentiment
+
+### 3d: Launch Readiness (The Finish)
+
+- [ ] Mobile experience audit + fixes
+- [ ] Performance optimization — sub-2s meaningful paint on key pages
+- [ ] Load testing (QP-13) — handle launch traffic
+- [ ] Edge case polish — empty states, error recovery, loading skeletons
+- [ ] Legal/privacy baseline — terms of service, privacy policy
+
+### Flywheels activated: All loops closed
+
+- verify: anonymous → citizen conversion measurable via PostHog funnel
+- verify: citizens receive epoch-boundary notifications
+- verify: mobile experience is polished
+- verify: product handles load testing threshold
+
+**PUBLIC LAUNCH after Phase 3**
+
+---
+
+## Phase 4: Monetization Layer [POST-LAUNCH]
 
 - [ ] Subscription infrastructure (Stripe)
 - [ ] subscriptions + subscription_events tables
@@ -235,7 +282,7 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 
 ---
 
-## Phase 6: Integration Flywheel Activation [NOT STARTED]
+## Phase 5: Integration Flywheel Activation [POST-LAUNCH]
 
 - [ ] API v2 expansion — full entity, governance, scoring, matching endpoints
 - [ ] OpenAPI spec + SDK generation (TypeScript, Python)
@@ -255,13 +302,14 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 
 ---
 
-## Phase 7+: Advanced Intelligence & New Products [NOT STARTED]
+## Phase 6+: Advanced Intelligence & New Products [POST-LAUNCH]
 
 - [ ] Delegation network graph + influence mapping
 - [ ] Governance simulation engine
 - [ ] delegation_snapshots per-epoch collection
 - [ ] Catalyst Score (separate product line)
 - [ ] Cross-ecosystem governance identity
+- [ ] Enhanced Wrapped (multi-role, engagement stats, coverage)
 
 ---
 

--- a/docs/strategy/vision-changelog.md
+++ b/docs/strategy/vision-changelog.md
@@ -11,6 +11,17 @@ Track incremental updates to `ultimate-vision.md` and persona docs. Agents shoul
 
 ---
 
+### v3.1 -- 2026-03-12
+
+- **Build Phases:** Complete re-evaluation of Phases 2-4 after ~25 PRs since last strategy review. Old Phase 2 (engagement recomposition) too narrow. Old Phase 3 (funnel optimization) premature without viral engine. Old Phase 4 (viral/identity) too late for launch. Merged into two new launch phases:
+  - **Phase 2: "The Living Platform"** — Engagement activation + civic identity + milestones + share engine + representative activation. Activates Engagement + Viral/Identity + Content flywheels simultaneously.
+  - **Phase 3: "The Growth Engine"** — Conversion funnel + epoch-boundary return loop + community intelligence (feature-flagged) + launch readiness (mobile, performance, SEO, legal).
+- **Phase renumbering:** Old 5→4 (Monetization), 6→5 (Integration), 7→6+ (Advanced). Enhanced Wrapped moved to 6+.
+- **Launch strategy:** PUBLIC LAUNCH after Phase 3. Maximum buzz. V3 as MVP.
+- **Distribution strategy:** Added epoch-boundary email digest (opt-in, web3-first), "governance team" framing, community intelligence as organic distribution.
+- **Flywheel status:** Accountability ACTIVE. Content/Discourse STARTING. Engagement + Viral/Identity activate together in Phase 2.
+- **Phase status:** Phase 0 → COMPLETE. Phase 1 → ~95% COMPLETE.
+
 ### v2.2 -- 2026-03-07
 
 - **Step 4 audit:** Codebase audit revealed that Step 4 "net-new" items EpochBriefing.tsx, CivicIdentityCard.tsx, and TreasuryCitizenView.tsx were already built during Step 3. Moved to "already built" section.

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -15,15 +15,15 @@ export interface CCHealthSummaryResponse {
   trend: 'improving' | 'stable' | 'declining';
   activeMembers: number;
   totalMembers: number;
-  avgTransparency: number | null;
+  avgFidelity: number | null;
   tensionCount: number;
 }
 
 export interface CommitteeMemberQuickView {
   ccHotId: string;
   name: string | null;
-  transparencyGrade: string | null;
-  transparencyIndex: number | null;
+  fidelityGrade: string | null;
+  fidelityScore: number | null;
   voteCount: number;
   yesCount: number;
   noCount: number;

--- a/inngest/functions/sync-cc-rationales.ts
+++ b/inngest/functions/sync-cc-rationales.ts
@@ -10,13 +10,11 @@ import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { fetchCip136Rationale } from '@/lib/cc/parseCip136';
 import {
-  computeFidelityScore,
   computeRationaleProvision,
   computeAvgArticleCoverage,
   computeAvgReasoningQuality,
-  computeConsistencyIndependence,
 } from '@/lib/cc/fidelityScore';
-import { computeFullTransparencyIndex } from '@/lib/scoring/ccTransparency';
+import { computeFullConstitutionalFidelity } from '@/lib/scoring/ccTransparency';
 import type { CCMemberVoteData } from '@/lib/scoring/ccTransparency';
 import { logger } from '@/lib/logger';
 import { errMsg, capMsg } from '@/lib/sync-utils';
@@ -237,24 +235,6 @@ export const syncCcRationales = inngest.createFunction(
         });
       }
 
-      // Get DRep alignment data for independence scoring
-      const { data: alignmentRows } = await supabase
-        .from('inter_body_alignment')
-        .select('proposal_tx_hash, proposal_index, drep_yes_pct, drep_no_pct');
-
-      const drepMajorityMap = new Map<string, string>();
-      for (const row of alignmentRows ?? []) {
-        const key = `${row.proposal_tx_hash}:${row.proposal_index}`;
-        drepMajorityMap.set(
-          key,
-          row.drep_yes_pct > row.drep_no_pct
-            ? 'Yes'
-            : row.drep_no_pct > row.drep_yes_pct
-              ? 'No'
-              : 'Abstain',
-        );
-      }
-
       // Group votes by member
       const memberVotes = new Map<
         string,
@@ -277,9 +257,6 @@ export const syncCcRationales = inngest.createFunction(
         });
         memberVotes.set(v.cc_hot_id, list);
       }
-
-      // Compute distinct active proposal types
-      const activeTypes = new Set(Array.from(proposalMap.values()).map((p) => p.type));
 
       let scored = 0;
       for (const [ccHotId, mvotes] of memberVotes) {
@@ -322,62 +299,13 @@ export const syncCcRationales = inngest.createFunction(
               ? Math.round(articleCoverage * 0.7 + rationaleProvision * 0.3)
               : 0;
 
-        // Pillar 4: Consistency & Independence
-        let drepAgreements = 0;
-        let drepComparisons = 0;
-        let totalDaysToVote = 0;
-        let responsiveVotes = 0;
-        const memberTypes = new Set<string>();
-
-        for (const v of mvotes) {
-          const pKey = `${v.proposalTxHash}:${v.proposalIndex}`;
-          const proposal = proposalMap.get(pKey);
-          if (proposal) {
-            memberTypes.add(proposal.type);
-            // Responsiveness
-            const daysToVote = (v.blockTime - proposal.blockTime) / 86400;
-            if (daysToVote >= 0) {
-              totalDaysToVote += daysToVote;
-              responsiveVotes++;
-            }
-          }
-
-          const drepMajority = drepMajorityMap.get(pKey);
-          if (drepMajority && drepMajority !== 'Abstain') {
-            drepComparisons++;
-            if (v.vote === drepMajority) drepAgreements++;
-          }
-        }
-
-        const drepAlignmentPct =
-          drepComparisons > 0 ? (drepAgreements / drepComparisons) * 100 : 50;
-        const avgDaysToVote = responsiveVotes > 0 ? totalDaysToVote / responsiveVotes : 10;
-
-        const consistencyIndependence = computeConsistencyIndependence(
-          drepAlignmentPct,
-          avgDaysToVote,
-          memberTypes.size,
-          activeTypes.size,
-        );
-
-        // Compute composite score
-        const result = computeFidelityScore({
-          rationaleProvision,
-          articleCoverage,
-          reasoningQuality,
-          consistencyIndependence,
-        });
-
-        // Update cc_members with scores
+        // Update cc_members with granular pillar values
         const { error } = await supabase.from('cc_members').upsert(
           {
             cc_hot_id: ccHotId,
-            fidelity_score: result.score,
             rationale_provision_rate: rationaleProvision,
             avg_article_coverage: articleCoverage,
             avg_reasoning_quality: reasoningQuality,
-            consistency_score: consistencyIndependence,
-            responsiveness_score: Math.round(avgDaysToVote * 10) / 10,
             updated_at: new Date().toISOString(),
           },
           { onConflict: 'cc_hot_id' },
@@ -389,8 +317,8 @@ export const syncCcRationales = inngest.createFunction(
       return { scored };
     });
 
-    // Step 4: Compute Transparency Index + persist snapshots
-    const transparencyResult = await step.run('compute-transparency-index', async () => {
+    // Step 4: Compute Constitutional Fidelity Score + persist snapshots
+    const transparencyResult = await step.run('compute-constitutional-fidelity', async () => {
       const supabase = getSupabaseAdmin();
 
       // Get current epoch
@@ -440,43 +368,6 @@ export const syncCcRationales = inngest.createFunction(
         });
       }
 
-      // DRep alignment
-      const { data: alignmentRows } = await supabase
-        .from('inter_body_alignment')
-        .select('proposal_tx_hash, proposal_index, drep_yes_pct, drep_no_pct');
-
-      const drepMajorityMap = new Map<string, string>();
-      for (const row of alignmentRows ?? []) {
-        const key = `${row.proposal_tx_hash}:${row.proposal_index}`;
-        drepMajorityMap.set(
-          key,
-          row.drep_yes_pct > row.drep_no_pct
-            ? 'Yes'
-            : row.drep_no_pct > row.drep_yes_pct
-              ? 'No'
-              : 'Abstain',
-        );
-      }
-
-      // CC majority per proposal (for independence scoring)
-      const proposalCcVotes = new Map<string, Map<string, string>>();
-      for (const v of votes) {
-        const key = `${v.proposal_tx_hash}:${v.proposal_index}`;
-        const voteMap = proposalCcVotes.get(key) ?? new Map<string, string>();
-        voteMap.set(v.cc_hot_id, v.vote);
-        proposalCcVotes.set(key, voteMap);
-      }
-
-      const ccMajorityMap = new Map<string, string>();
-      for (const [key, voteMap] of proposalCcVotes) {
-        const counts: Record<string, number> = {};
-        for (const vote of voteMap.values()) {
-          counts[vote] = (counts[vote] ?? 0) + 1;
-        }
-        const majority = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
-        if (majority) ccMajorityMap.set(key, majority[0]);
-      }
-
       // Total eligible proposals (all proposals in the system)
       const totalEligibleProposals = new Set(
         proposals.map((p) => `${p.tx_hash}:${p.proposal_index}`),
@@ -498,28 +389,26 @@ export const syncCcRationales = inngest.createFunction(
 
       let scored = 0;
       for (const [ccHotId, mvotes] of memberVotes) {
-        const result = computeFullTransparencyIndex({
+        const result = computeFullConstitutionalFidelity({
           ccHotId,
           votes: mvotes,
           proposalMap,
           rationaleMap,
-          drepMajorityMap,
-          ccMajorityMap,
           totalEligibleProposals,
-          questionsAnswered: 0, // Not yet tracked
-          endorsementCount: 0, // Not yet tracked
         });
 
-        // Update cc_members with transparency index
+        // Update cc_members with Constitutional Fidelity Score
         const { error } = await supabase.from('cc_members').upsert(
           {
             cc_hot_id: ccHotId,
-            transparency_index: result.index,
+            fidelity_score: result.score,
+            transparency_index: result.score, // backward compat until migration
             transparency_grade: result.grade,
             participation_score: result.pillars.participation,
-            rationale_quality_score: result.pillars.rationaleQuality,
-            independence_score: result.pillars.independence,
-            community_engagement_score: result.pillars.communityEngagement,
+            rationale_quality_score: result.pillars.reasoningQuality,
+            // constitutionalGrounding stored in independence_score until migration adds proper column
+            independence_score: result.pillars.constitutionalGrounding,
+            community_engagement_score: 0, // pillar removed
             votes_cast: result.votesCast,
             eligible_proposals: result.eligibleProposals,
             updated_at: new Date().toISOString(),
@@ -533,19 +422,19 @@ export const syncCcRationales = inngest.createFunction(
             {
               cc_hot_id: ccHotId,
               epoch_no: currentEpoch,
-              transparency_index: result.index,
+              transparency_index: result.score,
               participation_score: result.pillars.participation,
-              rationale_quality_score: result.pillars.rationaleQuality,
-              responsiveness_score: result.pillars.responsiveness,
-              independence_score: result.pillars.independence,
-              community_engagement_score: result.pillars.communityEngagement,
+              rationale_quality_score: result.pillars.reasoningQuality,
+              responsiveness_score: 0, // pillar removed
+              independence_score: result.pillars.constitutionalGrounding,
+              community_engagement_score: 0, // pillar removed
               votes_cast: result.votesCast,
               eligible_proposals: result.eligibleProposals,
             },
             { onConflict: 'cc_hot_id,epoch_no' },
           );
           if (snapError) {
-            logger.error('[sync-cc-rationales] Transparency snapshot upsert failed', {
+            logger.error('[sync-cc-rationales] Fidelity snapshot upsert failed', {
               ccHotId,
               epoch: currentEpoch,
               error: snapError.message,
@@ -581,7 +470,7 @@ export const syncCcRationales = inngest.createFunction(
           { onConflict: 'snapshot_type,epoch_no,snapshot_date' },
         );
 
-        logger.info('[sync-cc-rationales] Transparency snapshots stored', {
+        logger.info('[sync-cc-rationales] Constitutional Fidelity snapshots stored', {
           scored,
           snapshotCount: actualCount,
           expected: expectedCount,

--- a/inngest/functions/sync-drep-scores.ts
+++ b/inngest/functions/sync-drep-scores.ts
@@ -205,7 +205,6 @@ export const syncDrepScores = inngest.createFunction(
 
         // Profile data for governance identity
         const profiles = new Map<string, DRepProfileData>();
-        const allDelegatorCounts: number[] = [];
 
         for (const row of drepRows) {
           const info = (row.info || {}) as Record<string, unknown>;
@@ -217,7 +216,6 @@ export const syncDrepScores = inngest.createFunction(
             delegatorCount,
             metadataHashVerified: row.metadata_hash_verified || false,
           });
-          allDelegatorCounts.push(delegatorCount);
         }
 
         timing.step2_build_maps_ms = Date.now() - s2;
@@ -246,7 +244,7 @@ export const syncDrepScores = inngest.createFunction(
           drepEpochData,
         );
 
-        const rawIdentity = computeGovernanceIdentity(profiles, allDelegatorCounts);
+        const rawIdentity = computeGovernanceIdentity(profiles);
 
         timing.step3_compute_pillars_ms = Date.now() - s3;
 
@@ -325,13 +323,13 @@ export const syncDrepScores = inngest.createFunction(
           return {
             id: drepId,
             score: s.composite,
-            engagement_quality: s.engagementQualityPercentile,
+            engagement_quality: s.engagementQualityCalibrated,
             engagement_quality_raw: s.engagementQualityRaw,
-            effective_participation_v3: s.effectiveParticipationPercentile,
+            effective_participation_v3: s.effectiveParticipationCalibrated,
             effective_participation_v3_raw: s.effectiveParticipationRaw,
-            reliability_v3: s.reliabilityPercentile,
+            reliability_v3: s.reliabilityCalibrated,
             reliability_v3_raw: s.reliabilityRaw,
-            governance_identity: s.governanceIdentityPercentile,
+            governance_identity: s.governanceIdentityCalibrated,
             governance_identity_raw: s.governanceIdentityRaw,
             score_momentum: s.momentum,
             confidence: s.confidence,
@@ -355,18 +353,18 @@ export const syncDrepScores = inngest.createFunction(
           score: s.composite,
           epoch_no: currentEpoch,
           score_momentum: s.momentum,
-          engagement_quality: s.engagementQualityPercentile,
+          engagement_quality: s.engagementQualityCalibrated,
           engagement_quality_raw: s.engagementQualityRaw,
-          effective_participation_v3: s.effectiveParticipationPercentile,
+          effective_participation_v3: s.effectiveParticipationCalibrated,
           effective_participation_v3_raw: s.effectiveParticipationRaw,
-          reliability_v3: s.reliabilityPercentile,
+          reliability_v3: s.reliabilityCalibrated,
           reliability_v3_raw: s.reliabilityRaw,
-          governance_identity: s.governanceIdentityPercentile,
+          governance_identity: s.governanceIdentityCalibrated,
           governance_identity_raw: s.governanceIdentityRaw,
-          effective_participation: s.effectiveParticipationPercentile,
-          rationale_rate: s.engagementQualityPercentile,
-          reliability_score: s.reliabilityPercentile,
-          profile_completeness: s.governanceIdentityPercentile,
+          effective_participation: s.effectiveParticipationCalibrated,
+          rationale_rate: s.engagementQualityCalibrated,
+          reliability_score: s.reliabilityCalibrated,
+          profile_completeness: s.governanceIdentityCalibrated,
         }));
 
         await batchUpsert(

--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -289,12 +289,10 @@ export const syncSpoScores = inngest.createFunction(
 
         // Build SPO profile data for Governance Identity pillar
         const spoProfiles = new Map<string, SpoProfileData>();
-        const allDelegatorCounts: number[] = [];
         const poolMetaMap = new Map<string, PoolRow>();
 
         for (const p of (poolRows || []) as PoolRow[]) {
           poolMetaMap.set(p.pool_id, p);
-          allDelegatorCounts.push(p.delegator_count ?? 0);
         }
 
         for (const poolId of poolVotes.keys()) {
@@ -310,13 +308,10 @@ export const syncSpoScores = inngest.createFunction(
             metadataHashVerified: meta?.metadata_hash_verified ?? false,
             delegatorCount: meta?.delegator_count ?? 0,
           });
-          if (!poolMetaMap.has(poolId)) {
-            allDelegatorCounts.push(0);
-          }
         }
 
         const identityScores = identityEnabled
-          ? computeSpoGovernanceIdentity(spoProfiles, allDelegatorCounts)
+          ? computeSpoGovernanceIdentity(spoProfiles)
           : new Map<string, number>();
 
         // Load score history for momentum (30-day window for V3)
@@ -429,16 +424,16 @@ export const syncSpoScores = inngest.createFunction(
             pool_id: poolId,
             governance_score: s.composite,
             participation_raw: Math.round(s.participationRaw),
-            participation_pct: Math.round(s.participationPercentile),
+            participation_pct: Math.round(s.participationCalibrated),
             deliberation_raw: Math.round(s.deliberationRaw),
-            deliberation_pct: Math.round(s.deliberationPercentile),
+            deliberation_pct: Math.round(s.deliberationCalibrated),
             // V2 compat columns
             consistency_raw: Math.round(s.consistencyRaw),
-            consistency_pct: Math.round(s.consistencyPercentile),
+            consistency_pct: Math.round(s.consistencyCalibrated),
             reliability_raw: Math.round(s.reliabilityRaw),
-            reliability_pct: Math.round(s.reliabilityPercentile),
+            reliability_pct: Math.round(s.reliabilityCalibrated),
             governance_identity_raw: Math.round(s.governanceIdentityRaw),
-            governance_identity_pct: Math.round(s.governanceIdentityPercentile),
+            governance_identity_pct: Math.round(s.governanceIdentityCalibrated),
             score_momentum: s.momentum,
             confidence: s.confidence,
             vote_count: voteCount,
@@ -468,15 +463,15 @@ export const syncSpoScores = inngest.createFunction(
           epoch_no: currentEpoch,
           governance_score: s.composite,
           participation_rate: Math.round(s.participationRaw),
-          participation_pct: Math.round(s.participationPercentile),
+          participation_pct: Math.round(s.participationCalibrated),
           deliberation_raw: Math.round(s.deliberationRaw),
-          deliberation_pct: Math.round(s.deliberationPercentile),
+          deliberation_pct: Math.round(s.deliberationCalibrated),
           consistency_raw: Math.round(s.consistencyRaw),
-          consistency_pct: Math.round(s.consistencyPercentile),
+          consistency_pct: Math.round(s.consistencyCalibrated),
           reliability_raw: Math.round(s.reliabilityRaw),
-          reliability_pct: Math.round(s.reliabilityPercentile),
+          reliability_pct: Math.round(s.reliabilityCalibrated),
           governance_identity_raw: Math.round(s.governanceIdentityRaw),
-          governance_identity_pct: Math.round(s.governanceIdentityPercentile),
+          governance_identity_pct: Math.round(s.governanceIdentityCalibrated),
           score_momentum: s.momentum,
           confidence: s.confidence,
           rationale_rate: null,

--- a/lib/alignment/dimensions.ts
+++ b/lib/alignment/dimensions.ts
@@ -163,20 +163,11 @@ function calcDecentralization(inputs: DimensionInput[], drep: DRepContext, now: 
     voteScore = totalWeight > 0 ? Math.round((weightedSum / totalWeight) * 100) : 50;
   }
 
-  // Size tier modifier (minor influence, not dominant)
-  const tierModifier: Record<string, number> = {
-    Small: 10,
-    Medium: 3,
-    Large: -5,
-    Whale: -12,
-  };
-  const modifier = tierModifier[drep.sizeTier] ?? 0;
-
   // Voting breadth bonus (more diverse proposal types = more engaged in governance)
   const proposalTypes = new Set(inputs.map((i) => i.proposalType));
   const breadthBonus = Math.min(8, proposalTypes.size * 2);
 
-  return clamp(voteScore + modifier + breadthBonus);
+  return clamp(voteScore + breadthBonus);
 }
 
 function calcSecurity(inputs: DimensionInput[], drep: DRepContext, now: number): number {

--- a/lib/cc/interpretations.ts
+++ b/lib/cc/interpretations.ts
@@ -13,15 +13,11 @@
  */
 
 // ---------------------------------------------------------------------------
-// Transparency Score
+// Constitutional Fidelity Score
 // ---------------------------------------------------------------------------
 
-export function interpretTransparencyScore(
-  score: number | null,
-  rank: number,
-  total: number,
-): string {
-  if (score == null) return 'No transparency data available yet.';
+export function interpretFidelityScore(score: number | null, rank: number, total: number): string {
+  if (score == null) return 'No fidelity data available yet.';
   const label =
     score >= 85
       ? 'Excellent'
@@ -32,8 +28,11 @@ export function interpretTransparencyScore(
           : score >= 40
             ? 'Weak'
             : 'Poor';
-  return `${label} transparency (${score}/100) — ranked ${ordinal(rank)} of ${total} members`;
+  return `${label} constitutional fidelity (${score}/100) — ranked ${ordinal(rank)} of ${total} members`;
 }
+
+/** @deprecated Use interpretFidelityScore */
+export const interpretTransparencyScore = interpretFidelityScore;
 
 // ---------------------------------------------------------------------------
 // Participation
@@ -110,20 +109,26 @@ export function interpretRationaleQuality(
 }
 
 // ---------------------------------------------------------------------------
-// Independence
+// Constitutional Grounding
 // ---------------------------------------------------------------------------
 
-export function interpretIndependence(score: number | null, unanimousRate: number | null): string {
-  if (score == null) return 'Independence data not yet available.';
+export function interpretConstitutionalGrounding(score: number | null): string {
+  if (score == null) return 'Constitutional grounding data not yet available.';
   if (score >= 80)
-    return 'High independence — regularly exercises independent judgment on proposals';
-  if (score >= 60) {
-    const ctx =
-      unanimousRate != null && unanimousRate >= 90 ? ' despite high overall CC consensus' : '';
-    return `Moderate independence${ctx} — balanced between consensus and independent judgment`;
-  }
-  if (score >= 40) return 'Low independence — tends to vote with the CC majority on most proposals';
-  return 'Very low independence — rarely diverges from the CC majority';
+    return 'Strong constitutional grounding — consistently cites relevant articles and sections';
+  if (score >= 60)
+    return 'Good constitutional grounding — cites articles on most votes with reasonable coverage';
+  if (score >= 40)
+    return 'Moderate constitutional grounding — some article citations but coverage could improve';
+  return 'Weak constitutional grounding — rarely cites constitutional articles in rationales';
+}
+
+/** @deprecated Use interpretConstitutionalGrounding */
+export function interpretIndependence(
+  score: number | null,
+  _unanimousRate?: number | null,
+): string {
+  return interpretConstitutionalGrounding(score);
 }
 
 // ---------------------------------------------------------------------------
@@ -149,16 +154,14 @@ export function interpretTrend(
 
 interface PillarScores {
   participation: number | null;
-  rationaleQuality: number | null;
-  responsiveness: number | null;
-  independence: number | null;
+  constitutionalGrounding: number | null;
+  reasoningQuality: number | null;
 }
 
 const PILLAR_LABELS: Record<keyof PillarScores, string> = {
   participation: 'Participation',
-  rationaleQuality: 'Rationale Quality',
-  responsiveness: 'Responsiveness',
-  independence: 'Independence',
+  constitutionalGrounding: 'Constitutional Grounding',
+  reasoningQuality: 'Reasoning Quality',
 };
 
 export function interpretPillarStrengthWeakness(pillars: PillarScores): string {
@@ -192,30 +195,35 @@ export type TrendDirection = 'improving' | 'stable' | 'declining';
 export interface CCHealthData {
   activeMembers: number;
   totalMembers: number;
-  avgTransparency: number | null;
+  avgFidelity: number | null;
+  /** @deprecated Use avgFidelity */
+  avgTransparency?: number | null;
   tensionCount: number;
   trend: TrendDirection;
 }
 
 export function interpretHealthStatus(data: CCHealthData): HealthStatus {
-  const { avgTransparency, activeMembers } = data;
-  if (avgTransparency == null) return 'attention';
+  const avg = data.avgFidelity ?? data.avgTransparency ?? null;
+  const { activeMembers } = data;
+  if (avg == null) return 'attention';
   if (activeMembers === 0) return 'critical';
-  if (avgTransparency >= 65) return 'healthy';
-  if (avgTransparency >= 45) return 'attention';
+  if (avg >= 65) return 'healthy';
+  if (avg >= 45) return 'attention';
   return 'critical';
 }
 
 export function generateCCHealthNarrative(data: CCHealthData): string {
-  const { activeMembers, totalMembers, avgTransparency, tensionCount } = data;
+  const { activeMembers } = data;
+  const avg = data.avgFidelity ?? data.avgTransparency ?? null;
+  const { tensionCount } = data;
   const status = interpretHealthStatus(data);
 
   const memberStr = `${activeMembers} active committee member${activeMembers !== 1 ? 's' : ''}`;
 
   const scoreStr =
-    avgTransparency != null
-      ? `Average transparency is ${avgTransparency >= 70 ? 'strong' : avgTransparency >= 55 ? 'moderate' : 'weak'} at ${avgTransparency}/100`
-      : 'Transparency scores are not yet available';
+    avg != null
+      ? `Average fidelity is ${avg >= 70 ? 'strong' : avg >= 55 ? 'moderate' : 'weak'} at ${avg}/100`
+      : 'Fidelity scores are not yet available';
 
   if (status === 'critical')
     return `${memberStr}. ${scoreStr}. Accountability gaps need attention.`;
@@ -235,7 +243,9 @@ export function generateCCHealthNarrative(data: CCHealthData): string {
 export interface MemberVerdictInput {
   rank: number;
   total: number;
-  transparencyScore: number | null;
+  fidelityScore: number | null;
+  /** @deprecated Use fidelityScore */
+  transparencyScore?: number | null;
   trend: TrendDirection;
   strongestPillar: string | null;
   weakestPillar: string | null;
@@ -243,9 +253,10 @@ export interface MemberVerdictInput {
 }
 
 export function generateMemberVerdict(input: MemberVerdictInput): string {
-  const { rank, total, transparencyScore, trend, strongestPillar, weakestPillar } = input;
+  const { rank, total, trend, strongestPillar, weakestPillar } = input;
+  const score = input.fidelityScore ?? input.transparencyScore ?? null;
 
-  if (transparencyScore == null) return 'Transparency data not yet available.';
+  if (score == null) return 'Fidelity data not yet available.';
 
   const positionStr =
     rank <= Math.ceil(total / 3)

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -989,22 +989,23 @@ export async function getCcVotesByProposal(
 }
 
 // ============================================================================
-// CC TRANSPARENCY INDEX
+// CC CONSTITUTIONAL FIDELITY
 // ============================================================================
 
-export interface CCTransparencySnapshot {
+export interface CCFidelitySnapshot {
   epochNo: number;
-  transparencyIndex: number;
+  fidelityScore: number;
   participationScore: number;
-  rationaleQualityScore: number;
-  responsivenessScore: number;
-  independenceScore: number;
-  communityEngagementScore: number;
+  constitutionalGroundingScore: number;
+  reasoningQualityScore: number;
   votesCast: number;
   eligibleProposals: number;
 }
 
-export async function getCCTransparencyHistory(ccHotId: string): Promise<CCTransparencySnapshot[]> {
+/** @deprecated Use CCFidelitySnapshot */
+export type CCTransparencySnapshot = CCFidelitySnapshot;
+
+export async function getCCFidelityHistory(ccHotId: string): Promise<CCFidelitySnapshot[]> {
   try {
     const supabase = createClient();
     const { data, error } = await supabase
@@ -1016,12 +1017,10 @@ export async function getCCTransparencyHistory(ccHotId: string): Promise<CCTrans
     if (error || !data) return [];
     return data.map((s) => ({
       epochNo: s.epoch_no,
-      transparencyIndex: s.transparency_index ?? 0,
+      fidelityScore: s.transparency_index ?? 0,
       participationScore: s.participation_score ?? 0,
-      rationaleQualityScore: s.rationale_quality_score ?? 0,
-      responsivenessScore: s.responsiveness_score ?? 0,
-      independenceScore: s.independence_score ?? 0,
-      communityEngagementScore: s.community_engagement_score ?? 0,
+      constitutionalGroundingScore: s.independence_score ?? 0, // repurposed column
+      reasoningQualityScore: s.rationale_quality_score ?? 0,
       votesCast: s.votes_cast ?? 0,
       eligibleProposals: s.eligible_proposals ?? 0,
     }));
@@ -1030,36 +1029,38 @@ export async function getCCTransparencyHistory(ccHotId: string): Promise<CCTrans
   }
 }
 
-export interface CCMemberTransparency {
+/** @deprecated Use getCCFidelityHistory */
+export const getCCTransparencyHistory = getCCFidelityHistory;
+
+export interface CCMemberFidelity {
   ccHotId: string;
   authorName: string | null;
   status: string | null;
   expirationEpoch: number | null;
-  transparencyIndex: number | null;
-  transparencyGrade: string | null;
-  participationScore: number | null;
-  rationaleQualityScore: number | null;
-  responsivenessScore: number | null;
-  independenceScore: number | null;
-  communityEngagementScore: number | null;
   fidelityScore: number | null;
+  fidelityGrade: string | null;
+  participationScore: number | null;
+  constitutionalGroundingScore: number | null;
+  reasoningQualityScore: number | null;
   rationaleProvisionRate: number | null;
   avgArticleCoverage: number | null;
   avgReasoningQuality: number | null;
-  consistencyScore: number | null;
   votesCast: number | null;
   eligibleProposals: number | null;
 }
 
-export async function getCCMembersTransparency(): Promise<CCMemberTransparency[]> {
+/** @deprecated Use CCMemberFidelity */
+export type CCMemberTransparency = CCMemberFidelity;
+
+export async function getCCMembersFidelity(): Promise<CCMemberFidelity[]> {
   try {
     const supabase = createClient();
     const { data, error } = await supabase
       .from('cc_members')
       .select(
-        'cc_hot_id, author_name, status, expiration_epoch, transparency_index, transparency_grade, participation_score, rationale_quality_score, independence_score, community_engagement_score, responsiveness_score, fidelity_score, rationale_provision_rate, avg_article_coverage, avg_reasoning_quality, consistency_score, votes_cast, eligible_proposals',
+        'cc_hot_id, author_name, status, expiration_epoch, fidelity_score, transparency_grade, participation_score, rationale_quality_score, independence_score, rationale_provision_rate, avg_article_coverage, avg_reasoning_quality, votes_cast, eligible_proposals',
       )
-      .order('transparency_index', { ascending: false, nullsFirst: false });
+      .order('fidelity_score', { ascending: false, nullsFirst: false });
 
     if (error || !data) return [];
     return data.map((m) => ({
@@ -1067,18 +1068,14 @@ export async function getCCMembersTransparency(): Promise<CCMemberTransparency[]
       authorName: m.author_name,
       status: m.status,
       expirationEpoch: m.expiration_epoch,
-      transparencyIndex: m.transparency_index,
-      transparencyGrade: m.transparency_grade,
-      participationScore: m.participation_score,
-      rationaleQualityScore: m.rationale_quality_score,
-      responsivenessScore: m.responsiveness_score,
-      independenceScore: m.independence_score,
-      communityEngagementScore: m.community_engagement_score,
       fidelityScore: m.fidelity_score,
+      fidelityGrade: m.transparency_grade, // column rename pending migration
+      participationScore: m.participation_score,
+      constitutionalGroundingScore: m.independence_score, // repurposed column
+      reasoningQualityScore: m.rationale_quality_score,
       rationaleProvisionRate: m.rationale_provision_rate,
       avgArticleCoverage: m.avg_article_coverage,
       avgReasoningQuality: m.avg_reasoning_quality,
-      consistencyScore: m.consistency_score,
       votesCast: m.votes_cast,
       eligibleProposals: m.eligible_proposals,
     }));
@@ -1086,6 +1083,9 @@ export async function getCCMembersTransparency(): Promise<CCMemberTransparency[]
     return [];
   }
 }
+
+/** @deprecated Use getCCMembersFidelity */
+export const getCCMembersTransparency = getCCMembersFidelity;
 
 // ============================================================================
 // CC HEALTH SUMMARY & MEMBER VERDICTS
@@ -1097,7 +1097,7 @@ export interface CCHealthSummary {
   trend: 'improving' | 'stable' | 'declining';
   activeMembers: number;
   totalMembers: number;
-  avgTransparency: number | null;
+  avgFidelity: number | null;
   tensionCount: number;
 }
 
@@ -1131,11 +1131,11 @@ export async function getCCHealthSummary(): Promise<CCHealthSummary> {
     const currentEpoch = stats?.current_epoch ?? 0;
     const activeMembers = members.filter((m) => m.status === 'authorized').length;
     const totalMembers = activeMembers; // Only count active members — expired ones are historical
-    const scoredMembers = members.filter((m) => m.transparencyIndex != null);
-    const avgTransparency =
+    const scoredMembers = members.filter((m) => m.fidelityScore != null);
+    const avgFidelity =
       scoredMembers.length > 0
         ? Math.round(
-            scoredMembers.reduce((sum, m) => sum + (m.transparencyIndex ?? 0), 0) /
+            scoredMembers.reduce((sum, m) => sum + (m.fidelityScore ?? 0), 0) /
               scoredMembers.length,
           )
         : null;
@@ -1186,17 +1186,17 @@ export async function getCCHealthSummary(): Promise<CCHealthSummary> {
         const oldAvg = Math.round(
           oldSnapshots.reduce((s, r) => s + (r.transparency_index ?? 0), 0) / oldSnapshots.length,
         );
-        const delta = (avgTransparency ?? 0) - oldAvg;
+        const delta = (avgFidelity ?? 0) - oldAvg;
         if (delta > 2) trend = 'improving';
         else if (delta < -2) trend = 'declining';
       }
     }
 
-    const healthData = { activeMembers, totalMembers, avgTransparency, tensionCount, trend };
+    const healthData = { activeMembers, totalMembers, avgFidelity, tensionCount, trend };
     const status = interpretHealthStatus(healthData);
     const narrative = generateCCHealthNarrative(healthData);
 
-    return { status, narrative, trend, activeMembers, totalMembers, avgTransparency, tensionCount };
+    return { status, narrative, trend, activeMembers, totalMembers, avgFidelity, tensionCount };
   } catch {
     return {
       status: 'attention',
@@ -1204,7 +1204,7 @@ export async function getCCHealthSummary(): Promise<CCHealthSummary> {
       trend: 'stable',
       activeMembers: 0,
       totalMembers: 0,
-      avgTransparency: null,
+      avgFidelity: null,
       tensionCount: 0,
     };
   }
@@ -1234,9 +1234,8 @@ export async function getCCMemberVerdicts(): Promise<CCMemberVerdict[]> {
 
     const PILLAR_LABELS: Record<string, string> = {
       participation: 'Participation',
-      rationaleQuality: 'Rationale Quality',
-      responsiveness: 'Responsiveness',
-      independence: 'Independence',
+      constitutionalGrounding: 'Constitutional Grounding',
+      reasoningQuality: 'Reasoning Quality',
     };
 
     return members.map((m, i) => {
@@ -1246,9 +1245,8 @@ export async function getCCMemberVerdicts(): Promise<CCMemberVerdict[]> {
       // Find strongest/weakest pillar
       const pillars: [string, number | null][] = [
         ['participation', m.participationScore],
-        ['rationaleQuality', m.rationaleQualityScore],
-        ['responsiveness', m.responsivenessScore],
-        ['independence', m.independenceScore],
+        ['constitutionalGrounding', m.constitutionalGroundingScore],
+        ['reasoningQuality', m.reasoningQualityScore],
       ];
       const validPillars = pillars.filter(([, v]) => v != null) as [string, number][];
       const sorted = [...validPillars].sort((a, b) => b[1] - a[1]);
@@ -1271,7 +1269,7 @@ export async function getCCMemberVerdicts(): Promise<CCMemberVerdict[]> {
       const narrative = generateMemberVerdict({
         rank,
         total,
-        transparencyScore: m.transparencyIndex,
+        fidelityScore: m.fidelityScore,
         trend,
         strongestPillar: strongest,
         weakestPillar: weakest,

--- a/lib/ghi/calibration.ts
+++ b/lib/ghi/calibration.ts
@@ -1,44 +1,12 @@
 /**
- * Component calibration curves — map raw metric values to 0-100 scores
- * using piecewise linear interpolation with floor/target/ceiling thresholds.
- *
- * This prevents raw percentages from being misleading (e.g., 40% participation
- * isn't "40 out of 100" — it might actually be healthy for governance).
+ * GHI calibration — re-exports the shared calibration function and GHI-specific curves
+ * from the centralized scoring configuration.
  */
 
-export interface CalibrationCurve {
-  floor: number;
-  targetLow: number;
-  targetHigh: number;
-  ceiling: number;
-}
-
-/**
- * Piecewise linear calibration.
- *
- * Below floor    → 0-20  (critical)
- * Floor-targetLow  → 20-50 (fair)
- * TargetLow-targetHigh → 50-80 (good)
- * TargetHigh-ceiling  → 80-95 (strong)
- * Above ceiling   → cap at 95
- */
-export function calibrate(raw: number, curve: CalibrationCurve): number {
-  if (raw <= curve.floor) {
-    return curve.floor === 0 ? 0 : Math.max(0, (raw / curve.floor) * 20);
-  }
-  if (raw <= curve.targetLow) {
-    return 20 + ((raw - curve.floor) / (curve.targetLow - curve.floor)) * 30;
-  }
-  if (raw <= curve.targetHigh) {
-    return 50 + ((raw - curve.targetLow) / (curve.targetHigh - curve.targetLow)) * 30;
-  }
-  if (raw <= curve.ceiling) {
-    return 80 + ((raw - curve.targetHigh) / (curve.ceiling - curve.targetHigh)) * 15;
-  }
-  return 95;
-}
+// Re-export the calibrate function and curve type from centralized config
+export { calibrate, type CalibrationCurve } from '@/lib/scoring/calibration';
 
 import { GHI_CALIBRATION } from '@/lib/scoring/calibration';
 
-// Re-export from centralized calibration config
+// Re-export GHI calibration curves
 export const CALIBRATION = GHI_CALIBRATION;

--- a/lib/ghi/components.ts
+++ b/lib/ghi/components.ts
@@ -1,9 +1,9 @@
 /**
  * GHI v2 Component Computations
  *
- * 6 components across 3 categories:
- *   Engagement (35%): DRep Participation (20%), Citizen Engagement (15%)
- *   Quality (40%):    Deliberation Quality (20%), Governance Effectiveness (20%)
+ * 8 components across 3 categories:
+ *   Engagement (35%): DRep Participation (15%), SPO Participation (10%), Citizen Engagement (10%)
+ *   Quality (40%):    Deliberation Quality (15%), Governance Effectiveness (15%), CC Constitutional Fidelity (10%)
  *   Resilience (25%): Power Distribution (15%), System Stability (10%)
  *
  * Each function returns a raw 0-100 score. Calibration is applied externally.
@@ -407,7 +407,94 @@ export async function computePowerDistribution({
 }
 
 // ---------------------------------------------------------------------------
-// 2F. System Stability (10%)
+// 2F. SPO Participation (10%)
+// ---------------------------------------------------------------------------
+
+export async function computeSPOParticipation({
+  supabase,
+}: ComponentInput): Promise<ComponentScore> {
+  // Get SPO governance votes and total eligible proposals
+  const { data: spoVotes } = await supabase
+    .from('spo_votes')
+    .select('pool_id, proposal_tx_hash, proposal_index');
+
+  const { data: proposals } = await supabase.from('proposals').select('tx_hash, proposal_index');
+
+  if (!proposals?.length) return { raw: 0 };
+
+  const totalProposals = new Set(proposals.map((p) => `${p.tx_hash}:${p.proposal_index}`)).size;
+
+  if (!spoVotes?.length) return { raw: 0, detail: { activeSpos: 0, medianParticipation: 0 } };
+
+  // Group by SPO and compute participation rate per pool
+  const poolVotes = new Map<string, Set<string>>();
+  for (const v of spoVotes) {
+    const set = poolVotes.get(v.pool_id) ?? new Set();
+    set.add(`${v.proposal_tx_hash}:${v.proposal_index}`);
+    poolVotes.set(v.pool_id, set);
+  }
+
+  const rates = Array.from(poolVotes.values())
+    .map((voted) => (voted.size / totalProposals) * 100)
+    .sort((a, b) => a - b);
+
+  const mid = Math.floor(rates.length / 2);
+  const medianParticipation =
+    rates.length % 2 === 0 ? (rates[mid - 1] + rates[mid]) / 2 : rates[mid];
+
+  return {
+    raw: Math.min(100, Math.max(0, Math.round(medianParticipation))),
+    detail: {
+      activeSpos: poolVotes.size,
+      medianParticipation: Math.round(medianParticipation),
+      totalProposals,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2G. CC Constitutional Fidelity (10%)
+// ---------------------------------------------------------------------------
+
+export async function computeCCConstitutionalFidelity({
+  supabase,
+}: ComponentInput): Promise<ComponentScore> {
+  // Read pre-computed fidelity scores from cc_members
+  const { data: members } = await supabase
+    .from('cc_members')
+    .select('cc_hot_id, fidelity_score, status')
+    .not('fidelity_score', 'is', null);
+
+  if (!members?.length) return { raw: 0 };
+
+  // Only score active members
+  const active = members.filter((m) => m.status === 'active' || m.status === 'Active');
+  const scored = active.length > 0 ? active : members;
+
+  const scores = scored
+    .map((m) => (m.fidelity_score as number) ?? 0)
+    .filter((s) => s > 0)
+    .sort((a, b) => a - b);
+
+  if (scores.length === 0) return { raw: 0, detail: { activeCcMembers: scored.length } };
+
+  // Median fidelity score across CC members
+  const mid = Math.floor(scores.length / 2);
+  const medianFidelity =
+    scores.length % 2 === 0 ? (scores[mid - 1] + scores[mid]) / 2 : scores[mid];
+
+  return {
+    raw: Math.min(100, Math.max(0, Math.round(medianFidelity))),
+    detail: {
+      activeCcMembers: scored.length,
+      medianFidelity: Math.round(medianFidelity),
+      scoredCount: scores.length,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2H. System Stability (10%)
 // ---------------------------------------------------------------------------
 
 export async function computeSystemStability({

--- a/lib/ghi/index.ts
+++ b/lib/ghi/index.ts
@@ -1,5 +1,5 @@
 /**
- * GHI v2 Orchestrator — computes the Governance Health Index from 6 components.
+ * GHI v2 Orchestrator — computes the Governance Health Index from 8 components.
  *
  * Replaces the old lib/ghi.ts computeGHI(). Re-exports types/constants for
  * backward compatibility so no consumer changes are needed.
@@ -10,9 +10,11 @@ import { getFeatureFlag } from '@/lib/featureFlags';
 import { calibrate, CALIBRATION } from './calibration';
 import {
   computeDRepParticipation,
+  computeSPOParticipation,
   computeCitizenEngagement,
   computeDeliberationQuality,
   computeGovernanceEffectiveness,
+  computeCCConstitutionalFidelity,
   computePowerDistribution,
   computeSystemStability,
   type ComponentInput,
@@ -42,7 +44,7 @@ const BASE_WEIGHTS = GHI_COMPONENT_WEIGHTS;
 type ComponentName = keyof typeof BASE_WEIGHTS;
 
 /**
- * When Citizen Engagement is off, redistribute its 15% proportionally.
+ * When Citizen Engagement is off, redistribute its 10% proportionally.
  */
 function getWeights(citizenEngagementEnabled: boolean): Record<ComponentName, number> {
   if (citizenEngagementEnabled) {
@@ -89,10 +91,20 @@ export async function computeGHI(): Promise<GHIComputeResult> {
   const weights = getWeights(citizenEngagementEnabled);
 
   // Compute all components in parallel
-  const [participation, deliberation, effectiveness, power, stability] = await Promise.all([
+  const [
+    participation,
+    spoParticipation,
+    deliberation,
+    effectiveness,
+    ccFidelity,
+    power,
+    stability,
+  ] = await Promise.all([
     computeDRepParticipation(input),
+    computeSPOParticipation(input),
     computeDeliberationQuality(input),
     computeGovernanceEffectiveness(input),
+    computeCCConstitutionalFidelity(input),
     computePowerDistribution(input),
     computeSystemStability(input),
   ]);
@@ -105,11 +117,13 @@ export async function computeGHI(): Promise<GHIComputeResult> {
   // Apply calibration curves
   const calibrated = {
     'DRep Participation': calibrate(participation.raw, CALIBRATION.drepParticipation),
+    'SPO Participation': calibrate(spoParticipation.raw, CALIBRATION.spoParticipation),
     'Citizen Engagement': citizenEngagementEnabled
       ? calibrate(engagement.raw, CALIBRATION.citizenEngagement)
       : 0,
     'Deliberation Quality': calibrate(deliberation.raw, CALIBRATION.deliberationQuality),
     'Governance Effectiveness': calibrate(effectiveness.raw, CALIBRATION.governanceEffectiveness),
+    'CC Constitutional Fidelity': calibrate(ccFidelity.raw, CALIBRATION.ccConstitutionalFidelity),
     'Power Distribution': calibrate(power.raw, CALIBRATION.powerDistribution),
     'System Stability': calibrate(stability.raw, CALIBRATION.systemStability),
   };

--- a/lib/scoring/calibration.ts
+++ b/lib/scoring/calibration.ts
@@ -129,12 +129,13 @@ export const IMPORTANCE_WEIGHTS = {
 
 /**
  * Reliability sub-component weights (must sum to 1.0).
+ * V3.1: Responsiveness (timeliness) removed — voting within the window is sufficient.
+ * Weights redistributed: Streak 35%, Recency 30%, Gap 25%, Tenure 10%.
  */
 export const RELIABILITY_WEIGHTS = {
-  streak: 0.3,
-  recency: 0.25,
-  gap: 0.2,
-  responsiveness: 0.15,
+  streak: 0.35,
+  recency: 0.3,
+  gap: 0.25,
   tenure: 0.1,
 } as const;
 
@@ -148,8 +149,6 @@ export const RELIABILITY_PARAMS = {
   recencyDecayDivisor: 5,
   /** Gap penalty: points lost per epoch gap. */
   gapPenaltyPerEpoch: 12,
-  /** Responsiveness: score = 100 * exp(-medianDays / divisor). */
-  responsivenessDivisor: 14,
   /** Tenure asymptote: 20-point floor, 80-point growth. */
   tenureFloor: 20,
   tenureGrowth: 80,
@@ -341,6 +340,117 @@ export const TIER_BOUNDARIES = [
 ] as const;
 
 // ---------------------------------------------------------------------------
+// DRep & SPO Pillar Calibration Curves (Absolute Scoring)
+// ---------------------------------------------------------------------------
+
+/**
+ * Absolute calibration curves for DRep pillar scores.
+ * Replaces percentile normalization: raw score → calibrated score via
+ * piecewise linear mapping. Your actions = your score, independent of
+ * how other DReps perform. Uses the same CalibrationCurve shape as GHI.
+ *
+ * This enables measuring growth in average DRep scores over time as a
+ * measure of Governada's impact on Cardano governance health.
+ */
+export const DREP_PILLAR_CALIBRATION = {
+  engagementQuality: {
+    floor: 5,
+    targetLow: 25,
+    targetHigh: 60,
+    ceiling: 85,
+  },
+  effectiveParticipation: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 65,
+    ceiling: 90,
+  },
+  reliability: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 65,
+    ceiling: 85,
+  },
+  governanceIdentity: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 60,
+    ceiling: 80,
+  },
+} as const;
+
+/**
+ * Absolute calibration curves for SPO pillar scores.
+ */
+export const SPO_PILLAR_CALIBRATION = {
+  participation: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 65,
+    ceiling: 90,
+  },
+  deliberation: {
+    floor: 5,
+    targetLow: 20,
+    targetHigh: 55,
+    ceiling: 80,
+  },
+  reliability: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 65,
+    ceiling: 85,
+  },
+  governanceIdentity: {
+    floor: 10,
+    targetLow: 30,
+    targetHigh: 60,
+    ceiling: 80,
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// DRep Community Presence — Absolute Delegator Tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Absolute delegator count tiers for Community Presence scoring.
+ * Replaces percentile-based delegator ranking (zero-sum) with absolute
+ * thresholds (every DRep can reach 100 by growing their community).
+ * Tiers are evaluated highest-first; first match wins.
+ */
+export const DELEGATOR_TIERS = [
+  { min: 250, score: 100 },
+  { min: 100, score: 95 },
+  { min: 50, score: 80 },
+  { min: 15, score: 60 },
+  { min: 5, score: 40 },
+  { min: 1, score: 20 },
+  { min: 0, score: 0 },
+] as const;
+
+// ---------------------------------------------------------------------------
+// CC Constitutional Fidelity Score
+// ---------------------------------------------------------------------------
+
+/**
+ * CC Constitutional Fidelity pillar weights (must sum to 1.0).
+ * Replaces the 5-pillar Transparency Index with a simpler 3-pillar model:
+ *   1. Participation (30%)    — Do they vote?
+ *   2. Constitutional Grounding (40%) — Do they cite relevant articles?
+ *   3. Reasoning Quality (30%) — How thorough is their reasoning?
+ *
+ * Removed: Responsiveness (timeliness), Independence, Community Engagement.
+ * Philosophy: "Do they vote in line with the constitution? In ambiguous cases,
+ * do they justify their votes enough to back it up?"
+ */
+export const CC_FIDELITY_WEIGHTS = {
+  participation: 0.3,
+  constitutionalGrounding: 0.4,
+  reasoningQuality: 0.3,
+} as const;
+
+// ---------------------------------------------------------------------------
 // GHI Calibration Curves
 // ---------------------------------------------------------------------------
 
@@ -361,6 +471,12 @@ export const GHI_CALIBRATION = {
     targetHigh: 70,
     ceiling: 90,
   },
+  spoParticipation: {
+    floor: 10,
+    targetLow: 25,
+    targetHigh: 55,
+    ceiling: 80,
+  },
   citizenEngagement: {
     floor: 10,
     targetLow: 30,
@@ -378,6 +494,12 @@ export const GHI_CALIBRATION = {
     targetLow: 40,
     targetHigh: 70,
     ceiling: 90,
+  },
+  ccConstitutionalFidelity: {
+    floor: 15,
+    targetLow: 35,
+    targetHigh: 65,
+    ceiling: 85,
   },
   powerDistribution: {
     floor: 15,
@@ -400,15 +522,17 @@ export const GHI_CALIBRATION = {
 /**
  * GHI component weights (must sum to 1.0).
  *
- * Engagement (35%): DRep Participation (20%) + Citizen Engagement (15%)
- * Quality (40%): Deliberation Quality (20%) + Governance Effectiveness (20%)
+ * Engagement (35%): DRep Participation (15%) + SPO Participation (10%) + Citizen Engagement (10%)
+ * Quality (40%): Deliberation Quality (15%) + Governance Effectiveness (15%) + CC Constitutional Fidelity (10%)
  * Resilience (25%): Power Distribution (15%) + System Stability (10%)
  */
 export const GHI_COMPONENT_WEIGHTS = {
-  'DRep Participation': 0.2,
-  'Citizen Engagement': 0.15,
-  'Deliberation Quality': 0.2,
-  'Governance Effectiveness': 0.2,
+  'DRep Participation': 0.15,
+  'SPO Participation': 0.1,
+  'Citizen Engagement': 0.1,
+  'Deliberation Quality': 0.15,
+  'Governance Effectiveness': 0.15,
+  'CC Constitutional Fidelity': 0.1,
   'Power Distribution': 0.15,
   'System Stability': 0.1,
 } as const;
@@ -465,6 +589,46 @@ export const DRIFT_THRESHOLDS = {
   moderate: 30,
   // Above moderate = high
 } as const;
+
+// ---------------------------------------------------------------------------
+// Piecewise Linear Calibration Function
+// ---------------------------------------------------------------------------
+
+/**
+ * Calibration curve shape for piecewise linear mapping.
+ */
+export interface CalibrationCurve {
+  floor: number;
+  targetLow: number;
+  targetHigh: number;
+  ceiling: number;
+}
+
+/**
+ * Piecewise linear calibration: maps a raw 0-100 score to a calibrated 0-95 score.
+ * Used by both GHI components and individual pillar scoring (DRep/SPO).
+ *
+ * Below floor    → 0-20  (critical)
+ * Floor→targetLow  → 20-50 (fair)
+ * TargetLow→targetHigh → 50-80 (good)
+ * TargetHigh→ceiling  → 80-95 (strong)
+ * Above ceiling   → cap at 95
+ */
+export function calibrate(raw: number, curve: CalibrationCurve): number {
+  if (raw <= curve.floor) {
+    return curve.floor === 0 ? 0 : Math.max(0, (raw / curve.floor) * 20);
+  }
+  if (raw <= curve.targetLow) {
+    return 20 + ((raw - curve.floor) / (curve.targetLow - curve.floor)) * 30;
+  }
+  if (raw <= curve.targetHigh) {
+    return 50 + ((raw - curve.targetLow) / (curve.targetHigh - curve.targetLow)) * 30;
+  }
+  if (raw <= curve.ceiling) {
+    return 80 + ((raw - curve.targetHigh) / (curve.ceiling - curve.targetHigh)) * 15;
+  }
+  return 95;
+}
 
 // ---------------------------------------------------------------------------
 // PCA Configuration

--- a/lib/scoring/ccTransparency.ts
+++ b/lib/scoring/ccTransparency.ts
@@ -1,89 +1,68 @@
 /**
- * CC Transparency Index — 5-pillar accountability score for Constitutional Committee members.
+ * CC Constitutional Fidelity Score — 3-pillar accountability score for Constitutional Committee members.
  *
- * Aligned with the CC Member persona doc specification:
- *   1. Participation (35%)    — Vote rate on governance actions
- *   2. Rationale Quality (30%) — Provision rate + article coverage + reasoning depth
- *   3. Responsiveness (15%)   — Time from proposal to CC vote
- *   4. Independence (10%)     — Independent judgment vs CC-bloc groupthink
- *   5. Community Engagement (10%) — Citizen endorsements + question responses
+ * Simplified from the 5-pillar Transparency Index to focus on what matters:
+ *   1. Participation (30%)            — Do they vote?
+ *   2. Constitutional Grounding (40%) — Do they cite relevant constitutional articles?
+ *   3. Reasoning Quality (30%)        — How thorough is their reasoning?
  *
- * Design: measures process, not outcomes. A CC member who votes against
- * community sentiment but provides thorough constitutional reasoning scores well.
+ * Removed: Responsiveness (timeliness — voting within the window is sufficient),
+ * Independence (hard to measure fairly), Community Engagement (no data sources yet).
+ *
+ * Philosophy: "Do they vote in line with the constitution? In ambiguous cases,
+ * do they justify their votes enough to back it up?"
  */
 
 import {
   computeRationaleProvision,
   computeAvgArticleCoverage,
   computeAvgReasoningQuality,
-  computeResponsivenessScore,
-  computeIndependenceScore as computeDRepAlignmentIndependence,
 } from '@/lib/cc/fidelityScore';
+import { CC_FIDELITY_WEIGHTS } from './calibration';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export interface TransparencyPillars {
+export interface ConstitutionalFidelityPillars {
   participation: number; // 0-100
-  rationaleQuality: number; // 0-100
-  responsiveness: number; // 0-100
-  independence: number; // 0-100
-  communityEngagement: number; // 0-100
+  constitutionalGrounding: number; // 0-100
+  reasoningQuality: number; // 0-100
 }
 
-export interface TransparencyResult {
-  index: number; // 0-100 composite
-  pillars: TransparencyPillars;
+export interface ConstitutionalFidelityResult {
+  score: number; // 0-100 composite
+  pillars: ConstitutionalFidelityPillars;
   grade: 'A' | 'B' | 'C' | 'D' | 'F';
 }
-
-// ---------------------------------------------------------------------------
-// Weights — per persona doc spec
-// ---------------------------------------------------------------------------
-
-// Weights — redistributed after removing Community Engagement (Pillar 5).
-// Pillar 5 data sources (questionsAnswered, endorsementCount) don't exist yet,
-// so the pillar was contributing 0 to every member's score, artificially deflating
-// all transparency indices by up to 10 points. Weights below redistribute the
-// original 10% proportionally across the 4 active pillars.
-// When engagement data becomes available, re-enable with its own weight slice.
-const WEIGHTS = {
-  participation: 0.39,
-  rationaleQuality: 0.33,
-  responsiveness: 0.17,
-  independence: 0.11,
-  communityEngagement: 0,
-};
 
 // ---------------------------------------------------------------------------
 // Composite
 // ---------------------------------------------------------------------------
 
-export function computeTransparencyIndex(pillars: TransparencyPillars): TransparencyResult {
-  const index = Math.round(
-    pillars.participation * WEIGHTS.participation +
-      pillars.rationaleQuality * WEIGHTS.rationaleQuality +
-      pillars.responsiveness * WEIGHTS.responsiveness +
-      pillars.independence * WEIGHTS.independence +
-      pillars.communityEngagement * WEIGHTS.communityEngagement,
+export function computeConstitutionalFidelity(
+  pillars: ConstitutionalFidelityPillars,
+): ConstitutionalFidelityResult {
+  const score = Math.round(
+    pillars.participation * CC_FIDELITY_WEIGHTS.participation +
+      pillars.constitutionalGrounding * CC_FIDELITY_WEIGHTS.constitutionalGrounding +
+      pillars.reasoningQuality * CC_FIDELITY_WEIGHTS.reasoningQuality,
   );
 
-  return { index, pillars, grade: indexToGrade(index) };
+  return { score, pillars, grade: scoreToGrade(score) };
 }
 
-function indexToGrade(index: number): TransparencyResult['grade'] {
-  if (index >= 85) return 'A';
-  if (index >= 70) return 'B';
-  if (index >= 55) return 'C';
-  if (index >= 40) return 'D';
+function scoreToGrade(score: number): ConstitutionalFidelityResult['grade'] {
+  if (score >= 85) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 55) return 'C';
+  if (score >= 40) return 'D';
   return 'F';
 }
 
 // ---------------------------------------------------------------------------
 // Pillar 1: Participation (0-100)
 // What % of eligible governance actions did they vote on?
-// Non-participation is the most basic accountability failure.
 // ---------------------------------------------------------------------------
 
 export function computeParticipationScore(votesCast: number, eligibleProposals: number): number {
@@ -92,97 +71,48 @@ export function computeParticipationScore(votesCast: number, eligibleProposals: 
 }
 
 // ---------------------------------------------------------------------------
-// Pillar 2: Rationale Quality (0-100)
-// Composite of: provision rate, article coverage, reasoning depth.
-// Uses existing fidelity sub-components.
+// Pillar 2: Constitutional Grounding (0-100)
+// How well do they cite relevant constitutional articles?
+// Combines rationale provision rate with article coverage.
 // ---------------------------------------------------------------------------
 
-export function computeRationaleQualityScore(
+export function computeConstitutionalGroundingScore(
+  totalVotes: number,
+  votesWithRationale: number,
+  votesWithArticleData: Array<{ proposalType: string; citedArticles: string[] }>,
+): number {
+  // Provision rate gates the score — no rationale means no grounding possible
+  const provision = computeRationaleProvision(totalVotes, votesWithRationale); // 0-100
+  const coverage = computeAvgArticleCoverage(votesWithArticleData); // 0-100
+
+  // Weight: provision 35% (did they even provide rationale?), coverage 65% (did they cite correctly?)
+  return Math.round(provision * 0.35 + coverage * 0.65);
+}
+
+// ---------------------------------------------------------------------------
+// Pillar 3: Reasoning Quality (0-100)
+// AI-assessed depth of constitutional reasoning.
+// Falls back to a blend of provision + coverage when no AI scores available.
+// ---------------------------------------------------------------------------
+
+export function computeReasoningQualityScore(
   totalVotes: number,
   votesWithRationale: number,
   votesWithArticleData: Array<{ proposalType: string; citedArticles: string[] }>,
   reasoningScores: number[],
 ): number {
-  // Sub-scores with internal weights
-  const provision = computeRationaleProvision(totalVotes, votesWithRationale); // 0-100
-  const coverage = computeAvgArticleCoverage(votesWithArticleData); // 0-100
-  const reasoning =
-    reasoningScores.length > 0
-      ? computeAvgReasoningQuality(reasoningScores)
-      : votesWithRationale > 0
-        ? Math.round(coverage * 0.7 + provision * 0.3)
-        : 0;
-
-  // Weight: provision 30%, coverage 35%, reasoning 35%
-  return Math.round(provision * 0.3 + coverage * 0.35 + reasoning * 0.35);
-}
-
-// ---------------------------------------------------------------------------
-// Pillar 3: Responsiveness (0-100)
-// Uses computeResponsivenessScore from fidelityScore.ts.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// Pillar 4: Independence (0-100)
-// Measures independent judgment vs CC-bloc groupthink.
-// Two sub-components:
-//   - CC-bloc independence (60%): How often do they diverge from unanimous CC votes?
-//     Some disagreement is healthy; perfect unanimity suggests groupthink.
-//   - DRep alignment independence (40%): Bell curve peaking at moderate alignment.
-// ---------------------------------------------------------------------------
-
-/**
- * CC-bloc independence: measures how often a member diverges from the CC majority.
- * Perfect unanimity on every vote = low score. Moderate independent votes = high score.
- * @param totalCcVotes Total proposals where the CC voted
- * @param memberDissentCount Proposals where this member voted differently from CC majority
- */
-export function computeBlocIndependenceScore(
-  totalCcVotes: number,
-  memberDissentCount: number,
-): number {
-  if (totalCcVotes === 0) return 50; // neutral default
-  const dissentRate = (memberDissentCount / totalCcVotes) * 100;
-
-  // Ideal dissent range: 5-25% (healthy independent judgment)
-  if (dissentRate >= 5 && dissentRate <= 25) return 100;
-  if (dissentRate < 5) {
-    // Too little dissent — groupthink signal
-    return Math.round(50 + dissentRate * 10); // 0%->50, 5%->100
+  if (reasoningScores.length > 0) {
+    return computeAvgReasoningQuality(reasoningScores);
   }
-  // More than 25% dissent — still scores well but tapers
-  return Math.max(40, Math.round(100 - (dissentRate - 25) * 2));
-}
 
-/**
- * Combined independence score.
- */
-export function computeIndependenceScoreCombined(
-  totalCcVotes: number,
-  memberDissentCount: number,
-  drepAlignmentPct: number,
-): number {
-  const bloc = computeBlocIndependenceScore(totalCcVotes, memberDissentCount);
-  const drepIndep = computeDRepAlignmentIndependence(drepAlignmentPct);
-  return Math.round(bloc * 0.6 + drepIndep * 0.4);
-}
+  // Fallback when AI scores aren't available yet
+  if (votesWithRationale > 0) {
+    const provision = computeRationaleProvision(totalVotes, votesWithRationale);
+    const coverage = computeAvgArticleCoverage(votesWithArticleData);
+    return Math.round(coverage * 0.7 + provision * 0.3);
+  }
 
-// ---------------------------------------------------------------------------
-// Pillar 5: Community Engagement (0-100)
-// Citizen questions answered, endorsement count, explanations beyond rationales.
-// When engagement data doesn't exist yet, returns 0.
-// ---------------------------------------------------------------------------
-
-export function computeCommunityEngagementScore(
-  questionsAnswered: number,
-  endorsementCount: number,
-): number {
-  // Score based on available engagement signals
-  // Each question answered = 15 points (max 60)
-  const questionScore = Math.min(60, questionsAnswered * 15);
-  // Each endorsement = 5 points (max 40)
-  const endorsementScore = Math.min(40, endorsementCount * 5);
-  return Math.min(100, questionScore + endorsementScore);
+  return 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,25 +132,23 @@ export interface CCMemberScoringInput {
   votes: CCMemberVoteData[];
   proposalMap: Map<string, { type: string; blockTime: number }>;
   rationaleMap: Map<string, { citedArticles: string[]; reasoningScore: number | null }>;
-  drepMajorityMap: Map<string, string>;
-  ccMajorityMap: Map<string, string>;
   totalEligibleProposals: number;
-  questionsAnswered: number;
-  endorsementCount: number;
 }
 
-export function computeFullTransparencyIndex(input: CCMemberScoringInput): TransparencyResult & {
+export function computeFullConstitutionalFidelity(
+  input: CCMemberScoringInput,
+): ConstitutionalFidelityResult & {
   votesCast: number;
   eligibleProposals: number;
 } {
-  const { votes, proposalMap, rationaleMap, drepMajorityMap, ccMajorityMap } = input;
+  const { votes, rationaleMap } = input;
   const totalVotes = votes.length;
   const votesWithRationale = votes.filter((v) => v.hasRationale).length;
 
   // Pillar 1: Participation
   const participation = computeParticipationScore(totalVotes, input.totalEligibleProposals);
 
-  // Pillar 2: Rationale Quality
+  // Build article data for Pillars 2 & 3
   const votesWithArticleData: Array<{ proposalType: string; citedArticles: string[] }> = [];
   const qualityScores: number[] = [];
   for (const v of votes) {
@@ -228,7 +156,7 @@ export function computeFullTransparencyIndex(input: CCMemberScoringInput): Trans
     const rationale = rationaleMap.get(rKey);
     if (rationale) {
       const pKey = `${v.proposalTxHash}:${v.proposalIndex}`;
-      const proposal = proposalMap.get(pKey);
+      const proposal = input.proposalMap.get(pKey);
       votesWithArticleData.push({
         proposalType: proposal?.type ?? 'InfoAction',
         citedArticles: rationale.citedArticles,
@@ -238,73 +166,26 @@ export function computeFullTransparencyIndex(input: CCMemberScoringInput): Trans
       }
     }
   }
-  const rationaleQuality = computeRationaleQualityScore(
+
+  // Pillar 2: Constitutional Grounding
+  const constitutionalGrounding = computeConstitutionalGroundingScore(
+    totalVotes,
+    votesWithRationale,
+    votesWithArticleData,
+  );
+
+  // Pillar 3: Reasoning Quality
+  const reasoningQuality = computeReasoningQualityScore(
     totalVotes,
     votesWithRationale,
     votesWithArticleData,
     qualityScores,
   );
 
-  // Pillar 3: Responsiveness
-  let totalDaysToVote = 0;
-  let responsiveVotes = 0;
-  for (const v of votes) {
-    const pKey = `${v.proposalTxHash}:${v.proposalIndex}`;
-    const proposal = proposalMap.get(pKey);
-    if (proposal) {
-      const daysToVote = (v.blockTime - proposal.blockTime) / 86400;
-      if (daysToVote >= 0) {
-        totalDaysToVote += daysToVote;
-        responsiveVotes++;
-      }
-    }
-  }
-  const avgDaysToVote = responsiveVotes > 0 ? totalDaysToVote / responsiveVotes : 10;
-  const responsiveness = computeResponsivenessScore(avgDaysToVote);
-
-  // Pillar 4: Independence
-  let drepAgreements = 0;
-  let drepComparisons = 0;
-  let memberDissentCount = 0;
-  let ccComparisons = 0;
-
-  for (const v of votes) {
-    const pKey = `${v.proposalTxHash}:${v.proposalIndex}`;
-
-    // DRep alignment
-    const drepMajority = drepMajorityMap.get(pKey);
-    if (drepMajority && drepMajority !== 'Abstain') {
-      drepComparisons++;
-      if (v.vote === drepMajority) drepAgreements++;
-    }
-
-    // CC-bloc dissent
-    const ccMajority = ccMajorityMap.get(pKey);
-    if (ccMajority) {
-      ccComparisons++;
-      if (v.vote !== ccMajority) memberDissentCount++;
-    }
-  }
-
-  const drepAlignmentPct = drepComparisons > 0 ? (drepAgreements / drepComparisons) * 100 : 50;
-  const independence = computeIndependenceScoreCombined(
-    ccComparisons,
-    memberDissentCount,
-    drepAlignmentPct,
-  );
-
-  // Pillar 5: Community Engagement
-  const communityEngagement = computeCommunityEngagementScore(
-    input.questionsAnswered,
-    input.endorsementCount,
-  );
-
-  const result = computeTransparencyIndex({
+  const result = computeConstitutionalFidelity({
     participation,
-    rationaleQuality,
-    responsiveness,
-    independence,
-    communityEngagement,
+    constitutionalGrounding,
+    reasoningQuality,
   });
 
   return {

--- a/lib/scoring/drepScore.ts
+++ b/lib/scoring/drepScore.ts
@@ -1,19 +1,22 @@
 /**
- * DRep Score V3 — Composite calculator + momentum + confidence.
- * Combines 4 percentile-normalized pillars with configurable weights.
- * Confidence-weighted percentile normalization prevents low-data DReps
- * from inflating rankings. Percentile dampening pulls low-confidence
- * scores toward the median.
+ * DRep Score V3.1 — Composite calculator + momentum + confidence.
+ * Combines 4 absolute-calibrated pillars with configurable weights.
+ * Replaces percentile normalization: raw score → calibrated score via
+ * piecewise linear curves. Your actions = your score, independent of
+ * how other DReps perform.
+ *
+ * Confidence dampening still applies to calibrated scores for low-data DReps.
  * Momentum is computed from score history via simple linear regression.
  */
 
 import { PILLAR_WEIGHTS, type DRepScoreResult } from './types';
-import { percentileNormalizeWeighted, dampenPercentile } from './confidence';
+import { dampenPercentile } from './confidence';
+import { calibrate, DREP_PILLAR_CALIBRATION } from './calibration';
 
 /**
  * Compute final DRep Scores for all DReps from raw pillar scores.
- * Percentile-normalizes each pillar (confidence-weighted), applies
- * confidence dampening, computes weighted composite, and momentum.
+ * Calibrates each pillar via absolute curves, applies confidence dampening,
+ * computes weighted composite, and momentum.
  *
  * @param rawEngagement Map<drepId, raw 0-100>
  * @param rawParticipation Map<drepId, raw 0-100>
@@ -30,9 +33,6 @@ export function computeDRepScores(
   scoreHistory: Map<string, { date: string; score: number }[]>,
   confidences?: Map<string, number>,
 ): Map<string, DRepScoreResult> {
-  // Use confidence-weighted percentile normalization when confidences provided,
-  // otherwise fall back to equal-weight (all confidence = 100)
-  const defaultConfidences = new Map<string, number>();
   const allDrepIds = new Set<string>([
     ...rawEngagement.keys(),
     ...rawParticipation.keys(),
@@ -40,49 +40,46 @@ export function computeDRepScores(
     ...rawIdentity.keys(),
   ]);
 
-  // Build default confidences if not provided
-  const effectiveConfidences = confidences ?? defaultConfidences;
-  if (!confidences) {
-    for (const id of allDrepIds) {
-      defaultConfidences.set(id, 100);
-    }
-  }
-
-  // Confidence-weighted percentile normalization for each pillar
-  const pctEngagement = percentileNormalizeWeighted(rawEngagement, effectiveConfidences);
-  const pctParticipation = percentileNormalizeWeighted(rawParticipation, effectiveConfidences);
-  const pctReliability = percentileNormalizeWeighted(rawReliability, effectiveConfidences);
-  const pctIdentity = percentileNormalizeWeighted(rawIdentity, effectiveConfidences);
-
   const results = new Map<string, DRepScoreResult>();
 
   for (const drepId of allDrepIds) {
-    const confidence = effectiveConfidences.get(drepId) ?? 100;
+    const confidence = confidences?.get(drepId) ?? 100;
 
-    // Dampen percentile scores toward median for low-confidence DReps
-    let eqPct = dampenPercentile(pctEngagement.get(drepId) ?? 0, confidence);
-    let epPct = dampenPercentile(pctParticipation.get(drepId) ?? 0, confidence);
-    let rlPct = dampenPercentile(pctReliability.get(drepId) ?? 0, confidence);
-    const giPct = dampenPercentile(pctIdentity.get(drepId) ?? 0, confidence);
-
-    // Zero-activity override: when ALL three activity pillars have raw score 0,
-    // the DRep has never participated in governance. Pull their activity percentiles
-    // to 0 instead of the dampened median, so composite reflects actual inactivity.
-    // GI (profile-based) is unaffected — it's legitimately earned from profile data.
+    // Calibrate raw scores via absolute piecewise linear curves
     const eqRaw = rawEngagement.get(drepId) ?? 0;
     const epRaw = rawParticipation.get(drepId) ?? 0;
     const rlRaw = rawReliability.get(drepId) ?? 0;
+    const giRaw = rawIdentity.get(drepId) ?? 0;
+
+    let eqCal = dampenPercentile(
+      calibrate(eqRaw, DREP_PILLAR_CALIBRATION.engagementQuality),
+      confidence,
+    );
+    let epCal = dampenPercentile(
+      calibrate(epRaw, DREP_PILLAR_CALIBRATION.effectiveParticipation),
+      confidence,
+    );
+    let rlCal = dampenPercentile(calibrate(rlRaw, DREP_PILLAR_CALIBRATION.reliability), confidence);
+    const giCal = dampenPercentile(
+      calibrate(giRaw, DREP_PILLAR_CALIBRATION.governanceIdentity),
+      confidence,
+    );
+
+    // Zero-activity override: when ALL three activity pillars have raw score 0,
+    // the DRep has never participated in governance. Force calibrated scores
+    // to 0 instead of the dampened median, so composite reflects actual inactivity.
+    // GI (profile-based) is unaffected — it's legitimately earned from profile data.
     if (eqRaw === 0 && epRaw === 0 && rlRaw === 0) {
-      eqPct = 0;
-      epPct = 0;
-      rlPct = 0;
+      eqCal = 0;
+      epCal = 0;
+      rlCal = 0;
     }
 
     const composite = Math.round(
-      eqPct * PILLAR_WEIGHTS.engagementQuality +
-        epPct * PILLAR_WEIGHTS.effectiveParticipation +
-        rlPct * PILLAR_WEIGHTS.reliability +
-        giPct * PILLAR_WEIGHTS.governanceIdentity,
+      eqCal * PILLAR_WEIGHTS.engagementQuality +
+        epCal * PILLAR_WEIGHTS.effectiveParticipation +
+        rlCal * PILLAR_WEIGHTS.reliability +
+        giCal * PILLAR_WEIGHTS.governanceIdentity,
     );
 
     const history = scoreHistory.get(drepId);
@@ -90,14 +87,14 @@ export function computeDRepScores(
 
     results.set(drepId, {
       composite: clamp(composite),
-      engagementQualityRaw: rawEngagement.get(drepId) ?? 0,
-      engagementQualityPercentile: eqPct,
-      effectiveParticipationRaw: rawParticipation.get(drepId) ?? 0,
-      effectiveParticipationPercentile: epPct,
-      reliabilityRaw: rawReliability.get(drepId) ?? 0,
-      reliabilityPercentile: rlPct,
-      governanceIdentityRaw: rawIdentity.get(drepId) ?? 0,
-      governanceIdentityPercentile: giPct,
+      engagementQualityRaw: eqRaw,
+      engagementQualityCalibrated: eqCal,
+      effectiveParticipationRaw: epRaw,
+      effectiveParticipationCalibrated: epCal,
+      reliabilityRaw: rlRaw,
+      reliabilityCalibrated: rlCal,
+      governanceIdentityRaw: giRaw,
+      governanceIdentityCalibrated: giCal,
       confidence,
       momentum,
     });

--- a/lib/scoring/governanceIdentity.ts
+++ b/lib/scoring/governanceIdentity.ts
@@ -6,7 +6,7 @@
 
 import { isValidatedSocialLink } from '@/utils/display';
 import type { DRepProfileData } from './types';
-import { IDENTITY_WEIGHTS, PROFILE_FIELD_SCORES } from './calibration';
+import { IDENTITY_WEIGHTS, PROFILE_FIELD_SCORES, DELEGATOR_TIERS } from './calibration';
 
 const SUB_WEIGHTS = IDENTITY_WEIGHTS;
 
@@ -14,20 +14,15 @@ const SUB_WEIGHTS = IDENTITY_WEIGHTS;
  * Compute raw Governance Identity scores (0-100) for all DReps.
  *
  * @param profiles Per-DRep profile data (metadata, delegator count, hash verified)
- * @param allDelegatorCounts All DReps' delegator counts (for percentile ranking)
  */
 export function computeGovernanceIdentity(
   profiles: Map<string, DRepProfileData>,
-  allDelegatorCounts: number[],
 ): Map<string, number> {
   const scores = new Map<string, number>();
 
-  // Pre-sort delegator counts for percentile computation
-  const sortedCounts = [...allDelegatorCounts].sort((a, b) => a - b);
-
   for (const [drepId, profile] of profiles) {
     const profileScore = computeProfileQuality(profile);
-    const communityScore = computeCommunityPresence(profile.delegatorCount, sortedCounts);
+    const communityScore = computeCommunityPresence(profile.delegatorCount);
 
     const raw =
       profileScore * SUB_WEIGHTS.profileQuality + communityScore * SUB_WEIGHTS.communityPresence;
@@ -93,32 +88,14 @@ function computeProfileQuality(profile: DRepProfileData): number {
 
 /**
  * Community Presence (40% of pillar).
- * Delegator count percentile: where does this DRep rank by number of delegators?
- * Count-based (not ADA-based) to measure trust breadth.
+ * Absolute delegator count tiers: every DRep can reach 100 by growing
+ * their community. Not zero-sum — independent of other DReps' counts.
  */
-function computeCommunityPresence(delegatorCount: number, sortedCounts: number[]): number {
-  if (sortedCounts.length === 0) return 0;
-  if (sortedCounts.length === 1) return 50;
-
-  // Find position in sorted array (average rank for ties)
-  let lo = 0;
-  let hi = sortedCounts.length - 1;
-
-  // Binary search for first occurrence
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (sortedCounts[mid] < delegatorCount) lo = mid + 1;
-    else hi = mid;
+function computeCommunityPresence(delegatorCount: number): number {
+  for (const tier of DELEGATOR_TIERS) {
+    if (delegatorCount >= tier.min) return tier.score;
   }
-
-  // Find range of ties
-  let first = lo;
-  let last = lo;
-  while (first > 0 && sortedCounts[first - 1] === delegatorCount) first--;
-  while (last < sortedCounts.length - 1 && sortedCounts[last + 1] === delegatorCount) last++;
-
-  const avgRank = (first + last) / 2;
-  return Math.round((avgRank / (sortedCounts.length - 1)) * 100);
+  return 0;
 }
 
 // --- Helpers ---

--- a/lib/scoring/reliability.ts
+++ b/lib/scoring/reliability.ts
@@ -1,7 +1,9 @@
 /**
  * Reliability pillar (25% of DRep Score).
- * Enhanced from V2 with new Responsiveness sub-component and rebalanced weights.
- * "Can I count on this DRep to keep showing up — and show up quickly?"
+ * "Can I count on this DRep to keep showing up?"
+ *
+ * 4 sub-components: Streak (35%), Recency (30%), Gap (25%), Tenure (10%).
+ * Timeliness removed — voting within the window is sufficient.
  */
 
 import type { VoteData } from './types';
@@ -14,7 +16,6 @@ export interface ReliabilityV3Result {
   streak: number;
   recency: number;
   longestGap: number;
-  responsiveness: number;
   tenure: number;
 }
 
@@ -68,7 +69,6 @@ function computeSingleDRepReliability(
     streak: 0,
     recency: 999,
     longestGap: 0,
-    responsiveness: 0,
     tenure: 0,
   };
 
@@ -118,10 +118,7 @@ function computeSingleDRepReliability(
   longestGap = Math.max(longestGap, currentGap);
   const gapScore = Math.max(0, 100 - longestGap * RELIABILITY_PARAMS.gapPenaltyPerEpoch);
 
-  // 4. Responsiveness (15%) — median days from proposal to vote
-  const responsivenessScore = computeResponsiveness(votes);
-
-  // 5. Tenure (10%) — epochs since first vote, diminishing returns
+  // 4. Tenure (10%) — epochs since first vote, diminishing returns
   const tenure = Math.max(0, currentEpoch - firstEpoch);
   const tenureScore = Math.min(
     100,
@@ -136,7 +133,6 @@ function computeSingleDRepReliability(
     streakScore * WEIGHTS.streak +
       recencyScore * WEIGHTS.recency +
       gapScore * WEIGHTS.gap +
-      responsivenessScore * WEIGHTS.responsiveness +
       tenureScore * WEIGHTS.tenure,
   );
 
@@ -145,32 +141,8 @@ function computeSingleDRepReliability(
     streak,
     recency,
     longestGap,
-    responsiveness: responsivenessScore,
     tenure,
   };
-}
-
-/**
- * Responsiveness: median days from proposal submission to DRep vote.
- * Score: 100 * exp(-median_days / 14)
- * Within 1 day ≈ 93, within 7 days ≈ 61, within 30 days ≈ 12
- */
-function computeResponsiveness(votes: VoteData[]): number {
-  const deltas: number[] = [];
-
-  for (const v of votes) {
-    if (v.proposalBlockTime > 0 && v.blockTime > v.proposalBlockTime) {
-      const daysToVote = (v.blockTime - v.proposalBlockTime) / 86400;
-      deltas.push(daysToVote);
-    }
-  }
-
-  if (deltas.length === 0) return 50; // no data, neutral score
-
-  deltas.sort((a, b) => a - b);
-  const median = deltas[Math.floor(deltas.length / 2)];
-
-  return Math.round(100 * Math.exp(-median / RELIABILITY_PARAMS.responsivenessDivisor));
 }
 
 function clamp(v: number): number {

--- a/lib/scoring/spoDeliberationQuality.ts
+++ b/lib/scoring/spoDeliberationQuality.ts
@@ -1,16 +1,16 @@
 /**
  * SPO Deliberation Quality pillar (25% of SPO Score V3).
- * Replaces the broken Consistency pillar from V2.
  *
- * Three sub-components:
- * - Rationale Provision (40%): % of votes with rationale, importance-weighted
- * - Vote Timing Distribution (30%): stddev of time-to-vote (bot/human detection)
- * - Proposal Coverage Entropy (30%): Shannon entropy across proposal types
+ * Two sub-components:
+ * - Rationale Provision (55%): % of votes with rationale, importance-weighted
+ * - Proposal Coverage Entropy (45%): Shannon entropy across proposal types
+ *
+ * Timeliness removed — voting within the window is sufficient.
  */
 
 import { DECAY_LAMBDA } from './types';
 
-const SUB_WEIGHTS = { rationaleProvision: 0.4, timingDistribution: 0.3, coverageEntropy: 0.3 };
+const SUB_WEIGHTS = { rationaleProvision: 0.55, coverageEntropy: 0.45 };
 const INFO_ACTION = 'InfoAction';
 
 export interface SpoDeliberationVoteData {
@@ -40,13 +40,9 @@ export function computeSpoDeliberationQuality(
     }
 
     const provision = computeRationaleProvision(votes, nowSeconds);
-    const timing = computeTimingDistribution(votes);
     const entropy = computeCoverageEntropy(votes, allProposalTypes);
 
-    const raw =
-      provision * SUB_WEIGHTS.rationaleProvision +
-      timing * SUB_WEIGHTS.timingDistribution +
-      entropy * SUB_WEIGHTS.coverageEntropy;
+    const raw = provision * SUB_WEIGHTS.rationaleProvision + entropy * SUB_WEIGHTS.coverageEntropy;
 
     scores.set(poolId, clamp(Math.round(raw)));
   }
@@ -76,37 +72,6 @@ function computeRationaleProvision(votes: SpoDeliberationVoteData[], nowSeconds:
   }
 
   return totalWeight === 0 ? 0 : (weightedHas / totalWeight) * 100;
-}
-
-/**
- * Vote Timing Distribution (30%): standard deviation of time-to-vote.
- * Penalizes bot-like patterns (near-zero stddev) and extreme variance.
- * Natural human deliberation variance (~3 days stddev) scores highest.
- */
-function computeTimingDistribution(votes: SpoDeliberationVoteData[]): number {
-  const responseDays: number[] = [];
-  for (const v of votes) {
-    if (v.proposalBlockTime > 0 && v.blockTime > v.proposalBlockTime) {
-      responseDays.push((v.blockTime - v.proposalBlockTime) / 86400);
-    }
-  }
-
-  if (responseDays.length < 3) return 50; // insufficient data
-
-  const mean = responseDays.reduce((a, b) => a + b, 0) / responseDays.length;
-  const variance = responseDays.reduce((sum, d) => sum + (d - mean) ** 2, 0) / responseDays.length;
-  const stddev = Math.sqrt(variance);
-
-  // Target stddev: ~3 days of natural variation
-  const TARGET_STDDEV = 3;
-
-  // Score: peaks at target, decays on both sides
-  // Low stddev (bot-like): steep penalty
-  // High stddev (erratic): gradual penalty
-  const riseScore = 1 - Math.exp(-stddev / TARGET_STDDEV);
-  const decayScore = Math.exp(-Math.max(0, stddev - 3 * TARGET_STDDEV) / (2 * TARGET_STDDEV));
-
-  return clamp(Math.round(riseScore * decayScore * 100));
 }
 
 /**

--- a/lib/scoring/spoGovernanceIdentity.ts
+++ b/lib/scoring/spoGovernanceIdentity.ts
@@ -2,13 +2,14 @@
  * SPO Governance Identity pillar (15% of SPO Score V3).
  * Two sub-components: Pool Identity Quality (60%) and Delegation Responsiveness (40%).
  *
- * V3 changes from V2:
+ * V3.1 changes:
  * - Governance statement uses keyword quality checklist instead of pure character count
  * - Community Presence replaced by Delegation Responsiveness (delegator retention after votes)
- * - Falls back to delegator count percentile when insufficient retention data
+ * - Falls back to absolute delegator count tiers (not percentile) when insufficient retention data
  */
 
 import { isValidatedSocialLink } from '@/utils/display';
+import { DELEGATOR_TIERS } from './calibration';
 
 const SUB_WEIGHTS = { poolIdentityQuality: 0.6, delegationResponsiveness: 0.4 };
 
@@ -50,15 +51,13 @@ export interface DelegationRetentionData {
 
 /**
  * Compute raw Governance Identity scores (0-100) for all SPOs.
- * Uses delegation responsiveness when available, falls back to delegator count percentile.
+ * Uses delegation responsiveness when available, falls back to absolute delegator count tiers.
  */
 export function computeSpoGovernanceIdentity(
   profiles: Map<string, SpoProfileData>,
-  allDelegatorCounts: number[],
   retentionData?: Map<string, DelegationRetentionData>,
 ): Map<string, number> {
   const scores = new Map<string, number>();
-  const sortedCounts = [...allDelegatorCounts].sort((a, b) => a - b);
 
   for (const [poolId, profile] of profiles) {
     const identityScore = computePoolIdentityQuality(profile);
@@ -69,8 +68,8 @@ export function computeSpoGovernanceIdentity(
       // Delegation responsiveness: retention rate after governance activity
       communityScore = computeDelegationResponsiveness(responsiveness);
     } else {
-      // Fallback: delegator count percentile
-      communityScore = computeCommunityPresencePercentile(profile.delegatorCount, sortedCounts);
+      // Fallback: absolute delegator count tiers
+      communityScore = computeCommunityPresence(profile.delegatorCount);
     }
 
     const raw =
@@ -199,31 +198,14 @@ function computeDelegationResponsiveness(data: DelegationRetentionData): number 
 }
 
 /**
- * Fallback: delegator count percentile (same as V2).
+ * Community Presence fallback: absolute delegator count tiers.
+ * Not zero-sum — every SPO can reach 100 by growing their community.
  */
-function computeCommunityPresencePercentile(
-  delegatorCount: number,
-  sortedCounts: number[],
-): number {
-  if (sortedCounts.length === 0) return 0;
-  if (sortedCounts.length === 1) return 50;
-
-  let lo = 0;
-  let hi = sortedCounts.length - 1;
-
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (sortedCounts[mid] < delegatorCount) lo = mid + 1;
-    else hi = mid;
+function computeCommunityPresence(delegatorCount: number): number {
+  for (const tier of DELEGATOR_TIERS) {
+    if (delegatorCount >= tier.min) return tier.score;
   }
-
-  let first = lo;
-  let last = lo;
-  while (first > 0 && sortedCounts[first - 1] === delegatorCount) first--;
-  while (last < sortedCounts.length - 1 && sortedCounts[last + 1] === delegatorCount) last++;
-
-  const avgRank = (first + last) / 2;
-  return Math.round((avgRank / (sortedCounts.length - 1)) * 100);
+  return 0;
 }
 
 interface Tier {

--- a/lib/scoring/spoScore.ts
+++ b/lib/scoring/spoScore.ts
@@ -1,17 +1,18 @@
 /**
- * SPO Governance Score V3 — 4-pillar composite calculator.
+ * SPO Governance Score V3.1 — 4-pillar composite calculator.
  * Participation (35%) + Deliberation Quality (25%) + Reliability (25%) + Governance Identity (15%).
- * Confidence-weighted percentile normalization, proposal-aware reliability, 30-day momentum (ADR-006 V3).
+ * Absolute calibrated scoring (not percentile), proposal-aware reliability, 30-day momentum.
  */
 
-import { percentileNormalize } from './percentile';
-import { percentileNormalizeWeighted } from './confidence';
+import { dampenPercentile } from './confidence';
 import { DECAY_LAMBDA } from './types';
 import {
   SPO_PILLAR_WEIGHTS as _SPO_WEIGHTS,
   SPO_MARGIN,
   SPO_RELIABILITY_WEIGHTS,
   SPO_RELIABILITY_PARAMS,
+  SPO_PILLAR_CALIBRATION,
+  calibrate,
 } from './calibration';
 
 export const SPO_PILLAR_WEIGHTS = _SPO_WEIGHTS;
@@ -34,19 +35,19 @@ export type SpoVoteData = SpoVoteDataV3;
 export interface SpoScoreResult {
   composite: number;
   participationRaw: number;
-  participationPercentile: number;
+  participationCalibrated: number;
   deliberationRaw: number;
-  deliberationPercentile: number;
+  deliberationCalibrated: number;
   reliabilityRaw: number;
-  reliabilityPercentile: number;
+  reliabilityCalibrated: number;
   governanceIdentityRaw: number;
-  governanceIdentityPercentile: number;
+  governanceIdentityCalibrated: number;
   confidence: number;
   momentum: number | null;
   /** @deprecated V2 compat — same as deliberationRaw */
   consistencyRaw: number;
-  /** @deprecated V2 compat — same as deliberationPercentile */
-  consistencyPercentile: number;
+  /** @deprecated V2 compat — same as deliberationCalibrated */
+  consistencyCalibrated: number;
 }
 
 /**
@@ -74,58 +75,69 @@ export function computeSpoScores(
 
   const nowSeconds = allVotes.length > 0 ? Math.max(...allVotes.map((v) => v.blockTime)) : 0;
 
-  const participationRaw = new Map<string, number>();
-  const reliabilityRaw = new Map<string, number>();
+  const participationRawMap = new Map<string, number>();
+  const reliabilityRawMap = new Map<string, number>();
 
   for (const [poolId, votes] of byPool) {
-    participationRaw.set(
+    participationRawMap.set(
       poolId,
       computeParticipation(votes, totalProposalPool, nowSeconds, proposalMarginMultipliers),
     );
-    reliabilityRaw.set(poolId, computeReliability(votes, currentEpoch, activeEpochs));
+    reliabilityRawMap.set(poolId, computeReliability(votes, currentEpoch, activeEpochs));
   }
-
-  // Use confidence-weighted percentile normalization
-  const participationPct = percentileNormalizeWeighted(participationRaw, confidences);
-  const deliberationPct = percentileNormalizeWeighted(deliberationScores, confidences);
-  const reliabilityPct = percentileNormalizeWeighted(reliabilityRaw, confidences);
-  const identityPct = percentileNormalize(identityScores);
 
   const result = new Map<string, SpoScoreResult>();
   const allPoolIds = new Set([...byPool.keys(), ...identityScores.keys()]);
 
   for (const poolId of allPoolIds) {
-    const pPct = participationPct.get(poolId) ?? 0;
-    const dPct = deliberationPct.get(poolId) ?? 0;
-    const rPct = reliabilityPct.get(poolId) ?? 0;
-    const iPct = identityPct.get(poolId) ?? 0;
+    const confidence = confidences.get(poolId) ?? 0;
+
+    const pRaw = participationRawMap.get(poolId) ?? 0;
+    const dRaw = deliberationScores.get(poolId) ?? 0;
+    const rlRaw = reliabilityRawMap.get(poolId) ?? 0;
+    const giRaw = identityScores.get(poolId) ?? 0;
+
+    // Absolute calibrated scoring — your actions = your score
+    let pCal = dampenPercentile(calibrate(pRaw, SPO_PILLAR_CALIBRATION.participation), confidence);
+    let dCal = dampenPercentile(calibrate(dRaw, SPO_PILLAR_CALIBRATION.deliberation), confidence);
+    let rlCal = dampenPercentile(calibrate(rlRaw, SPO_PILLAR_CALIBRATION.reliability), confidence);
+    const giCal = dampenPercentile(
+      calibrate(giRaw, SPO_PILLAR_CALIBRATION.governanceIdentity),
+      confidence,
+    );
+
+    // Zero-activity override: if all 3 activity pillars have raw 0, force calibrated to 0
+    if (pRaw === 0 && dRaw === 0 && rlRaw === 0) {
+      pCal = 0;
+      dCal = 0;
+      rlCal = 0;
+    }
 
     const composite = Math.round(
-      SPO_PILLAR_WEIGHTS.participation * pPct +
-        SPO_PILLAR_WEIGHTS.deliberation * dPct +
-        SPO_PILLAR_WEIGHTS.reliability * rPct +
-        SPO_PILLAR_WEIGHTS.governanceIdentity * iPct,
+      SPO_PILLAR_WEIGHTS.participation * pCal +
+        SPO_PILLAR_WEIGHTS.deliberation * dCal +
+        SPO_PILLAR_WEIGHTS.reliability * rlCal +
+        SPO_PILLAR_WEIGHTS.governanceIdentity * giCal,
     );
 
     const history = scoreHistory.get(poolId);
     const momentum = history ? computeMomentum(history) : null;
-    const confidence = confidences.get(poolId) ?? 0;
 
     result.set(poolId, {
       composite: clamp(composite),
-      participationRaw: participationRaw.get(poolId) ?? 0,
-      participationPercentile: pPct,
-      deliberationRaw: deliberationScores.get(poolId) ?? 0,
-      deliberationPercentile: dPct,
-      reliabilityRaw: reliabilityRaw.get(poolId) ?? 0,
-      reliabilityPercentile: rPct,
-      governanceIdentityRaw: identityScores.get(poolId) ?? 0,
-      governanceIdentityPercentile: iPct,
+      participationRaw: pRaw,
+      participationCalibrated: pCal,
+      deliberationRaw: dRaw,
+      deliberationCalibrated: dCal,
+      reliabilityRaw: rlRaw,
+      reliabilityCalibrated: rlCal,
+      governanceIdentityRaw: giRaw,
+      governanceIdentityCalibrated: giCal,
       confidence,
       momentum,
       // V2 compat
-      consistencyRaw: deliberationScores.get(poolId) ?? 0,
-      consistencyPercentile: dPct,
+      consistencyRaw: dRaw,
+      consistencyCalibrated: dCal,
     });
   }
   return result;

--- a/lib/scoring/types.ts
+++ b/lib/scoring/types.ts
@@ -48,13 +48,13 @@ export interface DRepProfileData {
 export interface DRepScoreResult {
   composite: number;
   engagementQualityRaw: number;
-  engagementQualityPercentile: number;
+  engagementQualityCalibrated: number;
   effectiveParticipationRaw: number;
-  effectiveParticipationPercentile: number;
+  effectiveParticipationCalibrated: number;
   reliabilityRaw: number;
-  reliabilityPercentile: number;
+  reliabilityCalibrated: number;
   governanceIdentityRaw: number;
-  governanceIdentityPercentile: number;
+  governanceIdentityCalibrated: number;
   confidence: number;
   momentum: number | null;
 }


### PR DESCRIPTION
## Summary
- **Remove timeliness from DRep/SPO scoring**: Reliability drops responsiveness pillar, SPO deliberation drops timing bonus, governance identity drops recency decay
- **CC Transparency → Constitutional Fidelity**: 3-pillar model (Participation 30%, Constitutional Grounding 40%, Reasoning Quality 30%) replaces 5-pillar Transparency Index. Full frontend rename across all CC components, types, and copy
- **Absolute calibrated threshold curves**: Replace percentile normalization with sigmoid/piecewise calibration curves. Scores now meaningful in absolute terms
- **Remove size tier modifier** from Alignment 6D decentralization dimension
- **Expand GHI to 8 components**: Add SPO Participation (10%) and CC Constitutional Fidelity (10%)
- **Fix flaky reliability test**: Response time equality assertion matches new timeliness-free model

## Impact
- **What changed**: Complete scoring model overhaul — 7 directives touching 34 files across scoring engine, sync pipeline, GHI, frontend components, API routes, and tests
- **User-facing**: Yes — CC members see "Constitutional Fidelity" instead of "Transparency Index", 3-pillar breakdown replaces 5-pillar, all scores recalibrated on next sync
- **Risk**: Medium — scoring model changes affect all computed scores. Backward-compat aliases maintained for DB migration transition. No DB migration in this PR (column renames pending)
- **Scope**: `lib/scoring/`, `lib/ghi/`, `lib/cc/`, `lib/data.ts`, `hooks/queries.ts`, `inngest/functions/`, `app/governance/committee/`, `components/cc/`, tests

## Test plan
- [x] All 595 tests pass (43 test files)
- [x] TypeScript strict mode — zero type errors
- [x] ESLint — zero errors (pre-existing warnings only)
- [x] Prettier — all files formatted
- [ ] Verify CC member profiles render correctly in production
- [ ] Verify GHI explorer shows 8 components after next sync
- [ ] Apply DB migration (column renames) in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)