### PR TITLE
fix: depth prompt modal + sentiment gating + posthog tracking

### DIFF
--- a/components/civica/DepthPickerDropdown.tsx
+++ b/components/civica/DepthPickerDropdown.tsx
@@ -66,10 +66,19 @@ export function DepthPickerDropdown() {
 
   const { mutate, isPending } = useMutation({
     mutationFn: saveGovernanceDepth,
-    onSuccess: () => {
+    onSuccess: (_data, newDepth) => {
       queryClient.invalidateQueries({ queryKey: ['user'] });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      import('@/lib/posthog')
+        .then(({ posthog }) => {
+          posthog.capture('governance_depth_changed', {
+            from: depth,
+            to: newDepth,
+            source: 'header_dropdown',
+          });
+        })
+        .catch(() => {});
     },
     onError: () => {
       setOptimisticDepth(null);

--- a/components/civica/DepthPromptModal.tsx
+++ b/components/civica/DepthPromptModal.tsx
@@ -74,16 +74,31 @@ export function DepthPromptModal() {
     setSelectedDepth(getDefaultDepthForSegment(segment));
   }, [segment]);
 
+  const [error, setError] = useState<string | null>(null);
+
   const { mutate, isPending } = useMutation({
     mutationFn: saveGovernanceDepth,
-    onSuccess: () => {
+    onSuccess: (_data, depth) => {
       queryClient.invalidateQueries({ queryKey: ['user'] });
       localStorage.setItem(STORAGE_KEY, '1');
       setOpen(false);
+      import('@/lib/posthog')
+        .then(({ posthog }) => {
+          posthog.capture('governance_depth_changed', {
+            from: defaultDepth,
+            to: depth,
+            source: 'first_use_prompt',
+          });
+        })
+        .catch(() => {});
+    },
+    onError: () => {
+      setError('Could not save. You can try again or skip for now.');
     },
   });
 
   const handleContinue = useCallback(() => {
+    setError(null);
     mutate(selectedDepth);
   }, [mutate, selectedDepth]);
 
@@ -120,7 +135,7 @@ export function DepthPromptModal() {
                   'flex items-start gap-3 rounded-lg border px-3 py-3 text-left transition-all',
                   'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 outline-none',
                   isSelected
-                    ? 'border-primary bg-primary/5 dark:bg-primary/10'
+                    ? 'border-primary bg-primary/10'
                     : 'border-border hover:border-primary/40 hover:bg-muted/50',
                 )}
               >
@@ -170,6 +185,7 @@ export function DepthPromptModal() {
         </div>
 
         <DialogFooter className="flex-col gap-2 sm:flex-col">
+          {error && <p className="text-center text-xs text-destructive">{error}</p>}
           <Button onClick={handleContinue} disabled={isPending} className="w-full">
             {isPending ? (
               <>
@@ -180,6 +196,12 @@ export function DepthPromptModal() {
               'Continue'
             )}
           </Button>
+          <button
+            onClick={handleDismiss}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Skip for now
+          </button>
           <p className="text-center text-xs text-muted-foreground">
             You can change this anytime from the header or Settings.
           </p>

--- a/components/civica/mygov/GovernanceTuner.tsx
+++ b/components/civica/mygov/GovernanceTuner.tsx
@@ -108,10 +108,19 @@ export function GovernanceTuner() {
 
   const { mutate, isPending } = useMutation({
     mutationFn: saveGovernanceDepth,
-    onSuccess: () => {
+    onSuccess: (_data, newDepth) => {
       queryClient.invalidateQueries({ queryKey: ['user'] });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      import('@/lib/posthog')
+        .then(({ posthog }) => {
+          posthog.capture('governance_depth_changed', {
+            from: currentDepth,
+            to: newDepth,
+            source: 'settings_tuner',
+          });
+        })
+        .catch(() => {});
     },
     onError: () => {
       // Revert optimistic selection
@@ -174,7 +183,7 @@ export function GovernanceTuner() {
                 'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
                 isSelected
-                  ? 'border-primary bg-primary/10 dark:bg-primary/15 shadow-sm'
+                  ? 'border-primary bg-primary/15 shadow-sm'
                   : 'border-border bg-card hover:border-primary/40 hover:bg-muted/50',
               )}
             >

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -228,6 +228,7 @@ function ActiveProposalCard({ proposal }: { proposal: ConsequenceProposal }) {
   const typeLabel = PROPOSAL_TYPE_LABELS[proposal.proposalType] ?? proposal.proposalType;
   const { connected, isAuthenticated, address, delegatedDrepId, authenticate } = useWallet();
   const queryClient = useQueryClient();
+  const { showSentiment } = useDepthConfig('hub');
   const [voting, setVoting] = useState(false);
   const [voteError, setVoteError] = useState<string | null>(null);
 
@@ -350,8 +351,8 @@ function ActiveProposalCard({ proposal }: { proposal: ConsequenceProposal }) {
         </div>
       )}
 
-      {/* Inline sentiment buttons for connected users who haven't voted */}
-      {!hasVoted && connected && (
+      {/* Inline sentiment buttons for engaged+ connected users who haven't voted */}
+      {!hasVoted && connected && showSentiment && (
         <div className="flex gap-1.5 pt-1" role="radiogroup" aria-label="Share your sentiment">
           {[
             {

--- a/components/hub/cards/EngagementCard.tsx
+++ b/components/hub/cards/EngagementCard.tsx
@@ -19,6 +19,7 @@ import { resolveRewardAddress } from '@meshsdk/core';
 import { hapticLight } from '@/lib/haptics';
 import { HubCardSkeleton, HubCardError } from './HubCard';
 import { Button } from '@/components/ui/button';
+import { useDepthConfig } from '@/hooks/useDepthConfig';
 
 type SentimentChoice = 'support' | 'oppose' | 'unsure';
 
@@ -126,6 +127,7 @@ function InlineSentimentCard({
 }) {
   const { connected, isAuthenticated, address, delegatedDrepId, authenticate } = useWallet();
   const queryClient = useQueryClient();
+  const { showSentiment } = useDepthConfig('hub');
   const [voting, setVoting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -282,8 +284,8 @@ function InlineSentimentCard({
         </div>
       )}
 
-      {/* Inline voting buttons for connected users who haven't voted */}
-      {!hasVoted && connected && (
+      {/* Inline voting buttons for engaged+ connected users who haven't voted */}
+      {!hasVoted && connected && showSentiment && (
         <div className="flex gap-2" role="radiogroup" aria-label="Share your sentiment">
           {[
             {
@@ -332,8 +334,8 @@ function InlineSentimentCard({
         </div>
       )}
 
-      {/* CTA for unconnected users */}
-      {!hasVoted && !connected && (
+      {/* CTA for unconnected users (engaged+ only) */}
+      {!hasVoted && !connected && showSentiment && (
         <Button
           size="sm"
           variant="outline"


### PR DESCRIPTION
## Summary
- **DepthPromptModal bug fix**: Continue button trapped users when PATCH /api/user failed — added error state with retry, plus "Skip for now" dismiss button
- **Sentiment voting depth gating**: Inline voting buttons on CitizenHub and EngagementCard now respect `showSentiment` from `useDepthConfig('hub')` (hidden for hands_off/informed, shown for engaged/deep)
- **PostHog tracking**: Added `governance_depth_changed` event to all three depth-change surfaces (first-use prompt, header dropdown, settings tuner) with `from`/`to`/`source` properties

## Impact
- **What changed**: Bug fix for first-use modal, functional gating for sentiment voting, observability for depth changes
- **User-facing**: Yes — modal no longer traps users; hands_off/informed users no longer see sentiment voting buttons
- **Risk**: Low — additive error handling, conditional rendering, and analytics only
- **Scope**: 5 files (DepthPromptModal, DepthPickerDropdown, GovernanceTuner, CitizenHub, EngagementCard)

## Test plan
- [ ] Connect wallet → verify depth prompt modal appears → click Continue with network error → confirm error message shows + Skip button works
- [ ] Set depth to "Hands Off" or "Informed" → verify sentiment voting buttons are hidden on Hub
- [ ] Set depth to "Engaged" or "Deep" → verify sentiment voting buttons appear
- [ ] Change depth from any surface → verify PostHog event fires with correct from/to/source

🤖 Generated with [Claude Code](https://claude.com/claude-code)