### PR TITLE
feat: hub briefing + inbox reach engine

### DIFF
--- a/app/api/og/epoch-report/route.tsx
+++ b/app/api/og/epoch-report/route.tsx
@@ -1,0 +1,135 @@
+import { ImageResponse } from 'next/og';
+import { NextRequest } from 'next/server';
+import { OGBackground, OGFooter, OG } from '@/lib/og-utils';
+
+export const runtime = 'edge';
+
+/**
+ * GET /api/og/epoch-report?epoch=X&headline=...&decisions=N&ada=N&streak=N&drep=Name
+ *
+ * Generates a personalized epoch report card image (1200x630) for social sharing.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const epoch = searchParams.get('epoch') || '?';
+  const headline = searchParams.get('headline') || 'Your Governance Report';
+  const decisions = searchParams.get('decisions') || '0';
+  const ada = searchParams.get('ada') || '0';
+  const streak = searchParams.get('streak') || '0';
+  const drep = searchParams.get('drep');
+
+  return new ImageResponse(
+    <OGBackground glow={OG.indigo}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          height: '100%',
+          padding: '64px',
+          justifyContent: 'space-between',
+        }}
+      >
+        {/* Top: epoch label + headline */}
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '20px',
+              color: OG.textMuted,
+              fontWeight: 600,
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase' as const,
+            }}
+          >
+            Epoch {epoch} Report Card
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: '42px',
+              color: OG.text,
+              fontWeight: 700,
+              marginTop: '12px',
+              lineHeight: 1.2,
+              maxWidth: '900px',
+            }}
+          >
+            {headline}
+          </div>
+          {drep && (
+            <div
+              style={{
+                display: 'flex',
+                fontSize: '20px',
+                color: OG.textMuted,
+                marginTop: '12px',
+              }}
+            >
+              Represented by {drep}
+            </div>
+          )}
+        </div>
+
+        {/* Stats row */}
+        <div style={{ display: 'flex', gap: '32px', marginBottom: '60px' }}>
+          <ReportStat label="Decisions" value={decisions} icon="vote" color={OG.green} />
+          <ReportStat label="ADA Governed" value={ada} icon="coins" color={OG.amber} />
+          <ReportStat
+            label="Check-in Streak"
+            value={`${streak} epochs`}
+            icon="flame"
+            color={OG.indigo}
+          />
+        </div>
+
+        <OGFooter left="$governada" right="governada.io" />
+      </div>
+    </OGBackground>,
+    {
+      width: 1200,
+      height: 630,
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+    },
+  );
+}
+
+function ReportStat({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  icon: string;
+  color: string;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '28px 36px',
+        borderRadius: '16px',
+        background: OG.bgCard,
+        border: `1px solid ${OG.border}`,
+        minWidth: '200px',
+      }}
+    >
+      <div style={{ display: 'flex', fontSize: '40px', fontWeight: 700, color }}>{value}</div>
+      <div
+        style={{
+          display: 'flex',
+          fontSize: '16px',
+          color: OG.textMuted,
+          marginTop: '8px',
+          textTransform: 'uppercase' as const,
+          letterSpacing: '0.05em',
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/app/api/you/checkin/route.ts
+++ b/app/api/you/checkin/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+
+export const dynamic = 'force-dynamic';
+
+// Epoch derivation (same constants as lib/api/response.ts)
+const SHELLEY_GENESIS = 1596491091;
+const EPOCH_LEN = 432000;
+const SHELLEY_BASE = 209;
+
+function getCurrentEpoch(): number {
+  return Math.floor((Date.now() / 1000 - SHELLEY_GENESIS) / EPOCH_LEN) + SHELLEY_BASE;
+}
+
+/**
+ * Resolve userId to stake_address (same pattern as notifications route).
+ */
+async function resolveStakeAddress(userId: string): Promise<string | null> {
+  const supabase = getSupabaseAdmin();
+  const { data: wallet } = await supabase
+    .from('user_wallets')
+    .select('stake_address')
+    .eq('user_id', userId)
+    .limit(1)
+    .maybeSingle();
+  return wallet?.stake_address ?? null;
+}
+
+/**
+ * POST /api/you/checkin — record a hub check-in for the current epoch.
+ * Idempotent: multiple calls in the same epoch produce one row.
+ */
+export const POST = withRouteHandler(
+  async (_request: NextRequest, { userId }: RouteContext) => {
+    const stakeAddress = await resolveStakeAddress(userId!);
+    if (!stakeAddress) {
+      return NextResponse.json({ error: 'No wallet linked' }, { status: 400 });
+    }
+
+    const epoch = getCurrentEpoch();
+    const supabase = getSupabaseAdmin();
+
+    // Upsert: ON CONFLICT does nothing (idempotent)
+    await supabase
+      .from('user_hub_checkins')
+      .upsert(
+        { user_stake_address: stakeAddress, epoch },
+        { onConflict: 'user_stake_address,epoch', ignoreDuplicates: true },
+      );
+
+    return NextResponse.json({ ok: true, epoch });
+  },
+  { auth: 'required', rateLimit: { max: 30, window: 60 } },
+);
+
+/**
+ * GET /api/you/checkin — return current check-in streak and last check-in epoch.
+ * Streak counts consecutive epochs with a check-in, allowing a 1-epoch grace gap.
+ */
+export const GET = withRouteHandler(
+  async (_request: NextRequest, { userId }: RouteContext) => {
+    const stakeAddress = await resolveStakeAddress(userId!);
+    if (!stakeAddress) {
+      return NextResponse.json({ streak: 0, lastEpoch: null });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const currentEpoch = getCurrentEpoch();
+
+    // Fetch recent check-ins (descending by epoch), enough to compute streak
+    const { data: checkins } = await supabase
+      .from('user_hub_checkins')
+      .select('epoch')
+      .eq('user_stake_address', stakeAddress)
+      .order('epoch', { ascending: false })
+      .limit(200);
+
+    if (!checkins || checkins.length === 0) {
+      return NextResponse.json({ streak: 0, lastEpoch: null });
+    }
+
+    const epochSet = new Set(checkins.map((c) => c.epoch));
+    const lastEpoch = checkins[0].epoch;
+
+    // Count streak backward from current epoch with 1-epoch grace period.
+    // Start from current epoch (or last check-in if not checked in this epoch yet).
+    let streak = 0;
+    let e = currentEpoch;
+    let gracesUsed = 0;
+
+    // If user hasn't checked in this epoch or last epoch, streak is 0
+    if (!epochSet.has(currentEpoch) && !epochSet.has(currentEpoch - 1)) {
+      return NextResponse.json({ streak: 0, lastEpoch });
+    }
+
+    // Walk backward counting consecutive epochs (with grace)
+    while (e > 0) {
+      if (epochSet.has(e)) {
+        streak++;
+        gracesUsed = 0; // reset grace on a hit
+      } else {
+        gracesUsed++;
+        if (gracesUsed > 1) break; // more than 1-epoch gap breaks the streak
+      }
+      e--;
+    }
+
+    return NextResponse.json({ streak, lastEpoch });
+  },
+  { auth: 'required' },
+);

--- a/app/api/you/epoch-headline/route.ts
+++ b/app/api/you/epoch-headline/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/you/epoch-headline
+ *
+ * Returns the AI-generated epoch headline from the latest governance brief.
+ * Falls back to null if no brief exists (Hub uses its own template logic).
+ */
+export const GET = withRouteHandler(
+  async (_req, { userId }: RouteContext) => {
+    const supabase = getSupabaseAdmin();
+
+    const { data: brief } = await supabase
+      .from('governance_briefs')
+      .select('content_json, epoch')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!brief?.content_json) {
+      return NextResponse.json({ headline: null, epoch: null });
+    }
+
+    const content = brief.content_json as { headline?: string };
+
+    return NextResponse.json({
+      headline: content.headline ?? null,
+      epoch: brief.epoch,
+    });
+  },
+  { auth: 'required' },
+);

--- a/app/share/epoch/[epoch]/page.tsx
+++ b/app/share/epoch/[epoch]/page.tsx
@@ -1,0 +1,57 @@
+import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { BASE_URL } from '@/lib/constants';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ epoch: string }>;
+  searchParams: Promise<{
+    stake?: string;
+    headline?: string;
+    decisions?: string;
+    ada?: string;
+    streak?: string;
+    drep?: string;
+  }>;
+}
+
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
+  const { epoch } = await params;
+  const sp = await searchParams;
+  const headline = sp.headline || `Epoch ${epoch} Governance Report`;
+
+  const ogParams = new URLSearchParams({
+    epoch,
+    headline,
+    decisions: sp.decisions || '0',
+    ada: sp.ada || '0',
+    streak: sp.streak || '0',
+    ...(sp.drep ? { drep: sp.drep } : {}),
+  });
+
+  const ogImageUrl = `${BASE_URL}/api/og/epoch-report?${ogParams.toString()}`;
+
+  return {
+    title: `Epoch ${epoch} Report | Governada`,
+    description: headline,
+    openGraph: {
+      title: `Epoch ${epoch} Governance Report`,
+      description: headline,
+      images: [{ url: ogImageUrl, width: 1200, height: 630 }],
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `Epoch ${epoch} Governance Report`,
+      description: headline,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function ShareEpochPage({ params }: Props) {
+  const { epoch } = await params;
+  // Redirect to main Hub — the share page only exists for OG metadata
+  redirect(`/?epoch=${epoch}`);
+}

--- a/components/civica/CivicaHeader.tsx
+++ b/components/civica/CivicaHeader.tsx
@@ -18,6 +18,7 @@ import {
   Scale,
   Layers,
   HelpCircle,
+  CheckCheck,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { useTheme } from 'next-themes';
@@ -27,6 +28,12 @@ import { useWallet } from '@/utils/wallet-context';
 import { useSegment, type UserSegment } from '@/components/providers/SegmentProvider';
 import { TIER_SCORE_COLOR, type TierKey } from '@/components/civica/cards/tierStyles';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
+import {
+  useNotifications,
+  useMarkRead,
+  useMarkAllRead,
+  type Notification,
+} from '@/hooks/useNotifications';
 import { useAdminCheck } from '@/hooks/queries';
 import { Button } from '@/components/ui/button';
 import {
@@ -67,6 +74,102 @@ const SEGMENT_ICONS: Record<UserSegment, typeof User> = {
   spo: ShieldCheck,
   cc: Scale,
 };
+
+/* ── Notification bell dropdown ──────────────────────────────── */
+
+function formatRelativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d`;
+}
+
+function NotificationBell({ unreadCount }: { unreadCount: number }) {
+  const router = useRouter();
+  const { data: notifData } = useNotifications(true);
+  const markRead = useMarkRead();
+  const markAllRead = useMarkAllRead();
+  const recent = (notifData?.notifications ?? []).slice(0, 5);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative h-8 w-8 text-muted-foreground hover:text-foreground"
+          aria-label="Notifications"
+        >
+          <Bell className="h-4 w-4" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
+              {unreadCount > 9 ? '9+' : unreadCount}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80">
+        <DropdownMenuLabel className="flex items-center justify-between">
+          <span>Notifications</span>
+          {unreadCount > 0 && (
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                markAllRead.mutate();
+              }}
+              className="text-[10px] font-normal text-primary hover:underline cursor-pointer"
+            >
+              <CheckCheck className="inline h-3 w-3 mr-0.5" />
+              Mark all read
+            </button>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {recent.length === 0 && (
+          <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+            No notifications yet
+          </div>
+        )}
+        {recent.map((n: Notification) => (
+          <DropdownMenuItem
+            key={n.id}
+            className="flex items-start gap-2.5 py-2.5 cursor-pointer"
+            onSelect={() => {
+              if (!n.read) markRead.mutate([n.id]);
+              if (n.action_url) router.push(n.action_url);
+            }}
+          >
+            {!n.read && <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />}
+            {n.read && <span className="mt-1.5 h-2 w-2 shrink-0" />}
+            <div className="flex-1 min-w-0">
+              <p className={cn('text-sm leading-snug line-clamp-1', !n.read && 'font-medium')}>
+                {n.title}
+              </p>
+              {n.body && (
+                <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">{n.body}</p>
+              )}
+            </div>
+            <span className="text-[10px] text-muted-foreground/60 shrink-0 tabular-nums">
+              {formatRelativeTime(n.created_at)}
+            </span>
+          </DropdownMenuItem>
+        ))}
+        {recent.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild className="justify-center text-xs text-primary">
+              <Link href="/you/inbox">View all notifications</Link>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export function CivicaHeader() {
   const router = useRouter();
@@ -142,23 +245,8 @@ export function CivicaHeader() {
             </kbd>
           </Button>
 
-          {/* Notification bell */}
-          {connected && isAuthenticated && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="relative h-8 w-8 text-muted-foreground hover:text-foreground"
-              onClick={() => router.push('/you/inbox')}
-              aria-label="Notifications"
-            >
-              <Bell className="h-4 w-4" />
-              {unreadCount > 0 && (
-                <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-red-500 text-[9px] text-white flex items-center justify-center font-bold">
-                  {unreadCount > 9 ? '9+' : unreadCount}
-                </span>
-              )}
-            </Button>
-          )}
+          {/* Notification bell dropdown */}
+          {connected && isAuthenticated && <NotificationBell unreadCount={unreadCount} />}
 
           {/* Help dropdown */}
           <DropdownMenu>

--- a/components/civica/mygov/CivicaInbox.tsx
+++ b/components/civica/mygov/CivicaInbox.tsx
@@ -18,9 +18,11 @@ import {
   MessageSquare,
   Shield,
   Landmark,
+  Settings,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import {
   useDRepReportCard,
@@ -32,6 +34,7 @@ import {
 } from '@/hooks/queries';
 import { generateActions } from '@/lib/actionFeed';
 import { SPOInbox } from './SPOInbox';
+import { NotificationPreferences } from './NotificationPreferences';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -686,128 +689,157 @@ function CivicaInboxInner({
         )}
       </div>
 
-      {/* Filter tabs */}
-      <div className="flex gap-1 overflow-x-auto pb-1 scrollbar-none">
-        {FILTER_TABS.filter((t) => {
-          // Hide system tab for anon
-          if (t.key === 'system' && segment === 'anonymous') return false;
-          return true;
-        }).map((tab) => {
-          const count =
-            tab.key === 'all'
-              ? allNotifications.filter((n) => !readSet.has(n.id)).length
-              : allNotifications.filter((n) => n.category === tab.key && !readSet.has(n.id)).length;
-          return (
-            <button
-              key={tab.key}
-              onClick={() => setActiveFilter(tab.key)}
-              className={cn(
-                'shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
-                activeFilter === tab.key
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
-              )}
-            >
-              {tab.label}
-              {count > 0 && (
-                <span
+      <Tabs defaultValue="notifications" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-4">
+          <TabsTrigger value="notifications" className="flex items-center gap-1.5">
+            <Bell className="h-3.5 w-3.5" />
+            Notifications
+          </TabsTrigger>
+          <TabsTrigger value="preferences" className="flex items-center gap-1.5">
+            <Settings className="h-3.5 w-3.5" />
+            Preferences
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="notifications" className="space-y-4">
+          {/* Filter tabs */}
+          <div className="flex gap-1 overflow-x-auto pb-1 scrollbar-none">
+            {FILTER_TABS.filter((t) => {
+              // Hide system tab for anon
+              if (t.key === 'system' && segment === 'anonymous') return false;
+              return true;
+            }).map((tab) => {
+              const count =
+                tab.key === 'all'
+                  ? allNotifications.filter((n) => !readSet.has(n.id)).length
+                  : allNotifications.filter((n) => n.category === tab.key && !readSet.has(n.id))
+                      .length;
+              return (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveFilter(tab.key)}
                   className={cn(
-                    'inline-flex items-center justify-center h-4 min-w-4 rounded-full text-[10px] font-bold px-1',
+                    'shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors',
                     activeFilter === tab.key
-                      ? 'bg-primary-foreground/20 text-primary-foreground'
-                      : 'bg-primary/20 text-primary',
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/60',
                   )}
                 >
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
+                  {tab.label}
+                  {count > 0 && (
+                    <span
+                      className={cn(
+                        'inline-flex items-center justify-center h-4 min-w-4 rounded-full text-[10px] font-bold px-1',
+                        activeFilter === tab.key
+                          ? 'bg-primary-foreground/20 text-primary-foreground'
+                          : 'bg-primary/20 text-primary',
+                      )}
+                    >
+                      {count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
 
-      {/* Content — smart quiet mode */}
-      {(() => {
-        if (isLoading) {
-          return (
-            <div className="space-y-2">
-              {[...Array(4)].map((_, i) => (
-                <Skeleton key={i} className="h-16 w-full rounded-xl" />
-              ))}
-            </div>
-          );
-        }
-
-        if (filtered.length === 0) {
-          return (
-            <div className="rounded-xl border border-emerald-900/30 bg-emerald-950/10 px-5 py-10 text-center space-y-2">
-              <CheckCircle className="h-8 w-8 text-emerald-400 mx-auto" />
-              <p className="text-sm font-medium text-emerald-300">You&apos;re all caught up</p>
-              <p className="text-xs text-muted-foreground">
-                {activeFilter === 'all'
-                  ? 'No governance notifications right now. Your participation is healthy.'
-                  : `No ${activeFilter} notifications right now.`}
-              </p>
-            </div>
-          );
-        }
-
-        // Split into urgent (priority 1-2) and informational (priority 3)
-        const urgentItems = filtered.filter((n) => n.priority <= 2);
-        const infoItems = filtered.filter((n) => n.priority > 2);
-
-        // Quiet mode: no urgent items, only informational
-        if (urgentItems.length === 0 && infoItems.length > 0 && activeFilter === 'all') {
-          return (
-            <div className="space-y-2">
-              <QuietModeSummary
-                ghiScore={pulse?.ghiScore ?? undefined}
-                ghiDelta={pulse?.ghiDelta ?? undefined}
-                activeProposals={pulse?.activeProposals ?? undefined}
-                infoCount={infoItems.length}
-                showDetails={showInfoItems}
-                onToggleDetails={() => setShowInfoItems((v) => !v)}
-              />
-              {showInfoItems && (
+          {/* Content — smart quiet mode */}
+          {(() => {
+            if (isLoading) {
+              return (
                 <div className="space-y-2">
-                  {infoItems.map((item) => (
-                    <NotificationCard
-                      key={item.id}
-                      item={item}
-                      isRead={readSet.has(item.id)}
-                      onRead={handleRead}
-                    />
+                  {[...Array(4)].map((_, i) => (
+                    <Skeleton key={i} className="h-16 w-full rounded-xl" />
                   ))}
                 </div>
-              )}
-            </div>
-          );
-        }
+              );
+            }
 
-        // Normal mode: show urgent items first, then info items
-        return (
-          <div className="space-y-2">
-            {urgentItems.map((item) => (
-              <NotificationCard
-                key={item.id}
-                item={item}
-                isRead={readSet.has(item.id)}
-                onRead={handleRead}
-              />
-            ))}
-            {infoItems.length > 0 && urgentItems.length > 0 && (
-              <div className="pt-2">
-                <button
-                  onClick={() => setShowInfoItems((v) => !v)}
-                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-2"
-                >
-                  <ChevronDown
-                    className={cn('h-3 w-3 transition-transform', showInfoItems && 'rotate-180')}
+            if (filtered.length === 0) {
+              return (
+                <div className="rounded-xl border border-emerald-900/30 bg-emerald-950/10 px-5 py-10 text-center space-y-2">
+                  <CheckCircle className="h-8 w-8 text-emerald-400 mx-auto" />
+                  <p className="text-sm font-medium text-emerald-300">You&apos;re all caught up</p>
+                  <p className="text-xs text-muted-foreground">
+                    {activeFilter === 'all'
+                      ? 'No governance notifications right now. Your participation is healthy.'
+                      : `No ${activeFilter} notifications right now.`}
+                  </p>
+                </div>
+              );
+            }
+
+            // Split into urgent (priority 1-2) and informational (priority 3)
+            const urgentItems = filtered.filter((n) => n.priority <= 2);
+            const infoItems = filtered.filter((n) => n.priority > 2);
+
+            // Quiet mode: no urgent items, only informational
+            if (urgentItems.length === 0 && infoItems.length > 0 && activeFilter === 'all') {
+              return (
+                <div className="space-y-2">
+                  <QuietModeSummary
+                    ghiScore={pulse?.ghiScore ?? undefined}
+                    ghiDelta={pulse?.ghiDelta ?? undefined}
+                    activeProposals={pulse?.activeProposals ?? undefined}
+                    infoCount={infoItems.length}
+                    showDetails={showInfoItems}
+                    onToggleDetails={() => setShowInfoItems((v) => !v)}
                   />
-                  {showInfoItems ? 'Hide' : 'Show'} {infoItems.length} informational update
-                  {infoItems.length > 1 ? 's' : ''}
-                </button>
-                {showInfoItems &&
+                  {showInfoItems && (
+                    <div className="space-y-2">
+                      {infoItems.map((item) => (
+                        <NotificationCard
+                          key={item.id}
+                          item={item}
+                          isRead={readSet.has(item.id)}
+                          onRead={handleRead}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            }
+
+            // Normal mode: show urgent items first, then info items
+            return (
+              <div className="space-y-2">
+                {urgentItems.map((item) => (
+                  <NotificationCard
+                    key={item.id}
+                    item={item}
+                    isRead={readSet.has(item.id)}
+                    onRead={handleRead}
+                  />
+                ))}
+                {infoItems.length > 0 && urgentItems.length > 0 && (
+                  <div className="pt-2">
+                    <button
+                      onClick={() => setShowInfoItems((v) => !v)}
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-2"
+                    >
+                      <ChevronDown
+                        className={cn(
+                          'h-3 w-3 transition-transform',
+                          showInfoItems && 'rotate-180',
+                        )}
+                      />
+                      {showInfoItems ? 'Hide' : 'Show'} {infoItems.length} informational update
+                      {infoItems.length > 1 ? 's' : ''}
+                    </button>
+                    {showInfoItems &&
+                      infoItems.map((item) => (
+                        <NotificationCard
+                          key={item.id}
+                          item={item}
+                          isRead={readSet.has(item.id)}
+                          onRead={handleRead}
+                        />
+                      ))}
+                  </div>
+                )}
+                {infoItems.length > 0 &&
+                  urgentItems.length === 0 &&
                   infoItems.map((item) => (
                     <NotificationCard
                       key={item.id}
@@ -817,77 +849,71 @@ function CivicaInboxInner({
                     />
                   ))}
               </div>
-            )}
-            {infoItems.length > 0 &&
-              urgentItems.length === 0 &&
-              infoItems.map((item) => (
-                <NotificationCard
-                  key={item.id}
-                  item={item}
-                  isRead={readSet.has(item.id)}
-                  onRead={handleRead}
-                />
-              ))}
-          </div>
-        );
-      })()}
+            );
+          })()}
 
-      {/* DRep pending proposals detail (DRep segment only) */}
-      {segment === 'drep' && inbox?.pendingProposals && inbox.pendingProposals.length > 0 && (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-              Pending Votes ({inbox.pendingCount ?? 0})
-            </p>
-            {(inbox.scoreImpact?.potentialGain ?? 0) > 0 && (
-              <span className="text-xs text-emerald-400 font-medium">
-                +{inbox.scoreImpact!.potentialGain!.toFixed(1)} pts potential
-              </span>
-            )}
-          </div>
-          <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
-            {inbox.pendingProposals.slice(0, 5).map((p) => (
-              <Link
-                key={p.txHash ?? p.id ?? ''}
-                href={`/proposal/${p.txHash}/${p.index ?? 0}`}
-                className="flex items-center justify-between px-4 py-3 hover:bg-muted/30 transition-colors group"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm truncate font-medium">
-                    {p.title ?? p.proposalTitle ?? 'Proposal'}
-                  </p>
-                  <div className="flex items-center gap-2 mt-0.5">
-                    {p.priority === 'critical' && (
-                      <span className="text-[10px] font-bold text-rose-400 uppercase tracking-wider">
-                        Critical
-                      </span>
-                    )}
-                    {p.epochsRemaining != null && (
-                      <span className="text-[10px] text-muted-foreground">
-                        {p.epochsRemaining} epoch{p.epochsRemaining !== 1 ? 's' : ''} left
-                      </span>
-                    )}
-                    {(p.perProposalScoreImpact ?? 0) > 0 && (
-                      <span className="text-[10px] text-emerald-400">
-                        +{p.perProposalScoreImpact} pts
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
-              </Link>
-            ))}
-          </div>
-          {inbox.pendingProposals.length > 5 && (
-            <Link
-              href="/governance/proposals"
-              className="block text-center text-xs text-muted-foreground hover:text-primary transition-colors py-1"
-            >
-              View all {inbox.pendingCount ?? 0} pending proposals
-            </Link>
+          {/* DRep pending proposals detail (DRep segment only) */}
+          {segment === 'drep' && inbox?.pendingProposals && inbox.pendingProposals.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                  Pending Votes ({inbox.pendingCount ?? 0})
+                </p>
+                {(inbox.scoreImpact?.potentialGain ?? 0) > 0 && (
+                  <span className="text-xs text-emerald-400 font-medium">
+                    +{inbox.scoreImpact!.potentialGain!.toFixed(1)} pts potential
+                  </span>
+                )}
+              </div>
+              <div className="rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
+                {inbox.pendingProposals.slice(0, 5).map((p) => (
+                  <Link
+                    key={p.txHash ?? p.id ?? ''}
+                    href={`/proposal/${p.txHash}/${p.index ?? 0}`}
+                    className="flex items-center justify-between px-4 py-3 hover:bg-muted/30 transition-colors group"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm truncate font-medium">
+                        {p.title ?? p.proposalTitle ?? 'Proposal'}
+                      </p>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        {p.priority === 'critical' && (
+                          <span className="text-[10px] font-bold text-rose-400 uppercase tracking-wider">
+                            Critical
+                          </span>
+                        )}
+                        {p.epochsRemaining != null && (
+                          <span className="text-[10px] text-muted-foreground">
+                            {p.epochsRemaining} epoch{p.epochsRemaining !== 1 ? 's' : ''} left
+                          </span>
+                        )}
+                        {(p.perProposalScoreImpact ?? 0) > 0 && (
+                          <span className="text-[10px] text-emerald-400">
+                            +{p.perProposalScoreImpact} pts
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <ChevronRight className="h-3.5 w-3.5 text-muted-foreground group-hover:text-primary transition-colors shrink-0" />
+                  </Link>
+                ))}
+              </div>
+              {inbox.pendingProposals.length > 5 && (
+                <Link
+                  href="/governance/proposals"
+                  className="block text-center text-xs text-muted-foreground hover:text-primary transition-colors py-1"
+                >
+                  View all {inbox.pendingCount ?? 0} pending proposals
+                </Link>
+              )}
+            </div>
           )}
-        </div>
-      )}
+        </TabsContent>
+
+        <TabsContent value="preferences" className="space-y-4">
+          <NotificationPreferences />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/components/civica/mygov/NotificationPreferences.tsx
+++ b/components/civica/mygov/NotificationPreferences.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Mail, CheckCircle, Loader2 } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+interface Preferences {
+  email?: string;
+  digest_frequency?: string;
+  alert_drep_voted?: boolean;
+  alert_coverage_changed?: boolean;
+  alert_score_shifted?: boolean;
+  alert_milestone_earned?: boolean;
+}
+
+async function fetchPreferences(): Promise<Preferences> {
+  const token = getStoredSession();
+  if (!token) return {};
+  const res = await fetch('/api/you/notification-preferences', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return {};
+  return res.json();
+}
+
+async function savePreferences(body: Record<string, unknown>): Promise<void> {
+  const token = getStoredSession();
+  if (!token) return;
+  await fetch('/api/you/notification-preferences', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+}
+
+const DIGEST_OPTIONS = [
+  { value: 'epoch', label: 'Every epoch (~5 days)' },
+  { value: 'weekly', label: 'Weekly (Mondays)' },
+  { value: 'major_only', label: 'Major events only' },
+  { value: 'none', label: 'Off' },
+] as const;
+
+export function NotificationPreferences() {
+  const { segment } = useSegment();
+  const queryClient = useQueryClient();
+
+  const { data: prefs, isLoading } = useQuery<Preferences>({
+    queryKey: ['notification-preferences'],
+    queryFn: fetchPreferences,
+    enabled: segment !== 'anonymous',
+    staleTime: 60_000,
+  });
+
+  const [email, setEmail] = useState('');
+  const [digestFrequency, setDigestFrequency] = useState('none');
+  const [alertDrepVoted, setAlertDrepVoted] = useState(true);
+  const [alertCoverageChanged, setAlertCoverageChanged] = useState(true);
+  const [alertScoreShifted, setAlertScoreShifted] = useState(true);
+  const [alertMilestoneEarned, setAlertMilestoneEarned] = useState(true);
+  const [saved, setSaved] = useState(false);
+
+  // Sync local state when prefs load
+  useEffect(() => {
+    if (!prefs) return;
+    setEmail(prefs.email ?? '');
+    setDigestFrequency(prefs.digest_frequency ?? 'none');
+    setAlertDrepVoted(prefs.alert_drep_voted ?? true);
+    setAlertCoverageChanged(prefs.alert_coverage_changed ?? true);
+    setAlertScoreShifted(prefs.alert_score_shifted ?? true);
+    setAlertMilestoneEarned(prefs.alert_milestone_earned ?? true);
+  }, [prefs]);
+
+  const { mutate: save, isPending: saving } = useMutation({
+    mutationFn: (body: Record<string, unknown>) => savePreferences(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notification-preferences'] });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  function handleSave() {
+    save({
+      ...(email ? { email } : {}),
+      digestFrequency,
+      alertDrepVoted,
+      alertCoverageChanged,
+      alertScoreShifted,
+      alertMilestoneEarned,
+    });
+  }
+
+  if (segment === 'anonymous') {
+    return (
+      <div className="rounded-xl border border-border bg-card px-5 py-10 text-center space-y-2">
+        <Mail className="h-8 w-8 text-muted-foreground mx-auto" />
+        <p className="text-sm font-medium">Connect your wallet</p>
+        <p className="text-xs text-muted-foreground">
+          Sign in to manage your notification preferences.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Email */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="pref-email">
+          Email address
+        </label>
+        <p className="text-xs text-muted-foreground">
+          We&apos;ll send epoch digests and governance alerts to this address.
+        </p>
+        <input
+          id="pref-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="w-full rounded-lg border border-input bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:ring-ring/50 focus:ring-[3px] outline-none transition-all"
+        />
+      </div>
+
+      {/* Digest frequency */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Digest frequency</label>
+        <p className="text-xs text-muted-foreground">How often you receive epoch summary emails.</p>
+        <Select value={digestFrequency} onValueChange={setDigestFrequency}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DIGEST_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Alert toggles */}
+      <div className="space-y-1">
+        <p className="text-sm font-medium">In-app alerts</p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Choose which events trigger notifications.
+        </p>
+        <div className="space-y-3">
+          <AlertToggle
+            label="DRep voted"
+            description="When your DRep casts a vote on a proposal"
+            checked={alertDrepVoted}
+            onCheckedChange={setAlertDrepVoted}
+          />
+          <AlertToggle
+            label="Coverage changed"
+            description="When your delegation coverage changes"
+            checked={alertCoverageChanged}
+            onCheckedChange={setAlertCoverageChanged}
+          />
+          <AlertToggle
+            label="Score shifted"
+            description="When your DRep's score changes significantly"
+            checked={alertScoreShifted}
+            onCheckedChange={setAlertScoreShifted}
+          />
+          <AlertToggle
+            label="Milestone earned"
+            description="When you reach a new governance milestone"
+            checked={alertMilestoneEarned}
+            onCheckedChange={setAlertMilestoneEarned}
+          />
+        </div>
+      </div>
+
+      {/* Save button */}
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+      >
+        {saving ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : saved ? (
+          <CheckCircle className="h-3.5 w-3.5" />
+        ) : null}
+        {saved ? 'Saved' : 'Save preferences'}
+      </button>
+    </div>
+  );
+}
+
+function AlertToggle({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import {
@@ -23,6 +23,8 @@ import {
   Wallet,
   Server,
   Shield,
+  Sparkles,
+  Share2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { briefingContainer, briefingItem } from '@/lib/animations';
@@ -43,6 +45,8 @@ import { getStoredSession } from '@/lib/supabaseAuth';
 import { resolveRewardAddress } from '@meshsdk/core';
 import { hapticLight } from '@/lib/haptics';
 import { useSentimentResults } from '@/hooks/useEngagement';
+import { useCheckin } from '@/hooks/useCheckin';
+import { useEpochHeadline } from '@/hooks/useEpochHeadline';
 import { CommunityConsensus } from './CommunityConsensus';
 import { WhatChanged } from '@/components/hub/WhatChanged';
 
@@ -584,6 +588,15 @@ export function CitizenHub() {
   const { data: holderRaw, isLoading: holderLoading } = useGovernanceHolder(stakeAddress);
   const { data: impactScore } = useCitizenImpactScore(!!stakeAddress);
   const { data: poolRaw } = useSPOSummary(delegatedPool);
+  const { streak: checkinStreak, recordCheckin } = useCheckin(!!stakeAddress);
+  const { aiHeadline } = useEpochHeadline(!!stakeAddress);
+
+  // Fire check-in on mount (idempotent — one row per epoch)
+  useEffect(() => {
+    if (stakeAddress) recordCheckin();
+  }, [stakeAddress, recordCheckin]);
+
+  const [shareCopied, setShareCopied] = useState(false);
 
   const isLoading = consequenceLoading || holderLoading;
 
@@ -611,13 +624,36 @@ export function CitizenHub() {
   const delegationStreak = (footprint?.delegationStreak as number) ?? 0;
   const adaGoverned = votingPowerAda ?? 0;
 
-  // Build headline
-  const headlineText =
+  // Build headline — prefer AI-generated, fall back to template
+  const templateHeadline =
     adaDecided > 0
       ? `Your representative helped decide how ${formatAda(adaDecided)} ADA is spent`
       : decidedProposals.length > 0
         ? `${decidedProposals.length} decision${decidedProposals.length !== 1 ? 's' : ''} made this period`
         : 'No decisions yet this period';
+  const headlineText = aiHeadline || templateHeadline;
+
+  // Share epoch report card
+  function handleShare() {
+    const params = new URLSearchParams({
+      headline: headlineText,
+      decisions: String(proposalsInfluenced),
+      ada: formatAda(adaGoverned),
+      streak: String(checkinStreak || delegationStreak),
+      ...(drep ? { drep: drepName } : {}),
+    });
+    const shareUrl = `${window.location.origin}/share/epoch/${epoch}?${params.toString()}`;
+
+    if (navigator.share) {
+      navigator.share({ title: `Epoch ${epoch} Report`, url: shareUrl }).catch(() => {});
+    } else {
+      navigator.clipboard.writeText(shareUrl).then(() => {
+        setShareCopied(true);
+        setTimeout(() => setShareCopied(false), 2000);
+      });
+    }
+    hapticLight();
+  }
 
   return (
     <motion.div
@@ -641,12 +677,24 @@ export function CitizenHub() {
         </p>
         <h1 className="text-xl sm:text-2xl font-bold text-foreground leading-tight">
           {headlineText}
+          {aiHeadline && (
+            <Sparkles className="ml-1.5 inline-block h-4 w-4 text-muted-foreground/40" />
+          )}
         </h1>
         {votingPowerFraction != null && votingPowerFraction > 0 && (
           <p className="text-sm text-muted-foreground">
             Your {votingPowerAda ? `${formatAda(votingPowerAda)} ADA` : 'ADA'} adds weight to your
             representative&apos;s votes
           </p>
+        )}
+        {epoch > 0 && stakeAddress && (
+          <button
+            onClick={handleShare}
+            className="mt-2 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Share2 className="h-3.5 w-3.5" />
+            {shareCopied ? 'Link copied!' : 'Share epoch report'}
+          </button>
         )}
       </motion.header>
 
@@ -723,7 +771,11 @@ export function CitizenHub() {
             value={adaGoverned > 0 ? formatAda(adaGoverned) : '--'}
             label="ADA Represented"
           />
-          <FootprintStat icon={Flame} value={delegationStreak} label="Active Streak" />
+          <FootprintStat
+            icon={Flame}
+            value={checkinStreak || delegationStreak}
+            label="Check-in Streak"
+          />
           <FootprintStat
             icon={TrendingUp}
             value={impactScore?.computed ? Math.round(impactScore.score) : '--'}

--- a/emails/EpochDigest.tsx
+++ b/emails/EpochDigest.tsx
@@ -39,6 +39,10 @@ export interface EpochDigestProps {
     daysRemaining: number | null;
   }>;
   unsubscribeUrl: string;
+  /** AI-generated headline from governance_briefs (optional) */
+  aiHeadline?: string;
+  /** Epoch check-in streak count (optional) */
+  checkinStreak?: number;
 }
 
 // ── Shared Styles ────────────────────────────────────────────────────────
@@ -128,8 +132,12 @@ export default function EpochDigest({
   newMilestones = [],
   activeProposals = [],
   unsubscribeUrl = '#',
+  aiHeadline,
+  checkinStreak,
 }: EpochDigestProps) {
-  const previewText = `Epoch ${epoch}: ${proposalsDecided} proposals decided, ${adaGoverned} ADA governed`;
+  const previewText =
+    aiHeadline ||
+    `Epoch ${epoch}: ${proposalsDecided} proposals decided, ${adaGoverned} ADA governed`;
 
   return (
     <Html>
@@ -158,11 +166,23 @@ export default function EpochDigest({
                 margin: '0 0 4px',
               }}
             >
-              Epoch {epoch} Summary
+              {aiHeadline || `Epoch ${epoch} Summary`}
             </Heading>
             <Text style={{ color: '#64748b', fontSize: '14px', margin: 0 }}>
               {proposalsDecided} proposals decided &middot; {adaGoverned} ADA governed
             </Text>
+            {checkinStreak != null && checkinStreak > 1 && (
+              <Text
+                style={{
+                  color: '#f59e0b',
+                  fontSize: '13px',
+                  fontWeight: 600,
+                  margin: '8px 0 0',
+                }}
+              >
+                &#128293; You&apos;ve checked in {checkinStreak} epochs in a row!
+              </Text>
+            )}
           </Section>
 
           {/* DRep Activity Card */}
@@ -286,8 +306,16 @@ export default function EpochDigest({
           {/* CTA */}
           <Section style={{ textAlign: 'center', margin: '8px 0 24px' }}>
             <Button style={button} href={`${BASE_URL}/`}>
-              Open Governada
+              See your full briefing
             </Button>
+            <Text style={{ fontSize: '13px', color: '#64748b', marginTop: '12px' }}>
+              <Link
+                href={`${BASE_URL}/share/epoch/${epoch}`}
+                style={{ color: '#6366f1', textDecoration: 'none' }}
+              >
+                Share your epoch report &#8594;
+              </Link>
+            </Text>
           </Section>
 
           {/* Footer */}

--- a/hooks/useCheckin.ts
+++ b/hooks/useCheckin.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
+
+interface CheckinResponse {
+  streak: number;
+  lastEpoch: number | null;
+}
+
+async function fetchCheckin(): Promise<CheckinResponse> {
+  const token = getStoredSession();
+  if (!token) return { streak: 0, lastEpoch: null };
+
+  const res = await fetch('/api/you/checkin', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return { streak: 0, lastEpoch: null };
+  return res.json();
+}
+
+async function postCheckin(): Promise<void> {
+  const token = getStoredSession();
+  if (!token) return;
+
+  await fetch('/api/you/checkin', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+/**
+ * Records a hub check-in on mount and returns the current streak.
+ * Idempotent — safe to call on every Hub render.
+ */
+export function useCheckin(enabled: boolean) {
+  // Fire check-in POST on mount (fire-and-forget)
+  const { mutate } = useMutation({ mutationFn: postCheckin });
+
+  // Fetch streak data
+  const { data } = useQuery<CheckinResponse>({
+    queryKey: ['hub-checkin'],
+    queryFn: fetchCheckin,
+    enabled,
+    staleTime: 60_000,
+  });
+
+  return {
+    streak: data?.streak ?? 0,
+    lastEpoch: data?.lastEpoch ?? null,
+    recordCheckin: mutate,
+  };
+}

--- a/hooks/useEpochHeadline.ts
+++ b/hooks/useEpochHeadline.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
+
+interface EpochHeadlineResponse {
+  headline: string | null;
+  epoch: number | null;
+}
+
+async function fetchEpochHeadline(): Promise<EpochHeadlineResponse> {
+  const token = getStoredSession();
+  if (!token) return { headline: null, epoch: null };
+
+  const res = await fetch('/api/you/epoch-headline', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return { headline: null, epoch: null };
+  return res.json();
+}
+
+export function useEpochHeadline(enabled: boolean) {
+  const { data } = useQuery<EpochHeadlineResponse>({
+    queryKey: ['epoch-headline'],
+    queryFn: fetchEpochHeadline,
+    enabled,
+    staleTime: 5 * 60_000, // 5 min — headlines change per epoch, not per minute
+  });
+
+  return {
+    aiHeadline: data?.headline ?? null,
+    headlineEpoch: data?.epoch ?? null,
+  };
+}

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -1,15 +1,14 @@
 'use client';
-/* eslint-disable react-hooks/set-state-in-effect -- async/external state sync in useEffect is standard React pattern */
-import { useState, useEffect } from 'react';
 
-export function useUnreadNotifications(stakeAddress: string | null): number {
-  const [count, setCount] = useState(0);
+import { useNotificationCount } from './useNotifications';
 
-  useEffect(() => {
-    if (!stakeAddress) return;
-    // Phase 3E scaffold — real implementation queries the notifications table
-    setCount(0);
-  }, [stakeAddress]);
-
-  return count;
+/**
+ * Unread notification count for header bell, sidebar, and bottom nav.
+ * Delegates to useNotificationCount() which uses TanStack Query with 60s polling.
+ *
+ * @param stakeAddress — kept for call-site compatibility; auth is token-based internally.
+ */
+export function useUnreadNotifications(_stakeAddress: string | null): number {
+  const { unreadCount } = useNotificationCount();
+  return unreadCount;
 }

--- a/inngest/functions/generate-citizen-briefings.ts
+++ b/inngest/functions/generate-citizen-briefings.ts
@@ -10,7 +10,12 @@
 
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
-import { assembleHolderBriefContext, generateHolderBrief, storeBrief } from '@/lib/governanceBrief';
+import {
+  assembleHolderBriefContext,
+  generateAIHolderBrief,
+  generateHolderBrief,
+  storeBrief,
+} from '@/lib/governanceBrief';
 import { checkAndAwardCitizenMilestones } from '@/lib/citizenMilestones';
 import { errMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
@@ -93,7 +98,13 @@ export const generateCitizenBriefings = inngest.createFunction(
               continue;
             }
 
-            const brief = generateHolderBrief(ctx);
+            // Try AI generation for personalized headline; fall back to template
+            let brief;
+            try {
+              brief = await generateAIHolderBrief(ctx);
+            } catch {
+              brief = generateHolderBrief(ctx);
+            }
             await storeBrief(user.id, 'citizen', brief, epoch);
 
             // Award any new citizen milestones alongside briefing generation

--- a/inngest/functions/notify-epoch-recap.ts
+++ b/inngest/functions/notify-epoch-recap.ts
@@ -178,6 +178,39 @@ export const notifyEpochRecap = inngest.createFunction(
               ? `${(epochStats.treasuryWithdrawnAda / 1_000_000).toFixed(1)}M`
               : '0';
 
+          // Fetch AI headline from governance_briefs if available
+          let aiHeadline: string | undefined;
+          const { data: brief } = await supabase
+            .from('governance_briefs')
+            .select('content_json')
+            .eq('user_id', pref.user_id)
+            .eq('epoch', currentEpoch - 1)
+            .maybeSingle();
+          if (brief?.content_json) {
+            const content = brief.content_json as { headline?: string };
+            if (content.headline) aiHeadline = content.headline;
+          }
+
+          // Fetch check-in streak
+          let checkinStreak: number | undefined;
+          if (stakeAddr) {
+            const { data: checkins } = await supabase
+              .from('user_hub_checkins')
+              .select('epoch')
+              .eq('user_stake_address', stakeAddr)
+              .order('epoch', { ascending: false })
+              .limit(20);
+            if (checkins?.length) {
+              let streak = 1;
+              for (let ci = 1; ci < checkins.length; ci++) {
+                const gap = checkins[ci - 1].epoch - checkins[ci].epoch;
+                if (gap <= 2) streak++;
+                else break;
+              }
+              checkinStreak = streak;
+            }
+          }
+
           // Create inbox notification
           await notifyUser(pref.user_id, {
             eventType: 'governance-brief',
@@ -205,9 +238,13 @@ export const notifyEpochRecap = inngest.createFunction(
                 const EpochDigest = (await import('@/emails/EpochDigest')).default;
                 const unsubscribeUrl = generateUnsubscribeUrl(pref.user_id);
 
+                const emailSubject = aiHeadline
+                  ? `Epoch ${currentEpoch - 1}: ${aiHeadline}`
+                  : `Epoch ${currentEpoch - 1}: ${epochStats.proposalsDecided} proposals decided`;
+
                 const sent = await sendEmail(
                   pref.email,
-                  `Epoch ${currentEpoch - 1}: ${epochStats.proposalsDecided} proposals decided`,
+                  emailSubject,
                   React.createElement(EpochDigest, {
                     epoch: currentEpoch - 1,
                     proposalsDecided: epochStats.proposalsDecided,
@@ -227,6 +264,8 @@ export const notifyEpochRecap = inngest.createFunction(
                         : null,
                     })),
                     unsubscribeUrl,
+                    aiHeadline,
+                    checkinStreak,
                   }),
                   {
                     unsubscribeUrl,

--- a/lib/governanceBrief.ts
+++ b/lib/governanceBrief.ts
@@ -46,6 +46,7 @@ export interface BriefSection {
 
 export interface GeneratedBrief {
   greeting: string;
+  headline?: string;
   sections: BriefSection[];
   ctaText: string;
   ctaUrl: string;
@@ -189,7 +190,15 @@ export async function generateAIDRepBrief(ctx: DRepBriefContext): Promise<Genera
   try {
     const { generateText } = await import('./ai');
     const contextSummary = template.sections.map((s) => `${s.heading}: ${s.content}`).join('\n');
-    const prompt = `You are a governance analyst writing a personalized weekly brief for a Cardano DRep named ${ctx.drepName}. Rewrite the following data points into a warm, concise 150-word narrative. Tone: knowledgeable friend, not corporate. Keep all numbers accurate. Output only the narrative text, no headings.
+    const prompt = `You are a governance analyst writing a personalized weekly brief for a Cardano DRep named ${ctx.drepName}. Produce TWO things:
+
+1. HEADLINE: A single punchy sentence (max 15 words) summarizing the most important event this epoch for this DRep. Frame impact — score changes, votes cast, critical proposals. No generic statements.
+
+2. NARRATIVE: Rewrite the following data points into a warm, concise 150-word narrative. Tone: knowledgeable friend, not corporate. Keep all numbers accurate.
+
+Output format (exactly):
+HEADLINE: <your headline>
+NARRATIVE: <your narrative>
 
 DATA:
 ${contextSummary}
@@ -197,14 +206,19 @@ Score: ${ctx.currentScore} (${ctx.scoreChange > 0 ? 'up' : ctx.scoreChange < 0 ?
 Rank: #${ctx.rank} of ${ctx.totalDReps}
 Open proposals: ${ctx.proposalsOpen}${ctx.proposalsCritical > 0 ? ` (${ctx.proposalsCritical} critical)` : ''}`;
 
-    const narrative = await generateText(prompt, { maxTokens: 400 });
-    if (narrative) {
+    const response = await generateText(prompt, { maxTokens: 500 });
+    if (response) {
+      const headlineMatch = response.match(/HEADLINE:\s*(.+)/);
+      const narrativeMatch = response.match(/NARRATIVE:\s*([\s\S]+)/);
+      const aiHeadline = headlineMatch?.[1]?.trim();
+      const narrative = narrativeMatch?.[1]?.trim();
+
       return {
         greeting: template.greeting,
-        sections: [
-          { heading: 'Your Weekly Update', content: narrative },
-          ...template.sections.slice(1),
-        ],
+        headline: aiHeadline || template.headline,
+        sections: narrative
+          ? [{ heading: 'Your Weekly Update', content: narrative }, ...template.sections.slice(1)]
+          : template.sections,
         ctaText: template.ctaText,
         ctaUrl: template.ctaUrl,
       };
@@ -220,19 +234,32 @@ export async function generateAIHolderBrief(ctx: HolderBriefContext): Promise<Ge
   try {
     const { generateText } = await import('./ai');
     const contextSummary = template.sections.map((s) => `${s.heading}: ${s.content}`).join('\n');
-    const prompt = `You are a governance analyst writing a weekly brief for a Cardano ADA holder. Rewrite these data points into a warm, concise 100-word narrative. Tone: knowledgeable friend encouraging governance participation. Keep all numbers accurate. Output only the narrative text, no headings.
+    const prompt = `You are a governance analyst writing a weekly brief for a Cardano ADA holder. Produce TWO things:
+
+1. HEADLINE: A single punchy sentence (max 15 words) summarizing the most important governance event this epoch for this holder. Frame consequences — what happened to their ADA, their representation, or Cardano's treasury. No generic statements.
+
+2. NARRATIVE: Rewrite these data points into a warm, concise 100-word narrative. Tone: knowledgeable friend encouraging governance participation. Keep all numbers accurate.
+
+Output format (exactly):
+HEADLINE: <your headline>
+NARRATIVE: <your narrative>
 
 DATA:
 ${contextSummary}`;
 
-    const narrative = await generateText(prompt, { maxTokens: 300 });
-    if (narrative) {
+    const response = await generateText(prompt, { maxTokens: 400 });
+    if (response) {
+      const headlineMatch = response.match(/HEADLINE:\s*(.+)/);
+      const narrativeMatch = response.match(/NARRATIVE:\s*([\s\S]+)/);
+      const aiHeadline = headlineMatch?.[1]?.trim();
+      const narrative = narrativeMatch?.[1]?.trim();
+
       return {
         greeting: template.greeting,
-        sections: [
-          { heading: 'Your Weekly Update', content: narrative },
-          ...template.sections.slice(1),
-        ],
+        headline: aiHeadline || template.headline,
+        sections: narrative
+          ? [{ heading: 'Your Weekly Update', content: narrative }, ...template.sections.slice(1)]
+          : template.sections,
         ctaText: template.ctaText,
         ctaUrl: template.ctaUrl,
       };
@@ -272,8 +299,16 @@ function generateDRepBriefTemplate(ctx: DRepBriefContext): GeneratedBrief {
     },
   ];
 
+  const headline =
+    ctx.proposalsCritical > 0
+      ? `${ctx.proposalsCritical} critical proposal${ctx.proposalsCritical !== 1 ? 's' : ''} need your vote`
+      : ctx.votesThisEpoch > 0
+        ? `You cast ${ctx.votesThisEpoch} vote${ctx.votesThisEpoch !== 1 ? 's' : ''} this epoch`
+        : `${ctx.proposalsOpen} proposal${ctx.proposalsOpen !== 1 ? 's' : ''} await your attention`;
+
   return {
     greeting: `Hey ${ctx.drepName}, here's your weekly governance roundup.`,
+    headline,
     sections,
     ctaText: 'Open Dashboard',
     ctaUrl: '/my-gov',
@@ -315,8 +350,15 @@ function generateHolderBriefTemplate(ctx: HolderBriefContext): GeneratedBrief {
     });
   }
 
+  const headline = ctx.drepId
+    ? ctx.proposalsCritical > 0
+      ? `${ctx.proposalsCritical} critical proposal${ctx.proposalsCritical !== 1 ? 's' : ''} being decided — your delegation matters`
+      : `Your representative is working on ${ctx.proposalsOpen} open proposal${ctx.proposalsOpen !== 1 ? 's' : ''}`
+    : `${ctx.proposalsOpen} governance decision${ctx.proposalsOpen !== 1 ? 's' : ''} happening without you`;
+
   return {
     greeting: "Here's your weekly governance roundup from Governada.",
+    headline,
     sections,
     ctaText: 'Explore DReps',
     ctaUrl: '/governance/representatives',

--- a/types/database.ts
+++ b/types/database.ts
@@ -4013,6 +4013,27 @@ export type Database = {
           },
         ];
       };
+      user_hub_checkins: {
+        Row: {
+          checked_in_at: string;
+          epoch: number;
+          id: string;
+          user_stake_address: string;
+        };
+        Insert: {
+          checked_in_at?: string;
+          epoch: number;
+          id?: string;
+          user_stake_address: string;
+        };
+        Update: {
+          checked_in_at?: string;
+          epoch?: number;
+          id?: string;
+          user_stake_address?: string;
+        };
+        Relationships: [];
+      };
       user_notification_preferences: {
         Row: {
           alert_coverage_changed: boolean;


### PR DESCRIPTION
## Summary
- **Hub is the Briefing**: Real notification counts, bell dropdown, epoch check-in streaks, AI-generated headlines, shareable epoch report cards with OG images
- **Inbox is the Reach**: Two-tab layout (Notifications + Preferences), notification preferences component with email/digest/alert toggles, enhanced email digests with AI headlines and streak data

## Impact
- **What changed**: Hub gains AI headlines, share button, check-in streaks. Inbox restructured as archive + preferences. Email digests enhanced with AI content and Hub CTAs.
- **User-facing**: Yes — bell dropdown shows notifications inline, inbox has preferences tab, epoch report cards are shareable, emails include personalized AI headlines
- **Risk**: Low — additive features, no destructive changes to existing flows
- **Scope**: 16 files (9 modified, 7 new). New API routes: /api/you/checkin, /api/you/epoch-headline, /api/og/epoch-report. New share page: /share/epoch/[epoch]. Requires user_hub_checkins migration (already applied).

## Test plan
- [ ] Connect wallet → bell icon shows real unread count
- [ ] Click bell → dropdown shows latest notifications with mark-as-read
- [ ] Visit Hub → check-in recorded, streak stat displays correctly
- [ ] AI headline appears on Hub when governance_briefs has data (falls back to template)
- [ ] Share button generates URL, copies to clipboard or opens share sheet
- [ ] /share/epoch/123 renders OG metadata and redirects to Hub
- [ ] /api/og/epoch-report generates 1200x630 image
- [ ] Visit Inbox → two tabs (Notifications, Preferences)
- [ ] Preferences tab → email input, digest frequency select, alert toggles save correctly
- [ ] Trigger epoch recap → email includes AI headline and streak

🤖 Generated with [Claude Code](https://claude.com/claude-code)