### PR TITLE
fix: eliminate mobile pill bar gap

### DIFF
--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -213,10 +213,10 @@ export function GovernadaHeader() {
   return (
     <header
       className={cn(
-        'sticky top-0 z-50 hidden sm:block transition-[background-color,border-color,backdrop-filter] duration-300',
+        'sticky top-0 z-50 hidden md:block transition-[background-color,border-color,backdrop-filter] duration-300',
         headerTransparent
           ? 'bg-transparent'
-          : 'border-b border-border/30 bg-background/30 backdrop-blur-xl',
+          : 'border-b border-border/30 bg-background/80 backdrop-blur-xl',
       )}
     >
       <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">

--- a/components/governada/SectionPillBar.tsx
+++ b/components/governada/SectionPillBar.tsx
@@ -24,7 +24,7 @@ export function SectionPillBar({ section: _section }: SectionPillBarProps) {
   if (!items || items.length < 2) return null;
 
   return (
-    <div className="sticky top-0 sm:top-14 z-20 lg:hidden border-b border-border/50 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)] sm:pt-0">
+    <div className="sticky top-0 md:top-14 z-20 lg:hidden border-b border-border/50 bg-background/95 backdrop-blur-xl pt-[env(safe-area-inset-top)] md:pt-0">
       <nav
         className="flex items-center gap-1.5 px-4 py-2 overflow-x-auto scrollbar-none"
         aria-label="Section navigation"


### PR DESCRIPTION
## Summary
- **Header breakpoint** raised from `sm` (640px) to `md` (768px) — hides the transparent header on phones and small tablets where the bottom nav already provides navigation
- **Pill bar offset** updated from `sm:top-14` to `md:top-14` to match, so pills sit flush at `top-0` on mobile
- **Pill bar background** bumped from 80% to 95% opacity to prevent constellation bleed-through on iOS safe-area padding
- **Scrolled header opacity** increased from 30% to 80% so it reads as a proper UI bar on tablets

## Test plan
- [ ] Mobile viewport (< 640px): pill filters flush at top, no gap
- [ ] Small tablet (640-767px): same — no header, pills at top
- [ ] Medium tablet (768px+): header visible with solid backdrop, pills below
- [ ] Desktop (1024px+): sidebar nav, no pill bar, header present
- [ ] iOS Safari: safe-area padding doesn't show constellation through pill bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)