### PR TITLE
fix: remove confidence dampening from calibrated scores + improve DRep experience

### DIFF
--- a/__tests__/scoring/drepScore.test.ts
+++ b/__tests__/scoring/drepScore.test.ts
@@ -371,50 +371,62 @@ describe('computeDRepScores', () => {
     expect(partial.composite).toBeGreaterThan(0);
   });
 
-  // ── Confidence dampening ──
+  // ── Confidence does NOT affect calibrated scores (only tier assignment) ──
 
-  it('dampens low-confidence DRep calibrated scores toward median', () => {
-    // Three DReps: d1 (top, low confidence) should be pulled toward median.
-    // d3 (top, full confidence) should NOT be pulled toward median.
+  it('confidence does not affect composite — same raw scores produce same composite', () => {
+    // Two DReps with identical raw scores but different confidence levels
+    // should produce identical composites (confidence only gates tier, not score).
     const confidences = new Map([
-      ['d1', 50],
-      ['d2', 100],
-      ['d3', 100],
+      ['low_conf', 30],
+      ['high_conf', 100],
     ]);
 
     const results = computeDRepScores(
       new Map([
-        ['d1', 90],
-        ['d2', 50],
-        ['d3', 90],
+        ['low_conf', 90],
+        ['high_conf', 90],
       ]),
       new Map([
-        ['d1', 90],
-        ['d2', 50],
-        ['d3', 90],
+        ['low_conf', 90],
+        ['high_conf', 90],
       ]),
       new Map([
-        ['d1', 90],
-        ['d2', 50],
-        ['d3', 90],
+        ['low_conf', 90],
+        ['high_conf', 90],
       ]),
       new Map([
-        ['d1', 90],
-        ['d2', 50],
-        ['d3', 90],
+        ['low_conf', 90],
+        ['high_conf', 90],
       ]),
       new Map(),
       confidences,
     );
 
-    const d1 = results.get('d1')!;
-    const d3 = results.get('d3')!;
+    const low = results.get('low_conf')!;
+    const high = results.get('high_conf')!;
 
-    // d1 (low confidence) should score lower than d3 (full confidence)
-    // because dampening pulls d1 toward 50
-    expect(d1.composite).toBeLessThan(d3.composite);
-    // d1 should be closer to 50 than d3 is
-    expect(Math.abs(d1.composite - 50)).toBeLessThan(Math.abs(d3.composite - 50));
+    // Same raw scores → same composite, regardless of confidence
+    expect(low.composite).toBe(high.composite);
+    // Confidence is stored for downstream tier cap logic
+    expect(low.confidence).toBe(30);
+    expect(high.confidence).toBe(100);
+  });
+
+  // ── Scoring invariant: excellent DReps can reach 85+ ──
+
+  it('DRep with excellent raw metrics achieves 85+ composite', () => {
+    // Invariant: the scoring model must allow top performers to reach Gold/Diamond.
+    // If this test fails, something is compressing scores artificially.
+    const results = computeDRepScores(
+      new Map([['top', 90]]),
+      new Map([['top', 85]]),
+      new Map([['top', 80]]),
+      new Map([['top', 75]]),
+      new Map(),
+    );
+
+    const top = results.get('top')!;
+    expect(top.composite).toBeGreaterThanOrEqual(85);
   });
 });
 

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -563,6 +563,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           isActive: drep.isActive,
           totalVotes: drep.totalVotes,
           sizeTier: drep.sizeTier,
+          scoreMomentum: drep.scoreMomentum ?? null,
+          endorsementCount: endorsementCount,
         })}
         narrativeAccentColor={getIdentityColor(getDominantDimension(alignments)).hex}
       >

--- a/components/engagement/CitizenEndorsements.tsx
+++ b/components/engagement/CitizenEndorsements.tsx
@@ -4,107 +4,67 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useWallet } from '@/utils/wallet';
 import { getStoredSession } from '@/lib/supabaseAuth';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import {
-  Heart,
-  Info,
-  RefreshCw,
-  RotateCcw,
-  Wallet,
-  Check,
-  Landmark,
-  Code2,
-  MessageSquare,
-  Users,
-} from 'lucide-react';
+import { Heart, RefreshCw, Wallet, Check } from 'lucide-react';
 import { hapticLight } from '@/lib/haptics';
 import { useEndorsements, type EndorsementResults } from '@/hooks/useEngagement';
 import type { EndorsementType } from '@/lib/api/schemas/engagement';
 
-const ENDORSEMENT_CONFIG: {
-  type: EndorsementType;
-  label: string;
-  icon: typeof Heart;
-  tooltip: string;
-}[] = [
-  {
-    type: 'general',
-    label: 'General',
-    icon: Heart,
-    tooltip: 'Overall trust and confidence in this representative',
-  },
-  {
-    type: 'treasury_oversight',
-    label: 'Treasury',
-    icon: Landmark,
-    tooltip: 'Trust in their judgment on treasury spending proposals',
-  },
-  {
-    type: 'technical_expertise',
-    label: 'Technical',
-    icon: Code2,
-    tooltip: 'Trust in their ability to evaluate technical protocol changes',
-  },
-  {
-    type: 'communication',
-    label: 'Communication',
-    icon: MessageSquare,
-    tooltip: 'Recognition of clear, consistent communication with delegators',
-  },
-  {
-    type: 'community_leadership',
-    label: 'Community',
-    icon: Users,
-    tooltip: 'Recognition of community engagement and accessibility',
-  },
-];
-
 interface CitizenEndorsementsProps {
   entityType: 'drep' | 'spo';
   entityId: string;
+  /** Compact inline mode (no card wrapper) */
+  inline?: boolean;
 }
 
-export function CitizenEndorsements({ entityType, entityId }: CitizenEndorsementsProps) {
+/**
+ * Citizen Trust Signal — simplified from 5 categories to a single toggle.
+ * Uses 'general' endorsement type. Total count includes all legacy types for continuity.
+ */
+export function CitizenEndorsements({ entityType, entityId, inline }: CitizenEndorsementsProps) {
   const { connected, isAuthenticated, authenticate } = useWallet();
   const queryClient = useQueryClient();
   const { data: results, isLoading, isError, refetch } = useEndorsements(entityType, entityId);
 
-  const [toggling, setToggling] = useState<string | null>(null);
+  const [toggling, setToggling] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const queryKey = ['endorsements', entityType, entityId];
+  const endorsementType: EndorsementType = 'general';
 
-  const toggleEndorsement = async (endorsementType: EndorsementType) => {
+  const toggleTrust = async () => {
     hapticLight();
     if (!isAuthenticated) {
       const ok = await authenticate();
       if (!ok) return;
     }
 
-    setToggling(endorsementType);
+    setToggling(true);
     setError(null);
 
-    // Optimistic update
     const previousData = queryClient.getQueryData<EndorsementResults>(queryKey);
     queryClient.setQueryData<EndorsementResults>(queryKey, (old) => {
       if (!old) return old;
       const isRemoving = old.userEndorsements.includes(endorsementType);
       const newByType = { ...old.byType };
-      let newUserEndorsements: string[];
 
       if (isRemoving) {
         newByType[endorsementType] = Math.max(0, (newByType[endorsementType] || 0) - 1);
-        newUserEndorsements = old.userEndorsements.filter((t) => t !== endorsementType);
+        return {
+          ...old,
+          byType: newByType,
+          total: Object.values(newByType).reduce((s, n) => s + n, 0),
+          userEndorsements: old.userEndorsements.filter((t) => t !== endorsementType),
+        };
       } else {
         newByType[endorsementType] = (newByType[endorsementType] || 0) + 1;
-        newUserEndorsements = [...old.userEndorsements, endorsementType];
+        return {
+          ...old,
+          byType: newByType,
+          total: Object.values(newByType).reduce((s, n) => s + n, 0),
+          userEndorsements: [...old.userEndorsements, endorsementType],
+        };
       }
-
-      const newTotal = Object.values(newByType).reduce((sum, n) => sum + n, 0);
-      return { ...old, byType: newByType, total: newTotal, userEndorsements: newUserEndorsements };
     });
 
     try {
@@ -140,197 +100,85 @@ export function CitizenEndorsements({ entityType, entityId }: CitizenEndorsement
       if (previousData) queryClient.setQueryData(queryKey, previousData);
       setError(err instanceof Error ? err.message : 'Endorsement failed');
     } finally {
-      setToggling(null);
+      setToggling(false);
     }
   };
 
-  if (isLoading) {
-    return (
-      <Card className="ring-1 ring-border/50">
-        <CardHeader className="pb-2">
-          <Skeleton className="h-4 w-36" />
-        </CardHeader>
-        <CardContent className="space-y-2">
-          <Skeleton className="h-4 w-48" />
-          <div className="flex flex-wrap gap-1.5">
-            {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-8 w-24 rounded-full" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (isError) {
-    return (
-      <Card className="ring-1 ring-border/50">
-        <CardContent className="py-4 text-center space-y-2">
-          <p className="text-xs text-muted-foreground">Couldn&apos;t load endorsements</p>
-          <Button variant="outline" size="sm" onClick={() => refetch()}>
-            <RotateCcw className="mr-1.5 h-3 w-3" />
-            Try again
-          </Button>
-        </CardContent>
-      </Card>
-    );
-  }
-
   const total = results?.total ?? 0;
-  const byType = results?.byType ?? {};
   const userEndorsements = new Set(results?.userEndorsements ?? []);
-  const hasEndorsed = userEndorsements.size > 0;
+  const hasTrusted = userEndorsements.has(endorsementType);
+  const entityLabel = entityType === 'drep' ? 'DRep' : 'pool';
+
+  if (isLoading) {
+    return inline ? (
+      <Skeleton className="h-8 w-32 rounded-full" />
+    ) : (
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-8 w-32 rounded-full" />
+        <Skeleton className="h-4 w-20" />
+      </div>
+    );
+  }
+
+  if (isError) return null;
+
+  const trustButton = (
+    <button
+      onClick={
+        connected ? toggleTrust : () => window.dispatchEvent(new CustomEvent('openWalletConnect'))
+      }
+      disabled={toggling}
+      aria-pressed={hasTrusted}
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-150 border
+        motion-safe:hover:scale-[1.03] motion-safe:active:scale-[0.97]
+        ${
+          hasTrusted
+            ? 'bg-primary/10 border-primary/30 text-primary'
+            : 'bg-transparent border-border/60 text-muted-foreground hover:border-primary/30 hover:text-foreground'
+        }
+      `}
+    >
+      {toggling ? (
+        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+      ) : hasTrusted ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : connected ? (
+        <Heart className="h-3.5 w-3.5" />
+      ) : (
+        <Wallet className="h-3.5 w-3.5" />
+      )}
+      {hasTrusted ? 'Trusted' : connected ? 'I Trust' : 'Connect to Trust'}
+      {total > 0 && <span className="ml-0.5 tabular-nums opacity-70">{total}</span>}
+    </button>
+  );
+
+  if (inline) {
+    return (
+      <div className="flex items-center gap-2">
+        {trustButton}
+        {total > 0 && !inline && (
+          <span className="text-xs text-muted-foreground">
+            {total} citizen{total !== 1 ? 's' : ''} trust this {entityLabel}
+            {hasTrusted && <span className="text-primary"> — including you</span>}
+          </span>
+        )}
+        {error && <span className="text-xs text-destructive">{error}</span>}
+      </div>
+    );
+  }
 
   return (
-    <Card className="ring-1 ring-border/50">
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm flex items-center gap-1.5 text-muted-foreground font-medium">
-            <Heart className="h-3.5 w-3.5" />
-            Citizen Endorsements
-          </CardTitle>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
-              </TooltipTrigger>
-              <TooltipContent side="left" className="max-w-[240px]">
-                <p className="text-xs">
-                  Endorse this {entityType === 'drep' ? 'DRep' : 'SPO'} to signal your trust.
-                  Endorsements are social proof alongside the algorithmic score.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-3">
-        {/* Intro line */}
-        <p className="text-xs text-muted-foreground leading-relaxed">
-          Endorsements signal trust in specific governance competencies, complementing the
-          algorithmic score with social proof.
-        </p>
-
-        {/* Summary line */}
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2 flex-wrap">
+        {trustButton}
         {total > 0 && (
-          <p className="text-xs text-muted-foreground">
-            Endorsed by <span className="font-medium text-foreground tabular-nums">{total}</span>{' '}
-            citizen
-            {total !== 1 ? 's' : ''}
-            {hasEndorsed && <span className="text-primary"> (including you)</span>}
-          </p>
+          <span className="text-xs text-muted-foreground">
+            {total} citizen{total !== 1 ? 's' : ''} trust this {entityLabel}
+            {hasTrusted && <span className="text-primary"> — including you</span>}
+          </span>
         )}
-
-        {total === 0 && !connected && (
-          <p className="text-xs text-muted-foreground">
-            No endorsements yet. Be the first to endorse.
-          </p>
-        )}
-
-        {/* Endorsement type pills */}
-        {connected && (
-          <div
-            className="flex flex-wrap gap-1.5"
-            role="group"
-            aria-label={`Endorse this ${entityType === 'drep' ? 'DRep' : 'SPO'}`}
-          >
-            {ENDORSEMENT_CONFIG.map(({ type, label, icon: Icon, tooltip }) => {
-              const isActive = userEndorsements.has(type);
-              const count = byType[type] || 0;
-              const isCurrentlyToggling = toggling === type;
-
-              return (
-                <TooltipProvider key={type}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={() => toggleEndorsement(type)}
-                        disabled={toggling !== null}
-                        aria-pressed={isActive}
-                        className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1.5 text-xs font-medium transition-all duration-150 border
-                          motion-safe:hover:scale-[1.03] motion-safe:active:scale-[0.97]
-                          ${
-                            isActive
-                              ? 'bg-primary/10 border-primary/30 text-primary'
-                              : 'bg-transparent border-border/60 text-muted-foreground hover:border-primary/30 hover:text-foreground'
-                          }
-                          ${toggling !== null && !isCurrentlyToggling ? 'opacity-50' : ''}
-                        `}
-                      >
-                        {isCurrentlyToggling ? (
-                          <RefreshCw className="h-3 w-3 animate-spin" />
-                        ) : isActive ? (
-                          <Check className="h-3 w-3" />
-                        ) : (
-                          <Icon className="h-3 w-3" />
-                        )}
-                        {label}
-                        {count > 0 && (
-                          <span className="ml-0.5 tabular-nums opacity-70">{count}</span>
-                        )}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="max-w-[220px]">
-                      <p className="text-xs">{tooltip}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              );
-            })}
-          </div>
-        )}
-
-        {/* CTA for unconnected users */}
-        {!connected && (
-          <div className="relative">
-            <div className="opacity-30 pointer-events-none blur-[1px]">
-              <div className="flex flex-wrap gap-1.5">
-                {ENDORSEMENT_CONFIG.map(({ type, label, icon: Icon }) => (
-                  <span
-                    key={type}
-                    className="inline-flex items-center gap-1 rounded-full px-2.5 py-1.5 text-xs border border-border/60"
-                  >
-                    <Icon className="h-3 w-3" />
-                    {label}
-                  </span>
-                ))}
-              </div>
-            </div>
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5">
-              <Button
-                size="sm"
-                variant="outline"
-                className="gap-1.5 h-7 text-xs"
-                onClick={() => {
-                  const event = new CustomEvent('openWalletConnect');
-                  window.dispatchEvent(event);
-                }}
-              >
-                <Wallet className="h-3 w-3" />
-                Connect to Endorse
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Type breakdown when there are endorsements and user is not connected */}
-        {total > 0 && !connected && (
-          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
-            {ENDORSEMENT_CONFIG.filter(({ type }) => (byType[type] || 0) > 0).map(
-              ({ type, label }) => (
-                <span key={type}>
-                  {byType[type]} {label.toLowerCase()}
-                </span>
-              ),
-            )}
-          </div>
-        )}
-
-        <div aria-live="polite" role="status">
-          {error && <p className="text-xs text-destructive">{error}</p>}
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
   );
 }

--- a/components/governada/discover/GovernadaDRepBrowse.tsx
+++ b/components/governada/discover/GovernadaDRepBrowse.tsx
@@ -338,6 +338,18 @@ function YourDRepSummary({ dreps }: { dreps: EnrichedDRep[] }) {
           </Button>
         </div>
       )}
+      {/* Score health nudge for hands-off users */}
+      {yourDrep && yourDrep.drepScore != null && yourDrep.drepScore < 40 && (
+        <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 space-y-1.5">
+          <p className="text-xs text-amber-400/90">
+            Your representative&apos;s governance score is {yourDrep.drepScore}/100 — below average.
+            A low score means less participation, fewer explanations, or inconsistent voting.
+          </p>
+          <Button variant="outline" size="sm" asChild className="h-7 text-xs">
+            <Link href="/match">Explore alternatives &rarr;</Link>
+          </Button>
+        </div>
+      )}
       <p className="text-xs text-muted-foreground/60">
         {dreps.length > 0 ? `${dreps.length} DReps registered` : ''}
       </p>
@@ -628,20 +640,27 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
       {/* ── Content ──────────────────────────────────────────────── */}
       {isInformedOnly ? (
         /* Informed: top DReps by score, compact card grid, no filters */
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {activeItems.slice(0, 12).map((drep, i) => (
-            <div
-              key={drep.drepId}
-              className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
-              style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
-            >
-              <GovernadaDRepCard
-                drep={drep}
-                rank={i + 1}
-                endorsementCount={endorsementCounts[drep.drepId]}
-              />
-            </div>
-          ))}
+        <div className="space-y-4">
+          <p className="text-xs text-muted-foreground leading-relaxed max-w-lg">
+            Scores reflect participation, rationale quality, reliability, and profile completeness.
+            Higher is better — Gold (70+) and Diamond (85+) DReps are the most engaged voices in
+            governance.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {activeItems.slice(0, 12).map((drep, i) => (
+              <div
+                key={drep.drepId}
+                className="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-backwards"
+                style={{ animationDelay: `${Math.min(i, 11) * 30}ms` }}
+              >
+                <GovernadaDRepCard
+                  drep={drep}
+                  rank={i + 1}
+                  endorsementCount={endorsementCounts[drep.drepId]}
+                />
+              </div>
+            ))}
+          </div>
         </div>
       ) : pageItems.length === 0 && inactiveItems.length === 0 ? (
         <div className="py-16 text-center space-y-2">

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1508,6 +1508,8 @@ export async function getDRepRank(drepId: string): Promise<number | null> {
 
 /**
  * Returns epoch-by-epoch delegation power snapshots for a DRep.
+ * Reads from drep_power_snapshots (populated by secondary sync with fresh Koios data)
+ * rather than delegation_snapshots (which used stale DB counts).
  */
 export async function getDRepDelegationTrend(
   drepId: string,
@@ -1515,14 +1517,14 @@ export async function getDRepDelegationTrend(
   try {
     const supabase = createClient();
     const { data } = await supabase
-      .from('delegation_snapshots')
-      .select('epoch, total_power_lovelace, delegator_count')
+      .from('drep_power_snapshots')
+      .select('epoch_no, amount_lovelace, delegator_count')
       .eq('drep_id', drepId)
-      .order('epoch', { ascending: true })
+      .order('epoch_no', { ascending: true })
       .limit(30);
     return (data ?? []).map((s) => ({
-      epoch: s.epoch,
-      votingPowerAda: Math.round(Number(s.total_power_lovelace) / 1_000_000),
+      epoch: s.epoch_no,
+      votingPowerAda: Math.round(Number(s.amount_lovelace) / 1_000_000),
       delegatorCount: s.delegator_count ?? 0,
     }));
   } catch (err) {

--- a/lib/narratives.ts
+++ b/lib/narratives.ts
@@ -37,14 +37,6 @@ function participationWord(rate: number): string {
   return 'relatively few proposals';
 }
 
-function rationaleWord(rate: number): string {
-  if (rate >= 90) return 'always explains their reasoning';
-  if (rate >= 70) return 'regularly provides reasoning';
-  if (rate >= 40) return 'sometimes explains their votes';
-  if (rate > 0) return 'occasionally provides reasoning';
-  return 'has not yet published vote rationale';
-}
-
 function trendWord(delta: number): string {
   if (delta > 10) return 'surging';
   if (delta > 3) return 'climbing';
@@ -71,6 +63,12 @@ export interface DRepNarrativeData {
   isActive: boolean;
   totalVotes: number;
   sizeTier: string;
+  /** Optional: total active DReps for rank context */
+  totalActiveDReps?: number;
+  /** Optional: score momentum for trajectory */
+  scoreMomentum?: number | null;
+  /** Optional: endorsement count for social proof */
+  endorsementCount?: number;
 }
 
 /**
@@ -110,46 +108,76 @@ Output only the 2-sentence profile. No quotation marks, no preamble.`;
 
 export function generateDRepNarrative(data: DRepNarrativeData): string | null {
   if (!data.isActive && data.totalVotes === 0) {
-    return `${data.name} is registered but hasn't participated in governance yet — their story is just beginning.`;
+    return `Registered as a DRep but hasn't cast a vote yet. Their governance record is a blank slate — check back once they start participating.`;
   }
 
   if (!data.isActive) {
-    return `${data.name} is currently inactive in governance. They previously voted on ${data.totalVotes} proposal${data.totalVotes !== 1 ? 's' : ''} and have ${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''} representing ${formatAdaCompact(data.votingPower)} ADA.`;
+    return `Currently inactive. Previously voted on ${data.totalVotes} proposal${data.totalVotes !== 1 ? 's' : ''} with ${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''} representing ${formatAdaCompact(data.votingPower)} ADA. Inactive DReps can't vote on your behalf.`;
   }
 
   const dominant = getDominantDimension(data.alignments);
   const dominantLabel = getDimensionLabel(dominant).toLowerCase();
+  const tier = computeTier(data.drepScore);
   const parts: string[] = [];
 
-  const focusIntro = pick([
-    `A ${dominantLabel}-focused DRep who votes on ${participationWord(data.participationRate)}`,
-    `With a focus on ${dominantLabel}, ${data.name} votes on ${participationWord(data.participationRate)}`,
-    `${data.name} brings a ${dominantLabel} perspective and votes on ${participationWord(data.participationRate)}`,
-  ]);
+  // Sentence 1: Thesis — what kind of participant are they?
+  const pRate = Math.round(data.participationRate);
+  const rRate = Math.round(data.rationaleRate);
 
-  parts.push(`${focusIntro} and ${rationaleWord(data.rationaleRate)}.`);
-
-  const contextParts: string[] = [];
-  if (data.rank && data.rank <= 20) {
-    contextParts.push(`Ranked #${data.rank}`);
-  }
-  if (data.delegatorCount > 0) {
-    contextParts.push(
-      `${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''}`,
+  if (pRate >= 80 && rRate >= 70) {
+    parts.push(
+      `Votes on ${_pct(data.participationRate)} of proposals and explains their reasoning ${_pct(data.rationaleRate)} of the time — a ${dominantLabel} advocate who shows up and does the work.`,
+    );
+  } else if (pRate >= 60) {
+    parts.push(
+      `Votes on ${_pct(data.participationRate)} of proposals${rRate >= 40 ? ` with rationale ${_pct(data.rationaleRate)} of the time` : ' but rarely explains their reasoning'}. Leans toward ${dominantLabel}.`,
+    );
+  } else {
+    parts.push(
+      `Has voted on ${_pct(data.participationRate)} of proposals${data.totalVotes > 0 ? ` (${data.totalVotes} total)` : ''}. ${rRate > 0 ? `Provides reasoning ${_pct(data.rationaleRate)} of the time.` : 'Has not published vote rationale yet.'}`,
     );
   }
-  if (data.votingPower > 0) {
-    contextParts.push(`${formatAdaCompact(data.votingPower)} ADA delegated`);
+
+  // Sentence 2: Context — rank, trajectory, social proof
+  const contextBits: string[] = [];
+
+  // Rank context (specific, not vague)
+  if (data.rank && data.totalActiveDReps && data.totalActiveDReps > 0) {
+    const topPct = Math.max(1, Math.round((data.rank / data.totalActiveDReps) * 100));
+    if (topPct <= 10) {
+      contextBits.push(`top ${topPct}% of active DReps`);
+    } else if (topPct <= 25) {
+      contextBits.push(`ranked #${data.rank} of ${data.totalActiveDReps}`);
+    }
+  } else if (data.rank && data.rank <= 20) {
+    contextBits.push(`ranked #${data.rank}`);
   }
 
-  if (contextParts.length > 0) {
-    const sizeComment =
-      data.sizeTier === 'Whale'
-        ? ' — one of the largest voices in governance'
-        : data.sizeTier === 'Large'
-          ? ' — a significant voice in governance'
-          : '';
-    parts.push(`${contextParts.join(' · ')}${sizeComment}.`);
+  // Trajectory
+  if (data.scoreMomentum && Math.abs(data.scoreMomentum) > 0.5) {
+    contextBits.push(data.scoreMomentum > 0 ? 'score trending up' : 'score trending down');
+  }
+
+  // Social proof
+  if (data.endorsementCount && data.endorsementCount >= 3) {
+    contextBits.push(`trusted by ${data.endorsementCount} citizens`);
+  }
+
+  // Delegation size
+  if (data.delegatorCount > 0) {
+    contextBits.push(
+      `${data.delegatorCount.toLocaleString()} delegator${data.delegatorCount !== 1 ? 's' : ''} · ${formatAdaCompact(data.votingPower)} ADA`,
+    );
+  }
+
+  if (contextBits.length > 0) {
+    const tierPrefix =
+      tier === 'Gold' || tier === 'Diamond' || tier === 'Legendary' ? `${tier}-tier` : '';
+    if (tierPrefix) {
+      parts.push(`${tierPrefix}: ${contextBits.join(', ')}.`);
+    } else {
+      parts.push(`${contextBits.join(', ').replace(/^./, (c) => c.toUpperCase())}.`);
+    }
   }
 
   return parts.join(' ');

--- a/lib/scoring/drepScore.ts
+++ b/lib/scoring/drepScore.ts
@@ -5,12 +5,11 @@
  * piecewise linear curves. Your actions = your score, independent of
  * how other DReps perform.
  *
- * Confidence dampening still applies to calibrated scores for low-data DReps.
+ * Confidence gates tier assignment (via getDRepTierCap), NOT score magnitude.
  * Momentum is computed from score history via simple linear regression.
  */
 
 import { PILLAR_WEIGHTS, type DRepScoreResult } from './types';
-import { dampenPercentile } from './confidence';
 import { calibrate, DREP_PILLAR_CALIBRATION } from './calibration';
 
 /**
@@ -51,19 +50,12 @@ export function computeDRepScores(
     const rlRaw = rawReliability.get(drepId) ?? 0;
     const giRaw = rawIdentity.get(drepId) ?? 0;
 
-    let eqCal = dampenPercentile(
-      calibrate(eqRaw, DREP_PILLAR_CALIBRATION.engagementQuality),
-      confidence,
-    );
-    let epCal = dampenPercentile(
-      calibrate(epRaw, DREP_PILLAR_CALIBRATION.effectiveParticipation),
-      confidence,
-    );
-    let rlCal = dampenPercentile(calibrate(rlRaw, DREP_PILLAR_CALIBRATION.reliability), confidence);
-    const giCal = dampenPercentile(
-      calibrate(giRaw, DREP_PILLAR_CALIBRATION.governanceIdentity),
-      confidence,
-    );
+    // Absolute calibration — no confidence dampening on quality scores.
+    // Confidence only gates tier assignment (via getDRepTierCap).
+    let eqCal = Math.round(calibrate(eqRaw, DREP_PILLAR_CALIBRATION.engagementQuality));
+    let epCal = Math.round(calibrate(epRaw, DREP_PILLAR_CALIBRATION.effectiveParticipation));
+    let rlCal = Math.round(calibrate(rlRaw, DREP_PILLAR_CALIBRATION.reliability));
+    const giCal = Math.round(calibrate(giRaw, DREP_PILLAR_CALIBRATION.governanceIdentity));
 
     // Zero-activity override: when ALL three activity pillars have raw score 0,
     // the DRep has never participated in governance. Force calibrated scores

--- a/lib/scoring/spoScore.ts
+++ b/lib/scoring/spoScore.ts
@@ -4,7 +4,6 @@
  * Absolute calibrated scoring (not percentile), proposal-aware reliability, 30-day momentum.
  */
 
-import { dampenPercentile } from './confidence';
 import { DECAY_LAMBDA } from './types';
 import {
   SPO_PILLAR_WEIGHTS as _SPO_WEIGHTS,
@@ -97,14 +96,12 @@ export function computeSpoScores(
     const rlRaw = reliabilityRawMap.get(poolId) ?? 0;
     const giRaw = identityScores.get(poolId) ?? 0;
 
-    // Absolute calibrated scoring — your actions = your score
-    let pCal = dampenPercentile(calibrate(pRaw, SPO_PILLAR_CALIBRATION.participation), confidence);
-    let dCal = dampenPercentile(calibrate(dRaw, SPO_PILLAR_CALIBRATION.deliberation), confidence);
-    let rlCal = dampenPercentile(calibrate(rlRaw, SPO_PILLAR_CALIBRATION.reliability), confidence);
-    const giCal = dampenPercentile(
-      calibrate(giRaw, SPO_PILLAR_CALIBRATION.governanceIdentity),
-      confidence,
-    );
+    // Absolute calibration — no confidence dampening on quality scores.
+    // Confidence only gates tier assignment (via CONFIDENCE_TIER_THRESHOLD).
+    let pCal = Math.round(calibrate(pRaw, SPO_PILLAR_CALIBRATION.participation));
+    let dCal = Math.round(calibrate(dRaw, SPO_PILLAR_CALIBRATION.deliberation));
+    let rlCal = Math.round(calibrate(rlRaw, SPO_PILLAR_CALIBRATION.reliability));
+    const giCal = Math.round(calibrate(giRaw, SPO_PILLAR_CALIBRATION.governanceIdentity));
 
     // Zero-activity override: if all 3 activity pillars have raw 0, force calibrated to 0
     if (pRaw === 0 && dRaw === 0 && rlRaw === 0) {

--- a/lib/sync/secondary.ts
+++ b/lib/sync/secondary.ts
@@ -24,8 +24,9 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
     let integritySaved = 0;
 
     try {
-      const results = await Promise.allSettled([
-        // Step 1: Delegator counts
+      // Step 1: Delegator counts — must complete BEFORE power snapshots
+      // so that drep_power_snapshots have fresh Koios delegator counts.
+      const step1Result = await Promise.allSettled([
         (async () => {
           const { data: dreps } = await supabase
             .from('dreps')
@@ -62,8 +63,17 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
           }
           return updated;
         })(),
+      ]);
 
-        // Step 2: Power snapshots (includes delegator_count for Governance Identity pillar)
+      if (step1Result[0].status === 'fulfilled') {
+        delegatorsUpdated = step1Result[0].value;
+      } else {
+        errors.push(`Delegators: ${errMsg(step1Result[0].reason)}`);
+      }
+
+      // Step 2 + 3: Power snapshots (reads fresh delegator counts) + Integrity — parallel
+      const results = await Promise.allSettled([
+        // Step 2: Power snapshots (reads fresh delegator counts written by Step 1)
         (async () => {
           const { data: dreps } = await supabase
             .from('dreps')
@@ -94,7 +104,7 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
             const batch = rows.slice(i, i + BATCH_SIZE);
             const { error: batchErr } = await supabase
               .from('drep_power_snapshots')
-              .upsert(batch, { onConflict: 'drep_id,epoch_no', ignoreDuplicates: true });
+              .upsert(batch, { onConflict: 'drep_id,epoch_no' });
             if (batchErr)
               logger.error('[Secondary] power_snapshots batch upsert error', {
                 error: batchErr.message,
@@ -156,14 +166,13 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
 
       results.forEach((r, i) => {
         if (r.status === 'rejected') {
-          const label = ['Delegators', 'Power snapshots', 'Integrity'][i];
+          const label = ['Power snapshots', 'Integrity'][i];
           errors.push(`${label}: ${errMsg(r.reason)}`);
         }
       });
 
-      if (results[0].status === 'fulfilled') delegatorsUpdated = results[0].value;
-      if (results[1].status === 'fulfilled') powerSnapshots = results[1].value;
-      if (results[2].status === 'fulfilled') integritySaved = results[2].value;
+      if (results[0].status === 'fulfilled') powerSnapshots = results[0].value;
+      if (results[1].status === 'fulfilled') integritySaved = results[1].value;
     } catch (err) {
       errors.push(`Unhandled: ${errMsg(err)}`);
     }


### PR DESCRIPTION
## Summary
- **P0 scoring fix**: Removed `dampenPercentile` from absolute calibrated scores in both DRep and SPO scoring. Confidence was pulling scores toward median 50, compressing top DRep scores to ~67 (should be 85+) and SPO scores to ~47. Confidence now only gates tier assignment, not score magnitude.
- **Delegation momentum fix**: Switched `getDRepDelegationTrend` to read from `drep_power_snapshots` (fresh Koios data) instead of stale `delegation_snapshots`. Fixed secondary sync to complete delegator count fetch before power snapshot upsert.
- **Endorsements simplification**: Replaced 5-category endorsement pill system with single "I Trust" toggle using `general` type. Backward-compatible with all legacy endorsement types.
- **Narrative rewrite**: Thesis-style DRep narratives with score context, trajectory signals, and social proof.
- **Depth-level UX**: Added score context paragraph for `informed` level and low-score health nudge for `hands_off` citizens on DRep browse page.

## Impact
- **What changed**: Scoring engine produces correct scores (uncompressed by confidence), delegation trend data is fresh, endorsements are simplified, narratives are persona-aware
- **User-facing**: Yes — DRep/SPO scores will increase to correct values after resync, delegation trajectory will show data, trust signal is clearer
- **Risk**: Medium — scoring change affects all DRep/SPO scores (intentional fix). Sync pipeline change affects data freshness. All other changes are UI-only.
- **Scope**: `lib/scoring/drepScore.ts`, `lib/scoring/spoScore.ts`, `lib/data.ts`, `lib/sync/secondary.ts`, `lib/narratives.ts`, `components/engagement/CitizenEndorsements.tsx`, `components/governada/discover/GovernadaDRepBrowse.tsx`, `app/drep/[drepId]/page.tsx`, `__tests__/scoring/drepScore.test.ts`

## Test plan
- [x] Preflight passes (format, lint, types, 614 tests)
- [x] New invariant test: confidence doesn't affect composite scores
- [x] New invariant test: excellent raw metrics produce 85+ composite
- [ ] Post-merge: trigger scoring resync, verify top DRep scores reach 80-90+ range
- [ ] Post-merge: verify TrajectoryCard shows delegation data on DRep profiles
- [ ] Post-merge: verify endorsement toggle works on DRep/SPO profiles
- [ ] Smoke test production endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)