### PR TITLE
feat: governance depth foundation primitives

### DIFF
--- a/components/providers/DepthGate.tsx
+++ b/components/providers/DepthGate.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import type { GovernanceDepth } from '@/lib/governanceTuner';
+
+interface DepthGateProps {
+  /** Minimum depth required to render children */
+  minDepth: GovernanceDepth;
+  /** What to render when depth is below threshold (default: nothing) */
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Renders children only when the user's governance depth meets the minimum threshold.
+ *
+ * Critical: data-fetching hooks must live inside DepthGate'd child components,
+ * NOT at the parent level. When DepthGate returns the fallback, children don't
+ * mount and their hooks don't fire — keeping API calls proportional to what
+ * the user actually sees.
+ */
+export function DepthGate({ minDepth, fallback = null, children }: DepthGateProps) {
+  const { isAtLeast } = useGovernanceDepth();
+  return isAtLeast(minDepth) ? <>{children}</> : <>{fallback}</>;
+}

--- a/hooks/useDepthConfig.ts
+++ b/hooks/useDepthConfig.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import type { GovernanceDepth } from '@/lib/governanceTuner';
+
+// ---------------------------------------------------------------------------
+// Per-surface depth configurations
+// ---------------------------------------------------------------------------
+
+const HUB_CONFIG = {
+  hands_off: {
+    maxSections: 3,
+    showFootprint: false,
+    showSentiment: false,
+    showAnalytics: false,
+    proposalLimit: 2,
+  },
+  informed: {
+    maxSections: 5,
+    showFootprint: true,
+    showSentiment: false,
+    showAnalytics: false,
+    proposalLimit: 4,
+  },
+  engaged: {
+    maxSections: 8,
+    showFootprint: true,
+    showSentiment: true,
+    showAnalytics: false,
+    proposalLimit: 8,
+  },
+  deep: {
+    maxSections: 99,
+    showFootprint: true,
+    showSentiment: true,
+    showAnalytics: true,
+    proposalLimit: 99,
+  },
+} as const satisfies Record<GovernanceDepth, object>;
+
+const GOVERNANCE_CONFIG = {
+  hands_off: {
+    showRationales: false,
+    showHistoricalTrends: false,
+    showDRepPosition: false,
+    proposalDetail: 'headline' as const,
+  },
+  informed: {
+    showRationales: false,
+    showHistoricalTrends: false,
+    showDRepPosition: true,
+    proposalDetail: 'summary' as const,
+  },
+  engaged: {
+    showRationales: true,
+    showHistoricalTrends: false,
+    showDRepPosition: true,
+    proposalDetail: 'full' as const,
+  },
+  deep: {
+    showRationales: true,
+    showHistoricalTrends: true,
+    showDRepPosition: true,
+    proposalDetail: 'full' as const,
+  },
+} as const satisfies Record<GovernanceDepth, object>;
+
+// ---------------------------------------------------------------------------
+// Type mapping
+// ---------------------------------------------------------------------------
+
+type SurfaceConfigs = {
+  hub: (typeof HUB_CONFIG)[GovernanceDepth];
+  governance: (typeof GOVERNANCE_CONFIG)[GovernanceDepth];
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns depth-specific configuration for a given surface.
+ *
+ * To add depth-awareness to a new page, add a config object above and
+ * extend the SurfaceConfigs type. No other files need to change.
+ */
+export function useDepthConfig<S extends keyof SurfaceConfigs>(surface: S): SurfaceConfigs[S] {
+  const { depth } = useGovernanceDepth();
+  const configs: { hub: typeof HUB_CONFIG; governance: typeof GOVERNANCE_CONFIG } = {
+    hub: HUB_CONFIG,
+    governance: GOVERNANCE_CONFIG,
+  };
+  return configs[surface][depth] as SurfaceConfigs[S];
+}

--- a/hooks/useGovernanceDepth.ts
+++ b/hooks/useGovernanceDepth.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useUser } from '@/hooks/queries';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import {
+  type GovernanceDepth,
+  getDefaultDepthForSegment,
+  getTunerLevel,
+  isValidDepth,
+  type TunerLevel,
+} from '@/lib/governanceTuner';
+
+export interface GovernanceDepthState {
+  /** Active depth: View As override → user preference → segment default */
+  depth: GovernanceDepth;
+  /** Full level config for the active depth */
+  level: TunerLevel;
+  /** Numeric order (0-3) for comparison operators */
+  order: number;
+  /** Whether this is the segment default (user hasn't explicitly chosen) */
+  isDefault: boolean;
+  /** Convenience: depth >= threshold */
+  isAtLeast: (threshold: GovernanceDepth) => boolean;
+}
+
+export function useGovernanceDepth(): GovernanceDepthState {
+  const { segment, getGovernanceDepthOverride } = useSegment();
+  const { data: rawUser } = useUser();
+  const user = rawUser as Record<string, unknown> | undefined;
+
+  // Priority: View As override > user preference > segment default
+  const overrideDepth = getGovernanceDepthOverride();
+  const storedDepth =
+    typeof user?.governance_depth === 'string' ? user.governance_depth : undefined;
+  const userDepth = storedDepth && isValidDepth(storedDepth) ? storedDepth : undefined;
+  const defaultDepth = getDefaultDepthForSegment(segment);
+
+  // Anonymous users are locked to informed — ignore any stored preference
+  const depth = segment === 'anonymous' ? 'informed' : (overrideDepth ?? userDepth ?? defaultDepth);
+  const level = getTunerLevel(depth);
+  const isDefault = !overrideDepth && !userDepth;
+
+  return {
+    depth,
+    level,
+    order: level.order,
+    isDefault,
+    isAtLeast: (threshold: GovernanceDepth) => level.order >= getTunerLevel(threshold).order,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useGovernanceDepth()` hook — resolves active depth via priority chain (View As override → user preference → segment default), locks anonymous users to `informed`
- Add `useDepthConfig()` hook — returns depth-specific config per surface (hub, governance), the density knob for components
- Add `<DepthGate>` component — conditionally renders children based on minimum depth threshold, enabling hooks-in-children pattern where data-fetching hooks only fire when sections are visible

## Impact
- **What changed**: Three new foundation primitives for the governance depth platform. No existing code is modified.
- **User-facing**: No — nothing consumes these yet. Phases 2-6 will wire them into navigation, hubs, governance pages, and the depth picker UX.
- **Risk**: Low — additive only, no existing behavior changes
- **Scope**: 3 new files (`hooks/useGovernanceDepth.ts`, `hooks/useDepthConfig.ts`, `components/providers/DepthGate.tsx`)

## Test plan
- [ ] Type-check passes (`tsc --noEmit`)
- [ ] Lint passes (ESLint)
- [ ] Format passes (Prettier)
- [ ] No visual regressions (no UI changes in this PR)
- [ ] View As depth override still works in admin panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)