### PR TITLE
fix: compute GHI epoch from block time instead of governance_stats

### DIFF
--- a/inngest/functions/snapshot-ghi.ts
+++ b/inngest/functions/snapshot-ghi.ts
@@ -9,6 +9,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { computeGHI } from '@/lib/ghi';
+import { blockTimeToEpoch } from '@/lib/koios';
 import { SyncLogger, errMsg, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
@@ -39,19 +40,8 @@ export const snapshotGhi = inngest.createFunction(
     });
 
     const epoch = await step.run('get-current-epoch', async () => {
-      const supabase = getSupabaseAdmin();
-      const { data } = await supabase
-        .from('governance_stats')
-        .select('current_epoch')
-        .eq('id', 1)
-        .single();
-      return data?.current_epoch ?? 0;
+      return blockTimeToEpoch(Math.floor(Date.now() / 1000));
     });
-
-    if (epoch === 0) {
-      logger.warn('[snapshot-ghi] Could not determine current epoch, skipping');
-      return { skipped: true };
-    }
 
     await step.run('store-ghi-snapshot', async () => {
       const supabase = getSupabaseAdmin();


### PR DESCRIPTION
## Summary
- GHI snapshot function now computes epoch directly via `blockTimeToEpoch()` instead of reading `governance_stats.current_epoch`
- Removes hidden timing dependency on `generate-epoch-summary` running before `snapshot-ghi`
- Prevents missing epoch data when sync ordering shifts (as happened with epoch 618)

## Impact
- **What changed**: GHI snapshot epoch detection is now self-sufficient — no dependency on governance_stats being pre-updated
- **User-facing**: No — backend sync reliability improvement
- **Risk**: Low — `blockTimeToEpoch` is a pure deterministic function already used across 50+ files
- **Scope**: `inngest/functions/snapshot-ghi.ts` only. Inngest function changed.

## Test plan
- [x] Preflight passes (format, lint, types, 613 tests)
- [ ] CI green
- [ ] After deploy: PUT `/api/inngest` to re-register function
- [ ] Verify next daily GHI cron (04:30 UTC) writes correct epoch

🤖 Generated with [Claude Code](https://claude.com/claude-code)