### PR TITLE
fix: add missing notification_preferences column

### DIFF
--- a/types/database.ts
+++ b/types/database.ts
@@ -4166,6 +4166,7 @@ export type Database = {
           last_epoch_visited: number | null;
           last_push_check: string | null;
           last_visit_at: string | null;
+          notification_preferences: Json | null;
           onboarding_checklist: Json | null;
           poll_count: number | null;
           prefs: Json | null;
@@ -4188,6 +4189,7 @@ export type Database = {
           last_epoch_visited?: number | null;
           last_push_check?: string | null;
           last_visit_at?: string | null;
+          notification_preferences?: Json | null;
           onboarding_checklist?: Json | null;
           poll_count?: number | null;
           prefs?: Json | null;
@@ -4210,6 +4212,7 @@ export type Database = {
           last_epoch_visited?: number | null;
           last_push_check?: string | null;
           last_visit_at?: string | null;
+          notification_preferences?: Json | null;
           onboarding_checklist?: Json | null;
           poll_count?: number | null;
           prefs?: Json | null;


### PR DESCRIPTION
## Summary
- The `notification_preferences` jsonb column was missing from the `users` table
- The governance depth PATCH handler writes to this column when saving depth preferences, causing the entire update to fail
- This was the root cause of the first-use modal being stuck — the save always errored

## Impact
- **What changed**: Added `notification_preferences jsonb DEFAULT '{}'` to users table via migration, regenerated types
- **User-facing**: Yes — fixes the governance depth modal Continue button not working (save was silently failing)
- **Risk**: Low — additive column with safe default, no data changes
- **Scope**: 1 migration + types/database.ts

## Test plan
- [ ] Connect wallet → depth modal appears → select depth → click Continue → modal closes successfully
- [ ] Change depth from header dropdown → saves without error
- [ ] Change depth from Settings tuner → saves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)