### PR TITLE
feat: implement 4-level depth gating on health page

### DIFF
--- a/app/governance/health/page.tsx
+++ b/app/governance/health/page.tsx
@@ -7,6 +7,7 @@ import { FunnelExploreTracker } from '@/components/funnel/FunnelExploreTracker';
 import { GovernadaPulseOverview } from '@/components/governada/pulse/GovernadaPulseOverview';
 import { Skeleton } from '@/components/ui/skeleton';
 import { FeatureGate } from '@/components/FeatureGate';
+import { DepthGate } from '@/components/providers/DepthGate';
 import { GovernanceTemperature } from '@/components/community/GovernanceTemperature';
 import { CitizenMandate } from '@/components/community/CitizenMandate';
 import { SentimentDivergence } from '@/components/community/SentimentDivergence';
@@ -61,20 +62,24 @@ export default function HealthPage() {
           <GovernadaPulseOverview />
         </Suspense>
 
-        {/* Community Intelligence — all feature-flagged */}
-        <FeatureGate flag="governance_temperature">
-          <GovernanceTemperature />
-        </FeatureGate>
-
-        <div className="grid gap-6 lg:grid-cols-2">
-          <FeatureGate flag="community_mandate">
-            <CitizenMandate />
+        {/* Community Intelligence — feature-flagged + depth-gated */}
+        <DepthGate minDepth="engaged">
+          <FeatureGate flag="governance_temperature">
+            <GovernanceTemperature />
           </FeatureGate>
+        </DepthGate>
 
-          <FeatureGate flag="sentiment_divergence">
-            <SentimentDivergence />
-          </FeatureGate>
-        </div>
+        <DepthGate minDepth="deep">
+          <div className="grid gap-6 lg:grid-cols-2">
+            <FeatureGate flag="community_mandate">
+              <CitizenMandate />
+            </FeatureGate>
+
+            <FeatureGate flag="sentiment_divergence">
+              <SentimentDivergence />
+            </FeatureGate>
+          </div>
+        </DepthGate>
       </div>
     </>
   );

--- a/components/governada/pulse/GHIExplorer.tsx
+++ b/components/governada/pulse/GHIExplorer.tsx
@@ -34,6 +34,8 @@ interface GHIExplorerProps {
   componentTrends: Record<string, { direction: string; delta: number }>;
   band: string;
   score: number;
+  /** When false, hides sparklines, calibration zones, and trend deltas */
+  showTrends?: boolean;
 }
 
 const BAND_COLORS: Record<string, string> = {
@@ -149,6 +151,7 @@ export function GHIExplorer({
   componentTrends,
   band,
   score,
+  showTrends = true,
 }: GHIExplorerProps) {
   const [expanded, setExpanded] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -245,27 +248,30 @@ export function GHIExplorer({
                       />
                     </div>
 
-                    {/* Zone indicator */}
-                    {curve && <ZoneIndicator value={comp.value} curve={curve} />}
+                    {/* Zone indicator (deep only) */}
+                    {showTrends && curve && <ZoneIndicator value={comp.value} curve={curve} />}
 
-                    {/* Footer: sparkline + trend */}
-                    <div className="flex items-center justify-between">
-                      <MiniSparkline data={sparkData} />
-                      {trend && trend.delta !== 0 && (
-                        <span
-                          className={cn(
-                            'text-[10px] font-medium',
-                            trend.direction === 'up'
-                              ? 'text-emerald-500'
-                              : trend.direction === 'down'
-                                ? 'text-rose-500'
-                                : 'text-muted-foreground',
-                          )}
-                        >
-                          {trend.direction === 'up' ? '↑' : '↓'} {Math.abs(trend.delta).toFixed(1)}
-                        </span>
-                      )}
-                    </div>
+                    {/* Footer: sparkline + trend (deep only) */}
+                    {showTrends && (
+                      <div className="flex items-center justify-between">
+                        <MiniSparkline data={sparkData} />
+                        {trend && trend.delta !== 0 && (
+                          <span
+                            className={cn(
+                              'text-[10px] font-medium',
+                              trend.direction === 'up'
+                                ? 'text-emerald-500'
+                                : trend.direction === 'down'
+                                  ? 'text-rose-500'
+                                  : 'text-muted-foreground',
+                            )}
+                          >
+                            {trend.direction === 'up' ? '↑' : '↓'}{' '}
+                            {Math.abs(trend.delta).toFixed(1)}
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </motion.div>
                 );
               })}

--- a/components/governada/pulse/GovernadaPulseOverview.tsx
+++ b/components/governada/pulse/GovernadaPulseOverview.tsx
@@ -110,6 +110,14 @@ function GHIMinimal() {
   };
   const scoreColor = BAND_COLORS[band] ?? BAND_COLORS.fair;
 
+  const BAND_VERDICTS: Record<string, string> = {
+    strong: 'Governance is thriving. Nothing needs your attention.',
+    good: 'Governance is healthy. No action needed.',
+    fair: 'Governance needs attention. Some areas are underperforming.',
+    critical: 'Governance is struggling. Participation and accountability are low.',
+  };
+  const verdict = BAND_VERDICTS[band] ?? BAND_VERDICTS.fair;
+
   return (
     <div
       className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 space-y-1"
@@ -127,7 +135,7 @@ function GHIMinimal() {
         </span>
         <TrendIcon className={cn('h-4 w-4', trendColor)} />
       </div>
-      <p className="text-xs text-muted-foreground capitalize">{band}</p>
+      <p className="text-xs text-muted-foreground">{verdict}</p>
     </div>
   );
 }
@@ -270,7 +278,7 @@ export function GovernadaPulseOverview() {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { isAtLeast } = useGovernanceDepth();
-  const depthConfig = useDepthConfig('governance');
+  const healthConfig = useDepthConfig('health');
 
   const activeTab = resolvePulseTab(searchParams.get('tab'));
 
@@ -348,7 +356,7 @@ export function GovernadaPulseOverview() {
     return <GHIMinimal />;
   }
 
-  // ── Informed: score + dimension breakdown + briefing & alerts, no tabs ──
+  // ── Informed: score + dimension breakdown + briefing & critical alerts only ──
   if (!isAtLeast('engaged')) {
     return (
       <div className="space-y-6">
@@ -361,12 +369,16 @@ export function GovernadaPulseOverview() {
           losers={losers}
           criticalProposals={pulse?.criticalProposals}
           loading={loading}
+          alertLevel={healthConfig.alertLevel as 'critical' | 'full'}
         />
       </div>
     );
   }
 
-  // ── Engaged + Deep: full dashboard (current behavior = Engaged baseline) ─
+  // ── Engaged + Deep: full dashboard, config-driven ──────────────────────
+  const visibleTabs = TABS.filter((t) => healthConfig.availableTabs.includes(t.id));
+  // If user navigated to a tab their depth doesn't include, fall back to 'now'
+  const safeTab = healthConfig.availableTabs.includes(activeTab) ? activeTab : 'now';
 
   return (
     <div className="space-y-6 pt-4" data-discovery="gov-health">
@@ -390,17 +402,17 @@ export function GovernadaPulseOverview() {
         role="tablist"
         aria-label="Pulse view"
       >
-        {TABS.map((tab) => (
+        {visibleTabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             role="tab"
-            aria-selected={activeTab === tab.id}
+            aria-selected={safeTab === tab.id}
             aria-controls={`pulse-tabpanel-${tab.id}`}
             className={cn(
               'px-4 py-2 text-sm font-medium shrink-0 border-b-2 transition-colors',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-              activeTab === tab.id
+              safeTab === tab.id
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground',
             )}
@@ -410,23 +422,24 @@ export function GovernadaPulseOverview() {
         ))}
       </div>
 
-      {activeTab === 'observatory' && (
+      {/* ── Observatory tab (deep only) ───── */}
+      {healthConfig.showObservatory && safeTab === 'observatory' && (
         <div role="tabpanel" id="pulse-tabpanel-observatory" aria-label="Observatory">
           <GovernadaObservatory />
         </div>
       )}
 
       {/* ── History tab ───── */}
-      {activeTab === 'history' && (
+      {safeTab === 'history' && (
         <div className="space-y-8" role="tabpanel" id="pulse-tabpanel-history" aria-label="History">
           <GovernadaEpochReport />
-          <GovernadaGovernanceTrends />
+          {healthConfig.showTrends && <GovernadaGovernanceTrends />}
           <GovernadaGovernanceCalendar />
         </div>
       )}
 
       {/* ── Now tab ──────── */}
-      {activeTab === 'now' && (
+      {safeTab === 'now' && (
         <div className="space-y-8" role="tabpanel" id="pulse-tabpanel-now" aria-label="Now">
           {/* 1. GHI Verdict */}
           <GHIHero />
@@ -450,6 +463,7 @@ export function GovernadaPulseOverview() {
             losers={losers}
             criticalProposals={pulse?.criticalProposals}
             loading={loading}
+            alertLevel={healthConfig.alertLevel as 'critical' | 'full'}
           />
 
           {/* 5. GHI Explorer (click-to-expand breakdown) */}
@@ -461,6 +475,7 @@ export function GovernadaPulseOverview() {
               componentTrends={ghiData.componentTrends}
               band={ghiData.current.band}
               score={ghiData.current.score}
+              showTrends={healthConfig.showGHIExplorerTrends}
             />
           )}
           {!ghiData?.current && !loading && (
@@ -471,12 +486,11 @@ export function GovernadaPulseOverview() {
             />
           )}
 
-          {/* 6. Live Activity Ticker */}
-          <ActivityTicker variant="inline" />
+          {/* 6. Live Activity Ticker (deep only) */}
+          {healthConfig.showActivityTicker && <ActivityTicker variant="inline" />}
 
           {/* 7. Deep: historical overlay placeholder */}
           <DepthGate minDepth="deep">
-            {/* TODO: Phase 6+ — Historical health overlay, cross-epoch comparison, health projections */}
             <div className="rounded-xl border border-dashed border-border/40 bg-card/30 p-4 text-center">
               <p className="text-xs text-muted-foreground/60">
                 Historical health overlay and epoch comparison coming soon

--- a/components/governada/pulse/GovernanceAlerts.tsx
+++ b/components/governada/pulse/GovernanceAlerts.tsx
@@ -26,6 +26,8 @@ interface GovernanceAlertsProps {
   losers?: LeaderboardEntry[];
   criticalProposals?: number;
   loading?: boolean;
+  /** Filter alerts by level: 'critical' shows only priority 0, 'full' shows all */
+  alertLevel?: 'critical' | 'full';
 }
 
 interface Alert {
@@ -133,7 +135,7 @@ function buildAlerts(props: GovernanceAlertsProps): Alert[] {
 }
 
 export function GovernanceAlerts(props: GovernanceAlertsProps) {
-  const { loading } = props;
+  const { loading, alertLevel = 'full' } = props;
 
   if (loading) {
     return (
@@ -144,7 +146,8 @@ export function GovernanceAlerts(props: GovernanceAlertsProps) {
     );
   }
 
-  const alerts = buildAlerts(props);
+  const allAlerts = buildAlerts(props);
+  const alerts = alertLevel === 'critical' ? allAlerts.filter((a) => a.priority === 0) : allAlerts;
 
   return (
     <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">

--- a/hooks/useDepthConfig.ts
+++ b/hooks/useDepthConfig.ts
@@ -65,6 +65,49 @@ const GOVERNANCE_CONFIG = {
   },
 } as const satisfies Record<GovernanceDepth, object>;
 
+const HEALTH_CONFIG = {
+  hands_off: {
+    showTabs: false,
+    availableTabs: [] as readonly string[],
+    showActivityTicker: false,
+    showTrends: false,
+    showObservatory: false,
+    alertLevel: 'none' as const,
+    showGHIExplorerTrends: false,
+    communityIntel: 'none' as const,
+  },
+  informed: {
+    showTabs: false,
+    availableTabs: [] as readonly string[],
+    showActivityTicker: false,
+    showTrends: false,
+    showObservatory: false,
+    alertLevel: 'critical' as const,
+    showGHIExplorerTrends: false,
+    communityIntel: 'none' as const,
+  },
+  engaged: {
+    showTabs: true,
+    availableTabs: ['now', 'history'] as readonly string[],
+    showActivityTicker: false,
+    showTrends: false,
+    showObservatory: false,
+    alertLevel: 'full' as const,
+    showGHIExplorerTrends: false,
+    communityIntel: 'temperature' as const,
+  },
+  deep: {
+    showTabs: true,
+    availableTabs: ['now', 'history', 'observatory'] as readonly string[],
+    showActivityTicker: true,
+    showTrends: true,
+    showObservatory: true,
+    alertLevel: 'full' as const,
+    showGHIExplorerTrends: true,
+    communityIntel: 'all' as const,
+  },
+} as const satisfies Record<GovernanceDepth, object>;
+
 // ---------------------------------------------------------------------------
 // Type mapping
 // ---------------------------------------------------------------------------
@@ -72,6 +115,7 @@ const GOVERNANCE_CONFIG = {
 type SurfaceConfigs = {
   hub: (typeof HUB_CONFIG)[GovernanceDepth];
   governance: (typeof GOVERNANCE_CONFIG)[GovernanceDepth];
+  health: (typeof HEALTH_CONFIG)[GovernanceDepth];
 };
 
 // ---------------------------------------------------------------------------
@@ -86,9 +130,14 @@ type SurfaceConfigs = {
  */
 export function useDepthConfig<S extends keyof SurfaceConfigs>(surface: S): SurfaceConfigs[S] {
   const { depth } = useGovernanceDepth();
-  const configs: { hub: typeof HUB_CONFIG; governance: typeof GOVERNANCE_CONFIG } = {
+  const configs: {
+    hub: typeof HUB_CONFIG;
+    governance: typeof GOVERNANCE_CONFIG;
+    health: typeof HEALTH_CONFIG;
+  } = {
     hub: HUB_CONFIG,
     governance: GOVERNANCE_CONFIG,
+    health: HEALTH_CONFIG,
   };
   return configs[surface][depth] as SurfaceConfigs[S];
 }


### PR DESCRIPTION
## Summary
- Implements all 4 depth levels (hands-off / informed / engaged / deep) on the `/governance/health` page, which previously treated engaged and deep identically
- Adds `HEALTH_CONFIG` surface to `useDepthConfig` with per-level flags for tabs, alerts, trends, ticker, observatory, and community intelligence
- Hands-off now shows a plain-language verdict sentence alongside the score
- Informed alerts are filtered to critical-only (priority 0); engaged/deep get all alerts
- Engaged shows Now + History tabs; Deep unlocks Observatory tab + governance trends + activity ticker
- GHI Explorer hides sparklines/calibration at engaged level via new `showTrends` prop
- Community Intelligence: Temperature at engaged+, Mandate/Divergence at deep only

## Impact
- **What changed**: Health page now progressively discloses content based on the user's governance depth setting
- **User-facing**: Yes — users at different depth levels see meaningfully different amounts of information
- **Risk**: Low — no data changes, no API changes, no migrations. Pure frontend gating of existing components
- **Scope**: 5 files (useDepthConfig.ts, GovernadaPulseOverview.tsx, GovernanceAlerts.tsx, GHIExplorer.tsx, health/page.tsx)

## Test plan
- [x] Preflight passes (614 tests, 0 errors)
- [ ] Verify hands-off view shows score + verdict sentence
- [ ] Verify informed view shows critical alerts only (no leaderboard movers)
- [ ] Verify engaged view shows Now + History tabs (no Observatory)
- [ ] Verify deep view shows all 3 tabs + activity ticker + full alerts
- [ ] Verify Community Intelligence gating (Temperature at engaged, Mandate/Divergence at deep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)