### PR TITLE
feat: redesign proposal detail page UX

### DIFF
--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -5,7 +5,6 @@ import { blockTimeToEpoch } from '@/lib/koios';
 import { getTreasuryBalance, getNclUtilization } from '@/lib/treasury';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ProposalDescription } from '@/components/ProposalDescription';
-import { ThresholdMeter } from '@/components/ThresholdMeter';
 import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { getProposalStatus } from '@/utils/proposalPriority';
 import { ProposalOutcomeSection } from '@/components/ProposalOutcomeSection';
@@ -18,13 +17,12 @@ import { ProposalLifecycleTimeline } from '@/components/governada/proposals/Prop
 import { ImpactTags } from '@/components/engagement/ImpactTags';
 import { EngagementSummary } from '@/components/engagement/EngagementSummary';
 import { ConcernFlagBanner } from '@/components/engagement/ConcernFlagBanner';
-import { ProposalSentimentSection } from '@/components/engagement/ProposalSentimentSection';
-import { ConcernFlagsSection } from '@/components/engagement/ConcernFlagsSection';
 import { ProposalHeroV2 } from '@/components/governada/proposals/ProposalHeroV2';
 import { WatchEntityButton } from '@/components/WatchEntityButton';
 import { IntelligenceBriefing } from '@/components/governada/proposals/IntelligenceBriefing';
 import { DebateSection } from '@/components/governada/proposals/DebateSection';
-import { ActionPanel } from '@/components/governada/proposals/ActionPanel';
+import { ProposalActionZone } from '@/components/governada/proposals/ProposalActionZone';
+import { ProposalDepthGate } from '@/components/governada/proposals/ProposalDepthGate';
 
 export const dynamic = 'force-dynamic';
 
@@ -171,10 +169,14 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         triBody={proposal.triBody ?? null}
         blockTime={proposal.blockTime}
         nclUtilization={nclUtilization}
+        yesCount={proposal.yesCount}
+        noCount={proposal.noCount}
+        abstainCount={proposal.abstainCount}
+        totalVotes={proposal.totalVotes}
       />
 
-      {/* Zone 2: Take Action — vote flow + citizen voice side by side */}
-      <ActionPanel
+      {/* Zone 2: Primary Action — persona-branching (DRep/SPO vote flow vs citizen engagement) */}
+      <ProposalActionZone
         txHash={txHash}
         proposalIndex={proposalIndex}
         title={title}
@@ -184,7 +186,24 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         aiSummary={proposal.aiSummary}
       />
 
-      {/* Zone 3: Community Signals — engagement, concerns, dimension tags */}
+      {/* Zone 3: Intelligence Briefing — AI summary + constitutional + params */}
+      <IntelligenceBriefing
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+        aiSummary={proposal.aiSummary}
+        proposalType={proposal.proposalType}
+        paramChanges={proposal.paramChanges}
+      />
+
+      {/* Zone 4: The Debate — elevated for prominence, social sharing per rationale */}
+      <DebateSection
+        rationales={rationaleEntries}
+        proposalTitle={title}
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+      />
+
+      {/* Zone 5: Community Signals — read-only engagement, concerns, dimension tags */}
       <div className="space-y-4">
         <EngagementSummary txHash={txHash} proposalIndex={proposalIndex} />
         <ConcernFlagBanner
@@ -200,26 +219,10 @@ export default async function ProposalDetailPage({ params }: PageProps) {
                   : null
           }
         />
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <ProposalSentimentSection txHash={txHash} proposalIndex={proposalIndex} isOpen={isOpen} />
-          <ConcernFlagsSection txHash={txHash} proposalIndex={proposalIndex} isOpen={isOpen} />
-        </div>
         <ProposalDimensionTags relevantPrefs={proposal.relevantPrefs} />
       </div>
 
-      {/* Zone 4: Intelligence Briefing — AI summary + constitutional + params merged */}
-      <IntelligenceBriefing
-        txHash={txHash}
-        proposalIndex={proposalIndex}
-        aiSummary={proposal.aiSummary}
-        proposalType={proposal.proposalType}
-        paramChanges={proposal.paramChanges}
-      />
-
-      {/* Zone 5: The Debate — structured pro/con rationales */}
-      <DebateSection rationales={rationaleEntries} />
-
-      {/* Zone 6: Deep Dive — timeline, thresholds, adoption, voters, description */}
+      {/* Zone 6: Deep Dive — timeline, adoption, voters, description */}
       <ProposalLifecycleTimeline
         proposedEpoch={proposal.proposedEpoch}
         expirationEpoch={proposal.expirationEpoch}
@@ -230,49 +233,35 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         currentEpoch={currentEpoch}
       />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>DRep Voting Power</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <ThresholdMeter
+      {/* Deep dive sections — gated for anonymous */}
+      <ProposalDepthGate
+        message="Unlock vote analytics, voter details, and similar proposals"
+        surface="deep-dive"
+      >
+        <div className="space-y-6 sm:space-y-8">
+          {adoptionData.length > 1 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Vote Adoption</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <VoteAdoptionCurve votes={adoptionData} />
+              </CardContent>
+            </Card>
+          )}
+
+          <ProposalVoterTabs
+            votes={votes}
             txHash={txHash}
             proposalIndex={proposalIndex}
-            proposalType={proposal.proposalType}
-            yesCount={proposal.yesCount}
-            noCount={proposal.noCount}
-            abstainCount={proposal.abstainCount}
-            totalVotes={proposal.totalVotes}
-            isOpen={isOpen}
-            variant="full"
+            status={status}
           />
-          <p className="text-sm text-muted-foreground text-center">
-            {proposal.totalVotes} DReps voted on this proposal
-          </p>
-        </CardContent>
-      </Card>
 
-      {adoptionData.length > 1 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Vote Adoption</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <VoteAdoptionCurve votes={adoptionData} />
-          </CardContent>
-        </Card>
-      )}
+          <ProposalDescription aiSummary={null} abstract={proposal.abstract} />
 
-      <ProposalVoterTabs
-        votes={votes}
-        txHash={txHash}
-        proposalIndex={proposalIndex}
-        status={status}
-      />
-
-      <ProposalDescription aiSummary={null} abstract={proposal.abstract} />
-
-      <SimilarProposals txHash={txHash} proposalIndex={proposalIndex} />
+          <SimilarProposals txHash={txHash} proposalIndex={proposalIndex} />
+        </div>
+      </ProposalDepthGate>
 
       {!isOpen && (
         <ProposalOutcomeSection

--- a/components/TriBodyVotePanel.tsx
+++ b/components/TriBodyVotePanel.tsx
@@ -4,13 +4,28 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { TriBodyVoteBar } from '@/components/TriBodyVoteBar';
+import { ThresholdMeter } from '@/components/ThresholdMeter';
 import { Users, Server, ShieldCheck, TrendingUp, TrendingDown, Equal } from 'lucide-react';
+import { getVotingBodies, type GovernanceBody } from '@/lib/governance/votingBodies';
 import type { TriBodyVotes } from '@/lib/data';
+
+const BODY_CONFIG: Record<GovernanceBody, { label: string; icon: typeof Users; color: string }> = {
+  drep: { label: 'DReps', icon: Users, color: 'text-primary' },
+  spo: { label: 'SPOs', icon: Server, color: 'text-cyan-500' },
+  cc: { label: 'CC', icon: ShieldCheck, color: 'text-amber-500' },
+};
 
 interface TriBodyVotePanelProps {
   triBody: TriBodyVotes;
   txHash: string;
   proposalIndex: number;
+  proposalType: string;
+  /** DRep vote counts for integrated threshold meter */
+  yesCount?: number;
+  noCount?: number;
+  abstainCount?: number;
+  totalVotes?: number;
+  isOpen?: boolean;
 }
 
 interface AlignmentData {
@@ -72,7 +87,17 @@ function BodyColumn({
   );
 }
 
-export function TriBodyVotePanel({ triBody, txHash, proposalIndex }: TriBodyVotePanelProps) {
+export function TriBodyVotePanel({
+  triBody,
+  txHash,
+  proposalIndex,
+  proposalType,
+  yesCount,
+  noCount,
+  abstainCount,
+  totalVotes,
+  isOpen,
+}: TriBodyVotePanelProps) {
   const [alignment, setAlignment] = useState<AlignmentData | null>(null);
 
   useEffect(() => {
@@ -84,8 +109,11 @@ export function TriBodyVotePanel({ triBody, txHash, proposalIndex }: TriBodyVote
       .catch(() => {});
   }, [txHash, proposalIndex]);
 
-  const hasSpo = triBody.spo.yes + triBody.spo.no + triBody.spo.abstain > 0;
-  const hasCc = triBody.cc.yes + triBody.cc.no + triBody.cc.abstain > 0;
+  const eligibleBodies = getVotingBodies(proposalType);
+  const hasSpo =
+    eligibleBodies.includes('spo') && triBody.spo.yes + triBody.spo.no + triBody.spo.abstain > 0;
+  const hasCc =
+    eligibleBodies.includes('cc') && triBody.cc.yes + triBody.cc.no + triBody.cc.abstain > 0;
 
   const drepMajority =
     triBody.drep.yes >= triBody.drep.no && triBody.drep.yes >= triBody.drep.abstain
@@ -104,18 +132,34 @@ export function TriBodyVotePanel({ triBody, txHash, proposalIndex }: TriBodyVote
   let alignmentCallout: string | null = null;
   if (hasSpo && spoMajority) {
     if (drepMajority === spoMajority) {
-      alignmentCallout = `DReps and SPOs agreed on this proposal — both majority voted ${drepMajority}.`;
+      alignmentCallout = `DReps and SPOs agreed on this proposal \u2014 both majority voted ${drepMajority}.`;
     } else {
-      alignmentCallout = `DReps and SPOs diverged — DReps voted ${drepMajority} while SPOs voted ${spoMajority}.`;
+      alignmentCallout = `DReps and SPOs diverged \u2014 DReps voted ${drepMajority} while SPOs voted ${spoMajority}.`;
     }
   }
+
+  const gridCols =
+    eligibleBodies.length === 1
+      ? 'grid-cols-1'
+      : eligibleBodies.length === 2
+        ? 'grid-cols-2'
+        : 'grid-cols-3';
+
+  const showThreshold =
+    yesCount != null &&
+    noCount != null &&
+    abstainCount != null &&
+    totalVotes != null &&
+    isOpen != null;
 
   return (
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between flex-wrap gap-2">
-          <CardTitle>Tri-Body Governance Votes</CardTitle>
-          {alignment && (
+          <CardTitle>
+            {eligibleBodies.length === 1 ? 'DRep Governance Votes' : 'Governance Votes'}
+          </CardTitle>
+          {alignment && eligibleBodies.length > 1 && (
             <Badge
               variant="outline"
               className={
@@ -146,11 +190,41 @@ export function TriBodyVotePanel({ triBody, txHash, proposalIndex }: TriBodyVote
           cc={hasCc ? triBody.cc : undefined}
         />
 
-        <div className="grid grid-cols-3 gap-3">
-          <BodyColumn label="DReps" icon={Users} color="text-primary" votes={triBody.drep} />
-          <BodyColumn label="SPOs" icon={Server} color="text-cyan-500" votes={triBody.spo} />
-          <BodyColumn label="CC" icon={ShieldCheck} color="text-amber-500" votes={triBody.cc} />
+        <div className={`grid ${gridCols} gap-3`}>
+          {eligibleBodies.map((body) => {
+            const config = BODY_CONFIG[body];
+            return (
+              <BodyColumn
+                key={body}
+                label={config.label}
+                icon={config.icon}
+                color={config.color}
+                votes={triBody[body]}
+              />
+            );
+          })}
         </div>
+
+        {/* Integrated DRep voting power threshold (replaces standalone card) */}
+        {showThreshold && (
+          <div className="pt-2 border-t border-border/50">
+            <p className="text-xs font-medium text-muted-foreground mb-2">DRep Voting Power</p>
+            <ThresholdMeter
+              txHash={txHash}
+              proposalIndex={proposalIndex}
+              proposalType={proposalType}
+              yesCount={yesCount!}
+              noCount={noCount!}
+              abstainCount={abstainCount!}
+              totalVotes={totalVotes!}
+              isOpen={isOpen!}
+              variant="compact"
+            />
+            <p className="text-[10px] text-muted-foreground text-center mt-1.5">
+              {totalVotes} DReps voted on this proposal
+            </p>
+          </div>
+        )}
 
         {alignmentCallout && (
           <div className="rounded-md bg-muted/40 px-3 py-2 text-sm text-muted-foreground">

--- a/components/governada/proposals/CitizenEngagementSection.tsx
+++ b/components/governada/proposals/CitizenEngagementSection.tsx
@@ -1,0 +1,540 @@
+'use client';
+
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useWallet } from '@/utils/wallet';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  BarChart3,
+  CheckCircle2,
+  ThumbsUp,
+  ThumbsDown,
+  HelpCircle,
+  RefreshCw,
+  RotateCcw,
+  AlertTriangle,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { resolveRewardAddress } from '@meshsdk/core';
+import { hapticLight } from '@/lib/haptics';
+import { useSentimentResults, type SentimentResults } from '@/hooks/useEngagement';
+import { useConcernFlags } from '@/hooks/useEngagement';
+import { CONCERN_FLAG_LABELS } from '@/lib/engagement/labels';
+import { AskYourDRep } from '@/components/engagement/AskYourDRep';
+import type { ConcernFlagType } from '@/lib/api/schemas/engagement';
+
+type SentimentChoice = 'support' | 'oppose' | 'unsure';
+
+interface CitizenEngagementSectionProps {
+  txHash: string;
+  proposalIndex: number;
+  proposalTitle: string;
+  isOpen: boolean;
+}
+
+/**
+ * Unified citizen engagement section.
+ * Combines sentiment voting, concern flags, and Ask Your DRep
+ * into a single coherent card with clear context.
+ */
+export function CitizenEngagementSection({
+  txHash,
+  proposalIndex,
+  proposalTitle,
+  isOpen,
+}: CitizenEngagementSectionProps) {
+  const { connected, isAuthenticated, address, delegatedDrepId, ownDRepId, authenticate } =
+    useWallet();
+  const queryClient = useQueryClient();
+
+  const {
+    data: sentimentResults,
+    isLoading: sentimentLoading,
+    isError: sentimentError,
+    refetch: refetchSentiment,
+  } = useSentimentResults(txHash, proposalIndex, ownDRepId);
+
+  const {
+    data: concernResults,
+    isLoading: concernsLoading,
+    refetch: refetchConcerns,
+  } = useConcernFlags(txHash, proposalIndex);
+
+  const [voting, setVoting] = useState(false);
+  const [changingVote, setChangingVote] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [concernsExpanded, setConcernsExpanded] = useState(false);
+  const [submittingFlag, setSubmittingFlag] = useState<string | null>(null);
+
+  const hasVoted = sentimentResults?.hasVoted ?? false;
+  const userSentiment = sentimentResults?.userSentiment ?? null;
+  const sentimentQueryKey = ['citizen-sentiment', txHash, proposalIndex, ownDRepId ?? null];
+  const concernQueryKey = ['concern-flags', txHash, proposalIndex];
+
+  const castVote = async (sentiment: SentimentChoice) => {
+    hapticLight();
+    if (!isAuthenticated) {
+      const ok = await authenticate();
+      if (!ok) return;
+    }
+
+    setVoting(true);
+    setError(null);
+
+    const previousData = queryClient.getQueryData<SentimentResults>(sentimentQueryKey);
+    queryClient.setQueryData<SentimentResults>(sentimentQueryKey, (old) => {
+      if (!old) return old;
+      const prev = old.userSentiment;
+      const community = { ...old.community };
+      if (prev) {
+        community[prev] = Math.max(0, community[prev] - 1);
+        community.total = Math.max(0, community.total - 1);
+      }
+      community[sentiment] = (community[sentiment] ?? 0) + 1;
+      if (!prev) community.total += 1;
+      else community.total += 1;
+      return { ...old, community, userSentiment: sentiment, hasVoted: true };
+    });
+    setChangingVote(false);
+
+    try {
+      const token = getStoredSession();
+      if (!token) throw new Error('Not authenticated');
+
+      let stakeAddress: string | undefined;
+      if (address) {
+        try {
+          stakeAddress = resolveRewardAddress(address);
+        } catch {
+          /* script addresses won't resolve */
+        }
+      }
+
+      const res = await fetch('/api/engagement/sentiment/vote', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          proposalTxHash: txHash,
+          proposalIndex,
+          sentiment,
+          stakeAddress,
+          delegatedDrepId,
+        }),
+      });
+
+      if (res.status === 429) {
+        throw new Error(
+          "You've been active! You've reached the vote limit for this epoch — resets next epoch.",
+        );
+      }
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Vote failed');
+      }
+
+      await refetchSentiment();
+
+      import('@/lib/posthog')
+        .then(({ posthog }) => {
+          posthog.capture('citizen_sentiment_voted', {
+            proposal_tx_hash: txHash,
+            proposal_index: proposalIndex,
+            sentiment,
+          });
+        })
+        .catch(() => {});
+    } catch (err) {
+      if (previousData) queryClient.setQueryData(sentimentQueryKey, previousData);
+      setError(err instanceof Error ? err.message : 'Vote failed');
+    } finally {
+      setVoting(false);
+    }
+  };
+
+  const toggleFlag = async (flagType: ConcernFlagType) => {
+    hapticLight();
+    if (!isAuthenticated) {
+      const ok = await authenticate();
+      if (!ok) return;
+    }
+
+    const token = getStoredSession();
+    if (!token) return;
+
+    const isRemoving = concernResults?.userFlags.includes(flagType);
+    setSubmittingFlag(flagType);
+    setError(null);
+
+    const previousData = queryClient.getQueryData(concernQueryKey);
+    queryClient.setQueryData(concernQueryKey, (old: typeof concernResults) => {
+      if (!old) return old;
+      const flags = { ...old.flags };
+      const userFlags = [...old.userFlags];
+      let total = old.total;
+      if (isRemoving) {
+        flags[flagType] = Math.max(0, (flags[flagType] || 0) - 1);
+        total = Math.max(0, total - 1);
+        const idx = userFlags.indexOf(flagType);
+        if (idx >= 0) userFlags.splice(idx, 1);
+      } else {
+        flags[flagType] = (flags[flagType] || 0) + 1;
+        total += 1;
+        userFlags.push(flagType);
+      }
+      return { ...old, flags, userFlags, total };
+    });
+
+    try {
+      const res = await fetch('/api/engagement/concerns', {
+        method: isRemoving ? 'DELETE' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          proposalTxHash: txHash,
+          proposalIndex,
+          flagType,
+        }),
+      });
+
+      if (res.status === 429) {
+        throw new Error(
+          "You've been active! You've reached the flag limit for this epoch — resets next epoch.",
+        );
+      }
+      if (!res.ok && res.status !== 409) {
+        throw new Error('Failed to update flag');
+      }
+
+      await refetchConcerns();
+
+      import('@/lib/posthog')
+        .then(({ posthog }) => {
+          posthog.capture(isRemoving ? 'citizen_concern_removed' : 'citizen_concern_flagged', {
+            proposal_tx_hash: txHash,
+            proposal_index: proposalIndex,
+            flag_type: flagType,
+          });
+        })
+        .catch(() => {});
+    } catch (err) {
+      if (previousData) queryClient.setQueryData(concernQueryKey, previousData);
+      setError(err instanceof Error ? err.message : 'Failed to update flag');
+    } finally {
+      setSubmittingFlag(null);
+    }
+  };
+
+  if (sentimentLoading) {
+    return (
+      <Card className="ring-1 ring-primary/10">
+        <CardHeader className="pb-3">
+          <Skeleton className="h-5 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-4 w-64" />
+          <div className="flex gap-2">
+            <Skeleton className="h-11 flex-1" />
+            <Skeleton className="h-11 flex-1" />
+            <Skeleton className="h-11 flex-1" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (sentimentError) {
+    return (
+      <Card className="ring-1 ring-primary/10">
+        <CardContent className="py-6 text-center space-y-3">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load engagement data</p>
+          <Button variant="outline" size="sm" onClick={() => refetchSentiment()}>
+            <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const community = sentimentResults?.community ?? { support: 0, oppose: 0, unsure: 0, total: 0 };
+  const showButtons = isOpen && (!hasVoted || changingVote) && connected;
+
+  const flags = concernResults?.flags ?? {};
+  const userFlags = concernResults?.userFlags ?? [];
+  const totalFlags = concernResults?.total ?? 0;
+
+  const sortedFlags = (Object.keys(CONCERN_FLAG_LABELS) as ConcernFlagType[]).sort((a, b) => {
+    const aUser = userFlags.includes(a) ? 1 : 0;
+    const bUser = userFlags.includes(b) ? 1 : 0;
+    if (aUser !== bUser) return bUser - aUser;
+    return (flags[b] || 0) - (flags[a] || 0);
+  });
+
+  const labelMap: Record<SentimentChoice, string> = {
+    support: 'Support',
+    oppose: 'Oppose',
+    unsure: 'Unsure',
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card className="ring-1 ring-primary/10" aria-label="Your voice on this proposal">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base flex items-center gap-2">
+            <BarChart3 className="h-4 w-4 text-primary" aria-hidden="true" />
+            Your Voice on This Proposal
+          </CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">
+            Your opinion helps DReps understand what citizens want.
+            {community.total > 0 && (
+              <span className="font-medium">
+                {' '}
+                {community.total} citizen{community.total !== 1 ? 's' : ''} have shared theirs.
+              </span>
+            )}
+          </p>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {/* Current results */}
+          {community.total > 0 && (
+            <div className="space-y-2">
+              <SentimentBar
+                label="Support"
+                count={community.support}
+                total={community.total}
+                color="bg-green-500"
+              />
+              <SentimentBar
+                label="Oppose"
+                count={community.oppose}
+                total={community.total}
+                color="bg-red-500"
+              />
+              <SentimentBar
+                label="Unsure"
+                count={community.unsure}
+                total={community.total}
+                color="bg-amber-500"
+              />
+            </div>
+          )}
+
+          {/* User's current vote */}
+          {hasVoted && !changingVote && userSentiment && (
+            <div className="flex items-center gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 text-primary shrink-0" />
+              <span>
+                You voted <strong>{labelMap[userSentiment]}</strong>.
+              </span>
+              {isOpen && (
+                <button
+                  onClick={() => setChangingVote(true)}
+                  className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 transition-colors ml-auto"
+                >
+                  Change
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Voting buttons */}
+          {showButtons && (
+            <SentimentButtons
+              onVote={castVote}
+              voting={voting}
+              currentVote={changingVote ? userSentiment : null}
+            />
+          )}
+
+          {/* Prompt for unvoted connected users */}
+          {isOpen && !hasVoted && connected && !showButtons && community.total === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Be the first to share your opinion on this proposal.
+            </p>
+          )}
+
+          {/* Collapsible Concern Flags */}
+          {isOpen && !concernsLoading && (
+            <>
+              <div className="border-t border-border/50" />
+              <div>
+                <button
+                  onClick={() => setConcernsExpanded(!concernsExpanded)}
+                  className="flex items-center justify-between w-full text-sm font-medium text-muted-foreground hover:text-foreground transition-colors py-1"
+                >
+                  <span className="flex items-center gap-2">
+                    <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+                    Flag specific concerns
+                    {totalFlags > 0 && (
+                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                        {totalFlags}
+                      </Badge>
+                    )}
+                  </span>
+                  {concernsExpanded ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                </button>
+
+                {concernsExpanded && (
+                  <div className="pt-3 space-y-2">
+                    <div className="flex flex-wrap gap-2" role="group" aria-label="Flag concerns">
+                      {sortedFlags.map((flagType) => {
+                        const count = flags[flagType] || 0;
+                        const isUserFlag = userFlags.includes(flagType);
+                        const { label, emoji } = CONCERN_FLAG_LABELS[flagType];
+                        const isSubmittingThis = submittingFlag === flagType;
+
+                        return (
+                          <button
+                            key={flagType}
+                            onClick={() => connected && toggleFlag(flagType)}
+                            disabled={!connected || isSubmittingThis}
+                            aria-pressed={isUserFlag}
+                            className={`
+                              inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                              transition-all duration-150 border
+                              ${
+                                isUserFlag
+                                  ? 'bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-300'
+                                  : count > 0
+                                    ? 'bg-muted/50 border-border text-foreground hover:bg-muted'
+                                    : 'bg-transparent border-border/50 text-muted-foreground hover:border-border hover:bg-muted/30'
+                              }
+                              ${connected ? 'cursor-pointer' : 'cursor-default'}
+                              ${isSubmittingThis ? 'opacity-50' : ''}
+                            `}
+                          >
+                            <span>{emoji}</span>
+                            <span>{label}</span>
+                            {count > 0 && (
+                              <span className="ml-0.5 tabular-nums opacity-70">{count}</span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    {totalFlags === 0 && (
+                      <p className="text-xs text-muted-foreground">No concerns flagged yet.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
+
+      {/* Ask Your DRep (separate card, only for delegated citizens) */}
+      {isOpen && (
+        <AskYourDRep txHash={txHash} proposalIndex={proposalIndex} proposalTitle={proposalTitle} />
+      )}
+    </div>
+  );
+}
+
+function SentimentButtons({
+  onVote,
+  voting,
+  currentVote,
+}: {
+  onVote: (vote: SentimentChoice) => void;
+  voting: boolean;
+  currentVote: SentimentChoice | null;
+}) {
+  const buttons: {
+    vote: SentimentChoice;
+    label: string;
+    icon: typeof ThumbsUp;
+    activeClass: string;
+    hoverClass: string;
+  }[] = [
+    {
+      vote: 'support',
+      label: 'Support',
+      icon: ThumbsUp,
+      activeClass: 'bg-green-600 hover:bg-green-700 text-white border-green-600',
+      hoverClass: 'hover:border-green-500/50 hover:bg-green-500/5',
+    },
+    {
+      vote: 'oppose',
+      label: 'Oppose',
+      icon: ThumbsDown,
+      activeClass: 'bg-red-600 hover:bg-red-700 text-white border-red-600',
+      hoverClass: 'hover:border-red-500/50 hover:bg-red-500/5',
+    },
+    {
+      vote: 'unsure',
+      label: 'Unsure',
+      icon: HelpCircle,
+      activeClass: 'bg-amber-600 hover:bg-amber-700 text-white border-amber-600',
+      hoverClass: 'hover:border-amber-500/50 hover:bg-amber-500/5',
+    },
+  ];
+
+  return (
+    <div className="flex gap-2" role="radiogroup" aria-label="Share your sentiment">
+      {buttons.map(({ vote, label, icon: Icon, activeClass, hoverClass }) => (
+        <Button
+          key={vote}
+          variant="outline"
+          role="radio"
+          aria-checked={currentVote === vote}
+          className={`flex-1 gap-1.5 h-11 transition-all duration-150 ${
+            currentVote === vote ? activeClass : hoverClass
+          }`}
+          disabled={voting}
+          onClick={() => onVote(vote)}
+        >
+          {voting ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Icon className="h-4 w-4" />}
+          {label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+function SentimentBar({
+  label,
+  count,
+  total,
+  color,
+}: {
+  label: string;
+  count: number;
+  total: number;
+  color: string;
+}) {
+  const percent = total > 0 ? Math.round((count / total) * 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span>{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {count} ({percent}%)
+        </span>
+      </div>
+      <div className="h-2 rounded-full bg-muted overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color} transition-all duration-700 ease-out`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/governada/proposals/CitizenPulseReadOnly.tsx
+++ b/components/governada/proposals/CitizenPulseReadOnly.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BarChart3, Users } from 'lucide-react';
+import { useWallet } from '@/utils/wallet';
+import { useSentimentResults, useConcernFlags } from '@/hooks/useEngagement';
+import { CONCERN_FLAG_LABELS } from '@/lib/engagement/labels';
+import type { ConcernFlagType } from '@/lib/api/schemas/engagement';
+
+interface CitizenPulseReadOnlyProps {
+  txHash: string;
+  proposalIndex: number;
+}
+
+/**
+ * Read-only view of citizen sentiment and concerns for DReps/SPOs.
+ * Shows aggregated results without voting buttons.
+ * DReps also see their delegator sentiment breakdown.
+ */
+export function CitizenPulseReadOnly({ txHash, proposalIndex }: CitizenPulseReadOnlyProps) {
+  const { ownDRepId } = useWallet();
+  const { data: sentimentResults, isLoading: sentimentLoading } = useSentimentResults(
+    txHash,
+    proposalIndex,
+    ownDRepId,
+  );
+  const { data: concernResults, isLoading: concernsLoading } = useConcernFlags(
+    txHash,
+    proposalIndex,
+  );
+
+  if (sentimentLoading || concernsLoading) {
+    return (
+      <Card className="bg-muted/30">
+        <CardHeader className="pb-3">
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-3/4" />
+          <Skeleton className="h-3 w-1/2" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const community = sentimentResults?.community ?? { support: 0, oppose: 0, unsure: 0, total: 0 };
+  const delegators = ownDRepId ? (sentimentResults?.delegators ?? null) : null;
+  const stakeWeighted = ownDRepId ? (sentimentResults?.stakeWeighted ?? null) : null;
+  const flags = concernResults?.flags ?? {};
+  const totalFlags = concernResults?.total ?? 0;
+
+  const hasSentiment = community.total > 0;
+  const hasConcerns = totalFlags > 0;
+
+  if (!hasSentiment && !hasConcerns) {
+    return (
+      <Card className="bg-muted/30">
+        <CardContent className="py-4">
+          <p className="text-sm text-muted-foreground text-center flex items-center justify-center gap-2">
+            <Users className="h-4 w-4" />
+            No citizen feedback yet
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-muted/30">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <BarChart3 className="h-4 w-4 text-primary" />
+          What Citizens Think
+          {hasSentiment && (
+            <span className="text-xs font-normal text-muted-foreground ml-auto">
+              {community.total} citizen{community.total !== 1 ? 's' : ''} responded
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* DRep delegator sentiment */}
+        {delegators && delegators.total > 0 && (
+          <div className="rounded-lg bg-primary/5 border border-primary/10 p-3 space-y-2">
+            <p className="text-xs font-semibold text-primary">Your Delegators</p>
+            <SentimentBar
+              label="Support"
+              count={delegators.support}
+              total={delegators.total}
+              color="bg-green-500"
+            />
+            <SentimentBar
+              label="Oppose"
+              count={delegators.oppose}
+              total={delegators.total}
+              color="bg-red-500"
+            />
+            <SentimentBar
+              label="Unsure"
+              count={delegators.unsure}
+              total={delegators.total}
+              color="bg-amber-500"
+            />
+            <p className="text-xs text-muted-foreground">
+              {delegators.total} delegator{delegators.total !== 1 ? 's' : ''} voted
+              {stakeWeighted && stakeWeighted.total > 0 && (
+                <span>
+                  {' '}
+                  &middot; stake-weighted:{' '}
+                  {Math.round((stakeWeighted.support / stakeWeighted.total) * 100)}% support
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+
+        {/* Community sentiment */}
+        {hasSentiment && (
+          <div className="space-y-2">
+            {delegators && delegators.total > 0 && (
+              <p className="text-xs font-semibold text-muted-foreground">All Citizens</p>
+            )}
+            <SentimentBar
+              label="Support"
+              count={community.support}
+              total={community.total}
+              color="bg-green-500"
+            />
+            <SentimentBar
+              label="Oppose"
+              count={community.oppose}
+              total={community.total}
+              color="bg-red-500"
+            />
+            <SentimentBar
+              label="Unsure"
+              count={community.unsure}
+              total={community.total}
+              color="bg-amber-500"
+            />
+          </div>
+        )}
+
+        {/* Top concerns */}
+        {hasConcerns && (
+          <div className="pt-2 border-t border-border/50 space-y-2">
+            <p className="text-xs font-semibold text-muted-foreground">Top Concerns</p>
+            <div className="flex flex-wrap gap-1.5">
+              {(Object.entries(flags) as [ConcernFlagType, number][])
+                .filter(([, count]) => count > 0)
+                .sort(([, a], [, b]) => b - a)
+                .slice(0, 5)
+                .map(([flagType, count]) => {
+                  const label = CONCERN_FLAG_LABELS[flagType];
+                  if (!label) return null;
+                  return (
+                    <span
+                      key={flagType}
+                      className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[10px] bg-muted/50 border border-border/50 text-muted-foreground"
+                    >
+                      <span>{label.emoji}</span>
+                      <span>{label.label}</span>
+                      <span className="tabular-nums opacity-70">{count}</span>
+                    </span>
+                  );
+                })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SentimentBar({
+  label,
+  count,
+  total,
+  color,
+}: {
+  label: string;
+  count: number;
+  total: number;
+  color: string;
+}) {
+  const percent = total > 0 ? Math.round((count / total) * 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span>{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {count} ({percent}%)
+        </span>
+      </div>
+      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+        <div
+          className={`h-full rounded-full ${color} transition-all duration-700 ease-out`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/governada/proposals/DebateSection.tsx
+++ b/components/governada/proposals/DebateSection.tsx
@@ -4,42 +4,67 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { MessageSquare, ShieldCheck, ShieldAlert, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { ShareActions } from '@/components/ShareActions';
+import { ProposalDepthGate } from '@/components/governada/proposals/ProposalDepthGate';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { cn } from '@/lib/utils';
 import type { RationaleEntry } from './ProposalTopRationales';
 
 interface DebateSectionProps {
   rationales: RationaleEntry[];
+  proposalTitle?: string;
+  txHash?: string;
+  proposalIndex?: number;
 }
 
 function RationaleCard({
   entry,
   expanded,
   onToggle,
+  shareUrl,
+  shareText,
 }: {
   entry: RationaleEntry;
   expanded: boolean;
   onToggle: () => void;
+  shareUrl?: string;
+  shareText?: string;
 }) {
   const displayText = entry.rationaleAiSummary || entry.rationaleText;
   const hasFullText = entry.rationaleText != null && entry.rationaleText.length > 200;
 
   return (
     <div className="rounded-lg border border-border/50 bg-background/50 p-3 space-y-2">
-      <div className="flex items-center gap-2">
-        <Link
-          href={`/drep/${entry.drepId}`}
-          className="text-sm font-medium hover:text-primary transition-colors truncate"
-        >
-          {entry.drepName || `${entry.drepId.slice(0, 16)}\u2026`}
-        </Link>
-        {entry.hashVerified === true && (
-          <ShieldCheck
-            className="h-3.5 w-3.5 text-green-500 shrink-0"
-            aria-label="On-chain verified"
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Link
+            href={`/drep/${entry.drepId}`}
+            className="text-sm font-medium hover:text-primary transition-colors truncate"
+          >
+            {entry.drepName || `${entry.drepId.slice(0, 16)}\u2026`}
+          </Link>
+          {entry.hashVerified === true && (
+            <ShieldCheck
+              className="h-3.5 w-3.5 text-green-500 shrink-0"
+              aria-label="On-chain verified"
+            />
+          )}
+          {entry.hashVerified === false && (
+            <ShieldAlert
+              className="h-3.5 w-3.5 text-amber-500 shrink-0"
+              aria-label="Hash mismatch"
+            />
+          )}
+        </div>
+        {shareUrl && shareText && (
+          <ShareActions
+            url={shareUrl}
+            text={shareText}
+            surface="debate-rationale"
+            variant="compact"
+            metadata={{ drep_id: entry.drepId, vote: entry.vote }}
+            className="shrink-0"
           />
-        )}
-        {entry.hashVerified === false && (
-          <ShieldAlert className="h-3.5 w-3.5 text-amber-500 shrink-0" aria-label="Hash mismatch" />
         )}
       </div>
       <p className={cn('text-sm text-foreground/80 leading-relaxed', !expanded && 'line-clamp-3')}>
@@ -67,25 +92,123 @@ function RationaleCard({
   );
 }
 
-export function DebateSection({ rationales }: DebateSectionProps) {
+/** Build share text for a rationale */
+function buildShareText(entry: RationaleEntry, proposalTitle?: string): string {
+  const name = entry.drepName || `DRep ${entry.drepId.slice(0, 12)}`;
+  const excerpt = (entry.rationaleAiSummary || entry.rationaleText || '').slice(0, 120);
+  const suffix = excerpt.length >= 120 ? '...' : '';
+  const titlePart = proposalTitle ? ` on "${proposalTitle}"` : '';
+  return `${name}${titlePart}: "${excerpt}${suffix}" via @Governada`;
+}
+
+function RationaleColumn({
+  label,
+  color,
+  rationales,
+  expanded,
+  setExpanded,
+  emptyText,
+  shareUrl,
+  proposalTitle,
+  maxVisible,
+}: {
+  label: string;
+  color: string;
+  rationales: RationaleEntry[];
+  expanded: string | null;
+  setExpanded: (id: string | null) => void;
+  emptyText: string;
+  shareUrl?: string;
+  proposalTitle?: string;
+  maxVisible: number;
+}) {
+  const visible = rationales.slice(0, maxVisible);
+  const overflow = rationales.length - maxVisible;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 mb-4">
+        <div className={`h-1 w-8 rounded-full ${color}`} />
+        <span
+          className={`text-sm font-semibold ${color.replace('bg-', 'text-').replace('-500', '-400')}`}
+        >
+          {label} ({rationales.length})
+        </span>
+      </div>
+      {visible.map((r) => (
+        <RationaleCard
+          key={r.drepId}
+          entry={r}
+          expanded={expanded === r.drepId}
+          onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
+          shareUrl={shareUrl}
+          shareText={shareUrl ? buildShareText(r, proposalTitle) : undefined}
+        />
+      ))}
+      {rationales.length === 0 && (
+        <p className="text-sm text-muted-foreground/60 italic">{emptyText}</p>
+      )}
+      {overflow > 0 && (
+        <p className="text-xs text-muted-foreground text-center">
+          +{overflow} more rationale{overflow !== 1 ? 's' : ''}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function DebateSection({
+  rationales,
+  proposalTitle,
+  txHash,
+  proposalIndex,
+}: DebateSectionProps) {
   const [expanded, setExpanded] = useState<string | null>(null);
+  const { segment } = useSegment();
+  const isAnonymous = segment === 'anonymous';
 
   const withRationale = rationales.filter((r) => r.rationaleAiSummary || r.rationaleText);
   const yesRationales = withRationale.filter((r) => r.vote === 'Yes');
   const noRationales = withRationale.filter((r) => r.vote === 'No');
   const abstainRationales = withRationale.filter((r) => r.vote === 'Abstain');
 
+  const debateUrl =
+    txHash != null && proposalIndex != null
+      ? `https://governada.io/proposal/${encodeURIComponent(txHash)}/${proposalIndex}#debate`
+      : undefined;
+
+  // Anonymous: 2 per column visible, rest behind blur. Connected: 4.
+  const maxPerColumn = isAnonymous ? 2 : 4;
+  const hasOverflow =
+    abstainRationales.length > 0 ||
+    yesRationales.length > maxPerColumn ||
+    noRationales.length > maxPerColumn;
+
   return (
-    <section className="rounded-2xl border border-border/50 bg-card/50 overflow-hidden">
+    <section id="debate" className="rounded-2xl border border-border/50 bg-card/50 overflow-hidden">
       <div className="px-6 py-4 border-b border-border/50">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold flex items-center gap-2">
             <MessageSquare className="h-4 w-4" />
             The Debate
           </h2>
-          <span className="text-xs text-muted-foreground">
-            {withRationale.length} rationale{withRationale.length !== 1 ? 's' : ''} published
-          </span>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-muted-foreground">
+              {withRationale.length} rationale{withRationale.length !== 1 ? 's' : ''} published
+            </span>
+            {debateUrl && (
+              <ShareActions
+                url={debateUrl}
+                text={
+                  proposalTitle
+                    ? `The debate on "${proposalTitle}" — see what DReps are saying via @Governada`
+                    : 'See what DReps are saying about this proposal via @Governada'
+                }
+                surface="debate-section"
+                variant="compact"
+              />
+            )}
+          </div>
         </div>
       </div>
 
@@ -95,75 +218,66 @@ export function DebateSection({ rationales }: DebateSectionProps) {
             No representatives have published rationales yet.
           </p>
         ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* For column */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 mb-4">
-                <div className="h-1 w-8 rounded-full bg-emerald-500" />
-                <span className="text-sm font-semibold text-emerald-400">
-                  For ({yesRationales.length})
-                </span>
-              </div>
-              {yesRationales.slice(0, 4).map((r) => (
-                <RationaleCard
-                  key={r.drepId}
-                  entry={r}
-                  expanded={expanded === r.drepId}
-                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
-                />
-              ))}
-              {yesRationales.length === 0 && (
-                <p className="text-sm text-muted-foreground/60 italic">
-                  No supporting rationales yet
-                </p>
-              )}
+          <>
+            {/* Main For/Against columns — limited for anonymous */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <RationaleColumn
+                label="For"
+                color="bg-emerald-500"
+                rationales={yesRationales}
+                expanded={expanded}
+                setExpanded={setExpanded}
+                emptyText="No supporting rationales yet"
+                shareUrl={debateUrl}
+                proposalTitle={proposalTitle}
+                maxVisible={maxPerColumn}
+              />
+              <RationaleColumn
+                label="Against"
+                color="bg-red-500"
+                rationales={noRationales}
+                expanded={expanded}
+                setExpanded={setExpanded}
+                emptyText="No opposing rationales yet"
+                shareUrl={debateUrl}
+                proposalTitle={proposalTitle}
+                maxVisible={maxPerColumn}
+              />
             </div>
 
-            {/* Against column */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 mb-4">
-                <div className="h-1 w-8 rounded-full bg-red-500" />
-                <span className="text-sm font-semibold text-red-400">
-                  Against ({noRationales.length})
-                </span>
-              </div>
-              {noRationales.slice(0, 4).map((r) => (
-                <RationaleCard
-                  key={r.drepId}
-                  entry={r}
-                  expanded={expanded === r.drepId}
-                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
-                />
-              ))}
-              {noRationales.length === 0 && (
-                <p className="text-sm text-muted-foreground/60 italic">
-                  No opposing rationales yet
-                </p>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Abstain rationales */}
-        {abstainRationales.length > 0 && (
-          <div className="mt-6 pt-4 border-t border-border/50">
-            <div className="flex items-center gap-2 mb-3">
-              <div className="h-1 w-8 rounded-full bg-amber-500" />
-              <span className="text-sm font-semibold text-amber-400">
-                Abstained ({abstainRationales.length})
-              </span>
-            </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-              {abstainRationales.slice(0, 2).map((r) => (
-                <RationaleCard
-                  key={r.drepId}
-                  entry={r}
-                  expanded={expanded === r.drepId}
-                  onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
-                />
-              ))}
-            </div>
-          </div>
+            {/* Overflow + abstain rationales gated for anonymous */}
+            {hasOverflow && (
+              <ProposalDepthGate
+                message="Connect to see all rationales and join the debate"
+                surface="debate-overflow"
+              >
+                <div className="space-y-4">
+                  {abstainRationales.length > 0 && (
+                    <div className="mt-6 pt-4 border-t border-border/50">
+                      <div className="flex items-center gap-2 mb-3">
+                        <div className="h-1 w-8 rounded-full bg-amber-500" />
+                        <span className="text-sm font-semibold text-amber-400">
+                          Abstained ({abstainRationales.length})
+                        </span>
+                      </div>
+                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                        {abstainRationales.slice(0, 2).map((r) => (
+                          <RationaleCard
+                            key={r.drepId}
+                            entry={r}
+                            expanded={expanded === r.drepId}
+                            onToggle={() => setExpanded(expanded === r.drepId ? null : r.drepId)}
+                            shareUrl={debateUrl}
+                            shareText={debateUrl ? buildShareText(r, proposalTitle) : undefined}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </ProposalDepthGate>
+            )}
+          </>
         )}
       </div>
     </section>

--- a/components/governada/proposals/IntelligenceBriefing.tsx
+++ b/components/governada/proposals/IntelligenceBriefing.tsx
@@ -4,6 +4,7 @@ import { Sparkles } from 'lucide-react';
 import { ProposalAiSummary } from '@/components/ProposalAiSummary';
 import { ConstitutionalAlignmentCard } from '@/components/ConstitutionalAlignmentCard';
 import { ParamChangesCard } from '@/components/governada/proposals/ParamChangesCard';
+import { ProposalDepthGate } from '@/components/governada/proposals/ProposalDepthGate';
 
 interface IntelligenceBriefingProps {
   txHash: string;
@@ -35,9 +36,19 @@ export function IntelligenceBriefing({
       </div>
 
       <div className="p-6 space-y-6">
+        {/* AI summary visible to all */}
         {aiSummary && <ProposalAiSummary summary={aiSummary} />}
-        <ConstitutionalAlignmentCard txHash={txHash} proposalIndex={proposalIndex} />
-        {hasParams && <ParamChangesCard paramChanges={paramChanges} />}
+
+        {/* Constitutional alignment + param changes gated for anonymous */}
+        <ProposalDepthGate
+          message="Unlock constitutional analysis and parameter details"
+          surface="intelligence-briefing"
+        >
+          <div className="space-y-6">
+            <ConstitutionalAlignmentCard txHash={txHash} proposalIndex={proposalIndex} />
+            {hasParams && <ParamChangesCard paramChanges={paramChanges} />}
+          </div>
+        </ProposalDepthGate>
       </div>
     </section>
   );

--- a/components/governada/proposals/ProposalActionZone.tsx
+++ b/components/governada/proposals/ProposalActionZone.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { VoteRationaleFlow } from '@/components/governada/proposals/VoteRationaleFlow';
+import { CitizenPulseReadOnly } from '@/components/governada/proposals/CitizenPulseReadOnly';
+import { CitizenEngagementSection } from '@/components/governada/proposals/CitizenEngagementSection';
+import { ProposalDepthGate } from '@/components/governada/proposals/ProposalDepthGate';
+import { canBodyVote } from '@/lib/governance/votingBodies';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent } from '@/components/ui/card';
+
+interface ProposalActionZoneProps {
+  txHash: string;
+  proposalIndex: number;
+  title: string;
+  isOpen: boolean;
+  proposalAbstract?: string | null;
+  proposalType?: string | null;
+  aiSummary?: string | null;
+}
+
+/**
+ * Persona-branching action zone for the proposal detail page.
+ *
+ * - DRep/SPO: Vote flow (full width) + read-only citizen pulse
+ * - Citizen: Unified engagement section (sentiment + concerns + ask DRep)
+ * - Anonymous: Blurred teaser with wallet-connect CTA
+ */
+export function ProposalActionZone({
+  txHash,
+  proposalIndex,
+  title,
+  isOpen,
+  proposalAbstract,
+  proposalType,
+  aiSummary,
+}: ProposalActionZoneProps) {
+  const { segment, isLoading } = useSegment();
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-6 space-y-3">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-64" />
+          <div className="flex gap-2">
+            <Skeleton className="h-11 flex-1" />
+            <Skeleton className="h-11 flex-1" />
+            <Skeleton className="h-11 flex-1" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isGovernanceActor = segment === 'drep' || segment === 'spo' || segment === 'cc';
+
+  // For governance actors: check if their body can vote on this proposal type
+  const effectiveType = proposalType ?? 'InfoAction';
+  const voterBody = segment === 'spo' ? 'spo' : segment === 'cc' ? 'cc' : 'drep';
+  const canVote = isGovernanceActor && canBodyVote(voterBody, effectiveType);
+
+  if (isGovernanceActor) {
+    return (
+      <section className="space-y-4">
+        {/* Vote flow: only if this body can vote on this proposal type */}
+        {canVote && (
+          <VoteRationaleFlow
+            txHash={txHash}
+            proposalIndex={proposalIndex}
+            title={title}
+            isOpen={isOpen}
+            proposalAbstract={proposalAbstract}
+            proposalType={proposalType}
+            aiSummary={aiSummary}
+          />
+        )}
+
+        {/* Read-only citizen pulse (what citizens think) */}
+        <CitizenPulseReadOnly txHash={txHash} proposalIndex={proposalIndex} />
+      </section>
+    );
+  }
+
+  // Anonymous: blurred teaser with CTA
+  if (segment === 'anonymous') {
+    return (
+      <ProposalDepthGate message="See how citizens feel about this proposal" surface="action-zone">
+        <CitizenEngagementSection
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          proposalTitle={title}
+          isOpen={isOpen}
+        />
+      </ProposalDepthGate>
+    );
+  }
+
+  // Connected citizen — full engagement section
+  return (
+    <section>
+      <CitizenEngagementSection
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+        proposalTitle={title}
+        isOpen={isOpen}
+      />
+    </section>
+  );
+}

--- a/components/governada/proposals/ProposalDepthGate.tsx
+++ b/components/governada/proposals/ProposalDepthGate.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { WalletConnectCTA } from '@/components/governada/shared/WalletConnectCTA';
+import { cn } from '@/lib/utils';
+
+interface ProposalDepthGateProps {
+  children: React.ReactNode;
+  /** What the user will unlock (shown in the CTA) */
+  message: string;
+  /** PostHog surface for attribution */
+  surface?: string;
+  /** Hide for anonymous users (default). Set to 'citizen' to also gate non-workspace users. */
+  gateLevel?: 'anonymous' | 'citizen';
+}
+
+/**
+ * Depth gating wrapper for proposal detail zones.
+ *
+ * For anonymous users: renders children behind a blur overlay with a centered
+ * wallet-connect CTA. The real content is rendered but visually obscured,
+ * creating curiosity and encouraging connection.
+ *
+ * For connected users: renders children normally.
+ */
+export function ProposalDepthGate({
+  children,
+  message,
+  surface = 'proposal-detail',
+  gateLevel = 'anonymous',
+}: ProposalDepthGateProps) {
+  const { segment } = useSegment();
+
+  const isGated =
+    gateLevel === 'anonymous'
+      ? segment === 'anonymous'
+      : segment === 'anonymous' || segment === 'citizen';
+
+  if (!isGated) return <>{children}</>;
+
+  return (
+    <div className="relative rounded-xl overflow-hidden">
+      {/* Real content rendered behind blur */}
+      <div
+        className={cn('blur-[3px] pointer-events-none select-none', 'opacity-60')}
+        aria-hidden="true"
+      >
+        {children}
+      </div>
+
+      {/* Overlay with CTA */}
+      <div className="absolute inset-0 flex items-center justify-center bg-background/60 backdrop-blur-sm rounded-xl">
+        <WalletConnectCTA message={message} variant="overlay" surface={surface} />
+      </div>
+    </div>
+  );
+}

--- a/components/governada/proposals/ProposalHeroV1.tsx
+++ b/components/governada/proposals/ProposalHeroV1.tsx
@@ -186,7 +186,12 @@ export function ProposalHeroV1({
 
       {/* Tri-body vote bars */}
       {triBody && (
-        <TriBodyVotePanel triBody={triBody} txHash={txHash} proposalIndex={proposalIndex} />
+        <TriBodyVotePanel
+          triBody={triBody}
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          proposalType={proposalType}
+        />
       )}
 
       {/* User's DRep vote */}

--- a/components/governada/proposals/ProposalHeroV2.tsx
+++ b/components/governada/proposals/ProposalHeroV2.tsx
@@ -42,6 +42,11 @@ interface ProposalHeroV2Props {
   triBody: TriBodyVotes | null;
   blockTime: number | null;
   nclUtilization?: NclUtilization | null;
+  /** DRep vote counts for threshold meter (integrated into tri-body panel) */
+  yesCount?: number;
+  noCount?: number;
+  abstainCount?: number;
+  totalVotes?: number;
 }
 
 export function ProposalHeroV2({
@@ -63,6 +68,10 @@ export function ProposalHeroV2({
   triBody,
   blockTime,
   nclUtilization,
+  yesCount,
+  noCount,
+  abstainCount,
+  totalVotes,
 }: ProposalHeroV2Props) {
   const theme = getProposalTheme(proposalType);
   const TypeIcon = theme.icon;
@@ -172,13 +181,28 @@ export function ProposalHeroV2({
 
         {/* Verdict strip at bottom of hero */}
         <div className="px-6 pb-5">
-          <ProposalVerdict status={status} triBody={triBody} accentColor={theme.accent} />
+          <ProposalVerdict
+            status={status}
+            triBody={triBody}
+            proposalType={proposalType}
+            accentColor={theme.accent}
+          />
         </div>
       </div>
 
-      {/* Tri-body vote bars */}
+      {/* Tri-body vote bars (type-aware: only shows eligible governance bodies) */}
       {triBody && (
-        <TriBodyVotePanel triBody={triBody} txHash={txHash} proposalIndex={proposalIndex} />
+        <TriBodyVotePanel
+          triBody={triBody}
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          proposalType={proposalType}
+          yesCount={yesCount}
+          noCount={noCount}
+          abstainCount={abstainCount}
+          totalVotes={totalVotes}
+          isOpen={isOpen}
+        />
       )}
 
       {/* User's DRep vote */}

--- a/components/governada/proposals/ProposalLifecycleTimeline.tsx
+++ b/components/governada/proposals/ProposalLifecycleTimeline.tsx
@@ -32,6 +32,41 @@ interface TimelineEvent {
   color: string;
 }
 
+/**
+ * Merge events that are within 1 epoch of each other to prevent overlap.
+ * Combined events get a joined label like "Proposed / Now".
+ */
+function mergeCloseEvents(events: TimelineEvent[]): TimelineEvent[] {
+  if (events.length <= 1) return events;
+
+  const merged: TimelineEvent[] = [];
+  let i = 0;
+
+  while (i < events.length) {
+    const current = { ...events[i] };
+    let j = i + 1;
+
+    // Merge any subsequent events within 1 epoch
+    while (j < events.length && events[j].epoch - current.epoch <= 1) {
+      current.label = `${current.label} / ${events[j].label}`;
+      // Use the more "active" status and its icon/color
+      if (events[j].status === 'current') {
+        current.status = 'current';
+        current.icon = events[j].icon;
+        current.color = events[j].color;
+      }
+      // Use the later epoch for positioning
+      current.epoch = events[j].epoch;
+      j++;
+    }
+
+    merged.push(current);
+    i = j;
+  }
+
+  return merged;
+}
+
 interface ProposalLifecycleTimelineProps {
   proposedEpoch: number | null;
   expirationEpoch: number | null;
@@ -130,80 +165,95 @@ export function ProposalLifecycleTimeline({
     }
   }
 
-  // Sort by epoch
+  // Sort by epoch then merge close events
   events.sort((a, b) => a.epoch - b.epoch);
+  const merged = mergeCloseEvents(events);
 
-  if (events.length < 2) return null;
+  if (merged.length < 2) return null;
 
-  const minEpoch = events[0].epoch;
-  const maxEpoch = events[events.length - 1].epoch;
-  const range = maxEpoch - minEpoch || 1;
+  // Time remaining for open proposals
+  const remaining = isOpen && expirationEpoch ? Math.max(0, expirationEpoch - currentEpoch) : null;
+  const remainingDays = remaining != null ? remaining * 5 : null;
 
+  // Use flex layout for clean spacing — no absolute positioning overlap issues
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-sm flex items-center gap-2">
-          <Clock className="h-4 w-4" />
-          Lifecycle
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {/* Timeline bar */}
-        <div className="relative h-2 bg-muted rounded-full overflow-hidden mb-6">
-          {/* Progress fill */}
-          {isOpen && expirationEpoch ? (
-            <div
-              className="absolute h-full bg-primary/30 rounded-full"
-              style={{
-                left: '0%',
-                width: `${Math.min(((currentEpoch - minEpoch) / range) * 100, 100)}%`,
-              }}
-            />
-          ) : (
-            <div className="absolute h-full bg-primary/30 rounded-full w-full" />
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            Lifecycle
+          </CardTitle>
+          {remainingDays != null && remaining != null && remaining > 0 && (
+            <span
+              className={cn(
+                'text-xs font-medium',
+                remaining <= 2 ? 'text-red-500 dark:text-red-400' : 'text-muted-foreground',
+              )}
+            >
+              ~{remainingDays} days left
+            </span>
           )}
         </div>
-
-        {/* Event dots + labels — alternate above/below for dense timelines */}
-        <div className="relative" style={{ height: '5rem' }}>
-          {events.map((event, idx) => {
-            const pct = ((event.epoch - minEpoch) / range) * 100;
+      </CardHeader>
+      <CardContent>
+        {/* Flex-based timeline — evenly spaced events with connected segments */}
+        <div className="flex items-start">
+          {merged.map((event, idx) => {
             const Icon = event.icon;
-            const isBelow = idx % 2 === 0;
+            const isLast = idx === merged.length - 1;
+
+            // Progress fill: past segments are filled, current-to-future is partial
+            const segmentFilled =
+              idx < merged.length - 1 &&
+              (merged[idx + 1].status === 'past' ||
+                (event.status === 'past' && merged[idx + 1].status === 'current'));
+
             return (
               <div
                 key={`${event.label}-${event.epoch}`}
-                className={cn(
-                  'absolute flex items-center -translate-x-1/2',
-                  isBelow ? 'flex-col top-[1.25rem]' : 'flex-col-reverse bottom-[1.25rem]',
-                )}
-                style={{ left: `${pct}%` }}
+                className="flex items-start flex-1 min-w-0"
               >
-                <div
-                  className={cn(
-                    'rounded-full p-1',
-                    event.status === 'current'
-                      ? 'bg-amber-500/20 ring-2 ring-amber-500/40'
-                      : event.status === 'future'
-                        ? 'bg-muted'
-                        : 'bg-card',
-                  )}
-                >
-                  <Icon className={cn('h-3.5 w-3.5', event.color)} />
+                {/* Event marker + label */}
+                <div className="flex flex-col items-center shrink-0">
+                  <div
+                    className={cn(
+                      'rounded-full p-1.5',
+                      event.status === 'current'
+                        ? 'bg-amber-500/20 ring-2 ring-amber-500/40'
+                        : event.status === 'future'
+                          ? 'bg-muted'
+                          : 'bg-primary/10',
+                    )}
+                  >
+                    <Icon className={cn('h-3.5 w-3.5', event.color)} />
+                  </div>
+                  <span
+                    className={cn(
+                      'text-[10px] mt-1.5 font-medium text-center leading-tight',
+                      event.status === 'future'
+                        ? 'text-muted-foreground/50'
+                        : 'text-muted-foreground',
+                    )}
+                  >
+                    {event.label}
+                  </span>
+                  <span className="text-[9px] text-muted-foreground/50 tabular-nums text-center">
+                    {formatEpochLabel(event.epoch)}
+                  </span>
                 </div>
-                <span
-                  className={cn(
-                    'text-[9px] mt-1 whitespace-nowrap font-medium tabular-nums leading-tight text-center',
-                    event.status === 'future'
-                      ? 'text-muted-foreground/50'
-                      : 'text-muted-foreground',
-                    !isBelow && 'mb-1 mt-0',
-                  )}
-                >
-                  {event.label}
-                  <br />
-                  <span className="opacity-60">{formatEpochLabel(event.epoch)}</span>
-                </span>
+
+                {/* Connector segment */}
+                {!isLast && (
+                  <div className="flex-1 flex items-center px-1 pt-[0.85rem]">
+                    <div
+                      className={cn(
+                        'h-0.5 w-full rounded-full',
+                        segmentFilled ? 'bg-primary/40' : 'bg-border',
+                      )}
+                    />
+                  </div>
+                )}
               </div>
             );
           })}

--- a/components/governada/proposals/ProposalVerdict.tsx
+++ b/components/governada/proposals/ProposalVerdict.tsx
@@ -1,6 +1,7 @@
 import { CheckCircle2, XCircle, Scale, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getVerdict, type VerdictType } from './proposal-theme';
+import { getVotingBodies } from '@/lib/governance/votingBodies';
 
 const VERDICT_ICONS: Record<VerdictType, typeof CheckCircle2> = {
   passing: CheckCircle2,
@@ -11,6 +12,8 @@ const VERDICT_ICONS: Record<VerdictType, typeof CheckCircle2> = {
   expired: Clock,
 };
 
+const BODY_LABEL: Record<string, string> = { drep: 'DRep', spo: 'SPO', cc: 'CC' };
+
 interface ProposalVerdictProps {
   status: string;
   triBody?: {
@@ -18,12 +21,21 @@ interface ProposalVerdictProps {
     spo: { yes: number; no: number; abstain: number };
     cc: { yes: number; no: number; abstain: number };
   } | null;
+  proposalType?: string;
   accentColor?: string;
 }
 
-export function ProposalVerdict({ status, triBody, accentColor }: ProposalVerdictProps) {
+export function ProposalVerdict({
+  status,
+  triBody,
+  proposalType,
+  accentColor,
+}: ProposalVerdictProps) {
   const verdict = getVerdict(status, triBody);
   const Icon = VERDICT_ICONS[verdict.type];
+  const eligibleBodies = proposalType
+    ? getVotingBodies(proposalType)
+    : (['drep', 'spo', 'cc'] as const);
 
   return (
     <div
@@ -39,21 +51,16 @@ export function ProposalVerdict({ status, triBody, accentColor }: ProposalVerdic
 
       {triBody && (
         <div className="flex items-center gap-3 ml-auto">
-          {(
-            [
-              { label: 'DRep', data: triBody.drep },
-              { label: 'SPO', data: triBody.spo },
-              { label: 'CC', data: triBody.cc },
-            ] as const
-          ).map(({ label, data }) => {
+          {eligibleBodies.map((body) => {
+            const data = triBody[body];
             const total = data.yes + data.no + data.abstain;
             if (total === 0) return null;
             const yesPct = Math.round((data.yes / total) * 100);
             const color =
               yesPct >= 60 ? 'text-emerald-400' : yesPct >= 40 ? 'text-amber-400' : 'text-red-400';
             return (
-              <span key={label} className="text-xs tabular-nums">
-                <span className="text-muted-foreground">{label}</span>{' '}
+              <span key={body} className="text-xs tabular-nums">
+                <span className="text-muted-foreground">{BODY_LABEL[body]}</span>{' '}
                 <span className={cn('font-semibold', color)}>{yesPct}%</span>
               </span>
             );

--- a/components/governada/shared/WalletConnectCTA.tsx
+++ b/components/governada/shared/WalletConnectCTA.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { Wallet } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { posthog } from '@/lib/posthog';
+
+interface WalletConnectCTAProps {
+  /** What the user will unlock by connecting */
+  message: string;
+  /** inline = compact text link, overlay = centered card over blurred content */
+  variant?: 'inline' | 'overlay';
+  /** PostHog surface identifier for attribution */
+  surface?: string;
+}
+
+/**
+ * Reusable CTA for gated zones — encourages anonymous users to connect their wallet.
+ */
+export function WalletConnectCTA({
+  message,
+  variant = 'overlay',
+  surface = 'unknown',
+}: WalletConnectCTAProps) {
+  const handleClick = () => {
+    posthog.capture('wallet_cta_clicked', { surface, variant });
+  };
+
+  if (variant === 'inline') {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {message}{' '}
+        <Link
+          href="/match"
+          onClick={handleClick}
+          className="font-medium text-primary hover:underline"
+        >
+          Connect wallet &rarr;
+        </Link>
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 text-center py-6">
+      <div className="rounded-full bg-primary/10 p-3">
+        <Wallet className="h-5 w-5 text-primary" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{message}</p>
+        <p className="text-xs text-muted-foreground">
+          Connect your wallet to unlock the full experience
+        </p>
+      </div>
+      <Button asChild size="sm" onClick={handleClick}>
+        <Link href="/match">Get Started</Link>
+      </Button>
+    </div>
+  );
+}

--- a/lib/governance/votingBodies.ts
+++ b/lib/governance/votingBodies.ts
@@ -1,0 +1,52 @@
+/**
+ * Governance body eligibility per proposal type.
+ *
+ * CIP-1694 defines which governance bodies can vote on each proposal type.
+ * This module is the single source of truth — import from here instead of
+ * duplicating the lists in route handlers or components.
+ */
+
+export type GovernanceBody = 'drep' | 'spo' | 'cc';
+
+/** Proposal types where ONLY DReps vote (SPOs and CC are excluded) */
+export const DREP_ONLY_TYPES = ['TreasuryWithdrawals', 'InfoAction'];
+
+/** Proposal types that accept SPO votes */
+export const SPO_VOTABLE_TYPES = [
+  'ParameterChange',
+  'HardForkInitiation',
+  'NoConfidence',
+  'NewCommittee',
+  'NewConstitutionalCommittee',
+  'NewConstitution',
+  'UpdateConstitution',
+];
+
+/** Proposal types that accept CC votes */
+export const CC_VOTABLE_TYPES = [
+  'ParameterChange',
+  'HardForkInitiation',
+  'NewCommittee',
+  'NewConstitutionalCommittee',
+  'NewConstitution',
+  'UpdateConstitution',
+];
+
+/**
+ * Return the governance bodies eligible to vote on a given proposal type.
+ * DReps always vote. SPOs and CC are conditionally included.
+ */
+export function getVotingBodies(proposalType: string): GovernanceBody[] {
+  const bodies: GovernanceBody[] = ['drep'];
+  if (SPO_VOTABLE_TYPES.includes(proposalType)) bodies.push('spo');
+  if (CC_VOTABLE_TYPES.includes(proposalType)) bodies.push('cc');
+  return bodies;
+}
+
+/** Check if a specific body can vote on this proposal type */
+export function canBodyVote(body: GovernanceBody, proposalType: string): boolean {
+  if (body === 'drep') return true;
+  if (body === 'spo') return SPO_VOTABLE_TYPES.includes(proposalType);
+  if (body === 'cc') return CC_VOTABLE_TYPES.includes(proposalType);
+  return false;
+}


### PR DESCRIPTION
## Summary
- **Persona branching**: DReps/SPOs see vote flow + read-only citizen pulse; citizens see unified engagement section; anonymous users see blurred teaser with wallet CTA
- **Debate elevated**: moved up to Zone 4 with per-rationale social sharing (X + copy link), deep link anchor, and anonymous gating (2 rationales visible, rest blurred)
- **Type-aware Tri-Body**: only shows governance bodies eligible to vote per CIP-1694 (e.g., DRep-only for Treasury/Info proposals), with ThresholdMeter integrated
- **Depth gating**: blur overlay + wallet CTA for anonymous users across action zone, intelligence briefing, debate overflow, and deep dive sections
- **Lifecycle polish**: flex layout eliminates overlap on fresh proposals, merges close events, shows "~X days left"
- **Citizen UX overhaul**: unified CitizenEngagementSection replaces 3 scattered widgets (sentiment + concerns + AskYourDRep)

## Impact
- **What changed**: Complete proposal detail page restructure addressing 7 founder UX feedback points
- **User-facing**: Yes — all proposal page visitors see reorganized zones, DReps see cleaner focused workspace, anonymous users see gated teaser experience
- **Risk**: Medium — touches the core proposal page layout and adds 6 new components. No data/API changes, no migrations.
- **Scope**: 8 modified files, 6 new components, 1 new shared module (votingBodies.ts)

## Test plan
- [ ] ViewAs: anonymous — verify blur overlays on action zone, intelligence, debate overflow, deep dive
- [ ] ViewAs: citizen-delegated — verify unified engagement section with sentiment + concerns + AskYourDRep
- [ ] ViewAs: drep-claimed — verify VoteRationaleFlow + CitizenPulseReadOnly (no citizen voting buttons)
- [ ] ViewAs: spo-claimed — verify VoteRationaleFlow hidden on Treasury/Info proposals (SPO can't vote)
- [ ] Test proposal with few votes — lifecycle timeline should merge "Proposed / Now" markers
- [ ] Test debate sharing — X share and copy link on individual rationales
- [ ] Verify PostHog events: `citizen_sentiment_voted`, `citizen_concern_flagged`, `wallet_cta_clicked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)