### PR TITLE
fix: remove redundant pre-push hook and fix flaky proposal test

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
-npm run preflight
+# CI is the authoritative gate before merge.
+# Pre-commit (lint-staged) handles formatting and linting.
+# No pre-push check needed — it was running preflight a 3rd time.

--- a/__tests__/sync/proposals.test.ts
+++ b/__tests__/sync/proposals.test.ts
@@ -39,6 +39,8 @@ function setupMockChain() {
     eq: vi.fn().mockReturnThis(),
     neq: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
     in: vi.fn().mockResolvedValue({ data: [], error: null }),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- Remove pre-push hook that ran full `npm run preflight` redundantly — pre-commit (lint-staged) and CI already cover formatting, linting, type-checking, and tests
- Fix flaky `proposals.test.ts` timeout by adding missing `is` and `not` methods to the Supabase mock chain — the test was hanging because the query builder threw on the missing mock

## Impact
- **What changed**: Push is now instant instead of waiting ~60s for a redundant preflight. Proposal sync test no longer flakes.
- **User-facing**: No — dev tooling only
- **Risk**: Low — removing a redundant check, CI remains the authoritative gate. Test fix adds missing mock methods.
- **Scope**: `.husky/pre-push`, `__tests__/sync/proposals.test.ts`

## Test plan
- [x] `git push` completes instantly (no preflight delay)
- [x] `npx vitest run __tests__/sync/proposals.test.ts` — all 5 tests pass in <300ms (was timing out at 5000ms)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)