### PR TITLE
fix: civic identity polish — loading state, DRY rings, empty history UX

### DIFF
--- a/components/civica/identity/CivicIdentityProfile.tsx
+++ b/components/civica/identity/CivicIdentityProfile.tsx
@@ -186,7 +186,7 @@ export function CivicIdentityProfile() {
   const [shareOpen, setShareOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
 
-  const isLoading = segmentLoading || footprintLoading;
+  const isLoading = segmentLoading || footprintLoading || impactScoreLoading;
   const earned = milestonesData?.milestones ?? [];
 
   // Detect recent milestones (earned in last 10 days)

--- a/components/civica/identity/PulseHistoryChart.tsx
+++ b/components/civica/identity/PulseHistoryChart.tsx
@@ -102,8 +102,19 @@ export function PulseHistoryChart({ className }: PulseHistoryChartProps) {
   const { data, isLoading } = useRingHistory();
   const snapshots = data?.snapshots ?? [];
 
+  if (isLoading) return null;
+
   // Need at least 2 data points for a meaningful chart
-  if (isLoading || snapshots.length < 2) return null;
+  if (snapshots.length < 2) {
+    return (
+      <div className={cn('flex items-center gap-2', className)}>
+        <Minus className="h-3.5 w-3.5 text-muted-foreground/50" />
+        <span className="text-xs text-muted-foreground/50">
+          Pulse history available after 2 epochs
+        </span>
+      </div>
+    );
+  }
 
   const pulseValues = snapshots.map((s) => s.pulse);
   const latest = pulseValues[pulseValues.length - 1];

--- a/inngest/functions/snapshot-citizen-rings.ts
+++ b/inngest/functions/snapshot-citizen-rings.ts
@@ -10,6 +10,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
+import { computeRingValues } from '@/lib/governanceRings';
 
 export const snapshotCitizenRings = inngest.createFunction(
   {
@@ -83,19 +84,18 @@ export const snapshotCitizenRings = inngest.createFunction(
         const drepId = userDrepMap.get(citizen.user_id);
         const drepScore = drepId ? (drepScoreMap.get(drepId) ?? 0) : 0;
 
-        // Same normalization as lib/governanceRings.ts
-        const delegation = Math.min(Math.max(drepScore / 100, 0), 1);
-        const coverage = Math.min((citizen.coverage_score ?? 0) / 25, 1);
-        const engagement = Math.min((citizen.engagement_depth_score ?? 0) / 25, 1);
-
-        const pulse = Math.round((delegation * 0.4 + coverage * 0.35 + engagement * 0.25) * 100);
+        const { rings, pulse } = computeRingValues(
+          drepScore,
+          citizen.coverage_score ?? 0,
+          citizen.engagement_depth_score ?? 0,
+        );
 
         rows.push({
           user_id: citizen.user_id,
           epoch: currentEpoch,
-          delegation_ring: Number(delegation.toFixed(3)),
-          coverage_ring: Number(coverage.toFixed(3)),
-          engagement_ring: Number(engagement.toFixed(3)),
+          delegation_ring: Number(rings.delegation.toFixed(3)),
+          coverage_ring: Number(rings.coverage.toFixed(3)),
+          engagement_ring: Number(rings.engagement.toFixed(3)),
           pulse,
         });
       }

--- a/lib/governanceRings.ts
+++ b/lib/governanceRings.ts
@@ -35,7 +35,34 @@ export interface GovernanceRingsData {
   pulseLabel: string;
 }
 
-const RING_WEIGHTS = { delegation: 0.4, coverage: 0.35, engagement: 0.25 };
+export const RING_WEIGHTS = { delegation: 0.4, coverage: 0.35, engagement: 0.25 };
+
+/**
+ * Compute ring values from raw scores.
+ * Shared by both the client-side computation and the Inngest snapshot function.
+ *
+ * @param drepScore — DRep composite score (0-100)
+ * @param coverageScore — impact coverage score (0-25)
+ * @param engagementDepthScore — impact engagement depth score (0-25)
+ */
+export function computeRingValues(
+  drepScore: number,
+  coverageScore: number,
+  engagementDepthScore: number,
+): { rings: RingValues; pulse: number } {
+  const delegation = Math.min(Math.max(drepScore / 100, 0), 1);
+  const coverage = Math.min(coverageScore / 25, 1);
+  const engagement = Math.min(engagementDepthScore / 25, 1);
+
+  const pulse = Math.round(
+    (delegation * RING_WEIGHTS.delegation +
+      coverage * RING_WEIGHTS.coverage +
+      engagement * RING_WEIGHTS.engagement) *
+      100,
+  );
+
+  return { rings: { delegation, coverage, engagement }, pulse };
+}
 
 /**
  * Compute ring values from existing footprint + impact data.
@@ -45,26 +72,10 @@ export function computeGovernanceRings(
   footprint: GovernanceFootprint | null | undefined,
   impact: ImpactScoreBreakdown | null | undefined,
 ): GovernanceRingsData {
-  // Ring 1: Delegation Health — DRep score normalised to 0-1
-  const drepScore = footprint?.delegationRecord.drepScore ?? 0;
-  const delegation = Math.min(Math.max(drepScore / 100, 0), 1);
-
-  // Ring 2: Coverage — impact coverage score (0-25) normalised to 0-1
-  const coverageRaw = impact?.coverageScore ?? 0;
-  const coverage = Math.min(coverageRaw / 25, 1);
-
-  // Ring 3: Engagement — impact engagement depth score (0-25) normalised to 0-1
-  const engagementRaw = impact?.engagementDepthScore ?? 0;
-  const engagement = Math.min(engagementRaw / 25, 1);
-
-  const rings: RingValues = { delegation, coverage, engagement };
-
-  // Governance Pulse — weighted composite
-  const pulse = Math.round(
-    (delegation * RING_WEIGHTS.delegation +
-      coverage * RING_WEIGHTS.coverage +
-      engagement * RING_WEIGHTS.engagement) *
-      100,
+  const { rings, pulse } = computeRingValues(
+    footprint?.delegationRecord.drepScore ?? 0,
+    impact?.coverageScore ?? 0,
+    impact?.engagementDepthScore ?? 0,
   );
 
   const pulseColor =


### PR DESCRIPTION
## Summary
- Fix loading state gap: include `impactScoreLoading` in skeleton gate so UI doesn't flash with partial data
- Extract `computeRingValues()` shared helper from `lib/governanceRings.ts` — eliminates duplicated ring weight/normalization logic in the Inngest snapshot function
- Show "Pulse history available after 2 epochs" message instead of silently hiding the sparkline

## Impact
- **What changed**: Three polish fixes for the civic identity rings feature (Phase 1+2 followup)
- **User-facing**: Yes — smoother loading, visible empty state for pulse history
- **Risk**: Low — no behavior change, just better loading + DRY refactor + UX copy
- **Scope**: 4 files (CivicIdentityProfile, PulseHistoryChart, governanceRings, snapshot-citizen-rings)

## Test plan
- [ ] Verify identity page doesn't flash partial content during load
- [ ] Verify pulse history shows "available after 2 epochs" for new users
- [ ] Verify ring values are unchanged (shared computation produces same results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)