### PR TITLE
fix: spotlight overlay positioning — use viewport-relative coords

### DIFF
--- a/components/discovery/SpotlightOverlay.tsx
+++ b/components/discovery/SpotlightOverlay.tsx
@@ -7,7 +7,7 @@
  * the target element, plus an explanation tooltip card.
  */
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { X, ChevronRight, SkipForward } from 'lucide-react';
@@ -59,9 +59,10 @@ export function SpotlightOverlay({
       measureTimer = setTimeout(() => {
         if (cancelled) return;
         const rect = el.getBoundingClientRect();
+        // Viewport-relative coords — overlay container is position:fixed
         setTargetRect({
-          top: rect.top + window.scrollY,
-          left: rect.left + window.scrollX,
+          top: rect.top,
+          left: rect.left,
           width: rect.width,
           height: rect.height,
         });


### PR DESCRIPTION
## Summary
- Spotlight overlay cutout, highlight ring, and tooltip were rendered off-screen because scroll offsets were added to viewport-relative coordinates

## What changed
`SpotlightOverlay` uses a `position: fixed` container (viewport-relative), but `targetRect` was calculated as `getBoundingClientRect().top + window.scrollY`. This pushed everything below the visible area when the page was scrolled. Removed the scroll offset addition.

Also removed unused `useCallback` import.

## Impact
- **What changed**: Spotlight cutout and tooltip now appear at the correct position over the target element
- **User-facing**: Yes — guided tour spotlights were invisible, now they work
- **Risk**: Low — single file, 3-line change
- **Scope**: `components/discovery/SpotlightOverlay.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)