### PR TITLE
fix: guided tours — route-aware navigation, cross-instance state sync, feature tracking

### DIFF
--- a/components/discovery/SpotlightOverlay.tsx
+++ b/components/discovery/SpotlightOverlay.tsx
@@ -32,6 +32,8 @@ interface TargetRect {
 
 const PADDING = 8; // px around target element
 const TOOLTIP_GAP = 12; // px between target and tooltip
+const RETRY_INTERVAL_MS = 300;
+const MAX_RETRIES = 10; // 10 * 300ms = 3s max wait for DOM
 
 export function SpotlightOverlay({
   step,
@@ -45,21 +47,17 @@ export function SpotlightOverlay({
   const shouldReduceMotion = useReducedMotion();
   const tooltipRef = useRef<HTMLDivElement>(null);
 
-  // Find and measure the target element
+  // Find and measure the target element — retries to handle post-navigation DOM delays
   useEffect(() => {
-    const findTarget = () => {
-      const el = document.querySelector(step.targetSelector);
-      if (!el) {
-        // Target not found — skip this step automatically
-        onNext();
-        return;
-      }
+    let retryCount = 0;
+    let retryTimer: ReturnType<typeof setTimeout>;
+    let measureTimer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
 
-      // Scroll into view if needed
+    const measureTarget = (el: Element) => {
       el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-      // Measure after scroll settles
-      const timer = setTimeout(() => {
+      measureTimer = setTimeout(() => {
+        if (cancelled) return;
         const rect = el.getBoundingClientRect();
         setTargetRect({
           top: rect.top + window.scrollY,
@@ -67,21 +65,45 @@ export function SpotlightOverlay({
           width: rect.width,
           height: rect.height,
         });
-
-        // Determine tooltip position based on available space
         const spaceBelow = window.innerHeight - rect.bottom;
         const spaceAbove = rect.top;
         setTooltipPosition(spaceBelow > 200 || spaceBelow > spaceAbove ? 'bottom' : 'top');
       }, 300);
-
-      return () => clearTimeout(timer);
     };
 
+    const findTarget = () => {
+      if (cancelled) return;
+      const el = document.querySelector(step.targetSelector);
+      if (el) {
+        measureTarget(el);
+        return;
+      }
+      // Retry — DOM may not be rendered yet after navigation
+      retryCount++;
+      if (retryCount < MAX_RETRIES) {
+        retryTimer = setTimeout(findTarget, RETRY_INTERVAL_MS);
+      } else {
+        // Give up after max retries — skip this step
+        if (!cancelled) onNext();
+      }
+    };
+
+    // Reset rect when step changes
+    setTargetRect(null);
     findTarget();
-    // Re-measure on resize
-    const handleResize = () => findTarget();
+
+    const handleResize = () => {
+      const el = document.querySelector(step.targetSelector);
+      if (el) measureTarget(el);
+    };
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(retryTimer);
+      clearTimeout(measureTimer);
+      window.removeEventListener('resize', handleResize);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-runs only when step changes
   }, [step.targetSelector, step.id]);
 

--- a/components/discovery/SpotlightProvider.tsx
+++ b/components/discovery/SpotlightProvider.tsx
@@ -5,12 +5,14 @@
  *
  * Manages active tour state, renders SpotlightOverlay when a tour is
  * in progress, and provides methods to start/advance/skip tours.
+ *
+ * Route-aware: navigates between pages for multi-page tours and waits
+ * for the DOM to settle before rendering the spotlight overlay.
  */
 
-import { createContext, useContext, useCallback, useMemo } from 'react';
-import { usePathname } from 'next/navigation';
+import { createContext, useContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import { useDiscovery } from '@/hooks/useDiscovery';
-import { getTourById } from '@/lib/discovery/content';
 import { emitDiscoveryEvent } from '@/lib/discovery/events';
 import { posthog } from '@/lib/posthog';
 import { SpotlightOverlay } from './SpotlightOverlay';
@@ -31,6 +33,8 @@ export function useSpotlight() {
 
 export function SpotlightProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [isNavigating, setIsNavigating] = useState(false);
   const {
     state,
     activeTour,
@@ -39,7 +43,26 @@ export function SpotlightProvider({ children }: { children: React.ReactNode }) {
     advanceTourStep,
     completeTour,
     cancelTour,
+    markFeatureExplored,
   } = useDiscovery();
+
+  // Navigate to the current step's route if it differs from the current pathname
+  useEffect(() => {
+    if (!activeTour || !currentStep?.route) return;
+    if (currentStep.route !== pathname) {
+      setIsNavigating(true);
+      router.push(currentStep.route);
+    }
+  }, [activeTour, currentStep, pathname, router]);
+
+  // Clear navigating flag once we arrive at the correct route
+  useEffect(() => {
+    if (isNavigating && currentStep?.route === pathname) {
+      // Small delay for the new page's DOM to render
+      const timer = setTimeout(() => setIsNavigating(false), 400);
+      return () => clearTimeout(timer);
+    }
+  }, [isNavigating, currentStep?.route, pathname]);
 
   const handleStartTour = useCallback(
     (tourId: string) => {
@@ -53,7 +76,12 @@ export function SpotlightProvider({ children }: { children: React.ReactNode }) {
 
     const nextIndex = state.tourStepIndex + 1;
     if (nextIndex >= activeTour.steps.length) {
-      // Tour complete
+      // Tour complete — mark related features as explored
+      if (activeTour.relatedFeatures) {
+        for (const featureId of activeTour.relatedFeatures) {
+          markFeatureExplored(featureId);
+        }
+      }
       completeTour();
       emitDiscoveryEvent('tour_completed', { tour_id: activeTour.id });
       posthog.capture('discovery_tour_completed', {
@@ -61,14 +89,26 @@ export function SpotlightProvider({ children }: { children: React.ReactNode }) {
         steps_viewed: activeTour.steps.length,
       });
     } else {
+      // Check if next step requires navigation
+      const nextStep = activeTour.steps[nextIndex];
+      if (nextStep?.route && nextStep.route !== pathname) {
+        setIsNavigating(true);
+      }
       advanceTourStep();
       posthog.capture('discovery_tour_step_viewed', {
         tour_id: activeTour.id,
         step_index: nextIndex,
-        step_id: activeTour.steps[nextIndex]?.id,
+        step_id: nextStep?.id,
       });
     }
-  }, [activeTour, state.tourStepIndex, advanceTourStep, completeTour]);
+  }, [
+    activeTour,
+    state.tourStepIndex,
+    advanceTourStep,
+    completeTour,
+    markFeatureExplored,
+    pathname,
+  ]);
 
   const handleSkip = useCallback(() => {
     if (activeTour) {
@@ -88,10 +128,17 @@ export function SpotlightProvider({ children }: { children: React.ReactNode }) {
     [state.tourInProgress, handleStartTour],
   );
 
+  // Only show overlay when on the correct route and not mid-navigation
+  const shouldShowOverlay =
+    activeTour &&
+    currentStep &&
+    !isNavigating &&
+    (!currentStep.route || currentStep.route === pathname);
+
   return (
     <SpotlightContext.Provider value={contextValue}>
       {children}
-      {activeTour && currentStep && (
+      {shouldShowOverlay && (
         <SpotlightOverlay
           step={currentStep}
           stepIndex={state.tourStepIndex}

--- a/hooks/useDiscovery.ts
+++ b/hooks/useDiscovery.ts
@@ -19,6 +19,7 @@ import {
   markFeatureExplored as _markFeatureExplored,
   markHubOpened as _markHubOpened,
   markMilestoneCelebrated as _markMilestoneCelebrated,
+  onStateChange,
   type DiscoveryState,
 } from '@/lib/discovery/state';
 import {
@@ -35,6 +36,9 @@ export function useDiscovery() {
   const { segment } = useSegment();
   const [version, setVersion] = useState(0);
   const refresh = useCallback(() => setVersion((v) => v + 1), []);
+
+  // Sync with state changes from other hook instances (e.g., DiscoveryHub → SpotlightProvider)
+  useEffect(() => onStateChange(refresh), [refresh]);
 
   // Read state reactively (re-reads on version bump)
   // eslint-disable-next-line react-hooks/exhaustive-deps -- version drives re-reads

--- a/lib/discovery/content.ts
+++ b/lib/discovery/content.ts
@@ -17,6 +17,8 @@ export interface SpotlightStep {
   title: string;
   description: string;
   position: 'top' | 'bottom' | 'left' | 'right' | 'auto';
+  /** Route where this step's target element lives (for multi-page tours) */
+  route?: string;
 }
 
 /* ─── Mini tour ──────────────────────────────────────── */
@@ -32,6 +34,8 @@ export interface MiniTour {
   segments: UserSegment[];
   /** Route to navigate to before starting */
   startRoute: string;
+  /** Feature IDs that completing this tour should mark as explored */
+  relatedFeatures?: string[];
 }
 
 /* ─── Feature map item ───────────────────────────────── */
@@ -82,6 +86,7 @@ export const TOURS: MiniTour[] = [
     icon: 'Home',
     segments: ['citizen', 'anonymous'],
     startRoute: '/',
+    relatedFeatures: ['delegation-health', 'governance-coverage'],
     steps: [
       {
         id: 'hub-briefing',
@@ -90,6 +95,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your personalized summary of what happened this epoch — proposals, votes, and changes that affect your ADA.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'hub-representation',
@@ -98,6 +104,7 @@ export const TOURS: MiniTour[] = [
         description:
           'See who represents you and how well they are performing. This is your governance health at a glance.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'hub-actions',
@@ -106,6 +113,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Suggested next steps based on what is happening in governance right now. Proposals to review, votes to cast, and teams to build.',
         position: 'top',
+        route: '/',
       },
     ],
   },
@@ -117,6 +125,7 @@ export const TOURS: MiniTour[] = [
     icon: 'LayoutDashboard',
     segments: ['drep'],
     startRoute: '/',
+    relatedFeatures: ['workspace-votes'],
     steps: [
       {
         id: 'drep-voting-queue',
@@ -125,6 +134,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Active proposals awaiting your vote. These are sorted by urgency so you never miss a deadline.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'drep-delegators',
@@ -133,6 +143,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Track who trusts you with their voting power. See growth trends and engagement levels.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'drep-competitive',
@@ -141,6 +152,7 @@ export const TOURS: MiniTour[] = [
         description:
           'How you compare to other DReps on key governance metrics. Use this to improve your representation quality.',
         position: 'top',
+        route: '/',
       },
     ],
   },
@@ -152,6 +164,7 @@ export const TOURS: MiniTour[] = [
     icon: 'Server',
     segments: ['spo'],
     startRoute: '/',
+    relatedFeatures: [],
     steps: [
       {
         id: 'spo-score',
@@ -160,6 +173,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your pool governance reputation — how actively and responsibly you participate in Cardano governance.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'spo-delegators',
@@ -168,6 +182,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your delegators and their governance expectations. A differentiator for attracting delegation.',
         position: 'bottom',
+        route: '/',
       },
       {
         id: 'spo-position',
@@ -176,6 +191,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Declare and share your stance on key governance topics. Delegators want to know where you stand.',
         position: 'top',
+        route: '/workspace/position',
       },
     ],
   },
@@ -189,6 +205,7 @@ export const TOURS: MiniTour[] = [
     icon: 'Landmark',
     segments: ['anonymous', 'citizen', 'drep', 'spo', 'cc'],
     startRoute: '/governance/proposals',
+    relatedFeatures: ['browse-proposals', 'browse-dreps', 'governance-health'],
     steps: [
       {
         id: 'gov-proposals',
@@ -197,6 +214,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Every governance action being decided right now — treasury withdrawals, parameter changes, and more. Each proposal shows its current status and voting progress.',
         position: 'bottom',
+        route: '/governance/proposals',
       },
       {
         id: 'gov-representatives',
@@ -205,6 +223,7 @@ export const TOURS: MiniTour[] = [
         description:
           'The DReps who vote on your behalf. Browse, compare, and find representatives whose values match yours.',
         position: 'bottom',
+        route: '/governance/representatives',
       },
       {
         id: 'gov-health',
@@ -213,6 +232,7 @@ export const TOURS: MiniTour[] = [
         description:
           'An objective measure of how well Cardano governance is functioning — participation rates, voting quality, and systemic resilience.',
         position: 'bottom',
+        route: '/governance/health',
       },
     ],
   },
@@ -226,6 +246,7 @@ export const TOURS: MiniTour[] = [
     icon: 'Compass',
     segments: ['anonymous', 'citizen'],
     startRoute: '/match',
+    relatedFeatures: ['match-flow'],
     steps: [
       {
         id: 'match-questions',
@@ -234,6 +255,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Answer 3 quick questions about your governance priorities. No wallet needed — just your perspective.',
         position: 'bottom',
+        route: '/match',
       },
       {
         id: 'match-results',
@@ -242,6 +264,7 @@ export const TOURS: MiniTour[] = [
         description:
           'See DReps and pools ranked by how closely they align with your values. Each match shows a compatibility score.',
         position: 'bottom',
+        route: '/match',
       },
       {
         id: 'match-delegate',
@@ -250,6 +273,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Ready to delegate? Connect your wallet and make it official. Your ADA stays in your wallet — you are just choosing who votes for you.',
         position: 'top',
+        route: '/match',
       },
     ],
   },
@@ -263,6 +287,7 @@ export const TOURS: MiniTour[] = [
     icon: 'LayoutDashboard',
     segments: ['drep'],
     startRoute: '/workspace',
+    relatedFeatures: ['workspace-votes', 'workspace-rationales'],
     steps: [
       {
         id: 'ws-cockpit',
@@ -271,6 +296,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your dashboard for governance action — pending votes, recent activity, and key metrics at a glance.',
         position: 'bottom',
+        route: '/workspace',
       },
       {
         id: 'ws-votes',
@@ -279,6 +305,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Review proposals and cast your votes. Each vote includes space for your rationale — delegators want to know your reasoning.',
         position: 'bottom',
+        route: '/workspace/votes',
       },
       {
         id: 'ws-delegators',
@@ -287,6 +314,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Understand who trusts you: their ADA stake, how long they have delegated, and what they care about.',
         position: 'bottom',
+        route: '/workspace/delegators',
       },
       {
         id: 'ws-rationale',
@@ -295,6 +323,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Write and manage your voting rationales. Clear reasoning builds trust and attracts delegation.',
         position: 'top',
+        route: '/workspace/rationales',
       },
     ],
   },
@@ -306,6 +335,7 @@ export const TOURS: MiniTour[] = [
     icon: 'Server',
     segments: ['spo'],
     startRoute: '/workspace',
+    relatedFeatures: [],
     steps: [
       {
         id: 'ws-spo-score',
@@ -314,6 +344,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your pool governance reputation score — based on participation quality, reliability, and engagement.',
         position: 'bottom',
+        route: '/workspace',
       },
       {
         id: 'ws-spo-profile',
@@ -322,6 +353,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Edit your governance profile. Share your stance on key topics to attract like-minded delegators.',
         position: 'bottom',
+        route: '/workspace/pool-profile',
       },
       {
         id: 'ws-spo-delegators',
@@ -330,6 +362,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Track your pool delegators and their governance preferences. A unique differentiator for your pool.',
         position: 'top',
+        route: '/workspace',
       },
     ],
   },
@@ -343,6 +376,7 @@ export const TOURS: MiniTour[] = [
     icon: 'User',
     segments: ['citizen', 'drep', 'spo'],
     startRoute: '/you',
+    relatedFeatures: ['civic-identity'],
     steps: [
       {
         id: 'you-card',
@@ -351,6 +385,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Your governance identity at a glance — tier, engagement level, and delegation status.',
         position: 'bottom',
+        route: '/you',
       },
       {
         id: 'you-milestones',
@@ -359,6 +394,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Track your governance journey. Each milestone marks a meaningful step in your participation.',
         position: 'bottom',
+        route: '/you',
       },
       {
         id: 'you-history',
@@ -367,6 +403,7 @@ export const TOURS: MiniTour[] = [
         description:
           'A timeline of your governance activity — delegations, votes, and engagement over time.',
         position: 'top',
+        route: '/you',
       },
     ],
   },
@@ -380,6 +417,7 @@ export const TOURS: MiniTour[] = [
     icon: 'HelpCircle',
     segments: ['anonymous', 'citizen', 'drep', 'spo', 'cc'],
     startRoute: '/help',
+    relatedFeatures: ['getting-started', 'methodology'],
     steps: [
       {
         id: 'help-getting-started',
@@ -388,6 +426,7 @@ export const TOURS: MiniTour[] = [
         description:
           'New to Cardano governance? Start here for a quick overview of how it all works and what you can do.',
         position: 'bottom',
+        route: '/help',
       },
       {
         id: 'help-methodology',
@@ -396,6 +435,7 @@ export const TOURS: MiniTour[] = [
         description:
           'Full transparency on how we calculate scores, tiers, and health metrics. Every formula is documented.',
         position: 'bottom',
+        route: '/help',
       },
     ],
   },

--- a/lib/discovery/state.ts
+++ b/lib/discovery/state.ts
@@ -54,6 +54,22 @@ const DEFAULT_STATE: DiscoveryState = {
   fabPulseStopped: false,
 };
 
+/* ─── Cross-instance change notification ─────────────── */
+
+const CHANGE_EVENT = 'governada_discovery_changed';
+
+function notifyStateChange(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+/** Subscribe to state changes from ANY hook instance */
+export function onStateChange(handler: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(CHANGE_EVENT, handler);
+  return () => window.removeEventListener(CHANGE_EVENT, handler);
+}
+
 /* ─── Core read/write ────────────────────────────────── */
 
 export function getDiscoveryState(): DiscoveryState {
@@ -76,6 +92,7 @@ export function updateDiscoveryState(partial: Partial<DiscoveryState>): Discover
   } catch {
     /* localStorage may be full or disabled */
   }
+  notifyStateChange();
   return updated;
 }
 


### PR DESCRIPTION
## Summary
- **Spotlight tours now actually work**: Tours navigate between pages and highlight target elements with the spotlight overlay, instead of just navigating to the page
- **Cross-instance state sync**: Multiple `useDiscovery()` hook instances (DiscoveryHub, SpotlightProvider, etc.) now stay in sync via CustomEvent broadcasting
- **Tour completion marks features explored**: Completing a guided tour now automatically marks related features as "discovered" in the progress tracker

## What changed
Three root causes fixed:
1. **State desync** — Each `useDiscovery()` instance had independent version counters. When one wrote to localStorage, others didn't re-read. Added `CustomEvent('governada_discovery_changed')` broadcast from `updateDiscoveryState()` + listener in hook.
2. **Missing route navigation** — Tour steps span multiple pages but SpotlightProvider never navigated. Added `route` field to `SpotlightStep`, route-aware navigation in SpotlightProvider, and 400ms settling delay for DOM.
3. **Target not found = instant skip** — SpotlightOverlay skipped immediately when target wasn't in DOM (common after navigation). Added retry logic: 300ms intervals, max 10 retries (3s).

Bonus: Added `relatedFeatures` to `MiniTour` — completing a tour marks mapped features as explored.

## Files changed
- `lib/discovery/state.ts` — Cross-instance notification via CustomEvent
- `lib/discovery/content.ts` — Added `route` and `relatedFeatures` to tour definitions
- `hooks/useDiscovery.ts` — Subscribe to cross-instance state changes
- `components/discovery/SpotlightOverlay.tsx` — Retry-based target finding
- `components/discovery/SpotlightProvider.tsx` — Route-aware navigation + feature marking on tour completion

## Impact
- **What changed**: Guided tours now function end-to-end — navigation, spotlight highlights, and feature tracking
- **User-facing**: Yes — tours that previously did nothing now show spotlight overlays and update progress
- **Risk**: Low — changes are scoped to discovery system, no data/API changes
- **Scope**: 5 files in discovery layer only

## Test plan
- [ ] Start a hub tour → spotlight overlay appears highlighting target elements
- [ ] Start a governance tour → navigates between proposals/representatives/health pages with spotlights
- [ ] Complete a tour → related features marked as "discovered" in Discovery Hub progress
- [ ] Open Discovery Hub from one place, start tour → SpotlightProvider picks up state immediately
- [ ] Mobile: spotlights render correctly, tooltips don't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)