### PR TITLE
feat: implement 4-level depth on treasury page

### DIFF
--- a/app/governance/treasury/TreasuryOverview.tsx
+++ b/app/governance/treasury/TreasuryOverview.tsx
@@ -1,17 +1,24 @@
 'use client';
 
-import { TreasuryNarrativeHero } from '@/components/treasury/TreasuryNarrativeHero';
+import { TreasuryVerdict } from '@/components/treasury/TreasuryVerdict';
 import { NclBudgetBar } from '@/components/treasury/NclBudgetBar';
 import { NclUtilizationTrend } from '@/components/treasury/NclUtilizationTrend';
 import { TreasuryKeyMetrics } from '@/components/treasury/TreasuryKeyMetrics';
 import { TreasuryEpochFlow } from '@/components/treasury/TreasuryEpochFlow';
 import { TreasuryPendingProposals } from '@/components/TreasuryPendingProposals';
 import { TreasuryAccountabilitySection } from '@/components/TreasuryAccountabilitySection';
+import { TreasuryPersonalImpact } from '@/components/treasury/TreasuryPersonalImpact';
 import dynamic from 'next/dynamic';
 
 const TreasurySimulator = dynamic(
-  () => import('@/components/TreasurySimulator').then((m) => ({ default: m.TreasurySimulator })),
-  { ssr: false, loading: () => <div className="h-64 animate-pulse bg-muted rounded-xl" /> },
+  () =>
+    import('@/components/TreasurySimulator').then((m) => ({
+      default: m.TreasurySimulator,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="h-64 animate-pulse bg-muted rounded-xl" />,
+  },
 );
 import { DRepTreasuryTrackRecord } from '@/components/treasury/DRepTreasuryTrackRecord';
 import { SegmentGate } from '@/components/shared/SegmentGate';
@@ -24,6 +31,7 @@ import {
 import { useTreasuryCurrent, useTreasuryNcl, useTreasuryHistory } from '@/hooks/queries';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import type { NclUtilization, IncomeVsOutflow } from '@/lib/treasury';
+import { formatAda } from '@/lib/treasury';
 import { useQuery } from '@tanstack/react-query';
 
 interface TreasuryCurrentData {
@@ -46,17 +54,13 @@ async function fetchJson<T>(url: string): Promise<T> {
 }
 
 /**
- * Narrative-first treasury overview with NCL budget bar as visual anchor.
+ * 4-Level Treasury Overview
  *
- * Layout:
- * 1. Narrative hero — contextual paragraph
- * 2. NCL budget bar — horizontal segmented bar
- * 3. Key metrics — 3-stat row
- * 4. Epoch flow — income vs outflow last 6 epochs
- * 5. Pending proposals — with per-proposal NCL impact
- * 6. [DRep only] Track record
- * 7. Accordion: Spending Accountability
- * 8. Accordion: Runway Projections
+ * Level 1 — Verdict: health indicator + inline stats (5-second test)
+ * Level 2 — Budget Story: NCL bar + key metrics (the "where")
+ * Level 3 — Active Decisions: pending proposals + DRep stance (the "what")
+ * Level 4 — Your Impact: personal DRep track record + pending impact (the "you")
+ * Deep Dive — Accordions: utilization trend, epoch flow, accountability, simulator
  */
 export function TreasuryOverview() {
   const { drepId } = useSegment();
@@ -70,7 +74,6 @@ export function TreasuryOverview() {
   const incomeVsOutflow =
     (rawHistory as { incomeVsOutflow: IncomeVsOutflow[] } | undefined)?.incomeVsOutflow ?? [];
 
-  // Effectiveness rate for narrative + metrics
   const { data: rawEffectiveness } = useQuery({
     queryKey: ['treasury-effectiveness'],
     queryFn: () => fetchJson<{ effectivenessRate: number | null }>('/api/treasury/effectiveness'),
@@ -86,8 +89,6 @@ export function TreasuryOverview() {
   const pendingTotalAda = treasury?.pendingTotalAda ?? 0;
   const effectivenessRate = rawEffectiveness?.effectivenessRate ?? null;
 
-  const epochFlow = incomeVsOutflow;
-
   const nclImpact = ncl
     ? {
         utilizationPct: ncl.utilizationPct,
@@ -98,39 +99,63 @@ export function TreasuryOverview() {
 
   return (
     <div className="space-y-6">
-      {/* 1. Narrative hero */}
-      <TreasuryNarrativeHero
+      {/* ──────────────────────────────────────────────────────────────
+          LEVEL 1 — THE VERDICT
+          One glanceable health indicator + inline stats.
+          Passes the 5-second test on its own.
+         ────────────────────────────────────────────────────────────── */}
+      <TreasuryVerdict
         balanceAda={balance}
         trend={trend}
+        ncl={ncl}
         effectivenessRate={effectivenessRate}
         pendingCount={pendingCount}
-        pendingTotalAda={pendingTotalAda}
         runwayMonths={runway}
-        ncl={ncl}
       />
 
-      {/* 2. NCL Budget Bar */}
-      {ncl && <NclBudgetBar ncl={ncl} />}
-      {!ncl && treasury && (
-        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 text-sm text-muted-foreground">
-          No active NCL period. The community has not yet set a spending limit for the current epoch
-          range.
-        </div>
-      )}
+      {/* ──────────────────────────────────────────────────────────────
+          LEVEL 2 — THE BUDGET STORY
+          Where is the money going this period?
+         ────────────────────────────────────────────────────────────── */}
+      <section className="space-y-4">
+        {ncl && (
+          <p className="text-sm text-muted-foreground">
+            The community set a ₳{formatAda(ncl.period.nclAda)} spending limit for epochs{' '}
+            {ncl.period.startEpoch}–{ncl.period.endEpoch}. Here&apos;s how it&apos;s being used.
+          </p>
+        )}
 
-      {/* 3. Key metrics */}
-      <TreasuryKeyMetrics
-        ncl={ncl}
-        pendingCount={pendingCount}
-        effectivenessRate={effectivenessRate}
-      />
+        {ncl && <NclBudgetBar ncl={ncl} />}
+        {!ncl && treasury && (
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 text-sm text-muted-foreground">
+            No active NCL period. The community has not yet set a spending limit for the current
+            epoch range.
+          </div>
+        )}
 
-      {/* 4. Epoch flow */}
-      {epochFlow.length > 0 && <TreasuryEpochFlow data={epochFlow} />}
+        <TreasuryKeyMetrics
+          ncl={ncl}
+          pendingCount={pendingCount}
+          effectivenessRate={effectivenessRate}
+        />
+      </section>
 
-      {/* 5. Pending proposals with NCL impact */}
+      {/* ──────────────────────────────────────────────────────────────
+          LEVEL 3 — ACTIVE DECISIONS
+          What's being decided right now?
+         ────────────────────────────────────────────────────────────── */}
       <section>
-        <h2 className="text-lg font-semibold mb-3">Pending Proposals</h2>
+        <h2 className="text-lg font-semibold mb-3">Active Decisions</h2>
+
+        {/* DRep stance callout (for DReps: your track record as context) */}
+        <SegmentGate show={['drep']}>
+          {drepId && (
+            <div className="mb-4">
+              <DRepTreasuryTrackRecord drepId={drepId} />
+            </div>
+          )}
+        </SegmentGate>
+
         <TreasuryPendingProposals
           treasuryBalanceAda={balance}
           runwayMonths={runway}
@@ -138,16 +163,23 @@ export function TreasuryOverview() {
         />
       </section>
 
-      {/* 6. DRep track record (segment-gated) */}
-      <SegmentGate show={['drep']}>
-        {drepId && (
-          <section>
-            <DRepTreasuryTrackRecord drepId={drepId} />
-          </section>
-        )}
+      {/* ──────────────────────────────────────────────────────────────
+          LEVEL 4 — YOUR IMPACT
+          How does this affect you personally?
+          Gated to connected users with a DRep.
+         ────────────────────────────────────────────────────────────── */}
+      <SegmentGate show={['drep', 'citizen']}>
+        <TreasuryPersonalImpact
+          balanceAda={balance}
+          nclRemainingAda={ncl?.remainingAda ?? null}
+          nclAda={ncl?.period.nclAda ?? null}
+          nclUtilizationPct={ncl?.utilizationPct ?? null}
+        />
       </SegmentGate>
 
-      {/* 7, 8, 9. Depth sections behind accordion */}
+      {/* ──────────────────────────────────────────────────────────────
+          DEEP DIVE — Analytical depth behind accordions
+         ────────────────────────────────────────────────────────────── */}
       <Accordion type="multiple" className="space-y-2">
         {ncl && (
           <AccordionItem
@@ -155,7 +187,7 @@ export function TreasuryOverview() {
             className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
           >
             <AccordionTrigger className="text-sm font-semibold hover:no-underline">
-              Budget Utilization Over Time
+              How has spending evolved?
               <span className="ml-2 text-xs font-normal text-muted-foreground">
                 {Math.round(ncl.utilizationPct)}% used
               </span>
@@ -166,12 +198,26 @@ export function TreasuryOverview() {
           </AccordionItem>
         )}
 
+        {incomeVsOutflow.length > 0 && (
+          <AccordionItem
+            value="epoch-flow"
+            className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
+          >
+            <AccordionTrigger className="text-sm font-semibold hover:no-underline">
+              Income vs outflow by epoch
+            </AccordionTrigger>
+            <AccordionContent>
+              <TreasuryEpochFlow data={incomeVsOutflow} />
+            </AccordionContent>
+          </AccordionItem>
+        )}
+
         <AccordionItem
           value="accountability"
           className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
         >
           <AccordionTrigger className="text-sm font-semibold hover:no-underline">
-            Spending Accountability
+            Did funded projects deliver?
             {effectivenessRate !== null && (
               <span className="ml-2 text-xs font-normal text-muted-foreground">
                 {effectivenessRate}% delivered
@@ -188,7 +234,7 @@ export function TreasuryOverview() {
           className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5"
         >
           <AccordionTrigger className="text-sm font-semibold hover:no-underline">
-            Explore Runway Scenarios
+            How long will the treasury last?
           </AccordionTrigger>
           <AccordionContent>
             <TreasurySimulator currentBalance={balance} burnRate={burnRate} currentEpoch={epoch} />

--- a/components/treasury/TreasuryPersonalImpact.tsx
+++ b/components/treasury/TreasuryPersonalImpact.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { formatAda } from '@/lib/treasury';
+import type { DRepTreasuryRecord } from '@/lib/treasury';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { useTreasuryPending } from '@/hooks/queries';
+
+interface TreasuryPersonalImpactProps {
+  balanceAda: number;
+  nclRemainingAda: number | null;
+  nclAda: number | null;
+  nclUtilizationPct: number | null;
+}
+
+export function TreasuryPersonalImpact({
+  balanceAda,
+  nclRemainingAda,
+  nclAda,
+  nclUtilizationPct,
+}: TreasuryPersonalImpactProps) {
+  const { drepId } = useSegment();
+
+  const { data: rawRecord } = useQuery<{ record: DRepTreasuryRecord }>({
+    queryKey: ['treasury-drep-record', drepId],
+    queryFn: async () => {
+      const res = await fetch(`/api/treasury/drep-record?drepId=${encodeURIComponent(drepId!)}`);
+      if (!res.ok) throw new Error('Failed to fetch DRep treasury record');
+      return res.json();
+    },
+    enabled: !!drepId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: rawPending } = useTreasuryPending();
+  const pending = rawPending as { totalAda: number; proposals: unknown[] } | undefined;
+
+  const record = rawRecord?.record;
+  const hasDRepData = !!record && record.totalProposals > 0;
+
+  // Compute what-if: if all pending pass, new utilization
+  const pendingTotalAda = pending?.totalAda ?? 0;
+  const postPendingUtilization =
+    nclAda && nclRemainingAda != null && nclUtilizationPct != null
+      ? Math.round(((nclAda - nclRemainingAda + pendingTotalAda) / nclAda) * 100)
+      : null;
+
+  if (!hasDRepData && pendingTotalAda === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
+      <h3 className="text-sm font-semibold mb-3">Your Treasury Impact</h3>
+
+      <div className="space-y-3">
+        {/* DRep voting record summary */}
+        {hasDRepData && record && (
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">Approved </span>
+              <span className="font-semibold text-emerald-400">
+                ₳{formatAda(record.approvedAda)}
+              </span>
+              <span className="text-muted-foreground text-xs ml-1">
+                ({record.approvedCount} proposals)
+              </span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Opposed </span>
+              <span className="font-semibold text-red-400">₳{formatAda(record.opposedAda)}</span>
+              <span className="text-muted-foreground text-xs ml-1">({record.opposedCount})</span>
+            </div>
+            {record.abstainedCount > 0 && (
+              <div>
+                <span className="text-muted-foreground">Abstained </span>
+                <span className="font-semibold">{record.abstainedCount}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Judgment score */}
+        {hasDRepData && record?.judgmentScore !== null && record?.judgmentScore !== undefined && (
+          <div className="text-sm">
+            <span className="text-muted-foreground">Of what you approved, </span>
+            <span className="font-semibold">{record.judgmentScore}%</span>
+            <span className="text-muted-foreground"> delivered results</span>
+          </div>
+        )}
+
+        {/* Pending impact projection */}
+        {pendingTotalAda > 0 && (
+          <div className="text-sm text-muted-foreground pt-2 border-t border-border/30">
+            If all {pending?.proposals.length ?? 0} pending proposals pass:{' '}
+            <span className="font-semibold text-foreground">₳{formatAda(pendingTotalAda)}</span>{' '}
+            leaves the treasury
+            {postPendingUtilization !== null && nclUtilizationPct !== null && (
+              <span>
+                {' '}
+                — budget utilization{' '}
+                <span className="font-semibold text-foreground">
+                  {Math.round(nclUtilizationPct)}% → {postPendingUtilization}%
+                </span>
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/treasury/TreasuryVerdict.tsx
+++ b/components/treasury/TreasuryVerdict.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { formatAda } from '@/lib/treasury';
+import type { NclUtilization } from '@/lib/treasury';
+
+interface TreasuryVerdictProps {
+  balanceAda: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  ncl: NclUtilization | null;
+  effectivenessRate: number | null;
+  pendingCount: number;
+  runwayMonths: number;
+}
+
+type VerdictStatus = 'healthy' | 'attention' | 'critical';
+
+function deriveStatus(
+  ncl: NclUtilization | null,
+  effectivenessRate: number | null,
+  trend: 'growing' | 'shrinking' | 'stable',
+  runwayMonths: number,
+): VerdictStatus {
+  // Critical: NCL critical, or runway < 12 months
+  if (ncl?.status === 'critical') return 'critical';
+  if (runwayMonths > 0 && runwayMonths < 12) return 'critical';
+
+  // Attention: NCL elevated, effectiveness low, or shrinking trend
+  if (ncl?.status === 'elevated') return 'attention';
+  if (effectivenessRate !== null && effectivenessRate < 50) return 'attention';
+  if (trend === 'shrinking') return 'attention';
+
+  return 'healthy';
+}
+
+const STATUS_CONFIG = {
+  healthy: {
+    label: 'Treasury is Healthy',
+    color: 'text-emerald-400',
+    ring: 'ring-emerald-500/20',
+    bg: 'bg-emerald-500/10',
+    dot: 'bg-emerald-500',
+    glow: 'shadow-[0_0_12px_rgba(16,185,129,0.15)]',
+  },
+  attention: {
+    label: 'Treasury Needs Attention',
+    color: 'text-amber-400',
+    ring: 'ring-amber-500/20',
+    bg: 'bg-amber-500/10',
+    dot: 'bg-amber-500',
+    glow: 'shadow-[0_0_12px_rgba(245,158,11,0.15)]',
+  },
+  critical: {
+    label: 'Treasury Under Pressure',
+    color: 'text-red-400',
+    ring: 'ring-red-500/20',
+    bg: 'bg-red-500/10',
+    dot: 'bg-red-500',
+    glow: 'shadow-[0_0_12px_rgba(239,68,68,0.15)]',
+  },
+} as const;
+
+export function TreasuryVerdict({
+  balanceAda,
+  trend,
+  ncl,
+  effectivenessRate,
+  pendingCount,
+  runwayMonths,
+}: TreasuryVerdictProps) {
+  const status = deriveStatus(ncl, effectivenessRate, trend, runwayMonths);
+  const config = STATUS_CONFIG[status];
+
+  const nclPct = ncl ? `${Math.round(ncl.utilizationPct)}%` : null;
+  const effectivenessPct = effectivenessRate !== null ? `${effectivenessRate}%` : null;
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 ring-1',
+        config.ring,
+        config.glow,
+      )}
+    >
+      {/* Verdict headline */}
+      <div className="flex items-center gap-2.5 mb-3">
+        <span className={cn('h-2.5 w-2.5 rounded-full animate-pulse', config.dot)} />
+        <h2 className={cn('text-lg font-semibold', config.color)}>{config.label}</h2>
+      </div>
+
+      {/* Inline stats */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        {nclPct && (
+          <span className="text-muted-foreground">
+            Budget <span className="font-semibold text-foreground">{nclPct}</span> used
+          </span>
+        )}
+        {effectivenessPct && (
+          <span className="text-muted-foreground">
+            <span className="font-semibold text-foreground">{effectivenessPct}</span> delivered
+          </span>
+        )}
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-foreground">{pendingCount}</span> pending
+        </span>
+        <span className="text-muted-foreground">
+          ₳<span className="font-semibold text-foreground">{formatAda(balanceAda)}</span> balance
+          {trend !== 'stable' && (
+            <span className="ml-1 text-xs">({trend === 'growing' ? '↑' : '↓'})</span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Restructure `/governance/treasury` with progressive 4-level depth disclosure
- **Level 1 (Verdict)**: New `TreasuryVerdict` component — glanceable health indicator (green/amber/red) with inline stats (budget used, delivered %, pending count, balance + trend)
- **Level 2 (Budget Story)**: NCL budget bar + key metrics with contextual intro sentence
- **Level 3 (Active Decisions)**: DRep track record moved above pending proposals as contextual header
- **Level 4 (Your Impact)**: New `TreasuryPersonalImpact` component — DRep voting record summary, judgment score, and what-if pending impact projection. Segment-gated to DRep/Citizen.
- **Deep Dive**: EpochFlow demoted from always-visible to accordion. Accordion labels rewritten as questions ("How has spending evolved?", "Did funded projects deliver?", "How long will the treasury last?")

## Impact
- **What changed**: Treasury page restructured from flat layout to 4-level progressive disclosure
- **User-facing**: Yes — clearer 5-second verdict, better organized sections, new personal impact section for DReps
- **Risk**: Low — no data layer changes, no API changes, no migrations. Pure frontend restructuring using existing data hooks.
- **Scope**: 3 files (1 new TreasuryVerdict, 1 new TreasuryPersonalImpact, 1 rewritten TreasuryOverview)

## Test plan
- [ ] Verify treasury page loads for anonymous users (Level 1 + 2 visible, Level 3 proposals visible, Level 4 hidden)
- [ ] Verify DRep segment shows Level 3 track record + Level 4 personal impact
- [ ] Verify Citizen segment shows Level 4 pending impact (if applicable)
- [ ] Verify all deep-dive accordions expand/collapse correctly
- [ ] Verify health indicator color logic (healthy/attention/critical) with different NCL states

🤖 Generated with [Claude Code](https://claude.com/claude-code)