### PR TITLE
feat: return loop — epoch digest, alerts, notification pipeline, what-changed summary

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -37,7 +37,7 @@ import { precomputeEngagementSignals } from '@/inngest/functions/precompute-enga
 import { generateCitizenAssembly } from '@/inngest/functions/generate-citizen-assembly';
 import { trackProposalOutcomes } from '@/inngest/functions/track-proposal-outcomes';
 import { computeCommunityIntelligence } from '@/inngest/functions/compute-community-intelligence';
-
+import { notifyEngagementOutcomes } from '@/inngest/functions/notify-engagement-outcomes';
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [
@@ -78,5 +78,6 @@ export const { GET, POST, PUT } = serve({
     generateCitizenAssembly,
     trackProposalOutcomes,
     computeCommunityIntelligence,
+    notifyEngagementOutcomes,
   ],
 });

--- a/app/api/you/notification-preferences/route.ts
+++ b/app/api/you/notification-preferences/route.ts
@@ -1,0 +1,109 @@
+/**
+ * POST/GET /api/you/notification-preferences
+ * Manages email opt-in for epoch digests and alert preferences.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import React from 'react';
+import { z } from 'zod';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { sendEmail, generateVerificationUrl } from '@/lib/email';
+import { EmailVerificationEmail } from '@/lib/emailTemplates';
+import { captureServerEvent } from '@/lib/posthog-server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+const PreferencesSchema = z.object({
+  email: z.string().email().optional(),
+  digestFrequency: z.enum(['epoch', 'weekly', 'major_only', 'none']).optional().default('none'),
+  alertDrepVoted: z.boolean().optional(),
+  alertCoverageChanged: z.boolean().optional(),
+  alertScoreShifted: z.boolean().optional(),
+  alertMilestoneEarned: z.boolean().optional(),
+});
+
+/**
+ * GET — Fetch current notification preferences.
+ */
+export const GET = withRouteHandler(
+  async (_request: NextRequest, { userId }: RouteContext) => {
+    const supabase = getSupabaseAdmin();
+
+    const { data } = await supabase
+      .from('user_notification_preferences')
+      .select('*')
+      .eq('user_id', userId!)
+      .maybeSingle();
+
+    return NextResponse.json(data || { digestFrequency: 'none' });
+  },
+  { auth: 'required' },
+);
+
+/**
+ * POST — Save email and digest preferences. Sends verification email if new.
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, { userId }: RouteContext) => {
+    const body = await request.json();
+    const parsed = PreferencesSchema.parse(body);
+    const supabase = getSupabaseAdmin();
+
+    const update: Record<string, unknown> = {
+      user_id: userId!,
+      digest_frequency: parsed.digestFrequency,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (parsed.email !== undefined) update.email = parsed.email;
+    if (parsed.alertDrepVoted !== undefined) update.alert_drep_voted = parsed.alertDrepVoted;
+    if (parsed.alertCoverageChanged !== undefined)
+      update.alert_coverage_changed = parsed.alertCoverageChanged;
+    if (parsed.alertScoreShifted !== undefined)
+      update.alert_score_shifted = parsed.alertScoreShifted;
+    if (parsed.alertMilestoneEarned !== undefined)
+      update.alert_milestone_earned = parsed.alertMilestoneEarned;
+
+    const { error } = await supabase.from('user_notification_preferences').upsert(update, {
+      onConflict: 'user_id',
+    });
+
+    if (error) {
+      logger.error('[notification-preferences] Upsert failed', { error: error.message });
+      return NextResponse.json({ error: 'Failed to save preferences' }, { status: 500 });
+    }
+
+    // If email provided, also save to users table and send verification
+    if (parsed.email) {
+      // Check if email is already verified on users table
+      const { data: user } = await supabase
+        .from('users')
+        .select('email, email_verified')
+        .eq('id', userId!)
+        .single();
+
+      const needsVerification = !user?.email_verified || user?.email !== parsed.email;
+
+      if (needsVerification) {
+        await supabase
+          .from('users')
+          .update({ email: parsed.email, email_verified: false })
+          .eq('id', userId!);
+
+        const verifyUrl = generateVerificationUrl(userId!, parsed.email);
+        await sendEmail(
+          parsed.email,
+          'Verify your email — Governada',
+          React.createElement(EmailVerificationEmail, { verifyUrl }),
+        );
+      }
+    }
+
+    captureServerEvent('email_opted_in', { digest_frequency: parsed.digestFrequency }, userId!);
+
+    return NextResponse.json({ ok: true });
+  },
+  { auth: 'required', rateLimit: { max: 10, window: 60 } },
+);

--- a/app/api/you/what-changed/route.ts
+++ b/app/api/you/what-changed/route.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/you/what-changed?since=<unix_ms>
+ *
+ * Returns a summary of what happened in governance since the user's last visit.
+ * Used by the WhatChanged hub component.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, { userId }: RouteContext) => {
+    const sinceParam = request.nextUrl.searchParams.get('since');
+    const sinceMs = sinceParam ? parseInt(sinceParam, 10) : Date.now() - 5 * 86400 * 1000;
+    const sinceSeconds = Math.floor(sinceMs / 1000);
+    const sinceDate = new Date(sinceMs).toISOString();
+
+    const supabase = getSupabaseAdmin();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const currentEpoch = blockTimeToEpoch(nowSeconds);
+    const lastEpoch = blockTimeToEpoch(sinceSeconds);
+
+    // Get user's delegated DRep
+    let delegatedDrepId: string | null = null;
+    if (userId) {
+      const { data: wallet } = await supabase
+        .from('user_wallets')
+        .select('drep_id')
+        .eq('user_id', userId)
+        .limit(1)
+        .maybeSingle();
+      delegatedDrepId = wallet?.drep_id ?? null;
+    }
+
+    // Parallel queries for what changed
+    const [proposalsResult, drepVotesResult, milestonesResult] = await Promise.all([
+      // Proposals decided since last visit
+      supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .or(
+          `ratified_epoch.gte.${lastEpoch},expired_epoch.gte.${lastEpoch},dropped_epoch.gte.${lastEpoch}`,
+        ),
+
+      // DRep votes since last visit (if user has a DRep)
+      delegatedDrepId
+        ? supabase
+            .from('drep_votes')
+            .select('vote_tx_hash', { count: 'exact', head: true })
+            .eq('drep_id', delegatedDrepId)
+            .gte('block_time', sinceSeconds)
+        : Promise.resolve({ count: 0 }),
+
+      // New milestones earned since last visit
+      userId
+        ? supabase
+            .from('notifications')
+            .select('id', { count: 'exact', head: true })
+            .eq(
+              'user_stake_address',
+              (
+                await supabase
+                  .from('user_wallets')
+                  .select('stake_address')
+                  .eq('user_id', userId)
+                  .limit(1)
+                  .maybeSingle()
+              ).data?.stake_address ?? '',
+            )
+            .in('type', ['citizen-level-up', 'near-milestone'])
+            .gte('created_at', sinceDate)
+        : Promise.resolve({ count: 0 }),
+    ]);
+
+    return NextResponse.json({
+      lastEpoch,
+      currentEpoch,
+      proposalsDecided: proposalsResult.count ?? 0,
+      drepVotes: drepVotesResult.count ?? 0,
+      newMilestones: milestonesResult.count ?? 0,
+      newEndorsements: 0,
+    });
+  },
+  { auth: 'optional' },
+);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -278,6 +278,14 @@ export function Header() {
                     )}
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="flex items-center gap-2 p-2.5 cursor-pointer text-xs text-primary hover:bg-primary/10"
+                    onSelect={() => router.push('/you/inbox')}
+                  >
+                    <Inbox className="h-3.5 w-3.5" />
+                    <span>View all notifications</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
                   {alerts.length === 0 ? (
                     <DropdownMenuItem className="flex items-center gap-3 p-3 cursor-default text-muted-foreground">
                       <Info className="h-4 w-4" />

--- a/components/civica/mygov/CivicaProfile.tsx
+++ b/components/civica/mygov/CivicaProfile.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/civica/cards/tierStyles';
 import { computeTier } from '@/lib/scoring/tiers';
 import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
+import { EmailOptIn } from '@/components/notifications/EmailOptIn';
 
 // ---------------------------------------------------------------------------
 // Notification preference toggle
@@ -399,6 +400,9 @@ export function CivicaProfile() {
           </div>
         </div>
       </Section>
+
+      {/* Email opt-in for governance briefings */}
+      <EmailOptIn variant="inline" className="border border-border" />
 
       {/* Display preferences */}
       <Section icon={Settings} title="Display">

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -41,6 +41,7 @@ import { resolveRewardAddress } from '@meshsdk/core';
 import { hapticLight } from '@/lib/haptics';
 import { useSentimentResults } from '@/hooks/useEngagement';
 import { CommunityConsensus } from './CommunityConsensus';
+import { WhatChanged } from '@/components/hub/WhatChanged';
 
 type SentimentChoice = 'support' | 'oppose' | 'unsure';
 
@@ -489,6 +490,9 @@ export function CitizenHub() {
       animate="visible"
       className="mx-auto w-full max-w-2xl space-y-4 px-4 py-6"
     >
+      {/* ── What Changed (return visit summary) ──────────── */}
+      <WhatChanged />
+
       {/* ── Epoch headline ─────────────────────────────────── */}
       <motion.header variants={briefingItem} className="space-y-1 pb-1">
         <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">

--- a/components/hub/WhatChanged.tsx
+++ b/components/hub/WhatChanged.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Vote, TrendingUp, Award, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+const LAST_VISIT_KEY = 'governada_last_hub_visit';
+const DISMISSED_KEY = 'governada_what_changed_dismissed';
+
+interface WhatChangedData {
+  lastEpoch: number;
+  currentEpoch: number;
+  proposalsDecided: number;
+  drepVotes: number;
+  newMilestones: number;
+  newEndorsements: number;
+}
+
+/**
+ * WhatChanged — shown at top of CitizenHub when the user returns after being away.
+ *
+ * Uses localStorage to track the last visit time and compares against
+ * the current epoch from the API. Auto-dismisses when user interacts.
+ * Only shows if there are meaningful changes.
+ */
+export function WhatChanged() {
+  const { stakeAddress } = useSegment();
+  const [data, setData] = useState<WhatChangedData | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!stakeAddress) {
+      setLoading(false);
+      return;
+    }
+
+    // Check if user dismissed this session
+    const dismissed = sessionStorage.getItem(DISMISSED_KEY);
+    if (dismissed) {
+      setLoading(false);
+      return;
+    }
+
+    // Get last visit info
+    const lastVisit = localStorage.getItem(LAST_VISIT_KEY);
+    const lastVisitTime = lastVisit ? parseInt(lastVisit, 10) : 0;
+    const hoursSinceVisit = (Date.now() - lastVisitTime) / (1000 * 60 * 60);
+
+    // Only show if away for at least 12 hours
+    if (hoursSinceVisit < 12) {
+      // Update last visit
+      localStorage.setItem(LAST_VISIT_KEY, String(Date.now()));
+      setLoading(false);
+      return;
+    }
+
+    // Fetch what-changed data from API
+    fetch(`/api/you/what-changed?since=${lastVisitTime}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch');
+        return res.json();
+      })
+      .then((result: WhatChangedData) => {
+        // Only show if there's something meaningful
+        const hasChanges =
+          result.proposalsDecided > 0 || result.drepVotes > 0 || result.newMilestones > 0;
+
+        if (hasChanges) {
+          setData(result);
+          setVisible(true);
+        }
+      })
+      .catch(() => {
+        // Silent failure — non-critical feature
+      })
+      .finally(() => {
+        // Update last visit time
+        localStorage.setItem(LAST_VISIT_KEY, String(Date.now()));
+        setLoading(false);
+      });
+  }, [stakeAddress]);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+    sessionStorage.setItem(DISMISSED_KEY, 'true');
+  }, []);
+
+  if (loading || !visible || !data) return null;
+
+  const epochSpan =
+    data.currentEpoch - data.lastEpoch > 0
+      ? `Since Epoch ${data.lastEpoch}`
+      : 'Since your last visit';
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, height: 0, marginBottom: 0 }}
+        animate={{ opacity: 1, height: 'auto', marginBottom: 16 }}
+        exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+      >
+        <div className="relative rounded-2xl border border-primary/20 bg-primary/5 backdrop-blur-md p-4 sm:p-5">
+          <button
+            onClick={handleDismiss}
+            className="absolute top-3 right-3 p-1 rounded-lg hover:bg-white/10 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-3.5 w-3.5 text-muted-foreground" />
+          </button>
+
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-primary mb-2">
+            {epochSpan}
+          </p>
+
+          <div className="grid grid-cols-3 gap-3 mb-3">
+            {data.proposalsDecided > 0 && (
+              <StatPill
+                icon={Vote}
+                value={data.proposalsDecided}
+                label={`proposal${data.proposalsDecided !== 1 ? 's' : ''} decided`}
+              />
+            )}
+            {data.drepVotes > 0 && (
+              <StatPill
+                icon={TrendingUp}
+                value={data.drepVotes}
+                label={`DRep vote${data.drepVotes !== 1 ? 's' : ''} cast`}
+              />
+            )}
+            {data.newMilestones > 0 && (
+              <StatPill
+                icon={Award}
+                value={data.newMilestones}
+                label={`new milestone${data.newMilestones !== 1 ? 's' : ''}`}
+              />
+            )}
+          </div>
+
+          <Link
+            href="/you/inbox"
+            onClick={handleDismiss}
+            className="flex items-center justify-center gap-1.5 text-xs text-primary hover:underline group"
+          >
+            See full details
+            <ArrowRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+function StatPill({
+  icon: Icon,
+  value,
+  label,
+}: {
+  icon: typeof Vote;
+  value: number;
+  label: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center gap-1 rounded-xl bg-white/[0.04] p-2.5 text-center',
+      )}
+    >
+      <Icon className="h-3.5 w-3.5 text-primary/70" />
+      <p className="text-lg font-bold tabular-nums text-foreground">{value}</p>
+      <p className="text-[9px] font-medium text-muted-foreground leading-tight">{label}</p>
+    </div>
+  );
+}

--- a/components/notifications/EmailOptIn.tsx
+++ b/components/notifications/EmailOptIn.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Mail, X, Loader2, Check, Shield } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { getStoredSession } from '@/lib/supabaseAuth';
+
+type DigestFrequency = 'epoch' | 'weekly' | 'major_only' | 'none';
+
+const FREQUENCY_OPTIONS: Array<{ value: DigestFrequency; label: string; desc: string }> = [
+  { value: 'epoch', label: 'Every epoch', desc: '~5 days' },
+  { value: 'weekly', label: 'Weekly', desc: 'Mondays' },
+  { value: 'major_only', label: 'Major events', desc: 'Critical only' },
+];
+
+const STORAGE_KEY = 'governada_email_optin_dismissed';
+
+interface EmailOptInProps {
+  /** Show as a dismissible banner (hub/settings) vs. inline form */
+  variant?: 'banner' | 'inline';
+  /** Called after successful opt-in */
+  onSuccess?: () => void;
+  className?: string;
+}
+
+export function EmailOptIn({ variant = 'banner', onSuccess, className }: EmailOptInProps) {
+  const [email, setEmail] = useState('');
+  const [frequency, setFrequency] = useState<DigestFrequency>('epoch');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  });
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+    localStorage.setItem(STORAGE_KEY, 'true');
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!email.trim()) return;
+
+      setStatus('submitting');
+      setErrorMsg('');
+
+      try {
+        const token = getStoredSession();
+        if (!token) {
+          setErrorMsg('Please connect your wallet first.');
+          setStatus('error');
+          return;
+        }
+
+        const res = await fetch('/api/you/notification-preferences', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ email: email.trim(), digestFrequency: frequency }),
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to save preferences');
+        }
+
+        setStatus('success');
+        onSuccess?.();
+
+        // Track opt-in
+        try {
+          const { default: posthog } = await import('posthog-js');
+          posthog.capture('email_opted_in', { digest_frequency: frequency });
+        } catch {
+          /* posthog optional */
+        }
+      } catch (err) {
+        setErrorMsg(err instanceof Error ? err.message : 'Something went wrong');
+        setStatus('error');
+      }
+    },
+    [email, frequency, onSuccess],
+  );
+
+  if (dismissed && variant === 'banner') return null;
+
+  if (status === 'success') {
+    return (
+      <div
+        className={cn(
+          'rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4 flex items-center gap-3',
+          className,
+        )}
+      >
+        <Check className="h-5 w-5 text-emerald-400 shrink-0" />
+        <div>
+          <p className="text-sm font-medium text-emerald-300">
+            You&apos;re signed up for governance briefings
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Check your inbox for a verification email.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5',
+        variant === 'banner' && 'relative',
+        className,
+      )}
+    >
+      {variant === 'banner' && (
+        <button
+          onClick={handleDismiss}
+          className="absolute top-3 right-3 p-1 rounded-lg hover:bg-white/5 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X className="h-3.5 w-3.5 text-muted-foreground" />
+        </button>
+      )}
+
+      <div className="flex items-start gap-3 mb-4">
+        <div className="p-2 rounded-lg bg-primary/10">
+          <Mail className="h-4 w-4 text-primary" />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">
+            Get a governance briefing every epoch
+          </h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Stay informed about your DRep&apos;s activity, proposals, and milestones.
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <Input
+          type="email"
+          placeholder="your@email.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="bg-white/5 border-white/10 text-sm"
+          disabled={status === 'submitting'}
+        />
+
+        {/* Frequency selector */}
+        <div className="flex gap-2">
+          {FREQUENCY_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setFrequency(opt.value)}
+              className={cn(
+                'flex-1 rounded-lg border px-2 py-2 text-center transition-all text-xs',
+                frequency === opt.value
+                  ? 'border-primary/40 bg-primary/10 text-primary'
+                  : 'border-white/[0.08] bg-white/[0.03] text-muted-foreground hover:border-white/20',
+              )}
+            >
+              <span className="font-medium block">{opt.label}</span>
+              <span className="text-[10px] opacity-70">{opt.desc}</span>
+            </button>
+          ))}
+        </div>
+
+        {errorMsg && <p className="text-xs text-red-400">{errorMsg}</p>}
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <Shield className="h-3 w-3" />
+            <span>We&apos;ll never share your email. Unsubscribe anytime.</span>
+          </div>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={status === 'submitting' || !email.trim()}
+            className="shrink-0"
+          >
+            {status === 'submitting' ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              'Subscribe'
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/notifications/InboxFeed.tsx
+++ b/components/notifications/InboxFeed.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { useCallback } from 'react';
+import Link from 'next/link';
+import {
+  Vote,
+  TrendingDown,
+  TrendingUp,
+  Clock,
+  Star,
+  Bell,
+  CheckCircle,
+  ChevronRight,
+  AlertCircle,
+  Activity,
+  BarChart2,
+  Award,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  useNotifications,
+  useMarkRead,
+  useMarkAllRead,
+  type Notification,
+} from '@/hooks/useNotifications';
+
+// ── Type to icon/color mapping ──────────────────────────────────────────────
+
+const TYPE_META: Record<
+  string,
+  { icon: typeof Bell; iconColor: string; borderColor: string; bgColor: string }
+> = {
+  'score-change': {
+    icon: TrendingDown,
+    iconColor: 'text-amber-400',
+    borderColor: 'border-amber-900/30',
+    bgColor: 'bg-amber-950/10',
+  },
+  'drep-voted': {
+    icon: Vote,
+    iconColor: 'text-emerald-400',
+    borderColor: 'border-emerald-900/30',
+    bgColor: 'bg-emerald-950/10',
+  },
+  'drep-score-change': {
+    icon: TrendingDown,
+    iconColor: 'text-amber-400',
+    borderColor: 'border-amber-900/30',
+    bgColor: 'bg-amber-950/10',
+  },
+  'drep-missed-vote': {
+    icon: Vote,
+    iconColor: 'text-rose-400',
+    borderColor: 'border-rose-900/30',
+    bgColor: 'bg-rose-950/10',
+  },
+  'drep-inactive': {
+    icon: AlertCircle,
+    iconColor: 'text-rose-400',
+    borderColor: 'border-rose-900/30',
+    bgColor: 'bg-rose-950/10',
+  },
+  'tier-change': {
+    icon: Star,
+    iconColor: 'text-violet-400',
+    borderColor: 'border-violet-900/30',
+    bgColor: 'bg-violet-950/10',
+  },
+  'citizen-level-up': {
+    icon: Award,
+    iconColor: 'text-emerald-400',
+    borderColor: 'border-emerald-900/30',
+    bgColor: 'bg-emerald-950/10',
+  },
+  'engagement-outcome': {
+    icon: CheckCircle,
+    iconColor: 'text-primary',
+    borderColor: 'border-primary/20',
+    bgColor: 'bg-primary/5',
+  },
+  'pending-proposals': {
+    icon: Vote,
+    iconColor: 'text-primary',
+    borderColor: 'border-primary/20',
+    bgColor: 'bg-primary/5',
+  },
+  'urgent-deadline': {
+    icon: Clock,
+    iconColor: 'text-rose-400',
+    borderColor: 'border-rose-900/30',
+    bgColor: 'bg-rose-950/10',
+  },
+  'alignment-drift': {
+    icon: AlertCircle,
+    iconColor: 'text-amber-400',
+    borderColor: 'border-amber-900/30',
+    bgColor: 'bg-amber-950/10',
+  },
+  'governance-brief': {
+    icon: BarChart2,
+    iconColor: 'text-sky-400',
+    borderColor: 'border-sky-900/30',
+    bgColor: 'bg-sky-950/10',
+  },
+  'delegation-change': {
+    icon: Activity,
+    iconColor: 'text-amber-400',
+    borderColor: 'border-amber-900/30',
+    bgColor: 'bg-amber-950/10',
+  },
+  'score-opportunity': {
+    icon: TrendingUp,
+    iconColor: 'text-emerald-400',
+    borderColor: 'border-emerald-900/30',
+    bgColor: 'bg-emerald-950/10',
+  },
+};
+
+const DEFAULT_META = {
+  icon: Bell,
+  iconColor: 'text-muted-foreground',
+  borderColor: 'border-border',
+  bgColor: 'bg-card',
+};
+
+// ── Time formatting ─────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function dateGroupLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const daysDiff = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (daysDiff === 0) return 'Today';
+  if (daysDiff === 1) return 'Yesterday';
+  if (daysDiff < 7) return 'This week';
+  if (daysDiff < 30) return 'This month';
+  return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function groupNotificationsByDate(
+  notifications: Notification[] | undefined,
+): Array<{ label: string; notifications: Notification[] }> {
+  if (!notifications) return [];
+
+  const groups: Array<{ label: string; notifications: Notification[] }> = [];
+  let currentLabel = '';
+  let currentNotifications: Notification[] = [];
+
+  for (const n of notifications) {
+    const label = dateGroupLabel(n.created_at);
+    if (label !== currentLabel) {
+      if (currentNotifications.length > 0) {
+        groups.push({ label: currentLabel, notifications: currentNotifications });
+      }
+      currentLabel = label;
+      currentNotifications = [n];
+    } else {
+      currentNotifications.push(n);
+    }
+  }
+
+  if (currentNotifications.length > 0) {
+    groups.push({ label: currentLabel, notifications: currentNotifications });
+  }
+
+  return groups;
+}
+
+// ── Notification card ───────────────────────────────────────────────────────
+
+function NotificationCard({
+  notification,
+  onMarkRead,
+}: {
+  notification: Notification;
+  onMarkRead: (id: string) => void;
+}) {
+  const meta = TYPE_META[notification.type] ?? DEFAULT_META;
+  const Icon = meta.icon;
+
+  const cardContent = (
+    <>
+      {!notification.read && (
+        <span className="absolute top-4 right-4 h-2 w-2 rounded-full bg-primary shrink-0" />
+      )}
+      <Icon className={cn('h-4 w-4 mt-0.5 shrink-0', meta.iconColor)} />
+      <div className="flex-1 min-w-0 pr-4">
+        <p
+          className={cn(
+            'text-sm font-medium leading-snug',
+            !notification.read && 'text-foreground',
+          )}
+        >
+          {notification.title}
+        </p>
+        {notification.body && (
+          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{notification.body}</p>
+        )}
+        <p className="text-[10px] text-muted-foreground/60 mt-1">
+          {timeAgo(notification.created_at)}
+        </p>
+      </div>
+      {notification.action_url && (
+        <div className="flex items-center gap-0.5 shrink-0 text-xs font-medium text-muted-foreground">
+          View
+          <ChevronRight className="h-3 w-3" />
+        </div>
+      )}
+    </>
+  );
+
+  const cardClasses = cn(
+    'relative flex items-start gap-3 rounded-xl border p-4 transition-all',
+    meta.borderColor,
+    meta.bgColor,
+    !notification.read && 'shadow-sm',
+  );
+
+  const handleClick = () => {
+    if (!notification.read) onMarkRead(notification.id);
+  };
+
+  if (notification.action_url) {
+    return (
+      <Link
+        href={notification.action_url}
+        className={cn(cardClasses, 'hover:brightness-110 cursor-pointer block')}
+        onClick={handleClick}
+      >
+        {cardContent}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      className={cardClasses}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') handleClick();
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      {cardContent}
+    </div>
+  );
+}
+
+// ── Main component ──────────────────────────────────────────────────────────
+
+interface InboxFeedProps {
+  isAuthenticated: boolean;
+}
+
+export function InboxFeed({ isAuthenticated }: InboxFeedProps) {
+  const { data, isLoading } = useNotifications(isAuthenticated);
+  const markReadMutation = useMarkRead();
+  const markAllReadMutation = useMarkAllRead();
+
+  const handleMarkRead = useCallback(
+    (id: string) => {
+      markReadMutation.mutate([id]);
+    },
+    [markReadMutation],
+  );
+
+  const handleMarkAllRead = useCallback(() => {
+    markAllReadMutation.mutate();
+  }, [markAllReadMutation]);
+
+  // Group notifications by date
+  const notifications = data?.notifications;
+  const grouped = groupNotificationsByDate(notifications);
+
+  const unreadCount = data?.unreadCount ?? 0;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data?.notifications?.length) {
+    return (
+      <div className="rounded-xl border border-emerald-900/30 bg-emerald-950/10 px-5 py-10 text-center space-y-2">
+        <CheckCircle className="h-8 w-8 text-emerald-400 mx-auto" />
+        <p className="text-sm font-medium text-emerald-300">You&apos;re all caught up</p>
+        <p className="text-xs text-muted-foreground">
+          No governance notifications right now. Your participation is healthy.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {unreadCount > 0
+              ? `${unreadCount} unread notification${unreadCount > 1 ? 's' : ''}`
+              : 'All caught up'}
+          </p>
+        </div>
+        {unreadCount > 0 && (
+          <button
+            onClick={handleMarkAllRead}
+            className="text-xs text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
+          >
+            <CheckCircle className="h-3 w-3" />
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {/* Grouped notifications */}
+      {grouped.map((group) => (
+        <div key={group.label}>
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+            {group.label}
+          </p>
+          <div className="space-y-2">
+            {group.notifications.map((n) => (
+              <NotificationCard key={n.id} notification={n} onMarkRead={handleMarkRead} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Bell } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { useNotificationCount } from '@/hooks/useNotifications';
+
+interface NotificationBellProps {
+  className?: string;
+}
+
+/**
+ * NotificationBell — header icon with unread count badge.
+ * Links to /you/inbox.
+ */
+export function NotificationBell({ className }: NotificationBellProps) {
+  const { unreadCount } = useNotificationCount();
+
+  return (
+    <Link
+      href="/you/inbox"
+      className={cn(
+        'relative inline-flex items-center justify-center h-9 w-9 rounded-lg hover:text-primary hover:bg-primary/10 transition-colors',
+        className,
+      )}
+      aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+    >
+      <Bell className="h-4 w-4" />
+      {unreadCount > 0 && (
+        <span className="absolute top-1 right-1 flex items-center justify-center">
+          <span className="absolute h-2.5 w-2.5 rounded-full bg-amber-500 animate-pulse" />
+          <span className="relative h-2 w-2 rounded-full bg-amber-500" />
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/emails/EpochDigest.tsx
+++ b/emails/EpochDigest.tsx
@@ -1,0 +1,310 @@
+/**
+ * Epoch Digest Email — sent at epoch boundaries to opted-in users.
+ *
+ * Personalized summary: epoch stats, DRep activity, milestones,
+ * active proposals to watch.
+ */
+
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+import * as React from 'react';
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://governada.io';
+
+export interface EpochDigestProps {
+  epoch: number;
+  proposalsDecided: number;
+  adaGoverned: string;
+  drepName: string;
+  drepVotesCast: number;
+  drepParticipationRate: number;
+  drepScore: number;
+  drepTier: string;
+  newMilestones: string[];
+  activeProposals: Array<{
+    title: string;
+    txHash: string;
+    index: number;
+    daysRemaining: number | null;
+  }>;
+  unsubscribeUrl: string;
+}
+
+// ── Shared Styles ────────────────────────────────────────────────────────
+
+const main: React.CSSProperties = {
+  backgroundColor: '#0c1222',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+};
+
+const container: React.CSSProperties = {
+  margin: '0 auto',
+  padding: '40px 20px',
+  maxWidth: '580px',
+};
+
+const card: React.CSSProperties = {
+  backgroundColor: '#1e293b',
+  borderRadius: '12px',
+  padding: '24px',
+  marginBottom: '16px',
+};
+
+const sectionTitle: React.CSSProperties = {
+  fontSize: '11px',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.08em',
+  color: '#64748b',
+  margin: '0 0 12px',
+  fontWeight: 600,
+};
+
+const statValue: React.CSSProperties = {
+  fontSize: '28px',
+  fontWeight: 700,
+  color: '#e2e8f0',
+  margin: 0,
+  lineHeight: '1.2',
+};
+
+const statLabel: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#64748b',
+  margin: '4px 0 0',
+};
+
+const paragraph: React.CSSProperties = {
+  fontSize: '15px',
+  lineHeight: '24px',
+  color: '#94a3b8',
+  margin: '0 0 12px',
+};
+
+const button: React.CSSProperties = {
+  backgroundColor: '#6366f1',
+  borderRadius: '8px',
+  color: '#ffffff',
+  fontSize: '15px',
+  fontWeight: 600,
+  textDecoration: 'none',
+  textAlign: 'center' as const,
+  display: 'block',
+  padding: '14px 28px',
+};
+
+const footer: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#475569',
+  lineHeight: '20px',
+  textAlign: 'center' as const,
+  marginTop: '32px',
+};
+
+const hr: React.CSSProperties = {
+  borderColor: '#334155',
+  margin: '24px 0',
+};
+
+export default function EpochDigest({
+  epoch = 530,
+  proposalsDecided = 3,
+  adaGoverned = '12.4M',
+  drepName = 'Your DRep',
+  drepVotesCast = 2,
+  drepParticipationRate = 85,
+  drepScore = 72,
+  drepTier = 'Silver',
+  newMilestones = [],
+  activeProposals = [],
+  unsubscribeUrl = '#',
+}: EpochDigestProps) {
+  const previewText = `Epoch ${epoch}: ${proposalsDecided} proposals decided, ${adaGoverned} ADA governed`;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {/* Header */}
+          <Section style={{ textAlign: 'center', padding: '24px 0' }}>
+            <Text
+              style={{
+                color: '#6366f1',
+                fontSize: '14px',
+                fontWeight: 600,
+                letterSpacing: '0.5px',
+                margin: '0 0 8px',
+              }}
+            >
+              GOVERNADA
+            </Text>
+            <Heading
+              style={{
+                color: '#e2e8f0',
+                fontSize: '22px',
+                fontWeight: 700,
+                margin: '0 0 4px',
+              }}
+            >
+              Epoch {epoch} Summary
+            </Heading>
+            <Text style={{ color: '#64748b', fontSize: '14px', margin: 0 }}>
+              {proposalsDecided} proposals decided &middot; {adaGoverned} ADA governed
+            </Text>
+          </Section>
+
+          {/* DRep Activity Card */}
+          <Section style={card}>
+            <Text style={sectionTitle}>Your DRep&apos;s Activity</Text>
+            <table cellPadding={0} cellSpacing={0} style={{ width: '100%' }}>
+              <tbody>
+                <tr>
+                  <td style={{ textAlign: 'left', verticalAlign: 'top' }}>
+                    <Text
+                      style={{
+                        fontSize: '16px',
+                        fontWeight: 600,
+                        color: '#e2e8f0',
+                        margin: '0 0 4px',
+                      }}
+                    >
+                      {drepName}
+                    </Text>
+                    <Text style={{ fontSize: '13px', color: '#64748b', margin: 0 }}>
+                      {drepTier} tier
+                    </Text>
+                  </td>
+                  <td style={{ textAlign: 'right', verticalAlign: 'top' }}>
+                    <Text
+                      style={{
+                        fontSize: '32px',
+                        fontWeight: 700,
+                        color: '#6366f1',
+                        margin: 0,
+                        lineHeight: '1',
+                      }}
+                    >
+                      {drepScore}
+                    </Text>
+                    <Text style={{ fontSize: '11px', color: '#64748b', margin: '2px 0 0' }}>
+                      score
+                    </Text>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <Hr style={{ ...hr, margin: '16px 0' }} />
+
+            <table cellPadding={0} cellSpacing={0} style={{ width: '100%' }}>
+              <tbody>
+                <tr>
+                  <td style={{ textAlign: 'center', width: '50%' }}>
+                    <Text style={statValue}>{drepVotesCast}</Text>
+                    <Text style={statLabel}>Votes cast</Text>
+                  </td>
+                  <td style={{ textAlign: 'center', width: '50%' }}>
+                    <Text style={statValue}>{drepParticipationRate}%</Text>
+                    <Text style={statLabel}>Participation</Text>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </Section>
+
+          {/* Milestones */}
+          {newMilestones.length > 0 && (
+            <Section style={card}>
+              <Text style={sectionTitle}>New Milestones</Text>
+              {newMilestones.map((milestone, i) => (
+                <Text
+                  key={i}
+                  style={{
+                    ...paragraph,
+                    fontSize: '14px',
+                    margin: '4px 0',
+                    color: '#a5b4fc',
+                  }}
+                >
+                  &#127942; {milestone}
+                </Text>
+              ))}
+            </Section>
+          )}
+
+          {/* Active Proposals */}
+          {activeProposals.length > 0 && (
+            <Section style={card}>
+              <Text style={sectionTitle}>Proposals to Watch</Text>
+              {activeProposals.slice(0, 4).map((p, i) => (
+                <Section
+                  key={i}
+                  style={{
+                    padding: '10px 0',
+                    borderBottom: i < activeProposals.length - 1 ? '1px solid #334155' : 'none',
+                  }}
+                >
+                  <Link
+                    href={`${BASE_URL}/proposal/${p.txHash}/${p.index}`}
+                    style={{
+                      color: '#e2e8f0',
+                      fontSize: '14px',
+                      fontWeight: 500,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    {p.title}
+                  </Link>
+                  {p.daysRemaining != null && (
+                    <Text
+                      style={{
+                        fontSize: '12px',
+                        color: '#64748b',
+                        margin: '4px 0 0',
+                      }}
+                    >
+                      {p.daysRemaining} days remaining
+                    </Text>
+                  )}
+                </Section>
+              ))}
+            </Section>
+          )}
+
+          {/* CTA */}
+          <Section style={{ textAlign: 'center', margin: '8px 0 24px' }}>
+            <Button style={button} href={`${BASE_URL}/`}>
+              Open Governada
+            </Button>
+          </Section>
+
+          {/* Footer */}
+          <Hr style={hr} />
+          <Text style={footer}>
+            Governada &middot; Cardano Governance Intelligence
+            <br />
+            <Link href={BASE_URL} style={{ color: '#6366f1', textDecoration: 'none' }}>
+              governada.io
+            </Link>
+            {' · '}
+            <Link href={unsubscribeUrl} style={{ color: '#475569', textDecoration: 'underline' }}>
+              Unsubscribe
+            </Link>
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -1,0 +1,126 @@
+/**
+ * TanStack Query hooks for the notification system.
+ *
+ * useNotifications() — full notification list for inbox page
+ * useNotificationCount() — lightweight unread count for header bell
+ */
+
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface Notification {
+  id: string;
+  title: string;
+  body: string | null;
+  type: string;
+  action_url: string | null;
+  metadata: Record<string, unknown> | null;
+  read: boolean;
+  created_at: string;
+}
+
+interface NotificationsResponse {
+  notifications: Notification[];
+  hasMore: boolean;
+  unreadCount: number;
+}
+
+// ── Fetch helpers ───────────────────────────────────────────────────────────
+
+async function fetchNotifications(
+  unreadOnly = false,
+  cursor?: string,
+): Promise<NotificationsResponse> {
+  const token = getStoredSession();
+  if (!token) return { notifications: [], hasMore: false, unreadCount: 0 };
+
+  const params = new URLSearchParams();
+  if (unreadOnly) params.set('unread_only', 'true');
+  if (cursor) params.set('cursor', cursor);
+
+  const res = await fetch(`/api/you/notifications?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) return { notifications: [], hasMore: false, unreadCount: 0 };
+  return res.json();
+}
+
+async function patchNotifications(body: { ids?: string[]; markAllRead?: boolean }) {
+  const token = getStoredSession();
+  if (!token) return;
+
+  await fetch('/api/you/notifications', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Hooks ───────────────────────────────────────────────────────────────────
+
+/**
+ * Full notifications list for the inbox page.
+ * Polls every 60 seconds.
+ */
+export function useNotifications(enabled = true) {
+  return useQuery<NotificationsResponse>({
+    queryKey: ['notifications'],
+    queryFn: () => fetchNotifications(),
+    enabled,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+/**
+ * Lightweight unread count for the notification bell.
+ * Polls every 60 seconds.
+ */
+export function useNotificationCount() {
+  const { data } = useQuery<NotificationsResponse>({
+    queryKey: ['notifications'],
+    queryFn: () => fetchNotifications(),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  return {
+    unreadCount: data?.unreadCount ?? 0,
+  };
+}
+
+/**
+ * Mark specific notifications as read.
+ */
+export function useMarkRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ids: string[]) => patchNotifications({ ids }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}
+
+/**
+ * Mark all notifications as read.
+ */
+export function useMarkAllRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => patchNotifications({ markAllRead: true }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}

--- a/inngest/functions/notify-engagement-outcomes.ts
+++ b/inngest/functions/notify-engagement-outcomes.ts
@@ -1,0 +1,137 @@
+/**
+ * Engagement Outcome Notifications — notifies citizens when proposals
+ * they voted on reach a decision.
+ *
+ * Runs daily after proposal outcomes are tracked.
+ * Finds proposals resolved since last run, looks up citizens who cast
+ * sentiment votes, and creates personalized follow-up notifications.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { createAlert } from '@/lib/alerts';
+import { logger } from '@/lib/logger';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://governada.io';
+
+export const notifyEngagementOutcomes = inngest.createFunction(
+  {
+    id: 'notify-engagement-outcomes',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"engagement-outcomes"' },
+  },
+  { cron: '30 1 * * *' }, // Daily at 01:30 UTC, after track-proposal-outcomes
+  async ({ step }) => {
+    const supabase = getSupabaseAdmin();
+
+    const result = await step.run('process-outcomes', async () => {
+      const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+
+      // Find proposals resolved in the last epoch
+      const { data: resolvedProposals } = await supabase
+        .from('proposals')
+        .select(
+          'tx_hash, proposal_index, title, proposal_type, ratified_epoch, expired_epoch, dropped_epoch',
+        )
+        .or(
+          `ratified_epoch.eq.${currentEpoch},ratified_epoch.eq.${currentEpoch - 1},expired_epoch.eq.${currentEpoch},expired_epoch.eq.${currentEpoch - 1},dropped_epoch.eq.${currentEpoch},dropped_epoch.eq.${currentEpoch - 1}`,
+        );
+
+      if (!resolvedProposals?.length) {
+        logger.info('[engagement-outcomes] No recently resolved proposals');
+        return { processed: 0, notified: 0 };
+      }
+
+      let processed = 0;
+      let notified = 0;
+
+      for (const proposal of resolvedProposals) {
+        const outcome =
+          proposal.ratified_epoch != null
+            ? 'ratified'
+            : proposal.dropped_epoch != null
+              ? 'dropped'
+              : 'expired';
+
+        // Find citizens who voted sentiment on this proposal
+        const { data: sentimentVoters } = await supabase
+          .from('citizen_sentiment')
+          .select('user_id, sentiment')
+          .eq('proposal_tx_hash', proposal.tx_hash)
+          .eq('proposal_index', proposal.proposal_index);
+
+        if (!sentimentVoters?.length) continue;
+
+        // Get community sentiment stats
+        const supportCount = sentimentVoters.filter((v) => v.sentiment === 'support').length;
+        const opposeCount = sentimentVoters.filter((v) => v.sentiment === 'oppose').length;
+        const totalVotes = sentimentVoters.length;
+
+        // Check which users have already been notified (via followups table)
+        const { data: existing } = await supabase
+          .from('citizen_proposal_followups')
+          .select('user_id')
+          .eq('proposal_tx_hash', proposal.tx_hash)
+          .eq('proposal_index', proposal.proposal_index)
+          .eq('notified', true);
+
+        const alreadyNotified = new Set((existing || []).map((e) => e.user_id));
+
+        // Deduplicate voters
+        const notifiedInRun = new Set<string>();
+
+        for (const voter of sentimentVoters) {
+          if (alreadyNotified.has(voter.user_id) || notifiedInRun.has(voter.user_id)) continue;
+          notifiedInRun.add(voter.user_id);
+
+          // Calculate agreement percentage
+          const agreedWithOutcome =
+            (outcome === 'ratified' && voter.sentiment === 'support') ||
+            (outcome !== 'ratified' && voter.sentiment === 'oppose');
+
+          const agreementPct = agreedWithOutcome
+            ? Math.round(
+                ((voter.sentiment === 'support' ? supportCount : opposeCount) / totalVotes) * 100,
+              )
+            : Math.round(
+                ((voter.sentiment === 'support' ? supportCount : opposeCount) / totalVotes) * 100,
+              );
+
+          const proposalTitle = proposal.title || proposal.proposal_type || 'A governance proposal';
+          const proposalUrl = `${BASE_URL}/proposal/${proposal.tx_hash}/${proposal.proposal_index}`;
+
+          await createAlert(voter.user_id, 'engagement_outcome', {
+            outcome,
+            sentiment: voter.sentiment,
+            proposalTitle,
+            proposalUrl,
+            agreementPct,
+            totalVoters: totalVotes,
+          });
+
+          // Record followup to prevent duplicate notifications
+          await supabase.from('citizen_proposal_followups').upsert(
+            {
+              user_id: voter.user_id,
+              proposal_tx_hash: proposal.tx_hash,
+              proposal_index: proposal.proposal_index,
+              sentiment: voter.sentiment,
+              outcome,
+              notified: true,
+            },
+            { onConflict: 'id' },
+          );
+
+          notified++;
+        }
+        processed++;
+      }
+
+      return { processed, notified };
+    });
+
+    logger.info('[engagement-outcomes] Complete', result);
+    return result;
+  },
+);

--- a/inngest/functions/notify-epoch-recap.ts
+++ b/inngest/functions/notify-epoch-recap.ts
@@ -1,10 +1,30 @@
+/**
+ * Epoch Recap Notifications — generates personalized epoch digests
+ * and sends them to opted-in users via email.
+ *
+ * Triggered after DRep scores sync. Generates epoch summary notifications
+ * for all users with digest_frequency matching the current cadence.
+ */
+
+import React from 'react';
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { notifyUser } from '@/lib/notifications';
+import { sendEmail, generateUnsubscribeUrl } from '@/lib/email';
+import { logger } from '@/lib/logger';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://governada.io';
 
 export const notifyEpochRecap = inngest.createFunction(
-  { id: 'notify-epoch-recap', retries: 2 },
+  {
+    id: 'notify-epoch-recap',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"epoch-recap"' },
+  },
   [{ event: 'drepscore/sync.scores' }],
-  async ({ step, logger }) => {
+  async ({ step }) => {
     const supabase = getSupabaseAdmin();
 
     const flagEnabled = await step.run('check-flag', async () => {
@@ -17,17 +37,237 @@ export const notifyEpochRecap = inngest.createFunction(
     });
     if (!flagEnabled) return { skipped: true };
 
-    const EPOCH_START_UNIX = 1596491091;
-    const EPOCH_LENGTH = 432000;
-    const currentEpoch = Math.floor(
-      (Math.floor(Date.now() / 1000) - EPOCH_START_UNIX) / EPOCH_LENGTH,
-    );
+    const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
 
-    const notifyResult = await step.run('create-notifications', async () => {
-      logger.info('[epoch-recap] Epoch recap notifications queued', { epoch: currentEpoch });
-      return { epoch: currentEpoch, queued: 0 };
+    // Gather epoch-level stats
+    const epochStats = await step.run('gather-epoch-stats', async () => {
+      const [proposalsResult, recapResult] = await Promise.all([
+        supabase
+          .from('proposals')
+          .select('tx_hash', { count: 'exact', head: true })
+          .or(
+            `ratified_epoch.eq.${currentEpoch - 1},expired_epoch.eq.${currentEpoch - 1},dropped_epoch.eq.${currentEpoch - 1}`,
+          ),
+        supabase
+          .from('epoch_recaps')
+          .select('proposals_submitted, proposals_ratified, treasury_withdrawn_ada')
+          .eq('epoch', currentEpoch - 1)
+          .maybeSingle(),
+      ]);
+
+      // Count active proposals
+      const { count: activeCount } = await supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .is('ratified_epoch', null)
+        .is('enacted_epoch', null)
+        .is('dropped_epoch', null)
+        .is('expired_epoch', null);
+
+      return {
+        proposalsDecided: proposalsResult.count ?? 0,
+        proposalsSubmitted: recapResult.data?.proposals_submitted ?? 0,
+        proposalsRatified: recapResult.data?.proposals_ratified ?? 0,
+        treasuryWithdrawnAda: recapResult.data?.treasury_withdrawn_ada ?? 0,
+        activeProposals: activeCount ?? 0,
+      };
     });
 
-    return notifyResult;
+    // Find opted-in users and generate personalized digests
+    const digestResult = await step.run('generate-digests', async () => {
+      // Get users who opted in for epoch digests
+      const { data: prefs } = await supabase
+        .from('user_notification_preferences')
+        .select('user_id, email, digest_frequency')
+        .in('digest_frequency', ['epoch', 'weekly']);
+
+      if (!prefs?.length) {
+        logger.info('[epoch-recap] No opted-in users found');
+        return { queued: 0, emailed: 0 };
+      }
+
+      // Filter: weekly users only get notified on Mondays
+      const isMonday = new Date().getDay() === 1;
+      const eligiblePrefs = prefs.filter(
+        (p) => p.digest_frequency === 'epoch' || (p.digest_frequency === 'weekly' && isMonday),
+      );
+
+      if (eligiblePrefs.length === 0) {
+        return { queued: 0, emailed: 0 };
+      }
+
+      let queued = 0;
+      let emailed = 0;
+
+      for (const pref of eligiblePrefs) {
+        try {
+          // Get user's delegated DRep info
+          const { data: wallet } = await supabase
+            .from('user_wallets')
+            .select('drep_id')
+            .eq('user_id', pref.user_id)
+            .limit(1)
+            .maybeSingle();
+
+          let drepName = 'Your DRep';
+          let drepScore = 0;
+          let drepTier = 'Emerging';
+          let drepVotesCast = 0;
+          let drepParticipationRate = 0;
+
+          if (wallet?.drep_id) {
+            const { data: drep } = await supabase
+              .from('dreps')
+              .select('info, score, current_tier, participation_rate')
+              .eq('id', wallet.drep_id)
+              .single();
+
+            if (drep) {
+              const info = (drep.info || {}) as Record<string, unknown>;
+              drepName =
+                (info.givenName as string) || (info.name as string) || wallet.drep_id.slice(0, 12);
+              drepScore = drep.score ?? 0;
+              drepTier = drep.current_tier ?? 'Emerging';
+              drepParticipationRate = Math.round((drep.participation_rate ?? 0) * 100);
+            }
+
+            // Count votes this epoch
+            const { count } = await supabase
+              .from('drep_votes')
+              .select('vote_tx_hash', { count: 'exact', head: true })
+              .eq('drep_id', wallet.drep_id)
+              .eq('epoch_no', currentEpoch - 1);
+            drepVotesCast = count ?? 0;
+          }
+
+          // Get active proposals for the digest
+          const { data: activeProposals } = await supabase
+            .from('proposals')
+            .select('tx_hash, proposal_index, title, expiration_epoch')
+            .is('ratified_epoch', null)
+            .is('enacted_epoch', null)
+            .is('dropped_epoch', null)
+            .is('expired_epoch', null)
+            .order('proposed_epoch', { ascending: false })
+            .limit(4);
+
+          // Check for new milestones
+          const stakeAddr = (
+            await supabase
+              .from('user_wallets')
+              .select('stake_address')
+              .eq('user_id', pref.user_id)
+              .limit(1)
+              .maybeSingle()
+          ).data?.stake_address;
+
+          let newMilestones: string[] = [];
+          if (stakeAddr) {
+            const oneDayAgo = new Date(Date.now() - 5 * 86400 * 1000).toISOString();
+            const { data: milestoneNotifs } = await supabase
+              .from('notifications')
+              .select('title')
+              .eq('user_stake_address', stakeAddr)
+              .in('type', ['citizen-level-up', 'near-milestone'])
+              .gte('created_at', oneDayAgo);
+            newMilestones = (milestoneNotifs || []).map((n) => n.title);
+          }
+
+          const adaGoverned =
+            epochStats.treasuryWithdrawnAda > 0
+              ? `${(epochStats.treasuryWithdrawnAda / 1_000_000).toFixed(1)}M`
+              : '0';
+
+          // Create inbox notification
+          await notifyUser(pref.user_id, {
+            eventType: 'governance-brief',
+            title: `Epoch ${currentEpoch - 1} Summary`,
+            body: `${epochStats.proposalsDecided} proposals decided. Your DRep cast ${drepVotesCast} votes.`,
+            url: `${BASE_URL}/`,
+            metadata: {
+              epoch: currentEpoch - 1,
+              proposalsDecided: epochStats.proposalsDecided,
+              drepVotes: drepVotesCast,
+            },
+          });
+          queued++;
+
+          // Send email if verified
+          if (pref.email) {
+            const { data: user } = await supabase
+              .from('users')
+              .select('email_verified')
+              .eq('id', pref.user_id)
+              .single();
+
+            if (user?.email_verified) {
+              try {
+                const EpochDigest = (await import('@/emails/EpochDigest')).default;
+                const unsubscribeUrl = generateUnsubscribeUrl(pref.user_id);
+
+                const sent = await sendEmail(
+                  pref.email,
+                  `Epoch ${currentEpoch - 1}: ${epochStats.proposalsDecided} proposals decided`,
+                  React.createElement(EpochDigest, {
+                    epoch: currentEpoch - 1,
+                    proposalsDecided: epochStats.proposalsDecided,
+                    adaGoverned,
+                    drepName,
+                    drepVotesCast,
+                    drepParticipationRate,
+                    drepScore: Math.round(drepScore),
+                    drepTier,
+                    newMilestones,
+                    activeProposals: (activeProposals || []).map((p) => ({
+                      title: p.title || 'Untitled Proposal',
+                      txHash: p.tx_hash,
+                      index: p.proposal_index,
+                      daysRemaining: p.expiration_epoch
+                        ? Math.max(0, (p.expiration_epoch - currentEpoch) * 5)
+                        : null,
+                    })),
+                    unsubscribeUrl,
+                  }),
+                  {
+                    unsubscribeUrl,
+                    tags: [
+                      { name: 'type', value: 'epoch-digest' },
+                      { name: 'epoch', value: String(currentEpoch - 1) },
+                    ],
+                  },
+                );
+
+                if (sent) emailed++;
+              } catch (emailErr) {
+                logger.warn('[epoch-recap] Email send failed', {
+                  userId: pref.user_id,
+                  error: emailErr instanceof Error ? emailErr.message : emailErr,
+                });
+              }
+            }
+          }
+        } catch (err) {
+          logger.warn('[epoch-recap] Failed to process user', {
+            userId: pref.user_id,
+            error: err instanceof Error ? err.message : err,
+          });
+        }
+      }
+
+      return { queued, emailed };
+    });
+
+    captureServerEvent('digest_sent', {
+      epoch: currentEpoch - 1,
+      queued: digestResult.queued,
+      emailed: digestResult.emailed,
+    });
+
+    logger.info('[epoch-recap] Epoch recap complete', {
+      epoch: currentEpoch - 1,
+      ...digestResult,
+    });
+
+    return { epoch: currentEpoch - 1, ...digestResult };
   },
 );

--- a/lib/alerts.ts
+++ b/lib/alerts.ts
@@ -1,0 +1,146 @@
+/**
+ * Alert System — creates typed notifications for governance events.
+ *
+ * Used by Inngest functions to wire real governance events into
+ * the notification pipeline (inbox + channels).
+ */
+
+import {
+  notifyUser,
+  notifySegment,
+  type SegmentQuery,
+  type NotificationEvent,
+  type EventType,
+} from '@/lib/notifications';
+import { logger } from '@/lib/logger';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://governada.io';
+
+export type AlertType =
+  | 'drep_voted'
+  | 'coverage_changed'
+  | 'score_shifted'
+  | 'milestone_earned'
+  | 'epoch_summary'
+  | 'engagement_outcome';
+
+interface AlertConfig {
+  eventType: EventType;
+  title: string;
+  body: string;
+  url?: string;
+}
+
+const ALERT_BUILDERS: Record<AlertType, (data: Record<string, unknown>) => AlertConfig> = {
+  drep_voted: (data) => ({
+    eventType: 'drep-voted',
+    title: `Your DRep voted ${data.vote as string} on a proposal`,
+    body: (data.proposalTitle as string) || 'A governance proposal',
+    url: data.proposalUrl as string | undefined,
+  }),
+
+  coverage_changed: (data) => {
+    const delta = data.delta as number;
+    const direction = delta > 0 ? 'increased' : 'decreased';
+    return {
+      eventType: 'drep-score-change',
+      title: `Your DRep's coverage ${direction}`,
+      body: `Participation rate is now ${data.newRate as number}%. ${delta > 0 ? 'Good governance in action.' : 'Your DRep may be less active.'}`,
+      url: data.drepUrl as string | undefined,
+    };
+  },
+
+  score_shifted: (data) => {
+    const oldTier = data.oldTier as string;
+    const newTier = data.newTier as string;
+    return {
+      eventType: 'tier-change',
+      title: `Tier change: ${oldTier} → ${newTier}`,
+      body: `Score is now ${data.newScore as number}/100.`,
+      url: data.url as string | undefined,
+    };
+  },
+
+  milestone_earned: (data) => ({
+    eventType: 'citizen-level-up',
+    title: `Achievement unlocked: ${data.label as string}`,
+    body: (data.description as string) || 'You reached a new governance milestone.',
+    url: `${BASE_URL}/you`,
+  }),
+
+  epoch_summary: (data) => ({
+    eventType: 'governance-brief',
+    title: `Epoch ${data.epoch as number} Summary`,
+    body: `${data.proposalsDecided as number} proposals decided, ${data.drepVotes as number} DRep votes cast.`,
+    url: `${BASE_URL}/`,
+  }),
+
+  engagement_outcome: (data) => {
+    const outcome = data.outcome as string;
+    const sentiment = data.sentiment as string;
+    const sentimentLabel =
+      sentiment === 'support' ? 'supported' : sentiment === 'oppose' ? 'opposed' : 'weighed in on';
+    return {
+      eventType: 'engagement-outcome',
+      title: `Proposal you ${sentimentLabel} was ${outcome}`,
+      body: (data.proposalTitle as string) || 'A governance proposal',
+      url: data.proposalUrl as string | undefined,
+    };
+  },
+};
+
+/**
+ * Create an alert notification for a specific user.
+ * Persists to inbox and routes through enabled channels.
+ */
+export async function createAlert(
+  userId: string,
+  type: AlertType,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const builder = ALERT_BUILDERS[type];
+  if (!builder) {
+    logger.warn('[alerts] Unknown alert type', { type });
+    return;
+  }
+
+  const config = builder(data);
+
+  const event: NotificationEvent = {
+    eventType: config.eventType,
+    title: config.title,
+    body: config.body,
+    url: config.url,
+    metadata: data,
+  };
+
+  await notifyUser(userId, event);
+}
+
+/**
+ * Create an alert for all users delegated to a specific DRep.
+ */
+export async function createAlertForDelegators(
+  drepId: string,
+  type: AlertType,
+  data: Record<string, unknown>,
+): Promise<number> {
+  const builder = ALERT_BUILDERS[type];
+  if (!builder) {
+    logger.warn('[alerts] Unknown alert type', { type });
+    return 0;
+  }
+
+  const config = builder(data);
+  const segment: SegmentQuery = { type: 'delegated-to', drepId };
+
+  const event: NotificationEvent = {
+    eventType: config.eventType,
+    title: config.title,
+    body: config.body,
+    url: config.url,
+    metadata: data,
+  };
+
+  return notifySegment(segment, event);
+}

--- a/lib/notificationRegistry.ts
+++ b/lib/notificationRegistry.ts
@@ -332,6 +332,18 @@ export const EVENT_REGISTRY: EventDefinition[] = [
     channels: ['push', 'email', 'discord', 'telegram'],
   },
 
+  // ── Engagement Outcomes ──────────────────────────────────────────────────
+  {
+    key: 'engagement-outcome',
+    category: 'citizen',
+    audience: 'holder',
+    urgency: 'batched',
+    label: 'Proposal Outcome Follow-ups',
+    description: 'When a proposal you voted on reaches a decision',
+    defaultChannels: ['push', 'email'],
+    channels: ['push', 'email', 'discord', 'telegram'],
+  },
+
   // ── Digest ────────────────────────────────────────────────────────────────
   {
     key: 'governance-brief',

--- a/supabase/migrations/056_user_notification_preferences_and_what_changed.sql
+++ b/supabase/migrations/056_user_notification_preferences_and_what_changed.sql
@@ -1,0 +1,66 @@
+-- User notification preferences for digest/email opt-in
+-- This is separate from the per-event notification_preferences table.
+-- It stores email for notifications (NOT auth) and digest frequency.
+CREATE TABLE IF NOT EXISTS user_notification_preferences (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  email TEXT,
+  digest_frequency TEXT NOT NULL DEFAULT 'none' CHECK (digest_frequency IN ('epoch', 'weekly', 'major_only', 'none')),
+  alert_drep_voted BOOLEAN NOT NULL DEFAULT TRUE,
+  alert_coverage_changed BOOLEAN NOT NULL DEFAULT TRUE,
+  alert_score_shifted BOOLEAN NOT NULL DEFAULT TRUE,
+  alert_milestone_earned BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- RLS policies
+ALTER TABLE user_notification_preferences ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own preferences
+CREATE POLICY "Users can read own notification preferences"
+  ON user_notification_preferences FOR SELECT
+  USING (user_id = auth.uid());
+
+-- Users can insert their own preferences
+CREATE POLICY "Users can insert own notification preferences"
+  ON user_notification_preferences FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+-- Users can update their own preferences
+CREATE POLICY "Users can update own notification preferences"
+  ON user_notification_preferences FOR UPDATE
+  USING (user_id = auth.uid());
+
+-- Service role bypass (for Inngest functions)
+CREATE POLICY "Service role full access to notification preferences"
+  ON user_notification_preferences FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- Track proposal outcomes for citizen follow-ups
+CREATE TABLE IF NOT EXISTS citizen_proposal_followups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INTEGER NOT NULL,
+  sentiment TEXT NOT NULL,
+  outcome TEXT, -- 'ratified' | 'expired' | 'dropped'
+  notified BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_citizen_proposal_followups_user
+  ON citizen_proposal_followups(user_id);
+CREATE INDEX IF NOT EXISTS idx_citizen_proposal_followups_proposal
+  ON citizen_proposal_followups(proposal_tx_hash, proposal_index);
+CREATE INDEX IF NOT EXISTS idx_citizen_proposal_followups_pending
+  ON citizen_proposal_followups(notified) WHERE notified = FALSE;
+
+ALTER TABLE citizen_proposal_followups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own proposal followups"
+  ON citizen_proposal_followups FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Service role full access to citizen proposal followups"
+  ON citizen_proposal_followups FOR ALL
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary

- **Epoch-boundary digest**: Personalized email sent after DRep score sync with DRep activity, milestones, active proposals. Opt-in via `user_notification_preferences` table with frequency selector (epoch/weekly/major_only).
- **Email collection opt-in**: `EmailOptIn` component (banner + inline variants) wired into settings page. API route validates, saves preferences, and sends verification email via Resend.
- **Alert system**: Typed `createAlert()` in `lib/alerts.ts` maps 6 governance event types (DRep voted, coverage changed, score shifted, milestone earned, epoch summary, engagement outcome) into the notification pipeline.
- **Notification pipeline**: `InboxFeed` component with date grouping, unread indicators, mark-as-read. `useNotifications` / `useNotificationCount` TanStack Query hooks polling every 60s. Header bell dropdown now links to `/you/inbox`.
- **"What Changed" return visit summary**: `WhatChanged` component at top of CitizenHub shows proposals decided, DRep votes, milestones since last visit (12+ hour threshold). Auto-dismisses via sessionStorage.
- **Engagement result follow-ups**: `notify-engagement-outcomes` Inngest function runs daily at 01:30 UTC, finds resolved proposals, notifies sentiment voters with outcome + agreement stats. Deduplicates via `citizen_proposal_followups` table.
- **DB migration**: `user_notification_preferences` + `citizen_proposal_followups` tables with RLS policies (already applied via Supabase MCP).
- **Fix**: Added missing `@testing-library/dom` dev dependency that was causing 9 component test suites to fail.

## New files

| File | Purpose |
|------|---------|
| `lib/alerts.ts` | Typed alert creation utility |
| `emails/EpochDigest.tsx` | React Email template for epoch digest |
| `components/notifications/EmailOptIn.tsx` | Email opt-in component |
| `components/notifications/InboxFeed.tsx` | Grouped notification feed |
| `components/notifications/NotificationBell.tsx` | Header bell with unread dot |
| `components/hub/WhatChanged.tsx` | Return visit summary |
| `hooks/useNotifications.ts` | TanStack Query notification hooks |
| `app/api/you/notification-preferences/route.ts` | GET/POST notification prefs |
| `app/api/you/what-changed/route.ts` | GET what-changed since timestamp |
| `inngest/functions/notify-engagement-outcomes.ts` | Daily engagement follow-ups |
| `supabase/migrations/056_...sql` | DB migration |

## Test plan

- [ ] Verify `npm run preflight` passes (format, lint, types, all 591 tests green)
- [ ] Verify email opt-in flow: enter email, select frequency, submit, check verification email
- [ ] Verify WhatChanged appears after 12+ hours away, dismisses on click
- [ ] Verify InboxFeed renders grouped notifications with correct icons/colors
- [ ] Verify NotificationBell shows unread dot when notifications exist
- [ ] Verify engagement outcome notifications fire for resolved proposals
- [ ] Verify epoch digest email renders correctly with DRep data

🤖 Generated with [Claude Code](https://claude.com/claude-code)