### PR TITLE
fix: attach auth token to client-side API fetches

### DIFF
--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -4,7 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 import type { NclUtilization, DRepNclImpact } from '@/lib/treasury';
 
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  const headers: Record<string, string> = {};
+  try {
+    const { getStoredSession } = await import('@/lib/supabaseAuth');
+    const token = getStoredSession();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {
+    // No session available — proceed without auth
+  }
+  const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return res.json();
 }


### PR DESCRIPTION
## Summary
- The shared `fetchJson` helper in `hooks/queries.ts` was making plain `fetch` calls with no `Authorization` header
- All `auth: 'required'` API endpoints (`/api/governance/holder`, `/api/user`, etc.) returned 401 from client-side TanStack Query hooks
- Now reads the session JWT from localStorage and attaches it as `Bearer` token when available

## Impact
- **What changed**: Client-side API calls now include auth headers, fixing all authenticated endpoints
- **User-facing**: Yes — the Hub page was stuck on skeleton loading state after saving governance depth preferences because the holder endpoint returned 401
- **Risk**: Low — adds auth header to existing fetch calls; no behavior change for unauthenticated users
- **Scope**: `hooks/queries.ts` only (the `fetchJson` helper used by 20+ query hooks)

## Test plan
- [ ] Connect wallet, authenticate, navigate to Hub — should load fully (no infinite skeleton)
- [ ] Save governance depth in modal — Hub should render after modal closes
- [ ] Verify `/api/governance/holder` returns 200 with auth token in browser DevTools
- [ ] Verify anonymous users still see public content without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)