### PR TITLE
fix: mobile pill bar wastes space above filters

### DIFF
--- a/components/civica/SectionPillBar.tsx
+++ b/components/civica/SectionPillBar.tsx
@@ -24,7 +24,7 @@ export function SectionPillBar({ section: _section }: SectionPillBarProps) {
   if (!items || items.length < 2) return null;
 
   return (
-    <div className="sticky top-14 z-20 lg:hidden border-b border-border/50 bg-background/80 backdrop-blur-xl">
+    <div className="sticky top-0 sm:top-14 z-20 lg:hidden border-b border-border/50 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)] sm:pt-0">
       <nav
         className="flex items-center gap-1.5 px-4 py-2 overflow-x-auto scrollbar-none"
         aria-label="Section navigation"


### PR DESCRIPTION
## Summary
- Fixed `SectionPillBar` sticky position on mobile: `top-0` instead of `top-14` (header is hidden below `sm`)
- Added `pt-[env(safe-area-inset-top)]` for notched phones (Dynamic Island, etc.)
- At `sm+` where header is visible, behavior unchanged (`top-14`)

## Impact
- **What changed**: Pill bar now hugs the viewport top on mobile when scrolled, eliminating the 56px dead gap
- **User-facing**: Yes — less wasted space on all section pages (governance, workspace, you, help) on mobile
- **Risk**: Low — CSS-only change, no data/logic changes
- **Scope**: `components/civica/SectionPillBar.tsx` only

## Test plan
- [ ] Open /governance/proposals on mobile (< 640px) — pill bar should stick to top when scrolled
- [ ] Open on tablet (640-1023px) — pill bar should stick below header (56px)
- [ ] Test on notched phone (iPhone) — pills should clear the safe area
- [ ] Verify desktop sidebar nav is unaffected (pill bar is `lg:hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)