### PR TITLE
feat: UX overhaul — cockpit homepage, /you restructure, 9 MLE improvements

### DIFF
--- a/app/delegation/page.tsx
+++ b/app/delegation/page.tsx
@@ -1,20 +1,11 @@
-import type { Metadata } from 'next';
-import { PageViewTracker } from '@/components/PageViewTracker';
-import { DelegationPage } from '@/components/hub/DelegationPage';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-  title: 'Your Governance Coverage — Governada',
-  description:
-    'See who represents your ADA in Cardano governance. Review your DRep and stake pool delegation.',
-};
-
+/**
+ * /delegation is deprecated — its content has been folded into the CitizenHub homepage.
+ * Redirect any direct visits to the home page.
+ */
 export default function Delegation() {
-  return (
-    <>
-      <PageViewTracker event="delegation_viewed" />
-      <DelegationPage />
-    </>
-  );
+  redirect('/');
 }

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -168,7 +168,18 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         nclUtilization={nclUtilization}
       />
 
-      {/* Zone 2: Community Signals — engagement, concerns, dimension tags */}
+      {/* Zone 2: Take Action — vote flow + citizen voice side by side */}
+      <ActionPanel
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+        title={title}
+        isOpen={isOpen}
+        proposalAbstract={proposal.abstract}
+        proposalType={proposal.proposalType}
+        aiSummary={proposal.aiSummary}
+      />
+
+      {/* Zone 3: Community Signals — engagement, concerns, dimension tags */}
       <div className="space-y-4">
         <EngagementSummary txHash={txHash} proposalIndex={proposalIndex} />
         <ConcernFlagBanner
@@ -191,24 +202,13 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         <ProposalDimensionTags relevantPrefs={proposal.relevantPrefs} />
       </div>
 
-      {/* Zone 3: Intelligence Briefing — AI summary + constitutional + params merged */}
+      {/* Zone 4: Intelligence Briefing — AI summary + constitutional + params merged */}
       <IntelligenceBriefing
         txHash={txHash}
         proposalIndex={proposalIndex}
         aiSummary={proposal.aiSummary}
         proposalType={proposal.proposalType}
         paramChanges={proposal.paramChanges}
-      />
-
-      {/* Zone 4: Take Action — vote flow + citizen voice side by side */}
-      <ActionPanel
-        txHash={txHash}
-        proposalIndex={proposalIndex}
-        title={title}
-        isOpen={isOpen}
-        proposalAbstract={proposal.abstract}
-        proposalType={proposal.proposalType}
-        aiSummary={proposal.aiSummary}
       />
 
       {/* Zone 5: The Debate — structured pro/con rationales */}

--- a/app/you/drep/page.tsx
+++ b/app/you/drep/page.tsx
@@ -1,0 +1,22 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+import { DRepScorecardView } from '@/components/civica/identity/DRepScorecardView';
+
+export const metadata: Metadata = {
+  title: 'Governada — DRep Scorecard',
+  description: 'Your DRep governance scorecard — score breakdown, improvement actions, and trends.',
+  openGraph: {
+    title: 'Governada — DRep Scorecard',
+    description: 'Your DRep governance performance on Cardano.',
+    type: 'website',
+  },
+};
+
+export default function DRepScorecardPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 sm:px-6 py-8">
+      <DRepScorecardView />
+    </div>
+  );
+}

--- a/app/you/identity/page.tsx
+++ b/app/you/identity/page.tsx
@@ -1,23 +1,9 @@
-export const dynamic = 'force-dynamic';
+import { redirect } from 'next/navigation';
 
-import type { Metadata } from 'next';
-import { CivicIdentityProfile } from '@/components/civica/identity/CivicIdentityProfile';
-
-export const metadata: Metadata = {
-  title: 'Governada — Civic Identity',
-  description:
-    'Your civic identity — delegation history, governance footprint, milestones, and engagement stats.',
-  openGraph: {
-    title: 'Governada — Civic Identity',
-    description: 'Your civic identity on Cardano governance.',
-    type: 'website',
-  },
-};
-
-export default function IdentityPage() {
-  return (
-    <div className="mx-auto max-w-2xl px-4 sm:px-6 py-8">
-      <CivicIdentityProfile />
-    </div>
-  );
+/**
+ * /you/identity is deprecated — identity now lives at /you.
+ * This redirect ensures old bookmarks still work.
+ */
+export default function IdentityRedirect() {
+  redirect('/you');
 }

--- a/app/you/page.tsx
+++ b/app/you/page.tsx
@@ -4,11 +4,11 @@ import type { Metadata } from 'next';
 import { CivicIdentityProfile } from '@/components/civica/identity/CivicIdentityProfile';
 
 export const metadata: Metadata = {
-  title: 'Governada — You',
+  title: 'Governada — Identity',
   description:
-    'Your governance identity — delegation history, governance footprint, milestones, and engagement stats.',
+    'Your civic identity — delegation history, governance footprint, milestones, and engagement stats.',
   openGraph: {
-    title: 'Governada — Your Governance Identity',
+    title: 'Governada — Your Civic Identity',
     description: 'Your civic identity on Cardano governance.',
     type: 'website',
   },

--- a/app/you/spo/page.tsx
+++ b/app/you/spo/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
+import { SPOScorecardView } from '@/components/civica/identity/SPOScorecardView';
+
+export const metadata: Metadata = {
+  title: 'Governada — Pool Scorecard',
+  description:
+    'Your stake pool governance scorecard — score breakdown, competitive position, and improvement actions.',
+  openGraph: {
+    title: 'Governada — Pool Scorecard',
+    description: 'Your pool governance performance on Cardano.',
+    type: 'website',
+  },
+};
+
+export default function SPOScorecardPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 sm:px-6 py-8">
+      <SPOScorecardView />
+    </div>
+  );
+}

--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -9,11 +9,10 @@ import { getBottomBarItems } from '@/lib/nav/config';
 
 export function CivicaBottomNav() {
   const pathname = usePathname();
-  const { segment, stakeAddress, delegatedDrep, delegatedPool } = useSegment();
+  const { segment, stakeAddress } = useSegment();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
-  const hasDelegation = !!(delegatedDrep || delegatedPool);
 
-  const navItems = getBottomBarItems(segment, hasDelegation);
+  const navItems = getBottomBarItems(segment);
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -17,10 +17,12 @@ import {
   ShieldCheck,
   Scale,
   Layers,
+  HelpCircle,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
+import { HELP_ITEMS } from '@/lib/nav/config';
 import { useWallet } from '@/utils/wallet-context';
 import { useSegment, type UserSegment } from '@/components/providers/SegmentProvider';
 import { TIER_SCORE_COLOR, type TierKey } from '@/components/civica/cards/tierStyles';
@@ -157,6 +159,30 @@ export function CivicaHeader() {
               )}
             </Button>
           )}
+
+          {/* Help dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                aria-label="Help"
+              >
+                <HelpCircle className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {HELP_ITEMS.map(({ href, label, icon: Icon }) => (
+                <DropdownMenuItem key={href} asChild>
+                  <Link href={href}>
+                    <Icon className="h-4 w-4" />
+                    {label}
+                  </Link>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           <Button
             variant="ghost"

--- a/components/civica/CivicaShell.tsx
+++ b/components/civica/CivicaShell.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useState, useCallback } from 'react';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { cn } from '@/lib/utils';
-import { SegmentProvider } from '@/components/providers/SegmentProvider';
+import { SegmentProvider, useSegment } from '@/components/providers/SegmentProvider';
 import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { CivicaHeader } from './CivicaHeader';
 import { CivicaBottomNav } from './CivicaBottomNav';
@@ -50,6 +50,34 @@ function DeepLinkHandler() {
   return null;
 }
 
+/** Background globe — hidden on homepage only for anonymous users (who have their own hero globe in AnonymousLanding). */
+function BackgroundGlobe({
+  isHomepage,
+  sidebarCollapsed,
+}: {
+  isHomepage: boolean;
+  sidebarCollapsed: boolean;
+}) {
+  const { segment } = useSegment();
+  // Hide the background globe on homepage for anonymous/not-yet-loaded users
+  if (isHomepage && segment === 'anonymous') return null;
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
+        sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
+      )}
+      aria-hidden="true"
+    >
+      <div className="absolute inset-0 opacity-30">
+        <ConstellationScene interactive={false} className="w-full h-full" />
+      </div>
+      {/* Gradient fade — globe is most visible at top, fades toward bottom */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent via-60% to-background" />
+    </div>
+  );
+}
+
 /**
  * Governada layout shell — sidebar on desktop, bottom bar on mobile.
  * Sidebar is persona-adaptive via the nav config.
@@ -81,22 +109,8 @@ export function CivicaShell({ children }: { children: React.ReactNode }) {
         <CivicaHeader />
         <CivicaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
 
-        {/* Global constellation globe — subtle glassmorphic background (hidden on homepage which has its own hero globe) */}
-        {!isHomepage && (
-          <div
-            className={cn(
-              'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
-              sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
-            )}
-            aria-hidden="true"
-          >
-            <div className="absolute inset-0 opacity-30">
-              <ConstellationScene interactive={false} className="w-full h-full" />
-            </div>
-            {/* Gradient fade — globe is most visible at top, fades toward bottom */}
-            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent via-60% to-background" />
-          </div>
-        )}
+        {/* Global constellation globe — subtle glassmorphic background */}
+        <BackgroundGlobe isHomepage={isHomepage} sidebarCollapsed={sidebarCollapsed} />
 
         <main
           id="main-content"
@@ -108,6 +122,17 @@ export function CivicaShell({ children }: { children: React.ReactNode }) {
         >
           {children}
         </main>
+        <footer
+          className={cn(
+            'relative z-0 border-t border-border/40 py-4 px-4 text-center transition-[padding-left] duration-200',
+            sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+          )}
+        >
+          <p className="text-xs text-muted-foreground/70">
+            Governada is an independent community project and is not affiliated with, endorsed by,
+            or associated with the Cardano Foundation, IOG, or EMURGO.
+          </p>
+        </footer>
         <CivicaBottomNav />
       </TierThemeProvider>
     </SegmentProvider>

--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -14,6 +14,8 @@ import {
   AlertCircle,
   ArrowRight,
   Shield,
+  Users,
+  Landmark,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -108,6 +110,44 @@ function SectionHeader({ title }: { title: string }) {
   );
 }
 
+/* ── Empty-state CTAs ─────────────────────────────────────────── */
+
+function UndelegatedCTA() {
+  return (
+    <div className="rounded-xl border border-primary/20 bg-primary/[0.04] p-5 text-center space-y-3">
+      <Users className="h-6 w-6 text-primary mx-auto" />
+      <p className="text-sm font-semibold text-foreground">
+        Delegate to a DRep to start building your civic identity
+      </p>
+      <p className="text-xs text-muted-foreground max-w-xs mx-auto">
+        Your governance footprint begins when you delegate. Find a DRep whose values match yours and
+        your votes will count toward on-chain proposals.
+      </p>
+      <Button size="sm" asChild>
+        <Link href="/match">
+          Find Your DRep
+          <ArrowRight className="h-3.5 w-3.5 ml-1" />
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+function UnstakedCTA() {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 p-5 text-center space-y-3">
+      <Landmark className="h-6 w-6 text-muted-foreground mx-auto" />
+      <p className="text-sm font-semibold text-foreground">
+        Stake with a pool to complete your governance coverage
+      </p>
+      <p className="text-xs text-muted-foreground max-w-xs mx-auto">
+        Staking secures the network and earns rewards while your delegation shapes governance.
+        Together they make your civic identity complete.
+      </p>
+    </div>
+  );
+}
+
 /* ── Loading skeleton ──────────────────────────────────────────── */
 
 function ProfileSkeleton() {
@@ -174,6 +214,9 @@ export function CivicIdentityProfile() {
 
   if (isLoading) return <ProfileSkeleton />;
 
+  const isUndelegated = !footprint?.identity.delegatedDRep;
+  const isUnstaked = !footprint?.identity.delegatedPool;
+
   const shareUrl = stakeAddress
     ? `https://governada.io/my-gov/identity`
     : 'https://governada.io/my-gov/identity';
@@ -221,74 +264,84 @@ export function CivicIdentityProfile() {
       >
         {footprint && (
           <>
-            {/* Participation tier banner */}
-            <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-card p-4">
-              {(() => {
-                const tier = footprint.identity.participationTier;
-                const config = HEALTH_CONFIG[tier];
-                const TierIcon = config.icon;
-                return (
-                  <>
-                    <TierIcon className={cn('h-5 w-5', config.color)} />
-                    <div className="flex-1">
-                      <p className="text-sm font-semibold">{config.label} Citizen</p>
-                      <p className="text-xs text-muted-foreground">
-                        {footprint.identity.delegationAgeDays != null
-                          ? `Delegating for ${footprint.identity.delegationAgeDays} days`
-                          : 'Start delegating to build your identity'}
-                      </p>
-                    </div>
-                    {footprint.delegationRecord.drepName && (
-                      <Link
-                        href={`/drep/${footprint.identity.delegatedDRep}`}
-                        className="text-sm font-medium text-primary hover:underline"
-                      >
-                        {footprint.delegationRecord.drepName}
-                      </Link>
-                    )}
-                  </>
-                );
-              })()}
-            </div>
+            {isUndelegated ? (
+              /* Undelegated citizen — show onboarding CTA instead of empty stats */
+              <UndelegatedCTA />
+            ) : (
+              <>
+                {/* Participation tier banner */}
+                <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-card p-4">
+                  {(() => {
+                    const tier = footprint.identity.participationTier;
+                    const config = HEALTH_CONFIG[tier];
+                    const TierIcon = config.icon;
+                    return (
+                      <>
+                        <TierIcon className={cn('h-5 w-5', config.color)} />
+                        <div className="flex-1">
+                          <p className="text-sm font-semibold">{config.label} Citizen</p>
+                          <p className="text-xs text-muted-foreground">
+                            {footprint.identity.delegationAgeDays != null
+                              ? `Delegating for ${footprint.identity.delegationAgeDays} days`
+                              : 'Start delegating to build your identity'}
+                          </p>
+                        </div>
+                        {footprint.delegationRecord.drepName && (
+                          <Link
+                            href={`/drep/${footprint.identity.delegatedDRep}`}
+                            className="text-sm font-medium text-primary hover:underline"
+                          >
+                            {footprint.delegationRecord.drepName}
+                          </Link>
+                        )}
+                      </>
+                    );
+                  })()}
+                </div>
 
-            {/* Stats grid */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              <StatCard
-                icon={Calendar}
-                label="Citizen Since"
-                value={
-                  footprint.identity.delegationAgeDays != null
-                    ? `${Math.floor(footprint.identity.delegationAgeDays / 5)} epochs`
-                    : '--'
-                }
-                sub={
-                  footprint.identity.delegationAgeDays != null
-                    ? `${footprint.identity.delegationAgeDays} days`
-                    : undefined
-                }
-              />
-              <StatCard
-                icon={Flame}
-                label="Delegation Streak"
-                value={footprint.citizenActivity.epochsActive}
-                sub={`epoch${footprint.citizenActivity.epochsActive !== 1 ? 's' : ''} active`}
-              />
-              <StatCard
-                icon={Vote}
-                label="Proposals Influenced"
-                value={footprint.impact.proposalsInfluenced}
-              />
-              <StatCard
-                icon={Coins}
-                label="ADA Governed"
-                value={
-                  footprint.impact.adaGoverned > 0
-                    ? formatAdaCompact(footprint.impact.adaGoverned)
-                    : '--'
-                }
-                sub={footprint.impact.delegationWeight}
-              />
-            </div>
+                {/* Stats grid */}
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                  <StatCard
+                    icon={Calendar}
+                    label="Citizen Since"
+                    value={
+                      footprint.identity.delegationAgeDays != null
+                        ? `${Math.floor(footprint.identity.delegationAgeDays / 5)} epochs`
+                        : '--'
+                    }
+                    sub={
+                      footprint.identity.delegationAgeDays != null
+                        ? `${footprint.identity.delegationAgeDays} days`
+                        : undefined
+                    }
+                  />
+                  <StatCard
+                    icon={Flame}
+                    label="Delegation Streak"
+                    value={footprint.citizenActivity.epochsActive}
+                    sub={`epoch${footprint.citizenActivity.epochsActive !== 1 ? 's' : ''} active`}
+                  />
+                  <StatCard
+                    icon={Vote}
+                    label="Proposals Influenced"
+                    value={footprint.impact.proposalsInfluenced}
+                  />
+                  <StatCard
+                    icon={Coins}
+                    label="ADA Governed"
+                    value={
+                      footprint.impact.adaGoverned > 0
+                        ? formatAdaCompact(footprint.impact.adaGoverned)
+                        : '--'
+                    }
+                    sub={footprint.impact.delegationWeight}
+                  />
+                </div>
+              </>
+            )}
+
+            {/* Unstaked notice — shown below stats or below undelegated CTA */}
+            {isUnstaked && <UnstakedCTA />}
           </>
         )}
       </AsyncContent>
@@ -297,40 +350,59 @@ export function CivicIdentityProfile() {
       {footprint && (
         <div>
           <SectionHeader title="Governance Footprint" />
-          <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
-              <p className="text-xs text-muted-foreground">DRep Score</p>
-              <p className="text-2xl font-bold tabular-nums">
-                {footprint.delegationRecord.drepScore ?? '--'}
-                <span className="text-sm font-normal text-muted-foreground">/100</span>
+          {isUndelegated ? (
+            <div className="rounded-xl border border-border/50 bg-card/70 p-5 text-center space-y-3">
+              <Vote className="h-6 w-6 text-muted-foreground mx-auto" />
+              <p className="text-sm font-medium text-foreground">No governance footprint yet</p>
+              <p className="text-xs text-muted-foreground max-w-xs mx-auto">
+                Once you delegate to a DRep, this section will show their score, votes cast on your
+                behalf, and your delegation history.
               </p>
-              {footprint.delegationRecord.drepRank && (
-                <p className="text-xs text-muted-foreground">
-                  Rank #{footprint.delegationRecord.drepRank}
-                </p>
-              )}
-            </div>
-            <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
-              <p className="text-xs text-muted-foreground">DRep Votes Cast</p>
-              <p className="text-2xl font-bold tabular-nums">
-                {footprint.delegationRecord.keyVotes}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {footprint.delegationRecord.delegationChanges} delegation change
-                {footprint.delegationRecord.delegationChanges !== 1 ? 's' : ''}
-              </p>
-            </div>
-          </div>
-
-          {delegatedDrep && (
-            <div className="mt-3">
               <Button variant="outline" size="sm" asChild>
-                <Link href={`/drep/${delegatedDrep}`}>
-                  View your DRep
+                <Link href="/match">
+                  Browse DReps
                   <ArrowRight className="h-3.5 w-3.5 ml-1" />
                 </Link>
               </Button>
             </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
+                  <p className="text-xs text-muted-foreground">DRep Score</p>
+                  <p className="text-2xl font-bold tabular-nums">
+                    {footprint.delegationRecord.drepScore ?? '--'}
+                    <span className="text-sm font-normal text-muted-foreground">/100</span>
+                  </p>
+                  {footprint.delegationRecord.drepRank && (
+                    <p className="text-xs text-muted-foreground">
+                      Rank #{footprint.delegationRecord.drepRank}
+                    </p>
+                  )}
+                </div>
+                <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
+                  <p className="text-xs text-muted-foreground">DRep Votes Cast</p>
+                  <p className="text-2xl font-bold tabular-nums">
+                    {footprint.delegationRecord.keyVotes}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {footprint.delegationRecord.delegationChanges} delegation change
+                    {footprint.delegationRecord.delegationChanges !== 1 ? 's' : ''}
+                  </p>
+                </div>
+              </div>
+
+              {delegatedDrep && (
+                <div className="mt-3">
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href={`/drep/${delegatedDrep}`}>
+                      View your DRep
+                      <ArrowRight className="h-3.5 w-3.5 ml-1" />
+                    </Link>
+                  </Button>
+                </div>
+              )}
+            </>
           )}
         </div>
       )}
@@ -381,19 +453,21 @@ export function CivicIdentityProfile() {
       </div>
 
       {/* Alignment Profile */}
-      {footprint?.identity.delegatedDRep && (
+      {footprint && (
         <div>
           <SectionHeader title="Alignment" />
           <div className="rounded-xl border border-border/50 bg-card p-4 flex items-center justify-between">
             <div>
               <p className="text-sm font-medium">Quick Match</p>
               <p className="text-xs text-muted-foreground">
-                See how your values align with DReps across the network.
+                {isUndelegated
+                  ? 'Find a DRep who shares your governance values.'
+                  : 'See how your values align with DReps across the network.'}
               </p>
             </div>
-            <Button variant="outline" size="sm" asChild>
+            <Button variant={isUndelegated ? 'default' : 'outline'} size="sm" asChild>
               <Link href="/match">
-                Take Quiz
+                {isUndelegated ? 'Find Your DRep' : 'Take Quiz'}
                 <ArrowRight className="h-3.5 w-3.5 ml-1" />
               </Link>
             </Button>

--- a/components/civica/identity/DRepScorecardView.tsx
+++ b/components/civica/identity/DRepScorecardView.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import Link from 'next/link';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useWorkspaceCockpit } from '@/hooks/queries';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ExternalLink, TrendingUp, TrendingDown } from 'lucide-react';
+
+/**
+ * DRepScorecardView — Your personal DRep governance scorecard.
+ *
+ * Shows score breakdown, pillar analysis, tier progress, and improvement actions.
+ * Gated to DRep segment — non-DReps see a message.
+ */
+export function DRepScorecardView() {
+  const { segment, drepId } = useSegment();
+  const { data, isLoading, error } = useWorkspaceCockpit(drepId);
+
+  if (segment !== 'drep') {
+    return (
+      <div className="text-center space-y-4 py-12">
+        <h1 className="text-2xl font-bold text-foreground">DRep Scorecard</h1>
+        <p className="text-muted-foreground">
+          This page is available to registered DReps. Register as a DRep to see your governance
+          scorecard.
+        </p>
+        <Button asChild>
+          <Link href="/you">Back to Identity</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-40 w-full rounded-xl" />
+        <Skeleton className="h-32 w-full rounded-xl" />
+        <Skeleton className="h-24 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="text-center space-y-4 py-12">
+        <h1 className="text-2xl font-bold text-foreground">DRep Scorecard</h1>
+        <p className="text-muted-foreground">
+          Unable to load your scorecard. Please try refreshing.
+        </p>
+      </div>
+    );
+  }
+
+  const { score } = data;
+  const pillars = [
+    { label: 'Engagement Quality', value: score.pillars.engagementQuality, weight: '35%' },
+    {
+      label: 'Effective Participation',
+      value: score.pillars.effectiveParticipation,
+      weight: '25%',
+    },
+    { label: 'Reliability', value: score.pillars.reliability, weight: '25%' },
+    { label: 'Governance Identity', value: score.pillars.governanceIdentity, weight: '15%' },
+  ];
+
+  const TrendIcon = score.trend >= 0 ? TrendingUp : TrendingDown;
+  const trendColor = score.trend >= 0 ? 'text-emerald-500' : 'text-rose-500';
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold text-foreground">DRep Scorecard</h1>
+
+      {/* Score hero */}
+      <div className="rounded-2xl border border-border bg-card p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground font-medium">Governance Score</p>
+            <div className="flex items-baseline gap-2">
+              <span className="text-5xl font-bold tabular-nums text-foreground">
+                {score.current}
+              </span>
+              <span className="text-sm text-muted-foreground">/100</span>
+            </div>
+          </div>
+          <div className="text-right space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">{score.tier}</p>
+            {score.trend !== 0 && (
+              <div className={`flex items-center gap-1 ${trendColor}`}>
+                <TrendIcon className="h-3.5 w-3.5" />
+                <span className="text-sm font-medium tabular-nums">
+                  {score.trend > 0 ? '+' : ''}
+                  {score.trend}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Rank context */}
+        <p className="text-sm text-muted-foreground">
+          Top {score.percentile}%
+          {score.rank != null && ` · Rank ${score.rank} of ${score.totalDReps}`}
+        </p>
+
+        {/* Tier progress */}
+        {score.tierProgress.pointsToNext != null && (
+          <div className="space-y-1.5">
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>{score.tierProgress.currentTier}</span>
+              <span>
+                {score.tierProgress.pointsToNext} pts to {score.tierProgress.nextTier}
+              </span>
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${score.tierProgress.percentWithinTier}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Pillar breakdown */}
+      <div className="rounded-2xl border border-border bg-card p-5 space-y-4">
+        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+          Score Breakdown
+        </h2>
+        <div className="space-y-3">
+          {pillars.map((p) => (
+            <div key={p.label} className="space-y-1">
+              <div className="flex justify-between text-sm">
+                <span className="text-foreground">{p.label}</span>
+                <span className="tabular-nums font-medium text-foreground">
+                  {Math.round(p.value)}{' '}
+                  <span className="text-muted-foreground font-normal">({p.weight})</span>
+                </span>
+              </div>
+              <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${p.value}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Recommended action */}
+      {score.tierProgress.recommendedAction && (
+        <div className="rounded-xl border border-primary/20 bg-primary/5 p-4">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+            Recommended Action
+          </p>
+          <p className="text-sm font-medium text-foreground">
+            {score.tierProgress.recommendedAction}
+          </p>
+        </div>
+      )}
+
+      {/* Links */}
+      <div className="flex flex-wrap gap-2">
+        {drepId && (
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/drep/${encodeURIComponent(drepId)}`}>
+              <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+              View Public Profile
+            </Link>
+          </Button>
+        )}
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/votes">Voting Record</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/delegators">Delegators</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/civica/identity/SPOScorecardView.tsx
+++ b/components/civica/identity/SPOScorecardView.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import Link from 'next/link';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useSPOPoolCompetitive, useSPOSummary } from '@/hooks/queries';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ExternalLink } from 'lucide-react';
+
+/**
+ * SPOScorecardView — Your personal pool governance scorecard.
+ *
+ * Shows governance score, competitive position, and improvement suggestions.
+ * Gated to SPO segment — non-SPOs see a message.
+ */
+export function SPOScorecardView() {
+  const { segment, poolId } = useSegment();
+  const { data: competitiveRaw, isLoading: compLoading } = useSPOPoolCompetitive(poolId);
+  const { data: summaryRaw, isLoading: sumLoading } = useSPOSummary(poolId);
+
+  const isLoading = compLoading || sumLoading;
+
+  if (segment !== 'spo') {
+    return (
+      <div className="text-center space-y-4 py-12">
+        <h1 className="text-2xl font-bold text-foreground">Pool Scorecard</h1>
+        <p className="text-muted-foreground">
+          This page is available to stake pool operators. Register a pool to see your governance
+          scorecard.
+        </p>
+        <Button asChild>
+          <Link href="/you">Back to Identity</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-40 w-full rounded-xl" />
+        <Skeleton className="h-32 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  const competitive = competitiveRaw as Record<string, unknown> | undefined;
+  const summary = summaryRaw as Record<string, unknown> | undefined;
+  const pool = competitive?.pool as Record<string, unknown> | undefined;
+  const score = Math.round((pool?.governance_score as number) ?? 0);
+  const rank = (competitive?.rank as number) ?? 0;
+  const totalPools = (competitive?.totalPools as number) ?? 0;
+  const percentile = Math.round((competitive?.percentile as number) ?? 0);
+  const voteCount = (summary?.voteCount as number) ?? (pool?.vote_count as number) ?? 0;
+  const participationRate = Math.round((summary?.participationRate as number) ?? 0);
+  const delegatorCount = (pool?.delegator_count as number) ?? 0;
+
+  // Improvement suggestions
+  const suggestions: string[] = [];
+  if (voteCount === 0)
+    suggestions.push('Cast your first governance vote to appear on the leaderboard');
+  if (participationRate < 50)
+    suggestions.push('Vote on more proposals to improve participation rate');
+  if (score < 50) suggestions.push('Add a governance statement to your pool profile');
+  if (suggestions.length === 0) suggestions.push('Keep voting consistently to maintain your rank');
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold text-foreground">Pool Scorecard</h1>
+
+      {/* Score hero */}
+      <div className="rounded-2xl border border-border bg-card p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <p className="text-sm text-muted-foreground font-medium">Governance Score</p>
+            <div className="flex items-baseline gap-2">
+              <span className="text-5xl font-bold tabular-nums text-foreground">{score}</span>
+              <span className="text-sm text-muted-foreground">/100</span>
+            </div>
+          </div>
+          <div className="text-right space-y-1">
+            <p className="text-sm text-muted-foreground">
+              Rank {rank} of {totalPools}
+            </p>
+            <p className="text-sm font-medium text-foreground">Top {percentile}%</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{voteCount}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Votes Cast</p>
+          </div>
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{participationRate}%</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Participation</p>
+          </div>
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">
+              {delegatorCount.toLocaleString()}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">Delegators</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Improvement suggestions */}
+      <div className="space-y-2">
+        <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+          Next Steps
+        </h2>
+        {suggestions.slice(0, 3).map((s, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-2 rounded-lg border border-border bg-card p-3"
+          >
+            <span className="text-primary font-bold text-sm">{i + 1}.</span>
+            <p className="text-sm text-foreground">{s}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Links */}
+      <div className="flex flex-wrap gap-2">
+        {poolId && (
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/pool/${encodeURIComponent(poolId)}`}>
+              <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+              View Public Profile
+            </Link>
+          </Button>
+        )}
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/pool-profile">Pool Profile</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/delegators">Delegators</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/position">Competitive Position</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -21,6 +21,8 @@ import {
   TrendingUp,
   RefreshCw,
   Wallet,
+  Server,
+  Shield,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { briefingContainer, briefingItem } from '@/lib/animations';
@@ -29,6 +31,7 @@ import {
   useEpochConsequence,
   useGovernanceHolder,
   useCitizenImpactScore,
+  useSPOSummary,
   type ConsequenceProposal,
 } from '@/hooks/queries';
 import { computeTier } from '@/lib/scoring/tiers';
@@ -435,10 +438,123 @@ function CitizenHubSkeleton() {
   );
 }
 
+/* ── Pool + coverage indicator (inline in representation) ───── */
+
+function PoolAndCoverage({
+  delegatedDrep,
+  delegatedPool,
+  poolRaw,
+}: {
+  delegatedDrep: string | null;
+  delegatedPool: string | null;
+  poolRaw: unknown;
+}) {
+  const pool = poolRaw as Record<string, unknown> | undefined;
+  const poolName = (pool?.poolName as string) || (pool?.ticker as string) || null;
+  const ticker = (pool?.ticker as string) ?? '';
+  const govScore = Math.round((pool?.governanceScore as number) ?? 0);
+  const poolParticipation = Math.round((pool?.participationRate as number) ?? 0);
+  const poolVoteCount = (pool?.voteCount as number) ?? 0;
+  const poolIsGovActive = poolVoteCount > 0;
+
+  // Coverage calculation (mirrors DelegationPage CoverageSummary logic)
+  const hasDrep = !!delegatedDrep;
+  const hasPool = !!delegatedPool;
+  const coveredTypes = hasDrep ? 5 : 0;
+  const poolCoveredTypes = hasPool && poolIsGovActive ? 2 : 0;
+  const totalTypes = 7;
+  const covered = coveredTypes + poolCoveredTypes;
+  const coveragePct = Math.round((covered / totalTypes) * 100);
+
+  let coverageLabel: string;
+  let coverageColor: string;
+  if (coveragePct === 100) {
+    coverageLabel = 'Full coverage';
+    coverageColor = 'text-emerald-400';
+  } else if (coveragePct >= 50) {
+    coverageLabel = 'Partial coverage';
+    coverageColor = 'text-amber-400';
+  } else {
+    coverageLabel = 'Low coverage';
+    coverageColor = 'text-red-400';
+  }
+
+  return (
+    <div className="mt-3 space-y-3 pt-3 border-t border-white/[0.06]">
+      {/* Coverage indicator */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Shield className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">Governance coverage</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={cn('text-xs font-semibold', coverageColor)}>{coverageLabel}</span>
+          <span className={cn('text-xs font-bold tabular-nums', coverageColor)}>
+            {coveragePct}%
+          </span>
+        </div>
+      </div>
+
+      {/* Compact coverage bar */}
+      <div className="h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all',
+            coveragePct === 100
+              ? 'bg-emerald-500'
+              : coveragePct >= 50
+                ? 'bg-amber-500'
+                : 'bg-red-500',
+          )}
+          style={{ width: `${coveragePct}%` }}
+        />
+      </div>
+
+      {/* Pool info */}
+      {delegatedPool && poolName && (
+        <Link
+          href={`/pool/${encodeURIComponent(delegatedPool)}`}
+          className="flex items-center justify-between gap-3 group"
+        >
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Server className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-sm font-medium text-foreground">
+                {ticker ? `[${ticker}] ` : ''}
+                {poolName}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <span className="tabular-nums">Gov score: {govScore}</span>
+              <span className="text-muted-foreground/40">&middot;</span>
+              <span className="tabular-nums">{poolParticipation}% participation</span>
+            </div>
+          </div>
+          <ArrowRight className="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
+        </Link>
+      )}
+
+      {delegatedPool && !poolName && !pool && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Server className="h-3.5 w-3.5" />
+          <span>Pool delegated</span>
+        </div>
+      )}
+
+      {!delegatedPool && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground/70">
+          <Server className="h-3.5 w-3.5" />
+          <span>No stake pool — 2 action types unrepresented</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* ── Main component ──────────────────────────────────────────── */
 
 export function CitizenHub() {
-  const { stakeAddress, delegatedDrep } = useSegment();
+  const { stakeAddress, delegatedDrep, delegatedPool } = useSegment();
 
   const {
     data: consequence,
@@ -448,6 +564,7 @@ export function CitizenHub() {
 
   const { data: holderRaw, isLoading: holderLoading } = useGovernanceHolder(stakeAddress);
   const { data: impactScore } = useCitizenImpactScore(!!stakeAddress);
+  const { data: poolRaw } = useSPOSummary(delegatedPool);
 
   const isLoading = consequenceLoading || holderLoading;
 
@@ -617,7 +734,10 @@ export function CitizenHub() {
           delegatedDrep !== 'drep_always_abstain' &&
           delegatedDrep !== 'drep_always_no_confidence' &&
           drep && (
-            <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+            <Link
+              href={`/drep/${encodeURIComponent(delegatedDrep)}`}
+              className="flex items-center justify-between gap-3 group"
+            >
               <div className="space-y-1.5">
                 <div className="flex items-center gap-2">
                   {drepIsActive ? (
@@ -652,7 +772,7 @@ export function CitizenHub() {
           )}
 
         {delegatedDrep === 'drep_always_abstain' && (
-          <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+          <Link href="/match" className="flex items-center justify-between gap-3 group">
             <div className="space-y-1">
               <p className="text-sm font-semibold text-foreground">Always Abstain</p>
               <p className="text-xs text-muted-foreground">
@@ -664,7 +784,7 @@ export function CitizenHub() {
         )}
 
         {delegatedDrep === 'drep_always_no_confidence' && (
-          <Link href="/delegation" className="flex items-center justify-between gap-3 group">
+          <Link href="/match" className="flex items-center justify-between gap-3 group">
             <div className="space-y-1">
               <p className="text-sm font-semibold text-foreground">No Confidence</p>
               <p className="text-xs text-muted-foreground">
@@ -674,6 +794,13 @@ export function CitizenHub() {
             <ArrowRight className="h-4 w-4 text-muted-foreground/40 group-hover:text-primary transition-all group-hover:translate-x-0.5" />
           </Link>
         )}
+
+        {/* ── Pool + Coverage ───────────────────────────────────── */}
+        <PoolAndCoverage
+          delegatedDrep={delegatedDrep}
+          delegatedPool={delegatedPool}
+          poolRaw={poolRaw}
+        />
       </Section>
 
       {/* ── Quick links ────────────────────────────────────── */}
@@ -693,13 +820,6 @@ export function CitizenHub() {
           className="text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           Find a DRep
-        </Link>
-        <span className="text-muted-foreground/30">&middot;</span>
-        <Link
-          href="/delegation"
-          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          My delegation
         </Link>
       </motion.div>
     </motion.div>

--- a/components/hub/HubCardConfig.ts
+++ b/components/hub/HubCardConfig.ts
@@ -46,14 +46,14 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
     type: 'status',
     priority: 1,
     conditional: false,
-    href: '/delegation',
+    href: '/',
   },
   coverage: {
     id: 'coverage',
     type: 'status',
     priority: 2,
     conditional: false,
-    href: '/delegation',
+    href: '/',
   },
   'governance-health': {
     id: 'governance-health',
@@ -67,7 +67,7 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
     type: 'action',
     priority: 1,
     conditional: true,
-    href: '/delegation',
+    href: '/',
   },
   briefing: {
     id: 'briefing',

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -6,6 +6,10 @@ import { AnonymousLanding } from './AnonymousLanding';
 import { CitizenHub } from './CitizenHub';
 import { HubCardSkeleton } from './cards/HubCard';
 import { OnboardingChecklist } from '@/components/funnel/OnboardingChecklist';
+import { DRepCockpit } from '@/components/workspace/DRepCockpit';
+import { CompetitiveContext } from '@/components/workspace/CompetitiveContext';
+import { ProfileShareToolkit } from '@/components/workspace/ProfileShareToolkit';
+import { SPOCockpit } from '@/components/workspace/SPOCockpit';
 
 interface PulseData {
   totalAdaGoverned: string;
@@ -31,7 +35,7 @@ interface HubHomePageProps {
  * Other personas: Hub cards over constellation globe.
  */
 export function HubHomePage({ pulseData }: HubHomePageProps) {
-  const { segment, isLoading } = useSegment();
+  const { segment, isLoading, drepId, poolId } = useSegment();
 
   // While detecting segment, show skeleton cards to prevent CLS flash
   if (isLoading) {
@@ -59,6 +63,33 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     );
   }
 
-  // Other authenticated personas — globe provided by CivicaShell, cards float on glass
+  // DReps get the Governance Cockpit as their homepage
+  if (segment === 'drep') {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
+        <h1 className="text-xl font-bold text-foreground">Governance Cockpit</h1>
+        <DRepCockpit />
+        <CompetitiveContext />
+        {drepId && (
+          <ProfileShareToolkit entityType="drep" entityId={drepId} entityName="My DRep Profile" />
+        )}
+      </div>
+    );
+  }
+
+  // SPOs get their Governance Overview cockpit as homepage
+  if (segment === 'spo') {
+    return (
+      <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
+        <h1 className="text-xl font-bold text-foreground">Governance Overview</h1>
+        <SPOCockpit />
+        {poolId && (
+          <ProfileShareToolkit entityType="spo" entityId={poolId} entityName="My Pool Profile" />
+        )}
+      </div>
+    );
+  }
+
+  // CC and other authenticated personas — hub cards
   return <HubCardRenderer persona={segment} />;
 }

--- a/components/hub/WorkspacePage.tsx
+++ b/components/hub/WorkspacePage.tsx
@@ -1,159 +1,44 @@
 'use client';
 
+import { useEffect } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useSegment } from '@/components/providers/SegmentProvider';
-import { useSPOPoolCompetitive, useSPOSummary } from '@/hooks/queries';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import { DRepCockpit } from '@/components/workspace/DRepCockpit';
-import { CompetitiveContext } from '@/components/workspace/CompetitiveContext';
-import { ProfileShareToolkit } from '@/components/workspace/ProfileShareToolkit';
 
 /**
- * SPO Workspace — Governance score overview for SPOs.
+ * WorkspacePage — Redirects DReps/SPOs to the homepage cockpit.
  *
- * JTBD: "What's my governance reputation?"
- * Score with pillar breakdown, top improvement suggestions, trend.
- */
-function SPOWorkspace() {
-  const { poolId } = useSegment();
-  const { data: competitiveRaw, isLoading: compLoading } = useSPOPoolCompetitive(poolId);
-  const { data: summaryRaw, isLoading: sumLoading } = useSPOSummary(poolId);
-
-  const isLoading = compLoading || sumLoading;
-
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-6 w-40" />
-        <Skeleton className="h-32 w-full rounded-xl" />
-        <Skeleton className="h-24 w-full rounded-xl" />
-      </div>
-    );
-  }
-
-  const competitive = competitiveRaw as Record<string, unknown> | undefined;
-  const summary = summaryRaw as Record<string, unknown> | undefined;
-  const pool = competitive?.pool as Record<string, unknown> | undefined;
-  const score = Math.round((pool?.governance_score as number) ?? 0);
-  const rank = (competitive?.rank as number) ?? 0;
-  const totalPools = (competitive?.totalPools as number) ?? 0;
-  const percentile = Math.round((competitive?.percentile as number) ?? 0);
-  const voteCount = (summary?.voteCount as number) ?? (pool?.vote_count as number) ?? 0;
-  const participationRate = Math.round((summary?.participationRate as number) ?? 0);
-
-  // Improvement suggestions based on score components
-  const suggestions: string[] = [];
-  if (voteCount === 0)
-    suggestions.push('Cast your first governance vote to appear on the leaderboard');
-  if (participationRate < 50)
-    suggestions.push('Vote on more proposals to improve participation rate');
-  if (score < 50) suggestions.push('Add a governance statement to your pool profile');
-  if (suggestions.length === 0) suggestions.push('Keep voting consistently to maintain your rank');
-
-  return (
-    <div className="space-y-6">
-      {/* Score overview */}
-      <div className="rounded-2xl border border-border bg-card p-5 space-y-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-foreground">Governance Score</h2>
-            <p className="text-sm text-muted-foreground">
-              Rank {rank} of {totalPools} pools &middot; Top {percentile}%
-            </p>
-          </div>
-          <span className="text-4xl font-bold tabular-nums text-foreground">{score}</span>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div className="rounded-xl bg-muted/50 p-3 text-center">
-            <p className="text-xl font-bold tabular-nums text-foreground">{voteCount}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Votes Cast</p>
-          </div>
-          <div className="rounded-xl bg-muted/50 p-3 text-center">
-            <p className="text-xl font-bold tabular-nums text-foreground">{participationRate}%</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Participation</p>
-          </div>
-        </div>
-      </div>
-
-      {/* Improvement suggestions */}
-      <div className="space-y-2">
-        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
-          Next Steps
-        </h3>
-        {suggestions.slice(0, 3).map((s, i) => (
-          <div
-            key={i}
-            className="flex items-start gap-2 rounded-lg border border-border bg-card p-3"
-          >
-            <span className="text-primary font-bold text-sm">{i + 1}.</span>
-            <p className="text-sm text-foreground">{s}</p>
-          </div>
-        ))}
-      </div>
-
-      {/* Quick links */}
-      <div className="flex flex-wrap gap-2">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/workspace/pool-profile">Pool Profile</Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <Link href="/workspace/position">Competitive Position</Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <Link href="/workspace/delegators">Delegators</Link>
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-/**
- * WorkspacePage — Dispatches to DRep Cockpit or SPO workspace.
- *
- * DRep: Governance Cockpit — single-page command center.
- * SPO: Governance score overview.
+ * The Governance Cockpit now lives on `/` for DReps and SPOs.
+ * This page redirects them home. Non-DRep/SPO users see a message.
+ * Sub-routes (e.g. /workspace/delegators) are unaffected — they
+ * have their own page.tsx files.
  */
 export function WorkspacePage() {
-  const { segment, drepId, poolId } = useSegment();
+  const { segment } = useSegment();
+  const router = useRouter();
 
-  // Non-DRep/SPO users get redirected
-  if (segment !== 'drep' && segment !== 'spo') {
-    return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-12 text-center space-y-4">
-        <h1 className="text-2xl font-bold text-foreground">Workspace</h1>
-        <p className="text-muted-foreground">
-          The workspace is for DReps and SPOs who actively participate in governance.
-        </p>
-        <Button asChild>
-          <Link href="/">Back to Hub</Link>
-        </Button>
-      </div>
-    );
+  useEffect(() => {
+    if (segment === 'drep' || segment === 'spo') {
+      router.replace('/');
+    }
+  }, [segment, router]);
+
+  // While redirecting, render nothing
+  if (segment === 'drep' || segment === 'spo') {
+    return null;
   }
 
-  const entityType = segment === 'drep' ? 'drep' : 'spo';
-  const entityId = segment === 'drep' ? drepId : poolId;
-
+  // Non-DRep/SPO users get a message
   return (
-    <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
-      <h1 className="text-xl font-bold text-foreground">
-        {segment === 'drep' ? 'Governance Cockpit' : 'Governance Overview'}
-      </h1>
-      {segment === 'drep' ? <DRepCockpit /> : <SPOWorkspace />}
-
-      {/* Competitive Context — DRep only (SPO has its own position page) */}
-      {segment === 'drep' && <CompetitiveContext />}
-
-      {/* Profile Share Toolkit */}
-      {entityId && (
-        <ProfileShareToolkit
-          entityType={entityType as 'drep' | 'spo'}
-          entityId={entityId}
-          entityName={entityType === 'drep' ? 'My DRep Profile' : 'My Pool Profile'}
-        />
-      )}
+    <div className="mx-auto w-full max-w-2xl px-4 py-12 text-center space-y-4">
+      <h1 className="text-2xl font-bold text-foreground">Workspace</h1>
+      <p className="text-muted-foreground">
+        The workspace is for DReps and SPOs who actively participate in governance.
+      </p>
+      <Button asChild>
+        <Link href="/">Back to Hub</Link>
+      </Button>
     </div>
   );
 }

--- a/components/hub/cards/AlertCard.tsx
+++ b/components/hub/cards/AlertCard.tsx
@@ -80,7 +80,7 @@ export function AlertCard() {
   const AlertIcon = alert.icon;
 
   return (
-    <HubCard href="/delegation" urgency={alert.urgency} label={alert.message}>
+    <HubCard href="/" urgency={alert.urgency} label={alert.message}>
       <div className="space-y-1">
         <div className="flex items-center gap-2">
           <AlertIcon

--- a/components/hub/cards/CoverageCard.tsx
+++ b/components/hub/cards/CoverageCard.tsx
@@ -70,7 +70,7 @@ export function CoverageCard() {
 
   return (
     <HubCard
-      href="/delegation"
+      href="/"
       urgency={urgency === 'default' ? 'default' : urgency}
       label={`Governance coverage: ${verdict}`}
     >

--- a/components/hub/cards/RepresentationCard.tsx
+++ b/components/hub/cards/RepresentationCard.tsx
@@ -46,7 +46,7 @@ export function RepresentationCard() {
   // Always-abstain delegation — valid choice, no data fetch needed
   if (delegatedDrep === 'drep_always_abstain') {
     return (
-      <HubCard href="/delegation" urgency="default" label="Delegation: Always Abstain">
+      <HubCard href="/match" urgency="default" label="Delegation: Always Abstain">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <Ban className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +68,7 @@ export function RepresentationCard() {
   // No-confidence delegation — valid choice, no data fetch needed
   if (delegatedDrep === 'drep_always_no_confidence') {
     return (
-      <HubCard href="/delegation" urgency="warning" label="Delegation: No Confidence">
+      <HubCard href="/match" urgency="warning" label="Delegation: No Confidence">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <ThumbsDown className="h-4 w-4 text-amber-500" />
@@ -146,7 +146,7 @@ function DelegatedRepresentationCard({
         : 'text-red-600 dark:text-red-400';
 
   return (
-    <HubCard href="/delegation" urgency={urgency} label={`${statusLabel}: ${statusMessage}`}>
+    <HubCard href="/" urgency={urgency} label={`${statusLabel}: ${statusMessage}`}>
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <StatusIcon className={`h-4 w-4 ${statusColor}`} />

--- a/components/workspace/SPOCockpit.tsx
+++ b/components/workspace/SPOCockpit.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Link from 'next/link';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useSPOPoolCompetitive, useSPOSummary } from '@/hooks/queries';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+/**
+ * SPO Governance Cockpit — Governance score overview for SPOs.
+ *
+ * JTBD: "What's my governance reputation?"
+ * Score with pillar breakdown, top improvement suggestions, trend.
+ */
+export function SPOCockpit() {
+  const { poolId } = useSegment();
+  const { data: competitiveRaw, isLoading: compLoading } = useSPOPoolCompetitive(poolId);
+  const { data: summaryRaw, isLoading: sumLoading } = useSPOSummary(poolId);
+
+  const isLoading = compLoading || sumLoading;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-32 w-full rounded-xl" />
+        <Skeleton className="h-24 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  const competitive = competitiveRaw as Record<string, unknown> | undefined;
+  const summary = summaryRaw as Record<string, unknown> | undefined;
+  const pool = competitive?.pool as Record<string, unknown> | undefined;
+  const score = Math.round((pool?.governance_score as number) ?? 0);
+  const rank = (competitive?.rank as number) ?? 0;
+  const totalPools = (competitive?.totalPools as number) ?? 0;
+  const percentile = Math.round((competitive?.percentile as number) ?? 0);
+  const voteCount = (summary?.voteCount as number) ?? (pool?.vote_count as number) ?? 0;
+  const participationRate = Math.round((summary?.participationRate as number) ?? 0);
+
+  // Improvement suggestions based on score components
+  const suggestions: string[] = [];
+  if (voteCount === 0)
+    suggestions.push('Cast your first governance vote to appear on the leaderboard');
+  if (participationRate < 50)
+    suggestions.push('Vote on more proposals to improve participation rate');
+  if (score < 50) suggestions.push('Add a governance statement to your pool profile');
+  if (suggestions.length === 0) suggestions.push('Keep voting consistently to maintain your rank');
+
+  return (
+    <div className="space-y-6">
+      {/* Score overview */}
+      <div className="rounded-2xl border border-border bg-card p-5 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Governance Score</h2>
+            <p className="text-sm text-muted-foreground">
+              Rank {rank} of {totalPools} pools &middot; Top {percentile}%
+            </p>
+          </div>
+          <span className="text-4xl font-bold tabular-nums text-foreground">{score}</span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{voteCount}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Votes Cast</p>
+          </div>
+          <div className="rounded-xl bg-muted/50 p-3 text-center">
+            <p className="text-xl font-bold tabular-nums text-foreground">{participationRate}%</p>
+            <p className="text-xs text-muted-foreground mt-0.5">Participation</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Improvement suggestions */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+          Next Steps
+        </h3>
+        {suggestions.slice(0, 3).map((s, i) => (
+          <div
+            key={i}
+            className="flex items-start gap-2 rounded-lg border border-border bg-card p-3"
+          >
+            <span className="text-primary font-bold text-sm">{i + 1}.</span>
+            <p className="text-sm text-foreground">{s}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Quick links */}
+      <div className="flex flex-wrap gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/pool-profile">Pool Profile</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/position">Competitive Position</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/workspace/delegators">Delegators</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -5,6 +5,7 @@
  * - Desktop sidebar
  * - Mobile bottom bar (4 items, persona-adaptive)
  * - Mobile pill bar (section sub-pages)
+ * - Header help dropdown
  *
  * See docs/strategy/context/navigation-architecture.md for the full spec.
  */
@@ -15,7 +16,6 @@ import {
   Briefcase,
   Globe,
   User,
-  Handshake,
   Compass,
   HelpCircle,
   FileText,
@@ -106,13 +106,46 @@ export const GOVERNANCE_ITEMS: NavItem[] = [
   { href: '/governance/health', label: 'Health', icon: Activity },
 ];
 
-export const YOU_ITEMS: NavItem[] = [
-  { href: '/you', label: 'Governance ID', icon: BadgeCheck },
-  { href: '/you/identity', label: 'Identity', icon: UserCog },
+/** Base You items — all authenticated personas */
+const YOU_BASE: NavItem[] = [
+  { href: '/you', label: 'Identity', icon: UserCog },
   { href: '/you/inbox', label: 'Inbox', icon: Bell, badge: 'unread' },
   { href: '/you/settings', label: 'Settings', icon: Settings },
 ];
 
+/** Build persona-specific You items (adds scorecard links for DReps/SPOs) */
+export function getYouItems(
+  segment: UserSegment,
+  context?: { drepId?: string | null; poolId?: string | null },
+): NavItem[] {
+  const items = [...YOU_BASE];
+  const hasDrep = segment === 'drep' || !!context?.drepId;
+  const hasSpo = segment === 'spo' || !!context?.poolId;
+
+  const scorecardItems: NavItem[] = [];
+  if (hasDrep)
+    scorecardItems.push({
+      href: '/you/drep',
+      label: 'DRep Scorecard',
+      icon: BadgeCheck,
+      segments: ['drep'],
+    });
+  if (hasSpo)
+    scorecardItems.push({
+      href: '/you/spo',
+      label: 'Pool Scorecard',
+      icon: BarChart3,
+      segments: ['spo'],
+    });
+
+  if (scorecardItems.length > 0) {
+    items.splice(1, 0, ...scorecardItems); // Insert after Identity
+  }
+
+  return items;
+}
+
+/** Help items — used in header dropdown (no longer in sidebar) */
 export const HELP_ITEMS: NavItem[] = [
   { href: '/help', label: 'FAQ', icon: HelpCircle },
   { href: '/help/glossary', label: 'Glossary', icon: BookOpen },
@@ -196,37 +229,19 @@ export function getSidebarSections(segmentOrContext: UserSegment | SidebarContex
     items: GOVERNANCE_ITEMS,
   });
 
-  // Delegation — authenticated with delegation
-  if (segment !== 'anonymous') {
-    sections.push({
-      id: 'delegation',
-      label: 'Delegation',
-      icon: Handshake,
-      href: '/delegation',
-      requiresAuth: true,
-    });
-  }
-
-  // You — authenticated
+  // You — authenticated (persona-aware items)
   if (segment !== 'anonymous') {
     sections.push({
       id: 'you',
       label: 'You',
       icon: User,
       href: '/you',
-      items: YOU_ITEMS,
+      items: getYouItems(segment, { drepId, poolId }),
       requiresAuth: true,
     });
   }
 
-  // Help — everyone
-  sections.push({
-    id: 'help',
-    label: 'Help',
-    icon: HelpCircle,
-    href: '/help',
-    items: HELP_ITEMS,
-  });
+  // Help removed from sidebar — now in header dropdown
 
   return sections;
 }
@@ -242,17 +257,10 @@ const BOTTOM_BAR_ANONYMOUS: NavItem[] = [
   { href: '/help', label: 'Help', icon: HelpCircle },
 ];
 
-const BOTTOM_BAR_CITIZEN_UNDELEGATED: NavItem[] = [
+const BOTTOM_BAR_CITIZEN: NavItem[] = [
   { href: '/', label: 'Home', icon: Home },
   { href: '/governance', label: 'Governance', icon: Globe },
   { href: '/match', label: 'Match', icon: Compass },
-  { href: '/you', label: 'You', icon: User, badge: 'unread' },
-];
-
-const BOTTOM_BAR_CITIZEN_DELEGATED: NavItem[] = [
-  { href: '/', label: 'Home', icon: Home },
-  { href: '/governance', label: 'Governance', icon: Globe },
-  { href: '/delegation', label: 'Delegation', icon: Handshake },
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
 
@@ -273,16 +281,16 @@ const BOTTOM_BAR_SPO: NavItem[] = [
 const BOTTOM_BAR_CC: NavItem[] = [
   { href: '/', label: 'Home', icon: Home },
   { href: '/governance', label: 'Governance', icon: Globe },
-  { href: '/delegation', label: 'Delegation', icon: Handshake },
+  { href: '/match', label: 'Match', icon: Compass },
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
 
-export function getBottomBarItems(segment: UserSegment, hasDelegation: boolean): NavItem[] {
+export function getBottomBarItems(segment: UserSegment): NavItem[] {
   switch (segment) {
     case 'anonymous':
       return BOTTOM_BAR_ANONYMOUS;
     case 'citizen':
-      return hasDelegation ? BOTTOM_BAR_CITIZEN_DELEGATED : BOTTOM_BAR_CITIZEN_UNDELEGATED;
+      return BOTTOM_BAR_CITIZEN;
     case 'drep':
       return BOTTOM_BAR_DREP;
     case 'spo':
@@ -321,12 +329,12 @@ export function getPillBarItems(
     return WORKSPACE_DREP_ITEMS;
   }
   if (pathname.startsWith('/you')) {
-    return YOU_ITEMS;
+    return getYouItems(segment, context);
   }
   if (pathname.startsWith('/help')) {
     return HELP_ITEMS;
   }
-  // No pill bar for single-page sections (Home, Delegation, Match)
+  // No pill bar for single-page sections (Home, Match)
   return null;
 }
 
@@ -338,7 +346,6 @@ export function getCurrentSection(pathname: string): string | null {
   if (pathname === '/') return 'home';
   if (pathname.startsWith('/workspace')) return 'workspace';
   if (pathname.startsWith('/governance')) return 'governance';
-  if (pathname.startsWith('/delegation')) return 'delegation';
   if (pathname.startsWith('/you')) return 'you';
   if (pathname.startsWith('/match')) return 'match';
   if (pathname.startsWith('/help')) return 'help';

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -433,6 +433,19 @@ async function persistToInbox(
       return;
     }
 
+    // Deduplicate: skip if an unread notification of the same type was created within 24h
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: existing } = await supabase
+      .from('notifications')
+      .select('id')
+      .eq('user_stake_address', stakeAddress)
+      .eq('type', payload.eventType)
+      .eq('read', false)
+      .gte('created_at', cutoff)
+      .limit(1);
+
+    if (existing && existing.length > 0) return;
+
     await supabase.from('notifications').insert({
       user_stake_address: stakeAddress,
       type: payload.eventType,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 /**
  * Next.js Middleware
  * - Query-param redirects for old /discover?tab= routes
- * - Auth gate for protected routes (workspace, you, delegation)
+ * - Auth gate for protected routes (workspace, you)
  * - CORS for /api/v1/* routes
  * Auth and rate limiting for API routes are handled in lib/api/handler.ts.
  */
@@ -26,7 +26,7 @@ const DISCOVER_TAB_MAP: Record<string, string> = {
   rankings: '/governance/representatives?view=rankings',
 };
 
-const AUTH_REQUIRED_PATHS = ['/workspace', '/you', '/delegation'];
+const AUTH_REQUIRED_PATHS = ['/workspace', '/you'];
 
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;


### PR DESCRIPTION
## Summary
- **Cockpit as homepage**: DReps see Governance Cockpit, SPOs see new SPOCockpit on `/` (replaces card-based hub)
- **/you restructure**: Identity at `/you` (all personas), DRep Scorecard at `/you/drep`, Pool Scorecard at `/you/spo`; `/you/identity` redirects to `/you`
- **Globe background**: Restored for authenticated citizens on homepage (was hidden for all)
- **ActionPanel above fold**: Moved from Zone 4 to Zone 2 on proposal detail pages
- **Help dropdown**: Moved from sidebar to `?` icon dropdown in header
- **Community disclaimer footer**: "Governada is an independent community project..." on all pages
- **Empty states**: Aspirational CTAs for undelegated/unstaked citizens on Civic Identity
- **Notification dedup**: 24h same-type unread dedup window in `persistToInbox()`
- **/delegation deprecated**: Redirects to `/`, coverage summary folded into CitizenHub
- **Nav config simplified**: Persona-aware getYouItems(), simplified bottom bar, /delegation removed

## Impact
- **What changed**: 9 UX improvements across homepage, proposals, identity, navigation, and notifications
- **User-facing**: Yes — every persona sees improvements (cockpit homepages, better empty states, help dropdown, footer disclaimer, above-fold actions)
- **Risk**: Medium — touches many surfaces but all changes are UI/UX, no data model or migration changes
- **Scope**: 23 files (18 modified, 5 new). No migrations, no env vars, no Inngest changes.

## Test plan
- [ ] Preflight passes (format + lint + types + 595 tests)
- [ ] DRep homepage shows cockpit instead of cards
- [ ] SPO homepage shows SPOCockpit
- [ ] Citizen homepage shows globe background
- [ ] `/you` shows identity for all personas
- [ ] `/you/drep` shows DRep scorecard (gated)
- [ ] `/you/spo` shows Pool scorecard (gated)
- [ ] `/you/identity` redirects to `/you`
- [ ] `/delegation` redirects to `/`
- [ ] Help `?` dropdown in header works
- [ ] Community disclaimer visible in footer
- [ ] ActionPanel appears in Zone 2 on proposal pages
- [ ] Empty states show CTAs for undelegated citizens
- [ ] Duplicate notifications not created within 24h window

🤖 Generated with [Claude Code](https://claude.com/claude-code)