### PR TITLE
fix: refine depth gating for citizen-undelegated experience

### DIFF
--- a/components/drep/DelegationImpactPreview.tsx
+++ b/components/drep/DelegationImpactPreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSegment } from '@/components/providers/SegmentProvider';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { Card, CardContent } from '@/components/ui/card';
 import { Vote, FileText, Users } from 'lucide-react';
 
@@ -11,12 +12,16 @@ interface DelegationImpactPreviewProps {
   rationaleRate: number;
   votingPowerAda: number;
   delegatorCount: number;
+  compact?: boolean;
 }
 
 /**
  * Shows undelegated citizens what delegating to this DRep would mean in practice.
  * Hidden for anonymous users (who haven't connected a wallet) and for users
  * who already have a delegation.
+ *
+ * At hands_off depth, renders a compact single-line summary instead of the
+ * full 3-column grid.
  */
 export function DelegationImpactPreview({
   drepName,
@@ -25,11 +30,28 @@ export function DelegationImpactPreview({
   rationaleRate,
   votingPowerAda,
   delegatorCount,
+  compact,
 }: DelegationImpactPreviewProps) {
   const { segment, delegatedDrep } = useSegment();
+  const { isAtLeast } = useGovernanceDepth();
 
   // Only show to citizens who are NOT currently delegated
   if (segment !== 'citizen' || delegatedDrep) return null;
+
+  const isCompact = compact ?? !isAtLeast('informed');
+
+  if (isCompact) {
+    return (
+      <Card className="border-border/50 bg-card/70 backdrop-blur-md py-3">
+        <CardContent className="flex items-center gap-3">
+          <Vote className="h-4 w-4 shrink-0 text-primary/70" />
+          <p className="text-sm text-muted-foreground">
+            Votes on {participationRate}% of proposals &middot; {rationaleRate}% with reasoning
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="border-border/50 bg-card/70 backdrop-blur-md py-4">

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -400,6 +400,13 @@ function ActiveProposalCard({ proposal }: { proposal: ConsequenceProposal }) {
         </div>
       )}
 
+      {/* Depth nudge for connected users at informed (can see bars, can't vote) */}
+      {!hasVoted && connected && !showSentiment && (
+        <p className="text-[10px] text-muted-foreground/60 pt-1">
+          Adjust depth to Engaged to share your view
+        </p>
+      )}
+
       {/* Connect CTA for unconnected users */}
       {!hasVoted && !connected && (
         <Button
@@ -586,6 +593,44 @@ function PoolAndCoverage({
  * SECTION COMPONENTS — each owns its data hooks so DepthGate
  * prevents hook execution when the section is gated out.
  * ══════════════════════════════════════════════════════════════════ */
+
+/* ── Proposal Headlines (hands_off fallback) ─────────────────── */
+
+function ProposalHeadlines() {
+  const { stakeAddress } = useSegment();
+  const { data: consequence } = useEpochConsequence(stakeAddress);
+
+  const decided = consequence?.decidedProposals ?? [];
+  const active = consequence?.activeProposals ?? [];
+  const proposals = [...active, ...decided].slice(0, 2);
+
+  if (proposals.length === 0) return null;
+
+  return (
+    <Section>
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+        Governance activity
+      </h2>
+      <div className="space-y-1.5">
+        {proposals.map((p) => (
+          <Link
+            key={`${p.txHash}:${p.index}`}
+            href={`/proposal/${p.txHash}/${p.index}`}
+            className="block text-sm text-foreground/80 hover:text-primary transition-colors line-clamp-1"
+          >
+            {p.title ?? 'Untitled Proposal'}
+          </Link>
+        ))}
+      </div>
+      <Link
+        href="/governance/proposals"
+        className="mt-2 block text-xs text-primary hover:underline"
+      >
+        See all proposals
+      </Link>
+    </Section>
+  );
+}
 
 /* ── Decided Proposals Section (informed+) ────────────────────── */
 
@@ -1115,14 +1160,25 @@ export function CitizenHub() {
 
       {/* ── Governance Pulse teaser (undelegated citizens only) */}
       {!delegatedDrep && (
-        <GovernancePulse
-          activeProposalCount={consequence?.activeProposals?.length ?? 0}
-          aiHeadline={aiHeadline}
-        />
+        <DepthGate
+          minDepth="informed"
+          fallback={
+            <GovernancePulse
+              activeProposalCount={consequence?.activeProposals?.length ?? 0}
+              aiHeadline={null}
+              compact
+            />
+          }
+        >
+          <GovernancePulse
+            activeProposalCount={consequence?.activeProposals?.length ?? 0}
+            aiHeadline={aiHeadline}
+          />
+        </DepthGate>
       )}
 
-      {/* ── Decided proposals (informed+) ──────────────────── */}
-      <DepthGate minDepth="informed">
+      {/* ── Decided proposals (informed+, headlines fallback for hands_off) */}
+      <DepthGate minDepth="informed" fallback={<ProposalHeadlines />}>
         <DecidedProposalsSection />
       </DepthGate>
 

--- a/components/hub/GovernancePulse.tsx
+++ b/components/hub/GovernancePulse.tsx
@@ -11,6 +11,8 @@ interface GovernancePulseProps {
   activeProposalCount: number;
   /** AI-generated epoch headline, if available */
   aiHeadline: string | null;
+  /** Compact mode — single line, no description or CTA */
+  compact?: boolean;
 }
 
 /**
@@ -20,7 +22,11 @@ interface GovernancePulseProps {
  * to create urgency around delegation. Only rendered when the user has
  * no DRep delegation.
  */
-export function GovernancePulse({ activeProposalCount, aiHeadline }: GovernancePulseProps) {
+export function GovernancePulse({
+  activeProposalCount,
+  aiHeadline,
+  compact,
+}: GovernancePulseProps) {
   const hasActivity = activeProposalCount > 0;
 
   const summaryText = aiHeadline
@@ -36,15 +42,26 @@ export function GovernancePulse({ activeProposalCount, aiHeadline }: GovernanceP
           <div className="flex items-start gap-3">
             <Activity className="mt-0.5 h-4 w-4 shrink-0 text-primary/70" />
             <div className="min-w-0 space-y-1">
-              <p className="text-sm font-medium text-foreground">Governance This Epoch</p>
-              <p className="text-sm text-muted-foreground leading-snug">{summaryText}</p>
-              <Link
-                href="/match"
-                className="inline-flex items-center gap-1 text-xs text-primary hover:underline pt-0.5"
-              >
-                Delegate to get personalized briefings
-                <ArrowRight className="h-3 w-3" />
-              </Link>
+              <p className="text-sm font-medium text-foreground">
+                Governance This Epoch
+                {compact && hasActivity && (
+                  <span className="ml-2 text-muted-foreground font-normal">
+                    &middot; {activeProposalCount} active
+                  </span>
+                )}
+              </p>
+              {!compact && (
+                <>
+                  <p className="text-sm text-muted-foreground leading-snug">{summaryText}</p>
+                  <Link
+                    href="/match"
+                    className="inline-flex items-center gap-1 text-xs text-primary hover:underline pt-0.5"
+                  >
+                    Delegate to get personalized briefings
+                    <ArrowRight className="h-3 w-3" />
+                  </Link>
+                </>
+              )}
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary
- Add `ProposalHeadlines` fallback for hands_off users — shows 1-2 clickable proposal titles instead of hiding governance entirely
- Show compact `GovernancePulse` at hands_off depth (title + active count, no AI headline or CTA)
- Add depth nudge in `ActiveProposalCard` for informed users who can see sentiment bars but can't vote yet
- Add compact mode to `DelegationImpactPreview` at hands_off depth — single-line summary instead of full 3-column grid

## Impact
- **What changed**: Citizens at hands_off depth now see governance activity previews instead of blank sections
- **User-facing**: Yes — hands_off citizens see proposal headlines and compact cards; informed citizens see a nudge to upgrade depth
- **Risk**: Low — additive UI changes with progressive enhancement, no data or API changes
- **Scope**: `CitizenHub.tsx`, `GovernancePulse.tsx`, `DelegationImpactPreview.tsx`

## Test plan
- [ ] View Hub as citizen-undelegated at hands_off depth — verify proposal headlines and compact GovernancePulse appear
- [ ] View Hub at informed depth — verify full GovernancePulse and decided proposals section render
- [ ] View ActiveProposalCard at informed depth while connected — verify depth nudge text appears
- [ ] View DRep profile page at hands_off depth — verify compact DelegationImpactPreview renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)