### PR TITLE
feat: civic identity rings — governance visualization redesign

### DIFF
--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -9,13 +9,11 @@ import {
   Vote,
   Coins,
   Share2,
-  CheckCircle2,
-  AlertTriangle,
-  AlertCircle,
   ArrowRight,
   Shield,
   Users,
   Landmark,
+  ChevronDown,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -26,7 +24,12 @@ import { AsyncContent } from '@/components/civica/shared/AsyncContent';
 import { MilestoneGallery } from './MilestoneGallery';
 import { CitizenMilestoneCelebration } from './CitizenMilestoneCelebration';
 import { ImpactScoreCard } from './ImpactScoreCard';
+import { GovernanceRings } from './GovernanceRings';
+import { GovernancePulse } from './GovernancePulse';
+import { IdentityNarrative } from './IdentityNarrative';
+import { MilestoneStamps } from './MilestoneStamps';
 import { useCitizenImpactScore } from '@/hooks/queries';
+import { computeGovernanceRings, RING_CONFIG } from '@/lib/governanceRings';
 import type { GovernanceFootprint } from '@/lib/governanceFootprint';
 
 /* ── Data hooks (TanStack Query) ───────────────────────────────── */
@@ -71,13 +74,6 @@ function formatAdaCompact(ada: number): string {
   if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
   return ada.toFixed(0);
 }
-
-const HEALTH_CONFIG = {
-  champion: { icon: CheckCircle2, color: 'text-emerald-500', label: 'Champion' },
-  active: { icon: CheckCircle2, color: 'text-emerald-500', label: 'Active' },
-  participant: { icon: AlertTriangle, color: 'text-amber-500', label: 'Participant' },
-  observer: { icon: AlertCircle, color: 'text-muted-foreground', label: 'Observer' },
-} as const;
 
 /* ── Section components ────────────────────────────────────────── */
 
@@ -154,13 +150,15 @@ function ProfileSkeleton() {
   return (
     <div className="space-y-6">
       <Skeleton className="h-6 w-48" />
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="flex justify-center">
+        <Skeleton className="h-[200px] w-[200px] rounded-full" />
+      </div>
+      <Skeleton className="h-4 w-64 mx-auto" />
+      <div className="flex gap-2">
         {[...Array(4)].map((_, i) => (
-          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+          <Skeleton key={i} className="h-16 w-16 rounded-lg" />
         ))}
       </div>
-      <Skeleton className="h-32 w-full rounded-xl" />
-      <Skeleton className="h-48 w-full rounded-xl" />
     </div>
   );
 }
@@ -183,6 +181,7 @@ export function CivicIdentityProfile() {
     segment !== 'anonymous',
   );
   const [shareOpen, setShareOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   const isLoading = segmentLoading || footprintLoading;
   const earned = milestonesData?.milestones ?? [];
@@ -193,6 +192,9 @@ export function CivicIdentityProfile() {
   const recentKeys = new Set(
     earned.filter((m) => new Date(m.earnedAt).getTime() > recentCutoff).map((m) => m.key),
   );
+
+  // Compute governance rings from existing data
+  const ringsData = computeGovernanceRings(footprint, impactScoreData);
 
   if (segment === 'anonymous' && !segmentLoading) {
     return (
@@ -223,7 +225,7 @@ export function CivicIdentityProfile() {
   const shareOgUrl = stakeAddress
     ? `/api/og/civic-identity/${encodeURIComponent(stakeAddress)}`
     : '';
-  const shareText = `Check out my Civic Identity on Cardano! ${earned.length} milestones earned. @GovernadaIO`;
+  const shareText = `Check out my Civic Identity on Cardano! Governance Pulse: ${ringsData.pulse}/100. ${earned.length} milestones earned. @GovernadaIO`;
 
   return (
     <div className="space-y-8" data-discovery="you-card">
@@ -248,211 +250,87 @@ export function CivicIdentityProfile() {
         )}
       </div>
 
-      {/* Citizen Since + Key Stats */}
+      {/* ── Hero: Governance Rings + Pulse ───────────────────────── */}
       <AsyncContent
-        isLoading={footprintLoading}
+        isLoading={footprintLoading || impactScoreLoading}
         isError={footprintError}
         data={footprint}
         errorMessage="Unable to load your governance footprint."
         skeleton={
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {[...Array(4)].map((_, i) => (
-              <Skeleton key={i} className="h-24 w-full rounded-xl" />
-            ))}
+          <div className="flex justify-center">
+            <Skeleton className="h-[200px] w-[200px] rounded-full" />
           </div>
         }
       >
         {footprint && (
           <>
             {isUndelegated ? (
-              /* Undelegated citizen — show onboarding CTA instead of empty stats */
               <UndelegatedCTA />
             ) : (
-              <>
-                {/* Participation tier banner */}
-                <div className="flex items-center gap-3 rounded-xl border border-border/50 bg-card p-4">
-                  {(() => {
-                    const tier = footprint.identity.participationTier;
-                    const config = HEALTH_CONFIG[tier];
-                    const TierIcon = config.icon;
-                    return (
-                      <>
-                        <TierIcon className={cn('h-5 w-5', config.color)} />
-                        <div className="flex-1">
-                          <p className="text-sm font-semibold">{config.label} Citizen</p>
-                          <p className="text-xs text-muted-foreground">
-                            {footprint.identity.delegationAgeDays != null
-                              ? `Delegating for ${footprint.identity.delegationAgeDays} days`
-                              : 'Start delegating to build your identity'}
-                          </p>
-                        </div>
-                        {footprint.delegationRecord.drepName && (
-                          <Link
-                            href={`/drep/${footprint.identity.delegatedDRep}`}
-                            className="text-sm font-medium text-primary hover:underline"
-                          >
-                            {footprint.delegationRecord.drepName}
-                          </Link>
-                        )}
-                      </>
-                    );
-                  })()}
+              <div className="flex flex-col items-center gap-5">
+                {/* Rings with Pulse centered inside */}
+                <div className="relative">
+                  <GovernanceRings rings={ringsData.rings} size={200} />
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <GovernancePulse
+                      pulse={ringsData.pulse}
+                      pulseColor={ringsData.pulseColor}
+                      pulseLabel={ringsData.pulseLabel}
+                    />
+                  </div>
                 </div>
 
-                {/* Stats grid */}
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                  <StatCard
-                    icon={Calendar}
-                    label="Citizen Since"
-                    value={
-                      footprint.identity.delegationAgeDays != null
-                        ? `${Math.floor(footprint.identity.delegationAgeDays / 5)} epochs`
-                        : '--'
-                    }
-                    sub={
-                      footprint.identity.delegationAgeDays != null
-                        ? `${footprint.identity.delegationAgeDays} days`
-                        : undefined
-                    }
-                  />
-                  <StatCard
-                    icon={Flame}
-                    label="Delegation Streak"
-                    value={footprint.citizenActivity.epochsActive}
-                    sub={`epoch${footprint.citizenActivity.epochsActive !== 1 ? 's' : ''} active`}
-                  />
-                  <StatCard
-                    icon={Vote}
-                    label="Proposals Influenced"
-                    value={footprint.impact.proposalsInfluenced}
-                  />
-                  <StatCard
-                    icon={Coins}
-                    label="ADA Governed"
-                    value={
-                      footprint.impact.adaGoverned > 0
-                        ? formatAdaCompact(footprint.impact.adaGoverned)
-                        : '--'
-                    }
-                    sub={footprint.impact.delegationWeight}
-                  />
+                {/* Ring legend */}
+                <div className="flex flex-wrap justify-center gap-x-5 gap-y-1.5">
+                  {RING_CONFIG.map((config) => (
+                    <div key={config.key} className="flex items-center gap-1.5">
+                      <div
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ background: config.color }}
+                      />
+                      <span className="text-xs text-muted-foreground">{config.label}</span>
+                    </div>
+                  ))}
                 </div>
-              </>
+
+                {/* Identity narrative */}
+                <IdentityNarrative
+                  participationTier={footprint.identity.participationTier}
+                  drepName={footprint.delegationRecord.drepName}
+                  delegationAgeDays={footprint.identity.delegationAgeDays}
+                  proposalsInfluenced={footprint.impact.proposalsInfluenced}
+                  pulse={ringsData.pulse}
+                  pulseLabel={ringsData.pulseLabel}
+                />
+              </div>
             )}
 
-            {/* Unstaked notice — shown below stats or below undelegated CTA */}
             {isUnstaked && <UnstakedCTA />}
           </>
         )}
       </AsyncContent>
 
-      {/* Governance Footprint */}
-      {footprint && (
-        <div data-discovery="you-history">
-          <SectionHeader title="Governance Footprint" />
-          {isUndelegated ? (
-            <div className="rounded-xl border border-border/50 bg-card/70 p-5 text-center space-y-3">
-              <Vote className="h-6 w-6 text-muted-foreground mx-auto" />
-              <p className="text-sm font-medium text-foreground">No governance footprint yet</p>
-              <p className="text-xs text-muted-foreground max-w-xs mx-auto">
-                Once you delegate to a DRep, this section will show their score, votes cast on your
-                behalf, and your delegation history.
-              </p>
-              <Button variant="outline" size="sm" asChild>
-                <Link href="/match">
-                  Browse DReps
-                  <ArrowRight className="h-3.5 w-3.5 ml-1" />
-                </Link>
-              </Button>
+      {/* ── Milestone Stamps ─────────────────────────────────────── */}
+      <div data-discovery="you-milestones">
+        <SectionHeader title="Milestones" />
+        <AsyncContent
+          isLoading={milestonesLoading}
+          isError={milestonesError}
+          data={milestonesData}
+          errorMessage="Unable to load milestones."
+          skeleton={
+            <div className="flex gap-2">
+              {[...Array(4)].map((_, i) => (
+                <Skeleton key={i} className="h-16 w-16 rounded-lg" />
+              ))}
             </div>
-          ) : (
-            <>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
-                  <p className="text-xs text-muted-foreground">DRep Score</p>
-                  <p className="text-2xl font-bold tabular-nums">
-                    {footprint.delegationRecord.drepScore ?? '--'}
-                    <span className="text-sm font-normal text-muted-foreground">/100</span>
-                  </p>
-                  {footprint.delegationRecord.drepRank && (
-                    <p className="text-xs text-muted-foreground">
-                      Rank #{footprint.delegationRecord.drepRank}
-                    </p>
-                  )}
-                </div>
-                <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
-                  <p className="text-xs text-muted-foreground">DRep Votes Cast</p>
-                  <p className="text-2xl font-bold tabular-nums">
-                    {footprint.delegationRecord.keyVotes}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {footprint.delegationRecord.delegationChanges} delegation change
-                    {footprint.delegationRecord.delegationChanges !== 1 ? 's' : ''}
-                  </p>
-                </div>
-              </div>
-
-              {delegatedDrep && (
-                <div className="mt-3">
-                  <Button variant="outline" size="sm" asChild>
-                    <Link href={`/drep/${delegatedDrep}`}>
-                      View your DRep
-                      <ArrowRight className="h-3.5 w-3.5 ml-1" />
-                    </Link>
-                  </Button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      )}
-
-      {/* Engagement Stats */}
-      {footprint && (
-        <div>
-          <SectionHeader title="Engagement Stats" />
-          <div className="grid grid-cols-3 gap-3">
-            <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-              <p className="text-xl font-bold tabular-nums">
-                {footprint.citizenActivity.pollsTaken}
-              </p>
-              <p className="text-xs text-muted-foreground">Polls Taken</p>
-            </div>
-            <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-              <p className="text-xl font-bold tabular-nums">
-                {footprint.citizenActivity.pollStreak}
-              </p>
-              <p className="text-xs text-muted-foreground">Poll Streak</p>
-            </div>
-            <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
-              <p className="text-xl font-bold tabular-nums">
-                {footprint.citizenActivity.consistency != null
-                  ? `${footprint.citizenActivity.consistency}%`
-                  : '--'}
-              </p>
-              <p className="text-xs text-muted-foreground">Consistency</p>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Governance Impact Score */}
-      <div>
-        <SectionHeader title="Governance Impact" />
-        {impactScoreLoading ? (
-          <Skeleton className="h-64 w-full rounded-2xl" />
-        ) : impactScoreData ? (
-          <ImpactScoreCard data={impactScoreData} />
-        ) : (
-          <div className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-5 text-center">
-            <p className="text-sm text-muted-foreground">
-              Impact score will be calculated on the next sync cycle.
-            </p>
-          </div>
-        )}
+          }
+        >
+          <MilestoneStamps earned={earned} recentKeys={recentKeys} />
+        </AsyncContent>
       </div>
 
-      {/* Alignment Profile */}
+      {/* ── Alignment Quick Match ────────────────────────────────── */}
       {footprint && (
         <div>
           <SectionHeader title="Alignment" />
@@ -475,25 +353,166 @@ export function CivicIdentityProfile() {
         </div>
       )}
 
-      {/* Milestone Gallery */}
-      <div data-discovery="you-milestones">
-        <SectionHeader title="Milestones" />
-        <AsyncContent
-          isLoading={milestonesLoading}
-          isError={milestonesError}
-          data={milestonesData}
-          errorMessage="Unable to load milestones."
-          skeleton={
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {[...Array(6)].map((_, i) => (
-                <Skeleton key={i} className="h-24 w-full rounded-xl" />
-              ))}
+      {/* ── Collapsible Details ───────────────────────────────────── */}
+      {footprint && !isUndelegated && (
+        <div>
+          <button
+            type="button"
+            onClick={() => setDetailsOpen((prev) => !prev)}
+            className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 hover:text-foreground transition-colors"
+          >
+            <ChevronDown
+              className={cn('h-3.5 w-3.5 transition-transform', detailsOpen && 'rotate-180')}
+            />
+            Detailed Breakdown
+          </button>
+
+          {detailsOpen && (
+            <div className="space-y-6 animate-in fade-in-0 slide-in-from-top-2 duration-200">
+              {/* Stats grid */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <StatCard
+                  icon={Calendar}
+                  label="Citizen Since"
+                  value={
+                    footprint.identity.delegationAgeDays != null
+                      ? `${Math.floor(footprint.identity.delegationAgeDays / 5)} epochs`
+                      : '--'
+                  }
+                  sub={
+                    footprint.identity.delegationAgeDays != null
+                      ? `${footprint.identity.delegationAgeDays} days`
+                      : undefined
+                  }
+                />
+                <StatCard
+                  icon={Flame}
+                  label="Delegation Streak"
+                  value={footprint.citizenActivity.epochsActive}
+                  sub={`epoch${footprint.citizenActivity.epochsActive !== 1 ? 's' : ''} active`}
+                />
+                <StatCard
+                  icon={Vote}
+                  label="Proposals Influenced"
+                  value={footprint.impact.proposalsInfluenced}
+                />
+                <StatCard
+                  icon={Coins}
+                  label="ADA Governed"
+                  value={
+                    footprint.impact.adaGoverned > 0
+                      ? formatAdaCompact(footprint.impact.adaGoverned)
+                      : '--'
+                  }
+                  sub={footprint.impact.delegationWeight}
+                />
+              </div>
+
+              {/* Governance Footprint */}
+              <div data-discovery="you-history">
+                <SectionHeader title="Governance Footprint" />
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
+                    <p className="text-xs text-muted-foreground">DRep Score</p>
+                    <p className="text-2xl font-bold tabular-nums">
+                      {footprint.delegationRecord.drepScore ?? '--'}
+                      <span className="text-sm font-normal text-muted-foreground">/100</span>
+                    </p>
+                    {footprint.delegationRecord.drepRank && (
+                      <p className="text-xs text-muted-foreground">
+                        Rank #{footprint.delegationRecord.drepRank}
+                      </p>
+                    )}
+                  </div>
+                  <div className="rounded-xl border border-border/50 bg-card p-4 space-y-1">
+                    <p className="text-xs text-muted-foreground">DRep Votes Cast</p>
+                    <p className="text-2xl font-bold tabular-nums">
+                      {footprint.delegationRecord.keyVotes}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {footprint.delegationRecord.delegationChanges} delegation change
+                      {footprint.delegationRecord.delegationChanges !== 1 ? 's' : ''}
+                    </p>
+                  </div>
+                </div>
+                {delegatedDrep && (
+                  <div className="mt-3">
+                    <Button variant="outline" size="sm" asChild>
+                      <Link href={`/drep/${delegatedDrep}`}>
+                        View your DRep
+                        <ArrowRight className="h-3.5 w-3.5 ml-1" />
+                      </Link>
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {/* Engagement Stats */}
+              <div>
+                <SectionHeader title="Engagement Stats" />
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+                    <p className="text-xl font-bold tabular-nums">
+                      {footprint.citizenActivity.pollsTaken}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Polls Taken</p>
+                  </div>
+                  <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+                    <p className="text-xl font-bold tabular-nums">
+                      {footprint.citizenActivity.pollStreak}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Poll Streak</p>
+                  </div>
+                  <div className="rounded-xl border border-border/50 bg-card p-4 text-center">
+                    <p className="text-xl font-bold tabular-nums">
+                      {footprint.citizenActivity.consistency != null
+                        ? `${footprint.citizenActivity.consistency}%`
+                        : '--'}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Consistency</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Impact Score */}
+              <div>
+                <SectionHeader title="Governance Impact" />
+                {impactScoreLoading ? (
+                  <Skeleton className="h-64 w-full rounded-2xl" />
+                ) : impactScoreData ? (
+                  <ImpactScoreCard data={impactScoreData} />
+                ) : (
+                  <div className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-5 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      Impact score will be calculated on the next sync cycle.
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Full Milestone Gallery */}
+              <div>
+                <SectionHeader title="All Milestones" />
+                <AsyncContent
+                  isLoading={milestonesLoading}
+                  isError={milestonesError}
+                  data={milestonesData}
+                  errorMessage="Unable to load milestones."
+                  skeleton={
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                      {[...Array(6)].map((_, i) => (
+                        <Skeleton key={i} className="h-24 w-full rounded-xl" />
+                      ))}
+                    </div>
+                  }
+                >
+                  <MilestoneGallery earned={earned} recentKeys={recentKeys} />
+                </AsyncContent>
+              </div>
             </div>
-          }
-        >
-          <MilestoneGallery earned={earned} recentKeys={recentKeys} />
-        </AsyncContent>
-      </div>
+          )}
+        </div>
+      )}
 
       {/* Milestone celebration (for newly earned milestones) */}
       {recentKeys.size > 0 && (

--- a/components/civica/identity/GovernancePulse.tsx
+++ b/components/civica/identity/GovernancePulse.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface GovernancePulseProps {
+  pulse: number;
+  pulseColor: 'emerald' | 'primary' | 'amber' | 'muted';
+  pulseLabel: string;
+}
+
+/* ── Color map ──────────────────────────────────────────────────── */
+
+const COLOR_MAP: Record<GovernancePulseProps['pulseColor'], string> = {
+  emerald: 'text-emerald-500',
+  primary: 'text-primary',
+  amber: 'text-amber-500',
+  muted: 'text-muted-foreground',
+};
+
+/* ── Component ─────────────────────────────────────────────────── */
+
+export function GovernancePulse({ pulse, pulseColor, pulseLabel }: GovernancePulseProps) {
+  return (
+    <div className="flex flex-col items-center">
+      <span className={cn('text-3xl font-bold tabular-nums', COLOR_MAP[pulseColor])}>
+        {Math.round(pulse)}
+      </span>
+      <span className="text-xs text-muted-foreground">/100</span>
+      <span className="text-xs text-muted-foreground mt-0.5">{pulseLabel}</span>
+    </div>
+  );
+}

--- a/components/civica/identity/GovernanceRings.tsx
+++ b/components/civica/identity/GovernanceRings.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { RING_CONFIG } from '@/lib/governanceRings';
+import type { RingValues } from '@/lib/governanceRings';
+
+interface GovernanceRingsProps {
+  rings: RingValues;
+  size?: number;
+}
+
+export function GovernanceRings({ rings, size = 200 }: GovernanceRingsProps) {
+  const strokeWidth = 10;
+  const gap = 4;
+  const center = size / 2;
+
+  // Outermost ring sits 1px inside the SVG edge plus half the stroke
+  const outerRadius = size / 2 - strokeWidth / 2 - 1;
+
+  return (
+    <div className={cn('relative')} style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="-rotate-90">
+        {RING_CONFIG.map((config, i) => {
+          const radius = outerRadius - i * (strokeWidth + gap);
+          const circumference = 2 * Math.PI * radius;
+          const fill = Math.min(Math.max(rings[config.key], 0), 1);
+          const offset = circumference * (1 - fill);
+
+          return (
+            <g key={config.key}>
+              {/* Track */}
+              <circle
+                cx={center}
+                cy={center}
+                r={radius}
+                fill="none"
+                stroke={config.trackColor}
+                strokeWidth={strokeWidth}
+              />
+              {/* Progress arc */}
+              <circle
+                cx={center}
+                cy={center}
+                r={radius}
+                fill="none"
+                stroke={config.color}
+                strokeWidth={strokeWidth}
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={offset}
+                className="transition-all duration-700"
+              >
+                <title>
+                  {config.label}: {Math.round(fill * 100)}%
+                </title>
+              </circle>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/components/civica/identity/IdentityNarrative.tsx
+++ b/components/civica/identity/IdentityNarrative.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface IdentityNarrativeProps {
+  participationTier: 'observer' | 'participant' | 'active' | 'champion';
+  drepName: string | null;
+  delegationAgeDays: number | null;
+  proposalsInfluenced: number;
+  pulse: number;
+  pulseLabel: string;
+}
+
+/* ── Tier adjectives ───────────────────────────────────────────── */
+
+const TIER_ADJECTIVE: Record<IdentityNarrativeProps['participationTier'], string> = {
+  observer: 'Observing',
+  participant: 'Participating',
+  active: 'Active',
+  champion: 'Champion',
+};
+
+/* ── Helpers ────────────────────────────────────────────────────── */
+
+function formatDuration(days: number): string {
+  if (days < 1) return 'less than a day';
+  if (days === 1) return '1 day';
+  if (days < 30) return `${days} days`;
+  const epochs = Math.floor(days / 5);
+  return `${epochs} epochs`;
+}
+
+/* ── Component ─────────────────────────────────────────────────── */
+
+export function IdentityNarrative({
+  participationTier,
+  drepName,
+  delegationAgeDays,
+  proposalsInfluenced,
+  pulseLabel,
+}: IdentityNarrativeProps) {
+  if (!drepName) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Connect your delegation to start building your governance identity.
+      </p>
+    );
+  }
+
+  const duration = delegationAgeDays != null ? ` for ${formatDuration(delegationAgeDays)}` : '';
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      {TIER_ADJECTIVE[participationTier]} citizen. Delegating to {drepName}
+      {duration}. {proposalsInfluenced} proposals influenced. Governance Pulse: {pulseLabel}.
+    </p>
+  );
+}

--- a/components/civica/identity/MilestoneStamps.tsx
+++ b/components/civica/identity/MilestoneStamps.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  HandHeart,
+  Flame,
+  Vote,
+  Megaphone,
+  Coins,
+  MessageCircle,
+  Users,
+  ThumbsUp,
+  ShieldCheck,
+  TrendingUp,
+  Award,
+  type LucideIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CITIZEN_MILESTONES } from '@/lib/citizenMilestones';
+
+/* ── Icon map ──────────────────────────────────────────────────── */
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  HandHeart,
+  Flame,
+  Vote,
+  Megaphone,
+  Coins,
+  MessageCircle,
+  Users,
+  ThumbsUp,
+  ShieldCheck,
+  TrendingUp,
+  Award,
+};
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface EarnedMilestone {
+  key: string;
+  label: string;
+  earnedAt: string;
+}
+
+interface MilestoneStampsProps {
+  earned: EarnedMilestone[];
+  recentKeys?: Set<string>;
+  maxVisible?: number;
+}
+
+/* ── Component ─────────────────────────────────────────────────── */
+
+export function MilestoneStamps({ earned, recentKeys, maxVisible = 6 }: MilestoneStampsProps) {
+  if (earned.length === 0) {
+    return (
+      <div className="flex items-center justify-center rounded-lg border border-border/50 bg-muted/20 px-4 py-3">
+        <p className="text-xs text-muted-foreground">No milestones yet</p>
+      </div>
+    );
+  }
+
+  const visible = earned.slice(0, maxVisible);
+  const overflow = earned.length - maxVisible;
+
+  return (
+    <div className="flex gap-2 overflow-x-auto">
+      {visible.map((milestone) => {
+        const def = CITIZEN_MILESTONES.find((m) => m.key === milestone.key);
+        const Icon = (def ? ICON_MAP[def.icon] : null) ?? Vote;
+        const isRecent = recentKeys?.has(milestone.key);
+
+        return (
+          <div
+            key={milestone.key}
+            className={cn(
+              'flex w-16 h-16 flex-col items-center justify-center rounded-lg border shrink-0',
+              'border-primary/30 bg-primary/5',
+              isRecent && 'ring-2 ring-amber-400/50',
+            )}
+          >
+            <Icon className="h-4 w-4 text-primary" />
+            <span className="text-[10px] text-muted-foreground mt-1 text-center leading-tight line-clamp-2 px-0.5">
+              {milestone.label}
+            </span>
+          </div>
+        );
+      })}
+      {overflow > 0 && (
+        <div className="flex w-16 h-16 flex-col items-center justify-center rounded-lg border border-border/50 bg-muted/20 shrink-0">
+          <span className="text-xs font-medium text-muted-foreground">+{overflow} more</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/drepIdentity.ts
+++ b/lib/drepIdentity.ts
@@ -225,12 +225,27 @@ export function getRadarAxisEndpoints(size: number, padding = 24): [number, numb
 
 /** Short, evocative archetypes derived from alignment scores. */
 const PERSONALITY_ARCHETYPES: Record<AlignmentDimension, string[]> = {
-  treasuryConservative: ['The Guardian', 'The Fiscal Hawk', 'The Prudent Steward'],
-  treasuryGrowth: ['The Builder', 'The Growth Champion', 'The Catalyst'],
-  decentralization: ['The Federalist', 'The Power Distributor', 'The Decentralizer'],
-  security: ['The Sentinel', 'The Cautious Architect', 'The Shield'],
-  innovation: ['The Pioneer', 'The Changemaker', 'The Innovator'],
-  transparency: ['The Beacon', 'The Transparent Champion', 'The Open Book'],
+  treasuryConservative: ['The Guardian', 'The Fiscal Hawk', 'The Prudent Steward', 'The Moderate'],
+  treasuryGrowth: ['The Builder', 'The Growth Architect', 'The Catalyst', 'The Pragmatist'],
+  decentralization: [
+    'The Federalist',
+    'The Power Distributor',
+    'The Decentralizer',
+    'The Balanced Voice',
+  ],
+  security: [
+    'The Sentinel',
+    'The Protocol Guardian',
+    'The Cautious Architect',
+    'The Measured Thinker',
+  ],
+  innovation: ['The Pioneer', 'The Changemaker', 'The Explorer', 'The Curious Mind'],
+  transparency: [
+    'The Beacon',
+    'The Open Advocate',
+    'The Transparency Champion',
+    'The Thoughtful Observer',
+  ],
 };
 
 /**
@@ -245,7 +260,8 @@ export function getPersonalityLabel(alignments: AlignmentScores): string {
 
   if (distance > 30) return labels[0];
   if (distance > 15) return labels[1];
-  return labels[2];
+  if (distance > 8) return labels[2];
+  return labels[3];
 }
 
 /**

--- a/lib/governanceRings.ts
+++ b/lib/governanceRings.ts
@@ -1,0 +1,110 @@
+/**
+ * Governance Rings — computes three ring fill values from existing citizen data.
+ *
+ * Ring 1 (Delegation Health): How well is your DRep performing?
+ *   → DRep composite score normalised 0-1
+ *
+ * Ring 2 (Representation Coverage): What % of proposals are covered?
+ *   → Impact coverage score normalised 0-1
+ *
+ * Ring 3 (Civic Engagement): Are you actively participating?
+ *   → Impact engagement depth score normalised 0-1
+ *
+ * Governance Pulse: weighted composite of all three rings → 0-100.
+ */
+
+import type { GovernanceFootprint } from './governanceFootprint';
+import type { ImpactScoreBreakdown } from './citizenImpactScore';
+
+export interface RingValues {
+  /** 0-1 fill fraction */
+  delegation: number;
+  /** 0-1 fill fraction */
+  coverage: number;
+  /** 0-1 fill fraction */
+  engagement: number;
+}
+
+export interface GovernanceRingsData {
+  rings: RingValues;
+  /** 0-100 composite */
+  pulse: number;
+  /** Color token for pulse badge */
+  pulseColor: 'emerald' | 'primary' | 'amber' | 'muted';
+  /** One-word pulse label */
+  pulseLabel: string;
+}
+
+const RING_WEIGHTS = { delegation: 0.4, coverage: 0.35, engagement: 0.25 };
+
+/**
+ * Compute ring values from existing footprint + impact data.
+ * All inputs are nullable — missing data defaults to 0.
+ */
+export function computeGovernanceRings(
+  footprint: GovernanceFootprint | null | undefined,
+  impact: ImpactScoreBreakdown | null | undefined,
+): GovernanceRingsData {
+  // Ring 1: Delegation Health — DRep score normalised to 0-1
+  const drepScore = footprint?.delegationRecord.drepScore ?? 0;
+  const delegation = Math.min(Math.max(drepScore / 100, 0), 1);
+
+  // Ring 2: Coverage — impact coverage score (0-25) normalised to 0-1
+  const coverageRaw = impact?.coverageScore ?? 0;
+  const coverage = Math.min(coverageRaw / 25, 1);
+
+  // Ring 3: Engagement — impact engagement depth score (0-25) normalised to 0-1
+  const engagementRaw = impact?.engagementDepthScore ?? 0;
+  const engagement = Math.min(engagementRaw / 25, 1);
+
+  const rings: RingValues = { delegation, coverage, engagement };
+
+  // Governance Pulse — weighted composite
+  const pulse = Math.round(
+    (delegation * RING_WEIGHTS.delegation +
+      coverage * RING_WEIGHTS.coverage +
+      engagement * RING_WEIGHTS.engagement) *
+      100,
+  );
+
+  const pulseColor =
+    pulse >= 75 ? 'emerald' : pulse >= 50 ? 'primary' : pulse >= 25 ? 'amber' : 'muted';
+
+  const pulseLabel =
+    pulse >= 75
+      ? 'Thriving'
+      : pulse >= 50
+        ? 'Healthy'
+        : pulse >= 25
+          ? 'Growing'
+          : 'Getting Started';
+
+  return { rings, pulse, pulseColor, pulseLabel };
+}
+
+/**
+ * Ring configuration for rendering — labels, colors, descriptions.
+ */
+export const RING_CONFIG = [
+  {
+    key: 'delegation' as const,
+    label: 'Delegation Health',
+    color: '#3b82f6', // blue-500
+    trackColor: 'rgba(59, 130, 246, 0.15)',
+    description: "Your DRep's performance score",
+  },
+  {
+    key: 'coverage' as const,
+    label: 'Representation Coverage',
+    color: '#a855f7', // purple-500
+    trackColor: 'rgba(168, 85, 247, 0.15)',
+    description: 'Proposals covered by your delegation',
+  },
+  {
+    key: 'engagement' as const,
+    label: 'Civic Engagement',
+    color: '#f59e0b', // amber-500
+    trackColor: 'rgba(245, 158, 11, 0.15)',
+    description: 'Your active participation in governance',
+  },
+] as const;


### PR DESCRIPTION
## Summary
- Replace the 15-metric dashboard with Apple Watch-style governance rings (Delegation Health, Representation Coverage, Civic Engagement)
- Add Governance Pulse (0-100 weighted composite) centered inside the rings
- Add identity narrative sentence and compact milestone stamps above the fold
- Move detailed stats, footprint, engagement, and impact sections into a collapsible "Detailed Breakdown" toggle
- Expand personality archetype taxonomy from 3 to 4 labels per alignment dimension

## Impact
- **What changed**: Civic Identity page completely redesigned from metrics-wall to rings-first emotional dashboard. New components: GovernanceRings, GovernancePulse, IdentityNarrative, MilestoneStamps. Core computation in lib/governanceRings.ts.
- **User-facing**: Yes — citizens see three animated SVG rings and a pulse number instead of a stat grid. All existing data still accessible via collapse toggle.
- **Risk**: Low — all data derived from existing GovernanceFootprint + ImpactScoreBreakdown. No database changes, no API changes. Existing detail sections preserved under toggle.
- **Scope**: 7 files (5 new components/lib, 2 modified). No migrations, no env vars, no Inngest changes.

## Test plan
- [ ] Verify rings render correctly for delegated citizens (all 3 rings fill proportionally)
- [ ] Verify pulse number and label match ring values
- [ ] Verify identity narrative displays correct DRep name, duration, and proposals
- [ ] Verify milestone stamps show earned milestones with overflow count
- [ ] Verify "Detailed Breakdown" toggle reveals all existing stats/footprint/engagement/impact sections
- [ ] Verify undelegated citizens see the delegation CTA instead of rings
- [ ] Verify anonymous users see wallet connect prompt
- [ ] Verify share modal includes updated pulse score in share text
- [ ] Verify personality labels use expanded 4-tier taxonomy

🤖 Generated with [Claude Code](https://claude.com/claude-code)