### PR TITLE
feat: depth-aware navigation filtering

### DIFF
--- a/components/civica/CivicaBottomNav.tsx
+++ b/components/civica/CivicaBottomNav.tsx
@@ -6,13 +6,15 @@ import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 import { getBottomBarItems } from '@/lib/nav/config';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 
 export function CivicaBottomNav() {
   const pathname = usePathname();
   const { segment, stakeAddress } = useSegment();
+  const { depth } = useGovernanceDepth();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
 
-  const navItems = getBottomBarItems(segment);
+  const navItems = getBottomBarItems({ segment, depth });
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';

--- a/components/civica/CivicaSidebar.tsx
+++ b/components/civica/CivicaSidebar.tsx
@@ -12,6 +12,7 @@ import {
   type NavItemGroup,
 } from '@/lib/nav/config';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { Button } from '@/components/ui/button';
 
 interface CivicaSidebarProps {
@@ -22,9 +23,10 @@ interface CivicaSidebarProps {
 export function CivicaSidebar({ collapsed, onToggle }: CivicaSidebarProps) {
   const pathname = usePathname();
   const { segment, stakeAddress, drepId, poolId } = useSegment();
+  const { depth } = useGovernanceDepth();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
 
-  const sections = getSidebarSections({ segment, drepId, poolId });
+  const sections = getSidebarSections({ segment, drepId, poolId, depth });
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';

--- a/components/civica/SectionPillBar.tsx
+++ b/components/civica/SectionPillBar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { getPillBarItems } from '@/lib/nav/config';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 
 interface SectionPillBarProps {
   section: string;
@@ -17,7 +18,8 @@ interface SectionPillBarProps {
 export function SectionPillBar({ section: _section }: SectionPillBarProps) {
   const pathname = usePathname();
   const { segment, drepId, poolId } = useSegment();
-  const items = getPillBarItems(pathname, segment, { drepId, poolId });
+  const { depth } = useGovernanceDepth();
+  const items = getPillBarItems(pathname, segment, { drepId, poolId, depth });
 
   if (!items || items.length < 2) return null;
 

--- a/components/civica/mygov/GovernanceTuner.tsx
+++ b/components/civica/mygov/GovernanceTuner.tsx
@@ -152,8 +152,8 @@ export function GovernanceTuner() {
           {saved && <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />}
         </div>
         <p className="text-sm text-muted-foreground">
-          Choose how closely you follow Cardano governance. We&apos;ll tailor your notifications
-          accordingly.
+          Choose how closely you follow Cardano governance. We&apos;ll tailor your entire experience
+          &mdash; notifications, navigation, and information density.
         </p>
       </div>
 

--- a/lib/governanceTuner.ts
+++ b/lib/governanceTuner.ts
@@ -66,8 +66,7 @@ export const TUNER_LEVELS: Record<GovernanceDepth, TunerLevel> = {
   hands_off: {
     key: 'hands_off',
     label: 'Hands-Off',
-    description:
-      "You'll only hear from us if something needs your attention — like your delegation becoming inactive or a critical governance event.",
+    description: "A quick health check. We'll surface only what needs your attention.",
     shortDescription: "Alerts only when something's wrong",
     iconName: 'BellOff',
     eventTypes: HANDS_OFF_EVENTS,
@@ -77,8 +76,7 @@ export const TUNER_LEVELS: Record<GovernanceDepth, TunerLevel> = {
   informed: {
     key: 'informed',
     label: 'Informed',
-    description:
-      "Stay in the loop on major governance activity — new proposals, your DRep's score changes, and epoch summaries.",
+    description: 'A regular briefing on what matters. The essentials, clearly presented.',
     shortDescription: 'Major governance updates',
     iconName: 'Bell',
     eventTypes: INFORMED_EVENTS,
@@ -88,8 +86,7 @@ export const TUNER_LEVELS: Record<GovernanceDepth, TunerLevel> = {
   engaged: {
     key: 'engaged',
     label: 'Engaged',
-    description:
-      'Actively participate in governance decisions. Get notified about alignment drift, delegation milestones, and how your DRep voted on proposals you care about.',
+    description: 'Active governance participation. Full dashboard, all the tools.',
     shortDescription: 'Active governance participation',
     iconName: 'BellRing',
     eventTypes: ENGAGED_EVENTS,
@@ -99,8 +96,7 @@ export const TUNER_LEVELS: Record<GovernanceDepth, TunerLevel> = {
   deep: {
     key: 'deep',
     label: 'Deep',
-    description:
-      'Full visibility into everything happening in Cardano governance. Every event, individually configurable.',
+    description: 'Everything visible. Full event stream, all metrics, maximum detail.',
     shortDescription: 'Full visibility, full control',
     iconName: 'BellPlus',
     eventTypes: getAllUserFacingEventKeys(),

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -37,6 +37,7 @@ import {
   Shield,
 } from 'lucide-react';
 import type { UserSegment } from '@/components/providers/SegmentProvider';
+import { type GovernanceDepth, getTunerLevel } from '@/lib/governanceTuner';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,6 +53,8 @@ export interface NavItem {
   segments?: UserSegment[];
   /** Only show for authenticated users */
   requiresAuth?: boolean;
+  /** Minimum governance depth to show this item (undefined = all) */
+  minDepth?: GovernanceDepth;
 }
 
 /** A labelled group of items within a section (for dual-role workspace) */
@@ -166,6 +169,38 @@ export interface SidebarContext {
   poolId?: string | null;
 }
 
+/** Extended context that includes governance depth for filtering */
+export interface NavContext extends SidebarContext {
+  depth?: GovernanceDepth;
+}
+
+// ---------------------------------------------------------------------------
+// Depth filtering helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if item passes the depth threshold (or has no threshold). */
+function meetsDepth(item: NavItem, depth: GovernanceDepth | undefined): boolean {
+  if (!item.minDepth || !depth) return true;
+  return getTunerLevel(depth).order >= getTunerLevel(item.minDepth).order;
+}
+
+/** Filter a list of nav items by governance depth. */
+function filterByDepth(items: NavItem[], depth: GovernanceDepth | undefined): NavItem[] {
+  if (!depth) return items;
+  return items.filter((item) => meetsDepth(item, depth));
+}
+
+/** Filter nav item groups by governance depth. */
+function filterGroupsByDepth(
+  groups: NavItemGroup[],
+  depth: GovernanceDepth | undefined,
+): NavItemGroup[] {
+  if (!depth) return groups;
+  return groups
+    .map((g) => ({ ...g, items: filterByDepth(g.items, depth) }))
+    .filter((g) => g.items.length > 0);
+}
+
 /**
  * Build deduplicated dual-role workspace groups.
  * Items that appear in both lists (matched by href) are shown only in the
@@ -181,11 +216,13 @@ function buildDualRoleGroups(): NavItemGroup[] {
   ];
 }
 
-export function getSidebarSections(segmentOrContext: UserSegment | SidebarContext): NavSection[] {
-  // Support both the legacy single-segment call and the new context call
-  const ctx: SidebarContext =
+export function getSidebarSections(
+  segmentOrContext: UserSegment | SidebarContext | NavContext,
+): NavSection[] {
+  // Support legacy single-segment call, SidebarContext, and NavContext
+  const ctx: NavContext =
     typeof segmentOrContext === 'string' ? { segment: segmentOrContext } : segmentOrContext;
-  const { segment, drepId, poolId } = ctx;
+  const { segment, drepId, poolId, depth } = ctx;
 
   const isDualRole = !!(drepId && poolId);
 
@@ -200,22 +237,26 @@ export function getSidebarSections(segmentOrContext: UserSegment | SidebarContex
 
   // Workspace — DRep/SPO only (with dual-role grouping)
   if (isDualRole) {
-    sections.push({
-      id: 'workspace',
-      label: 'Workspace',
-      icon: Briefcase,
-      href: '/workspace',
-      groups: buildDualRoleGroups(),
-      segments: ['drep', 'spo'],
-    });
+    const filteredGroups = filterGroupsByDepth(buildDualRoleGroups(), depth);
+    if (filteredGroups.length > 0) {
+      sections.push({
+        id: 'workspace',
+        label: 'Workspace',
+        icon: Briefcase,
+        href: '/workspace',
+        groups: filteredGroups,
+        segments: ['drep', 'spo'],
+      });
+    }
   } else if (segment === 'drep' || segment === 'spo') {
     const workspaceItems = segment === 'drep' ? WORKSPACE_DREP_ITEMS : WORKSPACE_SPO_ITEMS;
+    const filteredItems = filterByDepth(workspaceItems, depth);
     sections.push({
       id: 'workspace',
       label: 'Workspace',
       icon: Briefcase,
       href: '/workspace',
-      items: workspaceItems,
+      items: filteredItems,
       segments: ['drep', 'spo'],
     });
   }
@@ -226,7 +267,7 @@ export function getSidebarSections(segmentOrContext: UserSegment | SidebarContex
     label: 'Governance',
     icon: Globe,
     href: '/governance',
-    items: GOVERNANCE_ITEMS,
+    items: filterByDepth(GOVERNANCE_ITEMS, depth),
   });
 
   // You — authenticated (persona-aware items)
@@ -236,7 +277,7 @@ export function getSidebarSections(segmentOrContext: UserSegment | SidebarContex
       label: 'You',
       icon: User,
       href: '/you',
-      items: getYouItems(segment, { drepId, poolId }),
+      items: filterByDepth(getYouItems(segment, { drepId, poolId }), depth),
       requiresAuth: true,
     });
   }
@@ -285,16 +326,46 @@ const BOTTOM_BAR_CC: NavItem[] = [
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
 
-export function getBottomBarItems(segment: UserSegment): NavItem[] {
+/** Hands-Off bottom bar for citizen: swap Match for Help */
+const BOTTOM_BAR_CITIZEN_HANDS_OFF: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/governance', label: 'Governance', icon: Globe },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+  { href: '/help', label: 'Help', icon: HelpCircle },
+];
+
+/** Hands-Off bottom bar for DRep: Home/Workspace/You/Help */
+const BOTTOM_BAR_DREP_HANDS_OFF: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase, badge: 'actions' },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+  { href: '/help', label: 'Help', icon: HelpCircle },
+];
+
+/** Hands-Off bottom bar for SPO: Home/Workspace/You/Help */
+const BOTTOM_BAR_SPO_HANDS_OFF: NavItem[] = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase },
+  { href: '/you', label: 'You', icon: User, badge: 'unread' },
+  { href: '/help', label: 'Help', icon: HelpCircle },
+];
+
+export function getBottomBarItems(
+  segmentOrOpts: UserSegment | { segment: UserSegment; depth?: GovernanceDepth },
+): NavItem[] {
+  const segment = typeof segmentOrOpts === 'string' ? segmentOrOpts : segmentOrOpts.segment;
+  const depth = typeof segmentOrOpts === 'string' ? undefined : segmentOrOpts.depth;
+  const isHandsOff = depth === 'hands_off';
+
   switch (segment) {
     case 'anonymous':
       return BOTTOM_BAR_ANONYMOUS;
     case 'citizen':
-      return BOTTOM_BAR_CITIZEN;
+      return isHandsOff ? BOTTOM_BAR_CITIZEN_HANDS_OFF : BOTTOM_BAR_CITIZEN;
     case 'drep':
-      return BOTTOM_BAR_DREP;
+      return isHandsOff ? BOTTOM_BAR_DREP_HANDS_OFF : BOTTOM_BAR_DREP;
     case 'spo':
-      return BOTTOM_BAR_SPO;
+      return isHandsOff ? BOTTOM_BAR_SPO_HANDS_OFF : BOTTOM_BAR_SPO;
     case 'cc':
       return BOTTOM_BAR_CC;
     default:
@@ -309,30 +380,33 @@ export function getBottomBarItems(segment: UserSegment): NavItem[] {
 export function getPillBarItems(
   pathname: string,
   segment: UserSegment,
-  context?: { drepId?: string | null; poolId?: string | null },
+  context?: { drepId?: string | null; poolId?: string | null; depth?: GovernanceDepth },
 ): NavItem[] | null {
+  const depth = context?.depth;
+
   if (pathname.startsWith('/governance')) {
-    return GOVERNANCE_ITEMS;
+    return filterByDepth(GOVERNANCE_ITEMS, depth);
   }
   if (pathname.startsWith('/workspace')) {
     const isDualRole = !!(context?.drepId && context?.poolId);
     if (isDualRole) {
       // For dual-role users, combine both item sets (deduped) for pill bar
       const drepHrefs = new Set(WORKSPACE_DREP_ITEMS.map((i) => i.href));
-      return [
+      const combined = [
         ...WORKSPACE_DREP_ITEMS,
         ...WORKSPACE_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href)),
       ];
+      return filterByDepth(combined, depth);
     }
-    if (segment === 'drep') return WORKSPACE_DREP_ITEMS;
-    if (segment === 'spo') return WORKSPACE_SPO_ITEMS;
-    return WORKSPACE_DREP_ITEMS;
+    if (segment === 'drep') return filterByDepth(WORKSPACE_DREP_ITEMS, depth);
+    if (segment === 'spo') return filterByDepth(WORKSPACE_SPO_ITEMS, depth);
+    return filterByDepth(WORKSPACE_DREP_ITEMS, depth);
   }
   if (pathname.startsWith('/you')) {
-    return getYouItems(segment, context);
+    return filterByDepth(getYouItems(segment, context), depth);
   }
   if (pathname.startsWith('/help')) {
-    return HELP_ITEMS;
+    return filterByDepth(HELP_ITEMS, depth);
   }
   // No pill bar for single-page sections (Home, Match)
   return null;


### PR DESCRIPTION
## Summary
- Add `minDepth` field to `NavItem` interface for depth-based nav filtering
- `getSidebarSections()`, `getBottomBarItems()`, `getPillBarItems()` now accept optional `depth` parameter (backwards-compatible)
- Hands-Off users get Help instead of Match in bottom bar; all other depths keep current nav
- GovernanceTuner labels updated to reflect full platform experience, not just notifications
- CivicaSidebar, CivicaBottomNav, SectionPillBar all pass depth from `useGovernanceDepth()`

## Impact
- **What changed**: Navigation surfaces are now depth-aware. Hands-Off users see a simplified nav. GovernanceTuner descriptions updated.
- **User-facing**: Yes — Hands-Off users will see Help instead of Match in bottom bar. GovernanceTuner descriptions are more accurate.
- **Risk**: Low — all signature changes are backwards-compatible, existing callers still work
- **Scope**: 6 files (3 nav components, GovernanceTuner, governanceTuner.ts, nav/config.ts)

## Test plan
- [ ] View As → toggle depth → verify bottom bar items change for each segment
- [ ] Sidebar items filter correctly per depth
- [ ] Pill bar items filter correctly per depth
- [ ] GovernanceTuner shows updated descriptions
- [ ] Existing nav behavior unchanged for Engaged/Deep users

🤖 Generated with [Claude Code](https://claude.com/claude-code)