### PR TITLE
feat: governance section depth-adaptive density

### DIFF
--- a/components/civica/discover/CivicaDRepBrowse.tsx
+++ b/components/civica/discover/CivicaDRepBrowse.tsx
@@ -14,6 +14,8 @@ import {
   TrendingUp,
   TrendingDown,
   Minus,
+  CheckCircle2,
+  XCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CivicaDRepCard } from '@/components/civica/cards/CivicaDRepCard';
@@ -28,6 +30,10 @@ import { useBatchEndorsementCounts } from '@/hooks/useEngagement';
 import { useDReps } from '@/hooks/queries';
 import type { EnrichedDRep } from '@/lib/koios';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
+import { useDepthConfig } from '@/hooks/useDepthConfig';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import { DepthGate } from '@/components/providers/DepthGate';
+import { useWallet } from '@/utils/wallet-context';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
 import {
@@ -284,12 +290,69 @@ function DRepTableRow({ drep, rank }: { drep: EnrichedDRep; rank: number }) {
   );
 }
 
+/* ── Hands-Off: single focused DRep card ──────────────────────────────────── */
+function YourDRepSummary({ dreps }: { dreps: EnrichedDRep[] }) {
+  const { delegatedDrepId } = useWallet();
+  const yourDrep = delegatedDrepId ? dreps.find((d) => d.drepId === delegatedDrepId) : null;
+  const displayName = yourDrep
+    ? yourDrep.name || yourDrep.ticker || yourDrep.handle || `${yourDrep.drepId.slice(0, 16)}\u2026`
+    : null;
+
+  return (
+    <div className="space-y-3" data-discovery="gov-representatives">
+      <h1 className="text-xl font-bold tracking-tight">Your Representative</h1>
+      {yourDrep ? (
+        <Link
+          href={`/drep/${yourDrep.drepId}`}
+          className="group flex items-center gap-4 p-4 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md hover:bg-muted/40 hover:border-border/70 transition-all"
+        >
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-base font-semibold truncate">{displayName}</span>
+              {yourDrep.isActive ? (
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
+                  <CheckCircle2 className="h-3.5 w-3.5" /> Active
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 text-xs text-rose-400">
+                  <XCircle className="h-3.5 w-3.5" /> Inactive
+                </span>
+              )}
+            </div>
+            <span className="text-xs text-muted-foreground">
+              Score: {yourDrep.drepScore ?? 0} &middot;{' '}
+              {yourDrep.delegatorCount?.toLocaleString() ?? 0} delegators
+            </span>
+          </div>
+          <ChevronRight className="h-4 w-4 text-muted-foreground/40 shrink-0" />
+        </Link>
+      ) : (
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {delegatedDrepId
+              ? 'Your representative is not yet registered on-chain.'
+              : "You haven't delegated to a representative yet."}
+          </p>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/match">Find a representative &rarr;</Link>
+          </Button>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground/60">
+        {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
+      </p>
+    </div>
+  );
+}
+
 type SortMode = 'score' | 'match';
 
 export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
   const { data: rawData, isLoading } = useDReps();
   const drepsData = rawData as { allDReps?: EnrichedDRep[] } | undefined;
   const dreps: EnrichedDRep[] = useMemo(() => drepsData?.allDReps ?? [], [drepsData]);
+  const depthConfig = useDepthConfig('governance');
+  const { isAtLeast } = useGovernanceDepth();
 
   const searchParams = useSearchParams();
   const contentRef = useRef<HTMLDivElement>(null);
@@ -439,117 +502,148 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
     );
   }
 
+  // ── Hands-Off: focused single-DRep card ────────────────────────────────
+  if (!isAtLeast('informed')) {
+    return <YourDRepSummary dreps={dreps} />;
+  }
+
+  // ── Informed: top DReps by activity + your DRep highlighted ─────────────
+  const isInformedOnly = !isAtLeast('engaged');
+
   return (
     <div ref={contentRef} className="space-y-3" data-discovery="gov-representatives">
       {/* ── Page header ──────────────────────────────────────────── */}
       <div className="-mx-4 sm:-mx-6 px-4 sm:px-6 pt-2 pb-3">
         <div className="flex items-baseline justify-between gap-4">
-          <h1 className="text-xl font-bold tracking-tight">Find Your Representative</h1>
+          <h1 className="text-xl font-bold tracking-tight">
+            {isInformedOnly ? 'Top Representatives' : 'Find Your Representative'}
+          </h1>
           <span className="text-xs text-muted-foreground shrink-0">
             {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
           </span>
         </div>
-        <p className="text-sm text-muted-foreground mt-1 max-w-xl">
-          Every DRep has a unique governance philosophy. Find someone who represents your values.
-        </p>
+        {!isInformedOnly && (
+          <p className="text-sm text-muted-foreground mt-1 max-w-xl">
+            Every DRep has a unique governance philosophy. Find someone who represents your values.
+          </p>
+        )}
       </div>
 
       <AnonymousNudge variant="representatives" />
 
-      {/* ── Sticky filter bar ────────────────────────────────────── */}
-      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
-        <DiscoverFilterBar
-          search={filters.search}
-          onSearchChange={(v) => setFilter('search', v)}
-          searchPlaceholder="Search by name, ticker, or ID\u2026"
-          chipGroups={[
-            {
-              label: 'Tier',
-              value: filters.tier,
-              options: TIER_CHIPS,
-              onChange: (v) => setFilter('tier', v),
-            },
-            {
-              label: 'Alignment',
-              value: filters.alignment,
-              options: ALIGNMENT_OPTIONS,
-              onChange: (v) => setFilter('alignment', v),
-            },
-          ]}
-          toggles={[
-            {
-              label: 'Active DReps only',
-              checked: filters.activeOnly,
-              onChange: (v) => setFilter('activeOnly', v),
-            },
-          ]}
-          resultCount={filtered.length}
-          totalCount={dreps.length}
-          entityLabel="DReps"
-          isFiltered={!isDefaultFilters}
-          onReset={resetFilters}
-          pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
-        />
+      {/* ── Sticky filter bar — Engaged+ ─────────────────────────── */}
+      <DepthGate minDepth="engaged">
+        <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+          <DiscoverFilterBar
+            search={filters.search}
+            onSearchChange={(v) => setFilter('search', v)}
+            searchPlaceholder="Search by name, ticker, or ID\u2026"
+            chipGroups={[
+              {
+                label: 'Tier',
+                value: filters.tier,
+                options: TIER_CHIPS,
+                onChange: (v) => setFilter('tier', v),
+              },
+              {
+                label: 'Alignment',
+                value: filters.alignment,
+                options: ALIGNMENT_OPTIONS,
+                onChange: (v) => setFilter('alignment', v),
+              },
+            ]}
+            toggles={[
+              {
+                label: 'Active DReps only',
+                checked: filters.activeOnly,
+                onChange: (v) => setFilter('activeOnly', v),
+              },
+            ]}
+            resultCount={filtered.length}
+            totalCount={dreps.length}
+            entityLabel="DReps"
+            isFiltered={!isDefaultFilters}
+            onReset={resetFilters}
+            pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
+          />
 
-        {/* Consolidated toolbar: match sort + view toggle */}
-        <div className="flex items-center justify-between mt-2 pt-2 border-t border-border/20">
-          <div className="flex items-center gap-2">
-            {matchProfile && (
-              <>
-                <button
-                  onClick={() => setSortMode(sortMode === 'match' ? 'score' : 'match')}
-                  className={cn(
-                    'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all border',
-                    sortMode === 'match'
-                      ? 'bg-primary/10 border-primary/30 text-primary'
-                      : 'bg-muted/30 border-border text-muted-foreground hover:text-foreground',
+          {/* Consolidated toolbar: match sort + view toggle */}
+          <div className="flex items-center justify-between mt-2 pt-2 border-t border-border/20">
+            <div className="flex items-center gap-2">
+              {matchProfile && (
+                <>
+                  <button
+                    onClick={() => setSortMode(sortMode === 'match' ? 'score' : 'match')}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all border',
+                      sortMode === 'match'
+                        ? 'bg-primary/10 border-primary/30 text-primary'
+                        : 'bg-muted/30 border-border text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <Sparkles className="h-3 w-3" />
+                    {sortMode === 'match' ? 'Sorted by match' : 'Sort by match'}
+                  </button>
+                  {sortMode === 'match' && (
+                    <span className="text-[10px] text-muted-foreground hidden sm:inline">
+                      Based on your{' '}
+                      <Link href="/match" className="text-primary hover:underline">
+                        profile
+                      </Link>
+                    </span>
                   )}
-                >
-                  <Sparkles className="h-3 w-3" />
-                  {sortMode === 'match' ? 'Sorted by match' : 'Sort by match'}
-                </button>
-                {sortMode === 'match' && (
-                  <span className="text-[10px] text-muted-foreground hidden sm:inline">
-                    Based on your{' '}
-                    <Link href="/match" className="text-primary hover:underline">
-                      profile
-                    </Link>
-                  </span>
+                </>
+              )}
+            </div>
+            <div className="hidden sm:flex items-center gap-0.5">
+              <button
+                onClick={() => toggleViewMode('cards')}
+                className={cn(
+                  'p-1.5 rounded transition-colors',
+                  viewMode === 'cards'
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:text-foreground',
                 )}
-              </>
-            )}
-          </div>
-          <div className="hidden sm:flex items-center gap-0.5">
-            <button
-              onClick={() => toggleViewMode('cards')}
-              className={cn(
-                'p-1.5 rounded transition-colors',
-                viewMode === 'cards'
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-              title="Card view"
-            >
-              <LayoutGrid className="h-3.5 w-3.5" />
-            </button>
-            <button
-              onClick={() => toggleViewMode('table')}
-              className={cn(
-                'p-1.5 rounded transition-colors',
-                viewMode === 'table'
-                  ? 'bg-primary/10 text-primary'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-              title="Table view"
-            >
-              <TableProperties className="h-3.5 w-3.5" />
-            </button>
+                title="Card view"
+              >
+                <LayoutGrid className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={() => toggleViewMode('table')}
+                className={cn(
+                  'p-1.5 rounded transition-colors',
+                  viewMode === 'table'
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                title="Table view"
+              >
+                <TableProperties className="h-3.5 w-3.5" />
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+      </DepthGate>
 
       {/* ── Content ──────────────────────────────────────────────── */}
-      {pageItems.length === 0 && inactiveItems.length === 0 ? (
+      {isInformedOnly ? (
+        /* Informed: top DReps by score, compact card grid, no filters */
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {activeItems.slice(0, 12).map((drep, i) => (
+            <div
+              key={drep.drepId}
+              className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
+              style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
+            >
+              <CivicaDRepCard
+                drep={drep}
+                rank={i + 1}
+                endorsementCount={endorsementCounts[drep.drepId]}
+              />
+            </div>
+          ))}
+        </div>
+      ) : pageItems.length === 0 && inactiveItems.length === 0 ? (
         <div className="py-16 text-center space-y-2">
           {filters.alignment !== 'all' ? (
             <>
@@ -645,7 +739,19 @@ export function CivicaDRepBrowse(_props: CivicaDRepBrowseProps) {
         </div>
       )}
 
-      <DiscoverPagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />
+      {/* Deep: analytics context placeholder */}
+      <DepthGate minDepth="deep">
+        {/* TODO: Phase 6+ — DRep analytics, voting pattern analysis, delegation flow visualization */}
+        <div className="rounded-xl border border-dashed border-border/40 bg-card/30 p-4 text-center">
+          <p className="text-xs text-muted-foreground/60">
+            DRep analytics and delegation flow visualization coming soon
+          </p>
+        </div>
+      </DepthGate>
+
+      {!isInformedOnly && (
+        <DiscoverPagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />
+      )}
     </div>
   );
 }

--- a/components/civica/discover/ProposalsBrowse.tsx
+++ b/components/civica/discover/ProposalsBrowse.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useRef, useCallback } from 'react';
 import Link from 'next/link';
-import { CircleDot } from 'lucide-react';
+import { CircleDot, ChevronRight } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { useProposals, useDRepVotes } from '@/hooks/queries';
@@ -10,6 +10,10 @@ import { useWallet } from '@/utils/wallet-context';
 import { ProposalStatusFunnel } from '@/components/civica/charts/ProposalStatusFunnel';
 import type { VotesResponseData, VoteItem } from '@/types/api';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
+import { useDepthConfig } from '@/hooks/useDepthConfig';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import { DepthGate } from '@/components/providers/DepthGate';
+import { getProposalTheme, getVerdict } from '@/components/civica/proposals/proposal-theme';
 import { ProposalCard } from './ProposalCard';
 import type { BrowseProposal } from './ProposalCard';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
@@ -29,6 +33,126 @@ const TYPE_FILTERS = [
 
 const PAGE_SIZE = 25;
 
+/* ── Hands-Off: ultra-compact status-only summary ─────────────────────────── */
+function ProposalStatusSummary({ proposals }: { proposals: BrowseProposal[] }) {
+  const counts: Record<string, number> = {};
+  for (const p of proposals) {
+    const s = p.status ?? 'Open';
+    counts[s] = (counts[s] || 0) + 1;
+  }
+  const active = counts['Open'] ?? 0;
+  const decided =
+    (counts['Ratified'] ?? 0) +
+    (counts['Enacted'] ?? 0) +
+    (counts['Expired'] ?? 0) +
+    (counts['Dropped'] ?? 0);
+
+  return (
+    <div className="space-y-3" data-discovery="gov-proposals">
+      <h1 className="text-xl font-bold tracking-tight">What&apos;s Being Decided</h1>
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center justify-center h-7 w-7 rounded-full bg-emerald-500/10 text-emerald-400 text-sm font-bold">
+              {active}
+            </span>
+            <span className="text-sm text-muted-foreground">active</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center justify-center h-7 w-7 rounded-full bg-muted/40 text-muted-foreground text-sm font-bold">
+              {decided}
+            </span>
+            <span className="text-sm text-muted-foreground">decided</span>
+          </div>
+        </div>
+        {/* Show most recent open proposals as compact clickable rows */}
+        {proposals
+          .filter((p) => (p.status ?? 'Open').toLowerCase() === 'open')
+          .slice(0, 3)
+          .map((p) => {
+            const theme = p.type ? getProposalTheme(p.type) : null;
+            const TypeIcon = theme?.icon;
+            return (
+              <Link
+                key={`${p.txHash}-${p.index}`}
+                href={`/proposal/${p.txHash}/${p.index}`}
+                className="group flex items-center gap-2.5 px-3 py-2 rounded-lg hover:bg-muted/30 transition-colors -mx-1"
+              >
+                {TypeIcon && <TypeIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
+                <span className="flex-1 text-sm truncate text-muted-foreground group-hover:text-foreground transition-colors">
+                  {p.title || `${p.txHash?.slice(0, 16)}\u2026`}
+                </span>
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/30 shrink-0" />
+              </Link>
+            );
+          })}
+        <Link
+          href="/governance/proposals"
+          className="text-xs text-primary hover:underline"
+          onClick={(e) => {
+            // Prevent navigation loop — we're already on this page, just prompt depth change
+            e.preventDefault();
+          }}
+        >
+          See all proposals &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/* ── Informed: headline card for proposals ─────────────────────────────────── */
+function ProposalHeadlineCard({
+  proposal: p,
+  drepVote,
+  animationDelay,
+}: {
+  proposal: BrowseProposal;
+  drepVote?: string;
+  animationDelay: number;
+}) {
+  const theme = p.type ? getProposalTheme(p.type) : null;
+  const TypeIcon = theme?.icon;
+  const verdict = getVerdict((p.status ?? 'Open').toLowerCase(), p.triBody);
+  const title = p.title || `${p.txHash?.slice(0, 16)}\u2026`;
+
+  const VOTE_PILL: Record<string, { label: string; cls: string }> = {
+    Yes: { label: 'Yes', cls: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20' },
+    No: { label: 'No', cls: 'text-red-400 bg-red-500/10 border-red-500/20' },
+    Abstain: { label: 'Abstain', cls: 'text-amber-400 bg-amber-500/10 border-amber-500/20' },
+  };
+  const pill = drepVote ? VOTE_PILL[drepVote] : null;
+
+  return (
+    <Link
+      href={`/proposal/${p.txHash}/${p.index}`}
+      className="group flex items-center gap-3 px-4 py-3 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md hover:bg-muted/40 hover:border-border/70 hover:shadow-sm transition-all duration-200 animate-in fade-in fill-mode-backwards"
+      style={{ animationDelay: `${animationDelay}ms` }}
+    >
+      {TypeIcon && <TypeIcon className="h-4 w-4 shrink-0" style={{ color: theme?.accent }} />}
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium text-foreground truncate block">{title}</span>
+        <span className="text-[11px] text-muted-foreground">
+          {theme?.label ?? 'Governance Action'}
+        </span>
+      </div>
+      {pill && (
+        <span
+          className={`text-[11px] font-semibold px-2 py-0.5 rounded-full border shrink-0 ${pill.cls}`}
+        >
+          DRep: {pill.label}
+        </span>
+      )}
+      <span
+        className={`text-[11px] font-medium px-2 py-0.5 rounded-full border shrink-0 ${verdict.color} ${verdict.bgColor} ${verdict.borderColor}`}
+      >
+        {verdict.label}
+      </span>
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/30 shrink-0" />
+    </Link>
+  );
+}
+
 export function ProposalsBrowse() {
   const contentRef = useRef<HTMLDivElement>(null);
   const { data: rawData, isLoading } = useProposals(200);
@@ -37,6 +161,8 @@ export function ProposalsBrowse() {
   const currentEpoch: number | null = data?.currentEpoch ?? null;
   const { delegatedDrepId } = useWallet();
   const { data: drepVotesRaw } = useDRepVotes(delegatedDrepId);
+  const depthConfig = useDepthConfig('governance');
+  const { isAtLeast } = useGovernanceDepth();
 
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('All');
@@ -138,19 +264,29 @@ export function ProposalsBrowse() {
     );
   }
 
+  // ── Hands-Off: compact status summary only ──────────────────────────────
+  if (depthConfig.proposalDetail === 'headline' && !isAtLeast('informed')) {
+    return <ProposalStatusSummary proposals={proposals} />;
+  }
+
+  // ── Informed: headline card list (title + status + DRep position) ───────
+  const isInformedOnly = depthConfig.proposalDetail === 'summary';
+
   return (
     <div ref={contentRef} className="space-y-3" data-discovery="gov-proposals">
       {/* Page heading */}
       <div className="flex items-baseline justify-between gap-4">
         <h1 className="text-xl font-bold tracking-tight">What&apos;s Being Decided</h1>
         <span className="text-xs text-muted-foreground shrink-0">
-          {delegatedDrepId ? "Your representative's votes shown" : ''}
+          {delegatedDrepId && depthConfig.showDRepPosition
+            ? "Your representative's votes shown"
+            : ''}
         </span>
       </div>
 
       <AnonymousNudge variant="proposals" />
 
-      {/* Status pipeline overview */}
+      {/* Status pipeline overview — Informed+ */}
       {statusCounts.length > 1 && (
         <div className="rounded-xl border border-border/50 bg-card/60 backdrop-blur-md p-4">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
@@ -160,49 +296,54 @@ export function ProposalsBrowse() {
         </div>
       )}
 
-      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
-        <DiscoverFilterBar
-          search={search}
-          onSearchChange={setFilter(setSearch)}
-          searchPlaceholder="Search proposals…"
-          chipGroups={[
-            {
-              label: 'Status',
-              value: statusFilter,
-              options: STATUS_FILTERS.map((s) => ({ value: s, label: s })),
-              onChange: setFilter(setStatusFilter),
-            },
-            {
-              label: 'Type',
-              value: typeFilter,
-              options: TYPE_FILTERS,
-              onChange: setFilter(setTypeFilter),
-            },
-          ]}
-          resultCount={filtered.length}
-          totalCount={proposals.length}
-          entityLabel="proposals"
-          isFiltered={!isDefault}
-          onReset={resetFilters}
-          pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
-        />
-      </div>
+      {/* Filters — Engaged+ get search/filter bar */}
+      <DepthGate minDepth="engaged">
+        <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+          <DiscoverFilterBar
+            search={search}
+            onSearchChange={setFilter(setSearch)}
+            searchPlaceholder="Search proposals…"
+            chipGroups={[
+              {
+                label: 'Status',
+                value: statusFilter,
+                options: STATUS_FILTERS.map((s) => ({ value: s, label: s })),
+                onChange: setFilter(setStatusFilter),
+              },
+              {
+                label: 'Type',
+                value: typeFilter,
+                options: TYPE_FILTERS,
+                onChange: setFilter(setTypeFilter),
+              },
+            ]}
+            resultCount={filtered.length}
+            totalCount={proposals.length}
+            entityLabel="proposals"
+            isFiltered={!isDefault}
+            onReset={resetFilters}
+            pageInfo={totalPages > 1 ? `Page ${page + 1} / ${totalPages}` : undefined}
+          />
+        </div>
+      </DepthGate>
 
-      {/* Needs attention banner */}
-      {needsAttentionCount > 0 &&
-        (statusFilter === 'All' || statusFilter === 'Open') &&
-        page === 0 && (
-          <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-lg bg-violet-500/5 border border-violet-500/20">
-            <CircleDot className="h-4 w-4 text-violet-400 shrink-0" />
-            <span className="text-sm text-muted-foreground">
-              Your representative hasn&apos;t voted on{' '}
-              <strong className="text-violet-300">{needsAttentionCount}</strong> open proposal
-              {needsAttentionCount !== 1 ? 's' : ''}
-            </span>
-          </div>
-        )}
+      {/* Needs attention banner — Engaged+ (requires rationale awareness) */}
+      <DepthGate minDepth="engaged">
+        {needsAttentionCount > 0 &&
+          (statusFilter === 'All' || statusFilter === 'Open') &&
+          page === 0 && (
+            <div className="flex items-center gap-2.5 px-4 py-2.5 rounded-lg bg-violet-500/5 border border-violet-500/20">
+              <CircleDot className="h-4 w-4 text-violet-400 shrink-0" />
+              <span className="text-sm text-muted-foreground">
+                Your representative hasn&apos;t voted on{' '}
+                <strong className="text-violet-300">{needsAttentionCount}</strong> open proposal
+                {needsAttentionCount !== 1 ? 's' : ''}
+              </span>
+            </div>
+          )}
+      </DepthGate>
 
-      {/* Proposal cards */}
+      {/* Proposal cards — density varies by depth */}
       {pageItems.length === 0 ? (
         <div className="py-16 text-center space-y-4">
           <p className="text-muted-foreground text-sm">No proposals match your filters.</p>
@@ -217,7 +358,22 @@ export function ProposalsBrowse() {
             </Button>
           </div>
         </div>
+      ) : isInformedOnly ? (
+        /* Informed: compact headline cards — title, status, DRep position */
+        <div key={page} className="space-y-2">
+          {pageItems.map((p, i: number) => (
+            <ProposalHeadlineCard
+              key={`${p.txHash}-${p.index}`}
+              proposal={p}
+              drepVote={
+                depthConfig.showDRepPosition ? drepVoteMap.get(`${p.txHash}:${p.index}`) : undefined
+              }
+              animationDelay={Math.min(i, 14) * 30}
+            />
+          ))}
+        </div>
       ) : (
+        /* Engaged / Deep: full proposal cards */
         <div key={page} className="space-y-3">
           {pageItems.map((p, i: number) => (
             <ProposalCard
@@ -232,6 +388,16 @@ export function ProposalsBrowse() {
           ))}
         </div>
       )}
+
+      {/* Deep: historical context placeholder */}
+      <DepthGate minDepth="deep">
+        {/* TODO: Phase 6+ — Historical proposal context, trend analysis, cross-epoch comparisons */}
+        <div className="rounded-xl border border-dashed border-border/40 bg-card/30 p-4 text-center">
+          <p className="text-xs text-muted-foreground/60">
+            Historical proposal trends and cross-epoch analysis coming soon
+          </p>
+        </div>
+      </DepthGate>
 
       <DiscoverPagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />
     </div>

--- a/components/civica/pulse/CivicaPulseOverview.tsx
+++ b/components/civica/pulse/CivicaPulseOverview.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { useSearchParams, usePathname } from 'next/navigation';
-import { Activity } from 'lucide-react';
+import { Activity, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ErrorCard } from '@/components/ui/ErrorCard';
 import { useGovernancePulse } from '@/hooks/queries';
@@ -22,6 +22,9 @@ import { useGovernanceHealthIndex } from '@/hooks/queries';
 import { EmptyState } from './EmptyState';
 import { FirstVisitBanner } from '@/components/ui/FirstVisitBanner';
 import { AnonymousNudge } from '@/components/civica/shared/AnonymousNudge';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import { useDepthConfig } from '@/hooks/useDepthConfig';
+import { DepthGate } from '@/components/providers/DepthGate';
 import type {
   TreasuryData,
   LeaderboardData,
@@ -65,6 +68,187 @@ const TABS: { id: PulseTab; label: string }[] = [
 
 const VALID_PULSE_TABS = new Set<PulseTab>(TABS.map((t) => t.id));
 
+/* ── Hands-Off: single score + trend arrow ─────────────────────────────────── */
+function GHIMinimal() {
+  const { data: rawGhi, isLoading } = useGovernanceHealthIndex(1);
+  const ghi = rawGhi as
+    | {
+        current?: { score: number; band: string };
+        trend?: { direction: string; delta: number };
+      }
+    | undefined;
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 flex items-center gap-4">
+        <div className="h-12 w-12 rounded-full bg-muted/40 animate-pulse" />
+        <div className="space-y-1">
+          <div className="h-4 w-32 bg-muted/40 rounded animate-pulse" />
+          <div className="h-3 w-20 bg-muted/40 rounded animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  const score = ghi?.current?.score ?? 0;
+  const band = ghi?.current?.band ?? 'fair';
+  const direction = (ghi?.trend?.direction ?? 'flat') as 'up' | 'down' | 'flat';
+  const arrow = direction === 'up' ? '\u2191' : direction === 'down' ? '\u2193' : '\u2192';
+  const TrendIcon = direction === 'up' ? TrendingUp : direction === 'down' ? TrendingDown : Minus;
+  const trendColor =
+    direction === 'up'
+      ? 'text-emerald-500'
+      : direction === 'down'
+        ? 'text-rose-500'
+        : 'text-muted-foreground';
+
+  const BAND_COLORS: Record<string, string> = {
+    strong: 'text-emerald-500',
+    good: 'text-green-500',
+    fair: 'text-amber-500',
+    critical: 'text-rose-500',
+  };
+  const scoreColor = BAND_COLORS[band] ?? BAND_COLORS.fair;
+
+  return (
+    <div
+      className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-1"
+      data-discovery="gov-health"
+    >
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        Governance Health
+      </p>
+      <div className="flex items-baseline gap-2">
+        <span className={cn('text-4xl font-bold tabular-nums', scoreColor)}>
+          {Math.round(score)}
+        </span>
+        <span className={cn('text-lg', trendColor)} aria-label={`Trend: ${direction}`}>
+          {arrow}
+        </span>
+        <TrendIcon className={cn('h-4 w-4', trendColor)} />
+      </div>
+      <p className="text-xs text-muted-foreground capitalize">{band}</p>
+    </div>
+  );
+}
+
+/* ── Informed: score + 4-dimension breakdown + trend ───────────────────────── */
+function GHIInformedView() {
+  const { data: rawGhi, isLoading, isError, refetch } = useGovernanceHealthIndex(5);
+  const ghi = rawGhi as
+    | {
+        current: {
+          score: number;
+          band: string;
+          components: { name: string; value: number; weight: number; contribution: number }[];
+        };
+        trend?: { direction: string; delta: number; streakEpochs: number };
+      }
+    | undefined;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 flex items-center gap-4">
+          <div className="h-[80px] w-[80px] rounded-full bg-muted/40 animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-40 bg-muted/40 rounded animate-pulse" />
+            <div className="h-3 w-60 bg-muted/40 rounded animate-pulse" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !ghi?.current) {
+    return (
+      <ErrorCard message="Governance Health temporarily unavailable." onRetry={() => refetch()} />
+    );
+  }
+
+  const { score, band, components } = ghi.current;
+  const direction = (ghi.trend?.direction ?? 'flat') as 'up' | 'down' | 'flat';
+  const delta = ghi.trend?.delta ?? 0;
+
+  const BAND_COLORS: Record<string, { text: string; bg: string }> = {
+    strong: { text: 'text-emerald-500', bg: 'bg-emerald-500/10' },
+    good: { text: 'text-green-500', bg: 'bg-green-500/10' },
+    fair: { text: 'text-amber-500', bg: 'bg-amber-500/10' },
+    critical: { text: 'text-rose-500', bg: 'bg-rose-500/10' },
+  };
+  const style = BAND_COLORS[band] ?? BAND_COLORS.fair;
+  const TrendIcon = direction === 'up' ? TrendingUp : direction === 'down' ? TrendingDown : Minus;
+  const trendColor =
+    direction === 'up'
+      ? 'text-emerald-500'
+      : direction === 'down'
+        ? 'text-rose-500'
+        : 'text-muted-foreground';
+
+  // Show top 4 components
+  const topComponents = [...components].sort((a, b) => b.weight - a.weight).slice(0, 4);
+
+  return (
+    <div className="space-y-4" data-discovery="gov-health">
+      {/* Score + band */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
+        <div className="flex items-center gap-4 mb-4">
+          <div className="text-center">
+            <span className={cn('text-3xl font-bold tabular-nums', style.text)}>
+              {Math.round(score)}
+            </span>
+            <span className="text-xs text-muted-foreground">/100</span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold">Governance Health</h2>
+              <span
+                className={cn(
+                  'text-xs font-semibold px-2 py-0.5 rounded-full',
+                  style.bg,
+                  style.text,
+                )}
+              >
+                {band.charAt(0).toUpperCase() + band.slice(1)}
+              </span>
+            </div>
+            {delta !== 0 && (
+              <span
+                className={cn('inline-flex items-center gap-0.5 text-xs font-medium', trendColor)}
+              >
+                <TrendIcon className="h-3 w-3" />
+                {delta > 0 ? '+' : ''}
+                {Math.round(delta * 10) / 10} this epoch
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Dimension breakdown */}
+        <div className="grid grid-cols-2 gap-3">
+          {topComponents.map((comp) => (
+            <div key={comp.name} className="space-y-1">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground truncate">{comp.name}</span>
+                <span className="text-xs font-medium tabular-nums">{Math.round(comp.value)}</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted/40 overflow-hidden">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-all',
+                    style.bg.replace('/10', '/60'),
+                  )}
+                  style={{ width: `${Math.min(100, comp.value)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Legacy tab aliases for backwards compatibility with bookmarked URLs
 const TAB_ALIASES: Record<string, PulseTab> = {
   overview: 'now',
@@ -85,6 +269,8 @@ function resolvePulseTab(param: string | null): PulseTab {
 export function CivicaPulseOverview() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const { isAtLeast } = useGovernanceDepth();
+  const depthConfig = useDepthConfig('governance');
 
   const activeTab = resolvePulseTab(searchParams.get('tab'));
 
@@ -156,6 +342,18 @@ export function CivicaPulseOverview() {
 
   const loading = pulseLoading || treasuryLoading;
   const hasError = pulseError || treasuryError;
+
+  // ── Hands-Off: single score + arrow ─────────────────────────────────────
+  if (!isAtLeast('informed')) {
+    return <GHIMinimal />;
+  }
+
+  // ── Informed: score + dimension breakdown, no tabs ─────────────────────
+  if (!isAtLeast('engaged')) {
+    return <GHIInformedView />;
+  }
+
+  // ── Engaged + Deep: full dashboard (current behavior = Engaged baseline) ─
 
   return (
     <div className="space-y-6 pt-4" data-discovery="gov-health">
@@ -262,6 +460,16 @@ export function CivicaPulseOverview() {
 
           {/* 6. Live Activity Ticker */}
           <ActivityTicker variant="inline" />
+
+          {/* 7. Deep: historical overlay placeholder */}
+          <DepthGate minDepth="deep">
+            {/* TODO: Phase 6+ — Historical health overlay, cross-epoch comparison, health projections */}
+            <div className="rounded-xl border border-dashed border-border/40 bg-card/30 p-4 text-center">
+              <p className="text-xs text-muted-foreground/60">
+                Historical health overlay and epoch comparison coming soon
+              </p>
+            </div>
+          </DepthGate>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Proposals page: Hands-Off shows compact status summary (counts + top 3 links), Informed shows headline cards, Engaged is unchanged, Deep adds historical placeholder
- Representatives page: Hands-Off shows "Your DRep" single-card focus, Informed shows top 12 without filters, Engaged is unchanged, Deep adds analytics placeholder
- GHI/Health page: Hands-Off shows single number + trend arrow, Informed shows score + 4 dimension bars, Engaged is unchanged, Deep adds historical overlay placeholder

## Impact
- **What changed**: All 3 governance section pages are now depth-responsive with 4 density levels each
- **User-facing**: Yes — Hands-Off/Informed users see dramatically simplified views. Engaged users see no change (current behavior preserved).
- **Risk**: Medium — significant rendering logic changes in 3 large components, but Engaged baseline is preserved
- **Scope**: 3 files (ProposalsBrowse, CivicaDRepBrowse, CivicaPulseOverview)

## Test plan
- [ ] View As → any segment + hands_off → Proposals shows status summary only
- [ ] View As → any segment + informed → Proposals shows headline cards with DRep position
- [ ] View As → any segment + engaged → Proposals renders identically to current
- [ ] Same pattern for Representatives page (your DRep → top 12 → full directory)
- [ ] Same pattern for GHI page (single number → breakdown → full dashboard)
- [ ] Deep depth shows placeholder panels for future analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)