### PR TITLE
feat: civic identity phase 2 — AI narrative, archetypes, pulse history

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -38,6 +38,7 @@ import { generateCitizenAssembly } from '@/inngest/functions/generate-citizen-as
 import { trackProposalOutcomes } from '@/inngest/functions/track-proposal-outcomes';
 import { computeCommunityIntelligence } from '@/inngest/functions/compute-community-intelligence';
 import { notifyEngagementOutcomes } from '@/inngest/functions/notify-engagement-outcomes';
+import { snapshotCitizenRings } from '@/inngest/functions/snapshot-citizen-rings';
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [
@@ -79,5 +80,6 @@ export const { GET, POST, PUT } = serve({
     trackProposalOutcomes,
     computeCommunityIntelligence,
     notifyEngagementOutcomes,
+    snapshotCitizenRings,
   ],
 });

--- a/app/api/you/identity-narrative/route.ts
+++ b/app/api/you/identity-narrative/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { generateText } from '@/lib/ai';
+import { cached } from '@/lib/redis';
+import { buildNarrativePrompt } from '@/lib/identity/narrativePrompt';
+
+export const dynamic = 'force-dynamic';
+
+interface NarrativeRequestBody {
+  archetype: string | null;
+  drepName: string | null;
+  delegationAgeDays: number | null;
+  participationTier: string;
+  pulse: number;
+  pulseLabel: string;
+  delegationRing: number;
+  coverageRing: number;
+  engagementRing: number;
+  milestonesEarned: number;
+  proposalsInfluenced: number;
+}
+
+export const POST = withRouteHandler(
+  async (request: NextRequest, { userId }: RouteContext) => {
+    const body = (await request.json()) as NarrativeRequestBody;
+
+    // Cache key includes userId + pulse (changes when governance state changes meaningfully)
+    const cacheKey = `identity-narrative:${userId}:${body.pulse}`;
+    const EPOCH_TTL = 5 * 24 * 60 * 60; // 5 days (1 Cardano epoch)
+
+    const narrative = await cached(cacheKey, EPOCH_TTL, async () => {
+      const prompt = buildNarrativePrompt(body);
+      const result = await generateText(prompt, {
+        model: 'FAST',
+        maxTokens: 256,
+        temperature: 0.7,
+      });
+      return result;
+    });
+
+    if (!narrative) {
+      return NextResponse.json({ narrative: null }, { status: 200 });
+    }
+
+    return NextResponse.json({ narrative });
+  },
+  { auth: 'required' },
+);

--- a/app/api/you/ring-history/route.ts
+++ b/app/api/you/ring-history/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, { userId }: RouteContext) => {
+    const limit = Math.min(Number(request.nextUrl.searchParams.get('limit') ?? '20'), 50);
+
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('citizen_ring_snapshots')
+      .select('epoch, delegation_ring, coverage_ring, engagement_ring, pulse')
+      .eq('user_id', userId!)
+      .order('epoch', { ascending: true })
+      .limit(limit);
+
+    if (error) {
+      return NextResponse.json({ error: 'Failed to load ring history' }, { status: 500 });
+    }
+
+    return NextResponse.json({ snapshots: data ?? [] });
+  },
+  { auth: 'required' },
+);

--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -28,8 +28,11 @@ import { GovernanceRings } from './GovernanceRings';
 import { GovernancePulse } from './GovernancePulse';
 import { IdentityNarrative } from './IdentityNarrative';
 import { MilestoneStamps } from './MilestoneStamps';
+import { PulseHistoryChart } from './PulseHistoryChart';
 import { useCitizenImpactScore } from '@/hooks/queries';
 import { computeGovernanceRings, RING_CONFIG } from '@/lib/governanceRings';
+import { getCompoundArchetype, getDominantDimension, getIdentityColor } from '@/lib/drepIdentity';
+import type { AlignmentScores } from '@/lib/drepIdentity';
 import type { GovernanceFootprint } from '@/lib/governanceFootprint';
 
 /* ── Data hooks (TanStack Query) ───────────────────────────────── */
@@ -293,6 +296,26 @@ export function CivicIdentityProfile() {
                   ))}
                 </div>
 
+                {/* Governance archetype (from delegated DRep's alignment) */}
+                {footprint.delegationRecord.drepAlignment &&
+                  (() => {
+                    const alignment = footprint.delegationRecord.drepAlignment as AlignmentScores;
+                    const archetype = getCompoundArchetype(alignment);
+                    const dominant = getDominantDimension(alignment);
+                    const color = getIdentityColor(dominant);
+                    return (
+                      <div className="text-center">
+                        <p
+                          className="text-lg font-bold tracking-tight"
+                          style={{ color: color.hex }}
+                        >
+                          {archetype}
+                        </p>
+                        <p className="text-xs text-muted-foreground">Your governance archetype</p>
+                      </div>
+                    );
+                  })()}
+
                 {/* Identity narrative */}
                 <IdentityNarrative
                   participationTier={footprint.identity.participationTier}
@@ -301,7 +324,19 @@ export function CivicIdentityProfile() {
                   proposalsInfluenced={footprint.impact.proposalsInfluenced}
                   pulse={ringsData.pulse}
                   pulseLabel={ringsData.pulseLabel}
+                  rings={ringsData.rings}
+                  archetype={
+                    footprint.delegationRecord.drepAlignment
+                      ? getCompoundArchetype(
+                          footprint.delegationRecord.drepAlignment as AlignmentScores,
+                        )
+                      : null
+                  }
+                  milestonesEarned={earned.length}
                 />
+
+                {/* Pulse history sparkline (only renders if snapshots exist) */}
+                <PulseHistoryChart className="justify-center" />
               </div>
             )}
 
@@ -326,7 +361,7 @@ export function CivicIdentityProfile() {
             </div>
           }
         >
-          <MilestoneStamps earned={earned} recentKeys={recentKeys} />
+          <MilestoneStamps earned={earned} recentKeys={recentKeys} stakeAddress={stakeAddress} />
         </AsyncContent>
       </div>
 

--- a/components/civica/identity/IdentityNarrative.tsx
+++ b/components/civica/identity/IdentityNarrative.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useQuery } from '@tanstack/react-query';
+import type { RingValues } from '@/lib/governanceRings';
+
 /* ── Types ──────────────────────────────────────────────────────── */
 
 interface IdentityNarrativeProps {
@@ -9,6 +12,12 @@ interface IdentityNarrativeProps {
   proposalsInfluenced: number;
   pulse: number;
   pulseLabel: string;
+  /** Ring fill values for AI narrative context */
+  rings?: RingValues;
+  /** Archetype label for AI narrative context */
+  archetype?: string | null;
+  /** Number of milestones earned for AI narrative context */
+  milestonesEarned?: number;
 }
 
 /* ── Tier adjectives ───────────────────────────────────────────── */
@@ -30,15 +39,46 @@ function formatDuration(days: number): string {
   return `${epochs} epochs`;
 }
 
+/* ── AI narrative fetcher ──────────────────────────────────────── */
+
+function useAINarrative(props: IdentityNarrativeProps) {
+  const hasRings = props.rings && props.drepName;
+
+  return useQuery<{ narrative: string | null }>({
+    queryKey: ['identity-narrative', props.pulse],
+    queryFn: async () => {
+      const res = await fetch('/api/you/identity-narrative', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          archetype: props.archetype ?? null,
+          drepName: props.drepName,
+          delegationAgeDays: props.delegationAgeDays,
+          participationTier: props.participationTier,
+          pulse: props.pulse,
+          pulseLabel: props.pulseLabel,
+          delegationRing: props.rings?.delegation ?? 0,
+          coverageRing: props.rings?.coverage ?? 0,
+          engagementRing: props.rings?.engagement ?? 0,
+          milestonesEarned: props.milestonesEarned ?? 0,
+          proposalsInfluenced: props.proposalsInfluenced,
+        }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      return res.json();
+    },
+    enabled: !!hasRings,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}
+
 /* ── Component ─────────────────────────────────────────────────── */
 
-export function IdentityNarrative({
-  participationTier,
-  drepName,
-  delegationAgeDays,
-  proposalsInfluenced,
-  pulseLabel,
-}: IdentityNarrativeProps) {
+export function IdentityNarrative(props: IdentityNarrativeProps) {
+  const { participationTier, drepName, delegationAgeDays, proposalsInfluenced, pulseLabel } = props;
+  const { data: aiData } = useAINarrative(props);
+
   if (!drepName) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -47,6 +87,12 @@ export function IdentityNarrative({
     );
   }
 
+  // Use AI narrative when available, fall back to template
+  if (aiData?.narrative) {
+    return <p className="text-sm text-muted-foreground italic">{aiData.narrative}</p>;
+  }
+
+  // Template fallback
   const duration = delegationAgeDays != null ? ` for ${formatDuration(delegationAgeDays)}` : '';
 
   return (

--- a/components/civica/identity/MilestoneStamps.tsx
+++ b/components/civica/identity/MilestoneStamps.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   HandHeart,
   Flame,
@@ -12,10 +13,12 @@ import {
   ShieldCheck,
   TrendingUp,
   Award,
+  X,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CITIZEN_MILESTONES } from '@/lib/citizenMilestones';
+import { ShareActions } from '@/components/ShareActions';
 
 /* ── Icon map ──────────────────────────────────────────────────── */
 
@@ -45,11 +48,82 @@ interface MilestoneStampsProps {
   earned: EarnedMilestone[];
   recentKeys?: Set<string>;
   maxVisible?: number;
+  stakeAddress?: string | null;
+}
+
+/* ── Stamp detail card ─────────────────────────────────────────── */
+
+function StampDetailCard({
+  milestone,
+  stakeAddress,
+  onClose,
+}: {
+  milestone: EarnedMilestone;
+  stakeAddress?: string | null;
+  onClose: () => void;
+}) {
+  const def = CITIZEN_MILESTONES.find((m) => m.key === milestone.key);
+  const Icon = (def ? ICON_MAP[def.icon] : null) ?? Vote;
+  const earnedDate = new Date(milestone.earnedAt).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const shareUrl = 'https://governada.io/my-gov/identity';
+  const shareText = def?.shareText ?? `I earned the "${milestone.label}" milestone! @GovernadaIO`;
+  const imageUrl = stakeAddress ? `/api/og/civic-identity/${encodeURIComponent(stakeAddress)}` : '';
+
+  return (
+    <div className="mt-3 animate-in fade-in-0 slide-in-from-top-2 duration-200">
+      <div className="rounded-xl border border-primary/20 bg-card shadow-lg p-4 space-y-3">
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-primary/10">
+              <Icon className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold">{milestone.label}</p>
+              <p className="text-xs text-muted-foreground">Earned {earnedDate}</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {def?.description && <p className="text-xs text-muted-foreground">{def.description}</p>}
+
+        {imageUrl && (
+          <ShareActions
+            url={shareUrl}
+            text={shareText}
+            imageUrl={imageUrl}
+            imageFilename={`milestone-${milestone.key}.png`}
+            surface="citizen_milestone_stamp"
+            metadata={{ milestone_key: milestone.key }}
+            variant="compact"
+          />
+        )}
+      </div>
+    </div>
+  );
 }
 
 /* ── Component ─────────────────────────────────────────────────── */
 
-export function MilestoneStamps({ earned, recentKeys, maxVisible = 6 }: MilestoneStampsProps) {
+export function MilestoneStamps({
+  earned,
+  recentKeys,
+  maxVisible = 6,
+  stakeAddress,
+}: MilestoneStampsProps) {
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
   if (earned.length === 0) {
     return (
       <div className="flex items-center justify-center rounded-lg border border-border/50 bg-muted/20 px-4 py-3">
@@ -62,33 +136,53 @@ export function MilestoneStamps({ earned, recentKeys, maxVisible = 6 }: Mileston
   const overflow = earned.length - maxVisible;
 
   return (
-    <div className="flex gap-2 overflow-x-auto">
-      {visible.map((milestone) => {
-        const def = CITIZEN_MILESTONES.find((m) => m.key === milestone.key);
-        const Icon = (def ? ICON_MAP[def.icon] : null) ?? Vote;
-        const isRecent = recentKeys?.has(milestone.key);
+    <div>
+      <div className="flex gap-2 overflow-x-auto">
+        {visible.map((milestone) => {
+          const def = CITIZEN_MILESTONES.find((m) => m.key === milestone.key);
+          const Icon = (def ? ICON_MAP[def.icon] : null) ?? Vote;
+          const isRecent = recentKeys?.has(milestone.key);
+          const isExpanded = expandedKey === milestone.key;
 
-        return (
-          <div
-            key={milestone.key}
-            className={cn(
-              'flex w-16 h-16 flex-col items-center justify-center rounded-lg border shrink-0',
-              'border-primary/30 bg-primary/5',
-              isRecent && 'ring-2 ring-amber-400/50',
-            )}
-          >
-            <Icon className="h-4 w-4 text-primary" />
-            <span className="text-[10px] text-muted-foreground mt-1 text-center leading-tight line-clamp-2 px-0.5">
-              {milestone.label}
-            </span>
+          return (
+            <button
+              key={milestone.key}
+              type="button"
+              onClick={() => setExpandedKey(isExpanded ? null : milestone.key)}
+              className={cn(
+                'flex w-16 h-16 flex-col items-center justify-center rounded-lg border shrink-0 transition-colors',
+                'border-primary/30 bg-primary/5 hover:bg-primary/10',
+                isRecent && 'ring-2 ring-amber-400/50',
+                isExpanded && 'border-primary/50 bg-primary/10',
+              )}
+            >
+              <Icon className="h-4 w-4 text-primary" />
+              <span className="text-[10px] text-muted-foreground mt-1 text-center leading-tight line-clamp-2 px-0.5">
+                {milestone.label}
+              </span>
+            </button>
+          );
+        })}
+        {overflow > 0 && (
+          <div className="flex w-16 h-16 flex-col items-center justify-center rounded-lg border border-border/50 bg-muted/20 shrink-0">
+            <span className="text-xs font-medium text-muted-foreground">+{overflow} more</span>
           </div>
-        );
-      })}
-      {overflow > 0 && (
-        <div className="flex w-16 h-16 flex-col items-center justify-center rounded-lg border border-border/50 bg-muted/20 shrink-0">
-          <span className="text-xs font-medium text-muted-foreground">+{overflow} more</span>
-        </div>
-      )}
+        )}
+      </div>
+
+      {/* Expanded stamp detail card */}
+      {expandedKey &&
+        (() => {
+          const milestone = earned.find((m) => m.key === expandedKey);
+          if (!milestone) return null;
+          return (
+            <StampDetailCard
+              milestone={milestone}
+              stakeAddress={stakeAddress}
+              onClose={() => setExpandedKey(null)}
+            />
+          );
+        })()}
     </div>
   );
 }

--- a/components/civica/identity/PulseHistoryChart.tsx
+++ b/components/civica/identity/PulseHistoryChart.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { cn } from '@/lib/utils';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+interface RingSnapshot {
+  epoch: number;
+  delegation_ring: number;
+  coverage_ring: number;
+  engagement_ring: number;
+  pulse: number;
+}
+
+interface PulseHistoryChartProps {
+  className?: string;
+}
+
+/* ── Data hook ─────────────────────────────────────────────────── */
+
+function useRingHistory() {
+  return useQuery<{ snapshots: RingSnapshot[] }>({
+    queryKey: ['ring-history'],
+    queryFn: async () => {
+      const res = await fetch('/api/you/ring-history?limit=20');
+      if (!res.ok) throw new Error(`${res.status}`);
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/* ── SVG Sparkline ─────────────────────────────────────────────── */
+
+function Sparkline({ values, width, height }: { values: number[]; width: number; height: number }) {
+  if (values.length < 2) return null;
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const padding = 2;
+  const innerHeight = height - padding * 2;
+  const innerWidth = width - padding * 2;
+
+  const points = values.map((v, i) => {
+    const x = padding + (i / (values.length - 1)) * innerWidth;
+    const y = padding + innerHeight - ((v - min) / range) * innerHeight;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const pathD = `M ${points.join(' L ')}`;
+
+  // Gradient fill area
+  const lastPoint = points[points.length - 1];
+  const firstPoint = points[0];
+  const areaD = `${pathD} L ${lastPoint.split(',')[0]},${height} L ${firstPoint.split(',')[0]},${height} Z`;
+
+  // Color based on trend
+  const latest = values[values.length - 1];
+  const previous = values[Math.max(0, values.length - 4)];
+  const trending = latest > previous ? 'up' : latest < previous ? 'down' : 'flat';
+  const strokeColor = trending === 'up' ? '#22c55e' : trending === 'down' ? '#f59e0b' : '#6366f1';
+  const fillColor =
+    trending === 'up'
+      ? 'rgba(34, 197, 94, 0.1)'
+      : trending === 'down'
+        ? 'rgba(245, 158, 11, 0.1)'
+        : 'rgba(99, 102, 241, 0.1)';
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="overflow-visible"
+    >
+      <path d={areaD} fill={fillColor} />
+      <path
+        d={pathD}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Latest value dot */}
+      <circle
+        cx={Number(lastPoint.split(',')[0])}
+        cy={Number(lastPoint.split(',')[1])}
+        r={2.5}
+        fill={strokeColor}
+      />
+    </svg>
+  );
+}
+
+/* ── Component ─────────────────────────────────────────────────── */
+
+export function PulseHistoryChart({ className }: PulseHistoryChartProps) {
+  const { data, isLoading } = useRingHistory();
+  const snapshots = data?.snapshots ?? [];
+
+  // Need at least 2 data points for a meaningful chart
+  if (isLoading || snapshots.length < 2) return null;
+
+  const pulseValues = snapshots.map((s) => s.pulse);
+  const latest = pulseValues[pulseValues.length - 1];
+  const earliest = pulseValues[0];
+  const delta = latest - earliest;
+
+  const TrendIcon = delta > 0 ? TrendingUp : delta < 0 ? TrendingDown : Minus;
+  const trendColor =
+    delta > 0 ? 'text-emerald-500' : delta < 0 ? 'text-amber-500' : 'text-muted-foreground';
+
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      <Sparkline values={pulseValues} width={120} height={32} />
+      <div className="flex items-center gap-1">
+        <TrendIcon className={cn('h-3.5 w-3.5', trendColor)} />
+        <span className={cn('text-xs font-medium tabular-nums', trendColor)}>
+          {delta > 0 ? '+' : ''}
+          {delta}
+        </span>
+        <span className="text-xs text-muted-foreground">/ {snapshots.length} epochs</span>
+      </div>
+    </div>
+  );
+}

--- a/inngest/functions/snapshot-citizen-rings.ts
+++ b/inngest/functions/snapshot-citizen-rings.ts
@@ -1,0 +1,132 @@
+/**
+ * Snapshot Citizen Rings — stores epoch-level ring values for all active citizens.
+ *
+ * Triggered daily via cron. Computes ring values from existing data
+ * (DRep scores + citizen impact scores) and upserts into citizen_ring_snapshots.
+ *
+ * This enables the Governance Pulse history chart (2D) showing trajectory over time.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+
+export const snapshotCitizenRings = inngest.createFunction(
+  {
+    id: 'snapshot-citizen-rings',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"citizen-ring-snapshots"' },
+  },
+  { cron: '30 4 * * *' }, // Daily at 04:30 UTC
+  async ({ step, logger }) => {
+    const supabase = getSupabaseAdmin();
+
+    const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+
+    // Step 1: Get all users who have impact scores (active citizens)
+    const citizens = await step.run('fetch-active-citizens', async () => {
+      const { data, error } = await supabase
+        .from('citizen_impact_scores')
+        .select('user_id, coverage_score, engagement_depth_score');
+
+      if (error) throw error;
+      return data ?? [];
+    });
+
+    if (citizens.length === 0) {
+      logger.info('[citizen-ring-snapshots] No active citizens found');
+      return { snapshotted: 0, epoch: currentEpoch };
+    }
+
+    // Step 2: Get DRep scores for citizens' delegated DReps
+    const snapshots = await step.run('compute-ring-snapshots', async () => {
+      // Get delegation info for all citizens
+      const userIds = citizens.map((c) => c.user_id);
+      const { data: wallets } = await supabase
+        .from('user_wallets')
+        .select('user_id, vote_delegation')
+        .in('user_id', userIds)
+        .not('vote_delegation', 'is', null);
+
+      // Map user_id → delegated DRep ID
+      const userDrepMap = new Map<string, string>();
+      for (const w of wallets ?? []) {
+        if (w.vote_delegation) userDrepMap.set(w.user_id, w.vote_delegation);
+      }
+
+      // Get all unique DRep IDs and their scores
+      const drepIds = [...new Set(userDrepMap.values())];
+      const drepScoreMap = new Map<string, number>();
+
+      if (drepIds.length > 0) {
+        const { data: dreps } = await supabase
+          .from('dreps')
+          .select('drep_id, score')
+          .in('drep_id', drepIds);
+
+        for (const d of dreps ?? []) {
+          if (d.score != null) drepScoreMap.set(d.drep_id, d.score);
+        }
+      }
+
+      // Compute ring values for each citizen
+      const rows: Array<{
+        user_id: string;
+        epoch: number;
+        delegation_ring: number;
+        coverage_ring: number;
+        engagement_ring: number;
+        pulse: number;
+      }> = [];
+
+      for (const citizen of citizens) {
+        const drepId = userDrepMap.get(citizen.user_id);
+        const drepScore = drepId ? (drepScoreMap.get(drepId) ?? 0) : 0;
+
+        // Same normalization as lib/governanceRings.ts
+        const delegation = Math.min(Math.max(drepScore / 100, 0), 1);
+        const coverage = Math.min((citizen.coverage_score ?? 0) / 25, 1);
+        const engagement = Math.min((citizen.engagement_depth_score ?? 0) / 25, 1);
+
+        const pulse = Math.round((delegation * 0.4 + coverage * 0.35 + engagement * 0.25) * 100);
+
+        rows.push({
+          user_id: citizen.user_id,
+          epoch: currentEpoch,
+          delegation_ring: Number(delegation.toFixed(3)),
+          coverage_ring: Number(coverage.toFixed(3)),
+          engagement_ring: Number(engagement.toFixed(3)),
+          pulse,
+        });
+      }
+
+      return rows;
+    });
+
+    // Step 3: Upsert snapshots in batches
+    const result = await step.run('upsert-snapshots', async () => {
+      const BATCH_SIZE = 500;
+      let upserted = 0;
+
+      for (let i = 0; i < snapshots.length; i += BATCH_SIZE) {
+        const batch = snapshots.slice(i, i + BATCH_SIZE);
+        const { error } = await supabase
+          .from('citizen_ring_snapshots')
+          .upsert(batch, { onConflict: 'user_id,epoch' });
+
+        if (error) {
+          logger.error('[citizen-ring-snapshots] Batch upsert error', { error, batch: i });
+          throw error;
+        }
+        upserted += batch.length;
+      }
+
+      return upserted;
+    });
+
+    logger.info(
+      `[citizen-ring-snapshots] Snapshotted ${result} citizens for epoch ${currentEpoch}`,
+    );
+    return { snapshotted: result, epoch: currentEpoch };
+  },
+);

--- a/lib/drepIdentity.ts
+++ b/lib/drepIdentity.ts
@@ -265,6 +265,43 @@ export function getPersonalityLabel(alignments: AlignmentScores): string {
 }
 
 /**
+ * Derive a compound archetype from alignment scores by combining
+ * the top-2 dominant dimensions. Produces labels like
+ * "The Guardian with a Pioneer's curiosity".
+ *
+ * Only uses the compound form when both top dimensions have
+ * meaningful distance from center (>10). Otherwise falls back
+ * to the single archetype.
+ */
+export function getCompoundArchetype(alignments: AlignmentScores): string {
+  const primary = getPersonalityLabel(alignments);
+
+  // Find the top-2 dimensions by distance from 50
+  const ranked = DIMENSION_ORDER.map((dim) => ({
+    dim,
+    distance: Math.abs((alignments[dim] ?? 50) - 50),
+  })).sort((a, b) => b.distance - a.distance);
+
+  const [first, second] = ranked;
+
+  // Only compound when both dimensions have strong signal
+  if (first.distance <= 10 || second.distance <= 10) return primary;
+  // Skip if both map to the same dimension (shouldn't happen, but guard)
+  if (first.dim === second.dim) return primary;
+
+  const secondaryLabels = PERSONALITY_ARCHETYPES[second.dim];
+  // Pick a descriptor based on second dimension's strength
+  const secondaryDescriptor =
+    second.distance > 30
+      ? secondaryLabels[0]
+      : second.distance > 15
+        ? secondaryLabels[1]
+        : secondaryLabels[2];
+
+  return `${primary} with ${secondaryDescriptor} instincts`;
+}
+
+/**
  * Hysteresis margin — new dominant dimension must lead by this many points
  * over the previous dominant dimension before the label is allowed to change.
  * Prevents flickering when a DRep's alignment hovers near a dimension boundary.

--- a/lib/governanceFootprint.ts
+++ b/lib/governanceFootprint.ts
@@ -21,6 +21,15 @@ export interface GovernanceFootprint {
     drepRank: number | null;
     keyVotes: number;
     delegationChanges: number;
+    /** DRep alignment scores (null if no delegation or alignment not computed) */
+    drepAlignment: {
+      treasuryConservative: number | null;
+      treasuryGrowth: number | null;
+      decentralization: number | null;
+      security: number | null;
+      innovation: number | null;
+      transparency: number | null;
+    } | null;
   };
   citizenActivity: {
     pollsTaken: number;
@@ -97,12 +106,15 @@ export async function buildGovernanceFootprint(
   let drepName: string | null = null;
   let drepScore: number | null = null;
   let drepRank: number | null = null;
+  let drepAlignment: GovernanceFootprint['delegationRecord']['drepAlignment'] = null;
   let keyVotes = 0;
 
   if (delegatedDRep) {
     const { data: drep } = await supabase
       .from('dreps')
-      .select('name, score, rank')
+      .select(
+        'name, score, rank, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+      )
       .eq('drep_id', delegatedDRep)
       .single();
 
@@ -110,6 +122,14 @@ export async function buildGovernanceFootprint(
       drepName = drep.name;
       drepScore = drep.score;
       drepRank = drep.rank;
+      drepAlignment = {
+        treasuryConservative: drep.alignment_treasury_conservative ?? null,
+        treasuryGrowth: drep.alignment_treasury_growth ?? null,
+        decentralization: drep.alignment_decentralization ?? null,
+        security: drep.alignment_security ?? null,
+        innovation: drep.alignment_innovation ?? null,
+        transparency: drep.alignment_transparency ?? null,
+      };
     }
 
     const { count } = await supabase
@@ -164,6 +184,7 @@ export async function buildGovernanceFootprint(
       drepRank,
       keyVotes,
       delegationChanges: delegationHistory.length,
+      drepAlignment,
     },
     citizenActivity: {
       pollsTaken: polls.length,

--- a/lib/identity/narrativePrompt.ts
+++ b/lib/identity/narrativePrompt.ts
@@ -1,0 +1,57 @@
+/**
+ * Prompt template for AI-generated civic identity narrative.
+ * Generates a 2-3 sentence paragraph that weaves together a citizen's
+ * governance story — archetype, ring strengths, milestones, trajectory.
+ */
+
+interface NarrativeContext {
+  archetype: string | null;
+  drepName: string | null;
+  delegationAgeDays: number | null;
+  participationTier: string;
+  pulse: number;
+  pulseLabel: string;
+  delegationRing: number; // 0-1
+  coverageRing: number; // 0-1
+  engagementRing: number; // 0-1
+  milestonesEarned: number;
+  proposalsInfluenced: number;
+}
+
+export function buildNarrativePrompt(ctx: NarrativeContext): string {
+  const epochsDelegated =
+    ctx.delegationAgeDays != null ? Math.floor(ctx.delegationAgeDays / 5) : null;
+
+  const ringSummary = [
+    `Delegation Health: ${Math.round(ctx.delegationRing * 100)}%`,
+    `Representation Coverage: ${Math.round(ctx.coverageRing * 100)}%`,
+    `Civic Engagement: ${Math.round(ctx.engagementRing * 100)}%`,
+  ].join(', ');
+
+  // Identify strongest and weakest rings
+  const rings = [
+    { name: 'Delegation Health', value: ctx.delegationRing },
+    { name: 'Representation Coverage', value: ctx.coverageRing },
+    { name: 'Civic Engagement', value: ctx.engagementRing },
+  ].sort((a, b) => b.value - a.value);
+
+  return `You are writing a brief, warm identity narrative for a citizen participating in Cardano blockchain governance through the Governada platform.
+
+Given this citizen's governance data, write exactly 2-3 sentences that feel personal and insightful. The tone should be encouraging but honest — acknowledge strengths and gently note areas for growth. Use second person ("you").
+
+Do NOT use technical jargon. Do NOT mention scores, percentages, or numbers directly. Instead, translate data into plain-language observations. Do NOT use emojis or exclamation marks.
+
+Citizen data:
+- Governance archetype: ${ctx.archetype ?? 'Not yet determined'}
+- DRep (representative): ${ctx.drepName ?? 'Not delegated'}
+- Delegation duration: ${epochsDelegated != null ? `${epochsDelegated} epochs (${ctx.delegationAgeDays} days)` : 'Not yet delegated'}
+- Participation tier: ${ctx.participationTier}
+- Governance Pulse: ${ctx.pulse}/100 (${ctx.pulseLabel})
+- Ring values: ${ringSummary}
+- Strongest area: ${rings[0].name}
+- Area with most room to grow: ${rings[rings.length - 1].name}
+- Milestones earned: ${ctx.milestonesEarned}
+- Proposals influenced: ${ctx.proposalsInfluenced}
+
+Write the narrative now. Output ONLY the 2-3 sentence paragraph, nothing else.`;
+}

--- a/types/database.ts
+++ b/types/database.ts
@@ -1144,6 +1144,39 @@ export type Database = {
           },
         ];
       };
+      citizen_ring_snapshots: {
+        Row: {
+          coverage_ring: number;
+          created_at: string | null;
+          delegation_ring: number;
+          engagement_ring: number;
+          epoch: number;
+          id: string;
+          pulse: number;
+          user_id: string;
+        };
+        Insert: {
+          coverage_ring: number;
+          created_at?: string | null;
+          delegation_ring: number;
+          engagement_ring: number;
+          epoch: number;
+          id?: string;
+          pulse: number;
+          user_id: string;
+        };
+        Update: {
+          coverage_ring?: number;
+          created_at?: string | null;
+          delegation_ring?: number;
+          engagement_ring?: number;
+          epoch?: number;
+          id?: string;
+          pulse?: number;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       citizen_sentiment: {
         Row: {
           created_at: string | null;


### PR DESCRIPTION
## Summary
- **AI-generated identity narrative** — Claude-powered 2-3 sentence paragraph describing the citizen's governance identity, cached in Redis with epoch-length TTL (5 days)
- **Compound governance archetypes** — combines top-2 alignment dimensions for richer identity labels (e.g., "The Guardian with The Pioneer instincts")
- **Epoch-level ring snapshots** — new `citizen_ring_snapshots` table + daily Inngest cron (`snapshotCitizenRings`) to track ring values over time
- **Pulse history sparkline** — pure SVG chart showing governance pulse trend across epochs, color-coded by direction
- **Expandable milestone stamp cards** — tap stamps to reveal detail cards with earned date, description, and per-stamp sharing via OG images
- **DRep alignment in governance footprint** — 6 alignment scores now surfaced for archetype computation

## Impact
- **What changed**: Civic Identity profile gains AI narrative, compound archetypes, pulse trend sparkline, and interactive stamp cards
- **User-facing**: Yes — citizens see richer identity content, temporal governance trends, and can share individual milestones
- **Risk**: Low — additive features on existing identity page, new Inngest function is read-only cron, AI narrative has template fallback
- **Scope**: 12 files changed (5 new, 7 modified). 1 new DB table (migration applied). 1 new Inngest function. 2 new API routes.

## Test plan
- [ ] Verify civic identity page renders archetype with identity color
- [ ] Verify AI narrative loads (or falls back to template gracefully)
- [ ] Verify pulse sparkline shows "not enough data" state initially
- [ ] Verify milestone stamps expand on tap and show share button
- [ ] Verify `snapshotCitizenRings` appears in Inngest dashboard after registration
- [ ] Verify `/api/you/ring-history` returns snapshots for authenticated user

🤖 Generated with [Claude Code](https://claude.com/claude-code)