### PR TITLE
feat: CC scoring fairness, proposal-anchored trends, and 4-level depth

### DIFF
--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -12,16 +12,18 @@ export const GET = withRouteHandler(async () => {
   // Parallel fetches: active members, votes, rationale names, health, verdicts
   const [
     { data: activeMembers, error: membersError },
-    { data: votes, error: votesError },
+    { data: votes, error: _votesError },
     { data: rationaleNames },
     health,
     verdicts,
   ] = await Promise.all([
     supabase
       .from('cc_members')
-      .select('cc_hot_id, author_name, fidelity_grade, fidelity_score, status')
+      .select(
+        'cc_hot_id, author_name, fidelity_grade, fidelity_score, status, rationale_provision_rate',
+      )
       .eq('status', 'authorized'),
-    supabase.from('cc_votes').select('cc_hot_id, vote'),
+    supabase.from('cc_votes').select('cc_hot_id, vote, proposal_tx_hash, proposal_index'),
     supabase.from('cc_rationales').select('cc_hot_id, author_name').not('author_name', 'is', null),
     getCCHealthSummary(),
     getCCMemberVerdicts(),
@@ -52,6 +54,22 @@ export const GET = withRouteHandler(async () => {
     else existing.abstain++;
     voteMap.set(v.cc_hot_id, existing);
   }
+
+  // Compute aggregate stats
+  const proposalSet = new Set<string>();
+  for (const v of votes ?? []) {
+    proposalSet.add(`${v.proposal_tx_hash}:${v.proposal_index}`);
+  }
+  const totalProposalsReviewed = proposalSet.size;
+  const totalCCVotes = (votes ?? []).length;
+
+  const ratesWithValues = (activeMembers ?? [])
+    .map((m) => m.rationale_provision_rate)
+    .filter((r): r is number => r != null);
+  const avgRationaleRate =
+    ratesWithValues.length > 0
+      ? Math.round(ratesWithValues.reduce((a, b) => a + b, 0) / ratesWithValues.length)
+      : null;
 
   // Build verdict lookup
   const verdictMap = new Map(verdicts.map((v) => [v.ccHotId, v]));
@@ -84,8 +102,10 @@ export const GET = withRouteHandler(async () => {
       return b.voteCount - a.voteCount;
     });
 
+  const stats = { totalProposalsReviewed, avgRationaleRate, totalCCVotes };
+
   return NextResponse.json(
-    { members, health },
+    { members, health, stats },
     {
       headers: {
         'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',

--- a/app/governance/committee/[ccHotId]/page.tsx
+++ b/app/governance/committee/[ccHotId]/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { createClient } from '@/lib/supabase';
-import { getCCFidelityHistory, getCCMembersFidelity } from '@/lib/data';
+import {
+  getCCFidelityHistory,
+  getCCMembersFidelity,
+  getCCProposalFidelityHistory,
+} from '@/lib/data';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { CCMemberProfileClient } from '@/components/cc/CCMemberProfileClient';
@@ -39,6 +43,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     { data: rationales },
     { data: alignmentRows },
     fidelityHistory,
+    proposalFidelityHistory,
     allMembers,
     { data: proposals },
   ] = await Promise.all([
@@ -60,6 +65,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
         'proposal_tx_hash, proposal_index, drep_yes_pct, drep_no_pct, spo_yes_pct, spo_no_pct',
       ),
     getCCFidelityHistory(decodedId),
+    getCCProposalFidelityHistory(decodedId),
     getCCMembersFidelity(),
     supabase.from('proposals').select('tx_hash, proposal_index, title, proposal_type'),
   ]);
@@ -166,6 +172,14 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
       }
     : null;
 
+  // Derive authorization epoch from earliest vote if not stored on the member
+  const authorizationEpoch: number | null =
+    (member as Record<string, unknown>)?.authorization_epoch != null
+      ? Number((member as Record<string, unknown>).authorization_epoch)
+      : safeVotes.length > 0
+        ? Math.min(...safeVotes.map((v) => v.epoch as number))
+        : null;
+
   const profileData = {
     ccHotId: decodedId,
     authorName,
@@ -173,6 +187,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     fidelityGrade: member?.fidelity_grade ?? null,
     status: member?.status ?? null,
     expirationEpoch: member?.expiration_epoch ?? null,
+    authorizationEpoch,
     rank: rank > 0 ? rank : null,
     totalScored,
     totalVotes,
@@ -191,6 +206,7 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
     pillarScores,
     enrichedVotes,
     fidelityHistory,
+    proposalFidelityHistory,
   };
 
   return (

--- a/app/governance/committee/compare/loading.tsx
+++ b/app/governance/committee/compare/loading.tsx
@@ -1,0 +1,29 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CompareLoading() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      {/* Breadcrumb skeleton */}
+      <Skeleton className="h-4 w-48" />
+
+      {/* Title skeleton */}
+      <Skeleton className="h-8 w-64" />
+
+      {/* Member selector grid skeleton */}
+      <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="rounded-xl border p-4 space-y-3">
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+            <Skeleton className="h-1.5 w-full rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/governance/committee/compare/page.tsx
+++ b/app/governance/committee/compare/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from 'next';
+import { getCCMembersFidelity } from '@/lib/data';
+import { PageViewTracker } from '@/components/PageViewTracker';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
+import { CCComparisonView } from '@/components/cc/CCComparisonView';
+import type { ComparisonMember } from '@/components/cc/CCComparisonView';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Compare CC Members — Constitutional Committee — Governada',
+  description:
+    'Side-by-side comparison of Constitutional Committee members on fidelity scores, participation, grounding, and reasoning quality.',
+};
+
+interface PageProps {
+  searchParams: Promise<{ members?: string }>;
+}
+
+export default async function ComparePage({ searchParams }: PageProps) {
+  const { members: membersParam } = await searchParams;
+  const allMembers = await getCCMembersFidelity();
+
+  // Map to comparison shape
+  const allComparisonMembers: ComparisonMember[] = allMembers.map((m) => ({
+    ccHotId: m.ccHotId,
+    authorName: m.authorName,
+    fidelityScore: m.fidelityScore,
+    fidelityGrade: m.fidelityGrade,
+    participationScore: m.participationScore,
+    constitutionalGroundingScore: m.constitutionalGroundingScore,
+    reasoningQualityScore: m.reasoningQualityScore,
+    rationaleProvisionRate: m.rationaleProvisionRate,
+    votesCast: m.votesCast,
+    eligibleProposals: m.eligibleProposals,
+  }));
+
+  // Parse selected member IDs from query param
+  let selectedMembers: ComparisonMember[] = [];
+  if (membersParam) {
+    const ids = membersParam
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean);
+    const memberMap = new Map(allComparisonMembers.map((m) => [m.ccHotId, m]));
+    selectedMembers = ids
+      .map((id) => memberMap.get(id))
+      .filter((m): m is ComparisonMember => m != null)
+      .slice(0, 4); // max 4
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6 sm:py-8 space-y-6">
+      <PageViewTracker
+        event="cc_compare_viewed"
+        properties={{ member_count: selectedMembers.length }}
+      />
+      <Breadcrumb
+        items={[
+          { label: 'Governance', href: '/' },
+          { label: 'Committee', href: '/governance/committee' },
+          { label: 'Compare' },
+        ]}
+      />
+      <CCComparisonView members={selectedMembers} allMembers={allComparisonMembers} />
+    </div>
+  );
+}

--- a/app/governance/committee/data/loading.tsx
+++ b/app/governance/committee/data/loading.tsx
@@ -1,0 +1,47 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DataLoading() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 py-6 space-y-6">
+      {/* Breadcrumb skeleton */}
+      <Skeleton className="h-4 w-48" />
+
+      {/* Title skeleton */}
+      <Skeleton className="h-8 w-64" />
+
+      {/* Heatmap skeleton */}
+      <div className="rounded-xl border p-5 space-y-4">
+        <Skeleton className="h-5 w-48" />
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton className="h-4 w-28 shrink-0" />
+              <div className="flex-1 flex gap-1">
+                {Array.from({ length: 6 }).map((_, j) => (
+                  <Skeleton key={j} className="h-8 flex-1 rounded" />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Export buttons skeleton */}
+      <div className="rounded-xl border p-5 space-y-4">
+        <Skeleton className="h-5 w-32" />
+        <div className="flex gap-3">
+          <Skeleton className="h-10 w-32 rounded-lg" />
+          <Skeleton className="h-10 w-32 rounded-lg" />
+        </div>
+      </div>
+
+      {/* Methodology skeleton */}
+      <div className="rounded-xl border p-5 space-y-4">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/app/governance/committee/data/page.tsx
+++ b/app/governance/committee/data/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from 'next';
+import { createClient } from '@/lib/supabase';
+import { getCCMembersFidelity } from '@/lib/data';
+import { PageViewTracker } from '@/components/PageViewTracker';
+import { Breadcrumb } from '@/components/shared/Breadcrumb';
+import { CCDataExport } from '@/components/cc/CCDataExport';
+import type { DataMember, CitationData } from '@/components/cc/CCDataExport';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Data & Methodology — Constitutional Committee — Governada',
+  description:
+    'Full scoring methodology, article citation analysis, and data export for CC member fidelity scores.',
+};
+
+export default async function DataPage() {
+  const supabase = createClient();
+
+  const [allMembers, { data: rationales }] = await Promise.all([
+    getCCMembersFidelity(),
+    supabase.from('cc_rationales').select('cc_hot_id, cited_articles'),
+  ]);
+
+  // Map to data export shape
+  const members: DataMember[] = allMembers.map((m) => ({
+    ccHotId: m.ccHotId,
+    authorName: m.authorName,
+    fidelityScore: m.fidelityScore,
+    fidelityGrade: m.fidelityGrade,
+    participationScore: m.participationScore,
+    constitutionalGroundingScore: m.constitutionalGroundingScore,
+    reasoningQualityScore: m.reasoningQualityScore,
+    rationaleProvisionRate: m.rationaleProvisionRate,
+    votesCast: m.votesCast,
+    eligibleProposals: m.eligibleProposals,
+  }));
+
+  // Process citation data — each rationale row becomes a CitationData entry
+  const citations: CitationData[] = (rationales ?? [])
+    .filter((r) => r.cited_articles != null)
+    .map((r) => ({
+      ccHotId: r.cc_hot_id,
+      citedArticles: (r.cited_articles as string[]) ?? [],
+    }));
+
+  return (
+    <div className="container mx-auto px-4 py-6 sm:py-8 space-y-6">
+      <PageViewTracker event="cc_data_viewed" />
+      <Breadcrumb
+        items={[
+          { label: 'Governance', href: '/' },
+          { label: 'Committee', href: '/governance/committee' },
+          { label: 'Data & Methodology' },
+        ]}
+      />
+      <CCDataExport members={members} citations={citations} />
+    </div>
+  );
+}

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -219,6 +219,12 @@ function Methodology() {
               </div>
             ))}
           </div>
+          <Link
+            href="/governance/committee/data"
+            className="inline-block text-xs text-muted-foreground hover:text-foreground transition-colors mt-1"
+          >
+            View full methodology &amp; data export &rarr;
+          </Link>
         </div>
       )}
     </div>
@@ -261,6 +267,7 @@ export default function CommitteePage() {
 
   const members = useMemo(() => data?.members ?? [], [data]);
   const health = data?.health;
+  const stats = data?.stats;
 
   const sorted = useMemo(
     () =>
@@ -295,9 +302,41 @@ export default function CommitteePage() {
           {/* Section 2: Key Insight (persona-adapted) */}
           <CCInsightCard health={health} members={members} segment={segment} />
 
-          {/* Section 3: Member Rankings */}
+          {/* Section 3: Aggregate Stats */}
+          {stats && (
+            <motion.div variants={fadeInUp} className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <div className="rounded-xl border border-border/60 bg-card/30 p-3 text-center">
+                <p className="text-2xl font-bold tabular-nums">{health.activeMembers}</p>
+                <p className="text-xs text-muted-foreground">Active Members</p>
+              </div>
+              <div className="rounded-xl border border-border/60 bg-card/30 p-3 text-center">
+                <p className="text-2xl font-bold tabular-nums">{stats.totalProposalsReviewed}</p>
+                <p className="text-xs text-muted-foreground">Proposals Reviewed</p>
+              </div>
+              <div className="rounded-xl border border-border/60 bg-card/30 p-3 text-center">
+                <p className="text-2xl font-bold tabular-nums">
+                  {stats.avgRationaleRate != null ? `${stats.avgRationaleRate}%` : '—'}
+                </p>
+                <p className="text-xs text-muted-foreground">Avg Rationale Rate</p>
+              </div>
+              <div className="rounded-xl border border-border/60 bg-card/30 p-3 text-center">
+                <p className="text-2xl font-bold tabular-nums">{stats.totalCCVotes}</p>
+                <p className="text-xs text-muted-foreground">Total Votes</p>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Section 4: Member Rankings */}
           <motion.div variants={fadeInUp} className="space-y-3">
-            <h2 className="text-base font-semibold">Member Rankings</h2>
+            <div className="flex items-center justify-between">
+              <h2 className="text-base font-semibold">Member Rankings</h2>
+              <Link
+                href="/governance/committee/compare"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Compare Members
+              </Link>
+            </div>
 
             {sorted.length === 0 ? (
               <div className="py-12 text-center text-sm text-muted-foreground">
@@ -321,7 +360,7 @@ export default function CommitteePage() {
             )}
           </motion.div>
 
-          {/* Section 4: Methodology (collapsed) */}
+          {/* Section 5: Methodology (collapsed) */}
           <motion.div variants={fadeInUp}>
             <Methodology />
           </motion.div>

--- a/components/cc/CCComparisonView.tsx
+++ b/components/cc/CCComparisonView.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { ArrowLeft, Vote, BookOpen, Sparkles, Check, GitCompareArrows } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { staggerContainer, fadeInUp } from '@/lib/animations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ComparisonMember {
+  ccHotId: string;
+  authorName: string | null;
+  fidelityScore: number | null;
+  fidelityGrade: string | null;
+  participationScore: number | null;
+  constitutionalGroundingScore: number | null;
+  reasoningQualityScore: number | null;
+  rationaleProvisionRate: number | null;
+  votesCast: number | null;
+  eligibleProposals: number | null;
+}
+
+interface CCComparisonViewProps {
+  members: ComparisonMember[];
+  allMembers: ComparisonMember[];
+}
+
+// ---------------------------------------------------------------------------
+// Grade utilities
+// ---------------------------------------------------------------------------
+
+const GRADE_COLORS: Record<string, { text: string; bg: string; border: string }> = {
+  A: { text: 'text-emerald-500', bg: 'bg-emerald-500/10', border: 'border-emerald-500/30' },
+  B: { text: 'text-sky-500', bg: 'bg-sky-500/10', border: 'border-sky-500/30' },
+  C: { text: 'text-amber-500', bg: 'bg-amber-500/10', border: 'border-amber-500/30' },
+  D: { text: 'text-orange-500', bg: 'bg-orange-500/10', border: 'border-orange-500/30' },
+  F: { text: 'text-rose-500', bg: 'bg-rose-500/10', border: 'border-rose-500/30' },
+};
+
+function pillarBarColor(score: number | null): string {
+  if (score == null) return 'bg-muted';
+  if (score >= 80) return 'bg-emerald-500/80';
+  if (score >= 60) return 'bg-sky-500/80';
+  if (score >= 40) return 'bg-amber-500/80';
+  return 'bg-rose-500/80';
+}
+
+const MEMBER_COLORS = ['bg-sky-500', 'bg-violet-500', 'bg-amber-500', 'bg-emerald-500'] as const;
+
+function displayName(m: ComparisonMember): string {
+  return m.authorName ?? `${m.ccHotId.slice(0, 8)}...${m.ccHotId.slice(-4)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Member Selector
+// ---------------------------------------------------------------------------
+
+function MemberSelector({
+  allMembers,
+  selected,
+  onToggle,
+  onCompare,
+}: {
+  allMembers: ComparisonMember[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onCompare: () => void;
+}) {
+  const sorted = useMemo(
+    () =>
+      [...allMembers].sort((a, b) => {
+        if (a.fidelityScore != null && b.fidelityScore != null)
+          return b.fidelityScore - a.fidelityScore;
+        if (a.fidelityScore != null) return -1;
+        if (b.fidelityScore != null) return 1;
+        return 0;
+      }),
+    [allMembers],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold">Select Members to Compare</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Choose 2-4 members for side-by-side comparison
+          </p>
+        </div>
+        <button
+          onClick={onCompare}
+          disabled={selected.size < 2}
+          className={cn(
+            'flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+            selected.size >= 2
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+              : 'bg-muted text-muted-foreground cursor-not-allowed',
+          )}
+        >
+          <GitCompareArrows className="h-4 w-4" />
+          Compare ({selected.size})
+        </button>
+      </div>
+
+      <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+        {sorted.map((member) => {
+          const isSelected = selected.has(member.ccHotId);
+          const gradeStyle = member.fidelityGrade ? GRADE_COLORS[member.fidelityGrade] : null;
+          const isDisabled = !isSelected && selected.size >= 4;
+
+          return (
+            <button
+              key={member.ccHotId}
+              onClick={() => !isDisabled && onToggle(member.ccHotId)}
+              disabled={isDisabled}
+              className={cn(
+                'relative rounded-xl border p-4 text-left transition-all',
+                isSelected
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+                  : 'border-border/60 hover:bg-muted/40',
+                isDisabled && 'opacity-40 cursor-not-allowed',
+              )}
+            >
+              {/* Selection indicator */}
+              {isSelected && (
+                <div className="absolute top-2 right-2 h-5 w-5 rounded-full bg-primary flex items-center justify-center">
+                  <Check className="h-3 w-3 text-primary-foreground" />
+                </div>
+              )}
+
+              <div className="flex items-center gap-3">
+                {/* Grade badge */}
+                {gradeStyle && member.fidelityGrade ? (
+                  <span
+                    className={cn(
+                      'flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border text-sm font-bold',
+                      gradeStyle.bg,
+                      gradeStyle.text,
+                      gradeStyle.border,
+                    )}
+                  >
+                    {member.fidelityGrade}
+                  </span>
+                ) : (
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted text-sm text-muted-foreground">
+                    —
+                  </span>
+                )}
+
+                <div className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium truncate">{displayName(member)}</span>
+                  <span className="block text-xs text-muted-foreground tabular-nums">
+                    {member.fidelityScore ?? '—'} / 100
+                  </span>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pillar comparison bars
+// ---------------------------------------------------------------------------
+
+interface PillarComparisonProps {
+  label: string;
+  icon: React.ReactNode;
+  weight: string;
+  members: ComparisonMember[];
+  getValue: (m: ComparisonMember) => number | null;
+}
+
+function PillarComparison({ label, icon, weight, members, getValue }: PillarComparisonProps) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/30 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium flex items-center gap-1.5">
+          {icon}
+          {label}
+        </span>
+        <span className="text-[10px] text-muted-foreground">{weight}</span>
+      </div>
+
+      <div className="space-y-2">
+        {members.map((member, idx) => {
+          const score = getValue(member);
+          return (
+            <div key={member.ccHotId} className="flex items-center gap-2">
+              <span
+                className={cn(
+                  'h-2.5 w-2.5 rounded-full shrink-0',
+                  MEMBER_COLORS[idx % MEMBER_COLORS.length],
+                )}
+              />
+              <span className="text-xs text-muted-foreground w-20 truncate shrink-0">
+                {displayName(member).split(' ')[0]}
+              </span>
+              <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                <motion.div
+                  className={cn('h-full rounded-full', pillarBarColor(score))}
+                  initial={{ width: 0 }}
+                  animate={{ width: `${score ?? 0}%` }}
+                  transition={{ duration: 0.7, ease: [0.4, 0, 0.2, 1], delay: 0.2 + idx * 0.1 }}
+                />
+              </div>
+              <span className="text-xs tabular-nums text-muted-foreground w-8 text-right">
+                {score != null ? Math.round(score) : '—'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Score Comparison (columns)
+// ---------------------------------------------------------------------------
+
+function ScoreComparison({ members }: { members: ComparisonMember[] }) {
+  const gridClass =
+    members.length === 2
+      ? 'grid-cols-2'
+      : members.length === 3
+        ? 'grid-cols-3'
+        : 'grid-cols-2 sm:grid-cols-4';
+
+  return (
+    <div className="space-y-6">
+      {/* Member columns */}
+      <div className={cn('grid gap-4', gridClass)}>
+        {members.map((member, idx) => {
+          const grade = member.fidelityGrade ? GRADE_COLORS[member.fidelityGrade] : null;
+          const voteRate =
+            member.votesCast != null &&
+            member.eligibleProposals != null &&
+            member.eligibleProposals > 0
+              ? Math.round((member.votesCast / member.eligibleProposals) * 100)
+              : null;
+
+          return (
+            <motion.div
+              key={member.ccHotId}
+              variants={fadeInUp}
+              className="rounded-xl border border-border/60 bg-card/30 overflow-hidden"
+            >
+              {/* Color bar */}
+              <div className={cn('h-1', MEMBER_COLORS[idx % MEMBER_COLORS.length])} />
+
+              <div className="p-4 space-y-4">
+                {/* Name + Grade */}
+                <div className="text-center space-y-2">
+                  <Link
+                    href={`/governance/committee/${encodeURIComponent(member.ccHotId)}`}
+                    className="text-sm font-medium hover:text-primary transition-colors line-clamp-2"
+                  >
+                    {displayName(member)}
+                  </Link>
+                  {grade && member.fidelityGrade && (
+                    <div
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5',
+                        grade.bg,
+                        grade.border,
+                      )}
+                    >
+                      <span className={cn('text-2xl font-bold tabular-nums', grade.text)}>
+                        {member.fidelityScore}
+                      </span>
+                      <span className={cn('text-xs font-bold', grade.text)}>
+                        {member.fidelityGrade}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                {/* Stats */}
+                <div className="space-y-2 text-xs">
+                  <div className="flex items-center justify-between">
+                    <span className="text-muted-foreground">Votes</span>
+                    <span className="font-mono tabular-nums">
+                      {member.votesCast ?? '—'}
+                      {member.eligibleProposals != null ? ` / ${member.eligibleProposals}` : ''}
+                    </span>
+                  </div>
+                  {voteRate != null && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-muted-foreground">Vote Rate</span>
+                      <span className="font-mono tabular-nums">{voteRate}%</span>
+                    </div>
+                  )}
+                  {member.rationaleProvisionRate != null && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-muted-foreground">Rationale Rate</span>
+                      <span className="font-mono tabular-nums">
+                        {Math.round(member.rationaleProvisionRate)}%
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      {/* Pillar comparison bars */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold">Pillar Comparison</h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <PillarComparison
+            label="Participation"
+            icon={<Vote className="h-3.5 w-3.5" />}
+            weight="30%"
+            members={members}
+            getValue={(m) => m.participationScore}
+          />
+          <PillarComparison
+            label="Constitutional Grounding"
+            icon={<BookOpen className="h-3.5 w-3.5" />}
+            weight="40%"
+            members={members}
+            getValue={(m) => m.constitutionalGroundingScore}
+          />
+          <PillarComparison
+            label="Reasoning Quality"
+            icon={<Sparkles className="h-3.5 w-3.5" />}
+            weight="30%"
+            members={members}
+            getValue={(m) => m.reasoningQualityScore}
+          />
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 flex-wrap text-xs text-muted-foreground">
+        {members.map((member, idx) => (
+          <span key={member.ccHotId} className="flex items-center gap-1.5">
+            <span
+              className={cn('h-2.5 w-2.5 rounded-full', MEMBER_COLORS[idx % MEMBER_COLORS.length])}
+            />
+            {displayName(member)}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export function CCComparisonView({ members, allMembers }: CCComparisonViewProps) {
+  const router = useRouter();
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(members.map((m) => m.ccHotId)),
+  );
+
+  const showComparison = members.length >= 2;
+
+  function handleToggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (next.size < 4) {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function handleCompare() {
+    if (selected.size < 2) return;
+    const ids = Array.from(selected).join(',');
+    router.push(`/governance/committee/compare?members=${encodeURIComponent(ids)}`);
+  }
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className="space-y-6"
+    >
+      {/* Back link */}
+      <motion.div variants={fadeInUp}>
+        <Link
+          href="/governance/committee"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Committee
+        </Link>
+      </motion.div>
+
+      {/* Title */}
+      <motion.div variants={fadeInUp}>
+        <h1 className="text-2xl font-bold">Compare Members</h1>
+        {showComparison && (
+          <p className="text-sm text-muted-foreground mt-1">
+            Side-by-side comparison of {members.length} CC members
+          </p>
+        )}
+      </motion.div>
+
+      {/* Comparison or Selector */}
+      {showComparison ? (
+        <motion.div variants={fadeInUp}>
+          <ScoreComparison members={members} />
+        </motion.div>
+      ) : (
+        <motion.div variants={fadeInUp}>
+          <MemberSelector
+            allMembers={allMembers}
+            selected={selected}
+            onToggle={handleToggle}
+            onCompare={handleCompare}
+          />
+        </motion.div>
+      )}
+
+      {/* If showing comparison, also show selector below to modify selection */}
+      {showComparison && (
+        <motion.div variants={fadeInUp}>
+          <MemberSelector
+            allMembers={allMembers}
+            selected={selected}
+            onToggle={handleToggle}
+            onCompare={handleCompare}
+          />
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/components/cc/CCConstitutionalReasoning.tsx
+++ b/components/cc/CCConstitutionalReasoning.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useMemo } from 'react';
+import { BookOpen, AlertTriangle, FileText } from 'lucide-react';
+import { EXPECTED_ARTICLES } from '@/lib/cc/fidelityScore';
+import type { EnrichedVote } from '@/components/cc/CCMemberProfileClient';
+
+interface CCConstitutionalReasoningProps {
+  votes: EnrichedVote[];
+}
+
+export function CCConstitutionalReasoning({ votes }: CCConstitutionalReasoningProps) {
+  // Article citation frequency
+  const articleCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const v of votes) {
+      for (const article of v.citedArticles) {
+        counts.set(article, (counts.get(article) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  }, [votes]);
+
+  const maxCitations = articleCounts.length > 0 ? articleCounts[0][1] : 1;
+
+  // Blind spots: expected articles per proposal type that were never cited
+  const blindSpots = useMemo(() => {
+    const allCitedArticles = new Set<string>();
+    for (const v of votes) {
+      for (const article of v.citedArticles) {
+        allCitedArticles.add(article);
+      }
+    }
+
+    // Collect proposal types this member voted on
+    const votedTypes = new Set(votes.map((v) => v.proposalType));
+
+    const spots: Array<{ proposalType: string; missingArticles: string[] }> = [];
+    for (const type of votedTypes) {
+      const expected = EXPECTED_ARTICLES[type];
+      if (!expected) continue;
+      const missing = expected.filter((exp) => {
+        // Fuzzy match: same logic as fidelityScore.ts
+        const parts = exp.split(/[,\xA7\s]+/).filter(Boolean);
+        return !Array.from(allCitedArticles).some((cited) =>
+          parts.every((part) => cited.includes(part)),
+        );
+      });
+      if (missing.length > 0) {
+        spots.push({ proposalType: type, missingArticles: missing });
+      }
+    }
+    return spots;
+  }, [votes]);
+
+  // Rationale quality distribution
+  const rationaleStats = useMemo(() => {
+    const withRationale = votes.filter((v) => v.hasRationale).length;
+    const withParsedRationale = votes.filter((v) => v.rationaleSummary).length;
+    const withArticles = votes.filter((v) => v.citedArticles.length > 0).length;
+    return {
+      total: votes.length,
+      withRationale,
+      withoutRationale: votes.length - withRationale,
+      withParsedRationale,
+      withArticles,
+    };
+  }, [votes]);
+
+  if (votes.length === 0) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-5 text-center">
+        <p className="text-sm text-muted-foreground">No votes to analyze.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Article Citation Frequency */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <BookOpen className="h-4 w-4" />
+          Article Citation Frequency
+        </h3>
+        {articleCounts.length > 0 ? (
+          <div className="space-y-2">
+            {articleCounts.map(([article, count]) => (
+              <div key={article} className="flex items-center gap-3">
+                <span className="text-xs text-muted-foreground w-40 shrink-0 truncate">
+                  {article}
+                </span>
+                <div className="flex-1 h-2.5 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-sky-500/70"
+                    style={{ width: `${(count / maxCitations) * 100}%` }}
+                  />
+                </div>
+                <span className="text-xs tabular-nums text-muted-foreground w-8 text-right">
+                  {count}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No constitutional articles cited in any rationale.
+          </p>
+        )}
+      </div>
+
+      {/* Blind Spots */}
+      {blindSpots.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
+            Citation Blind Spots
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Expected constitutional articles for voted proposal types that were never cited.
+          </p>
+          <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+            {blindSpots.map(({ proposalType, missingArticles }) => (
+              <div key={proposalType} className="px-4 py-2.5 space-y-1">
+                <p className="text-xs font-medium">{proposalType}</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {missingArticles.map((article) => (
+                    <span
+                      key={article}
+                      className="inline-flex items-center px-2 py-0.5 rounded-md bg-amber-500/10 text-amber-500 border border-amber-500/20 text-[10px]"
+                    >
+                      {article}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Rationale Quality Distribution */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <FileText className="h-4 w-4" />
+          Rationale Quality Distribution
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-3 text-center space-y-1">
+            <p className="text-lg font-bold tabular-nums text-emerald-500">
+              {rationaleStats.withRationale}
+            </p>
+            <p className="text-[10px] text-muted-foreground">With Rationale</p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-3 text-center space-y-1">
+            <p className="text-lg font-bold tabular-nums text-rose-500">
+              {rationaleStats.withoutRationale}
+            </p>
+            <p className="text-[10px] text-muted-foreground">Without Rationale</p>
+          </div>
+          <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-3 text-center space-y-1">
+            <p className="text-lg font-bold tabular-nums text-sky-500">
+              {rationaleStats.withArticles}
+            </p>
+            <p className="text-[10px] text-muted-foreground">With Article Citations</p>
+          </div>
+        </div>
+        {rationaleStats.total > 0 && (
+          <div className="h-3 rounded-full bg-muted overflow-hidden flex">
+            {rationaleStats.withRationale > 0 && (
+              <div
+                className="h-full bg-emerald-500/70"
+                style={{
+                  width: `${(rationaleStats.withRationale / rationaleStats.total) * 100}%`,
+                }}
+              />
+            )}
+            {rationaleStats.withoutRationale > 0 && (
+              <div
+                className="h-full bg-rose-500/30"
+                style={{
+                  width: `${(rationaleStats.withoutRationale / rationaleStats.total) * 100}%`,
+                }}
+              />
+            )}
+          </div>
+        )}
+        <div className="flex items-center gap-3 text-[10px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-emerald-500/70" /> With rationale
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-rose-500/30" /> Without rationale
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/cc/CCDataExport.tsx
+++ b/components/cc/CCDataExport.tsx
@@ -1,0 +1,547 @@
+'use client';
+
+import { useMemo, useCallback } from 'react';
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft,
+  Download,
+  FileJson,
+  Vote,
+  BookOpen,
+  Sparkles,
+  Scale,
+  FileText,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { staggerContainer, fadeInUp } from '@/lib/animations';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DataMember {
+  ccHotId: string;
+  authorName: string | null;
+  fidelityScore: number | null;
+  fidelityGrade: string | null;
+  participationScore: number | null;
+  constitutionalGroundingScore: number | null;
+  reasoningQualityScore: number | null;
+  rationaleProvisionRate: number | null;
+  votesCast: number | null;
+  eligibleProposals: number | null;
+}
+
+export interface CitationData {
+  ccHotId: string;
+  citedArticles: string[];
+}
+
+interface CCDataExportProps {
+  members: DataMember[];
+  citations: CitationData[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KNOWN_ARTICLES = [
+  'Article II, § 6',
+  'Article II, § 7',
+  'Article III',
+  'Article III, § 6',
+  'Article V',
+  'Article VI',
+];
+
+const EXPECTED_ARTICLES: Record<string, string[]> = {
+  TreasuryWithdrawals: ['Article II, § 6', 'Article II, § 7'],
+  ParameterChange: ['Article II, § 6', 'Article III'],
+  HardForkInitiation: ['Article II, § 6', 'Article III, § 6'],
+  InfoAction: ['Article II, § 6'],
+  NoConfidence: ['Article II, § 6', 'Article V'],
+  NewCommittee: ['Article II, § 6', 'Article V'],
+  NewConstitutionalCommittee: ['Article II, § 6', 'Article V'],
+  NewConstitution: ['Article II, § 6', 'Article VI'],
+  UpdateConstitution: ['Article II, § 6', 'Article VI'],
+};
+
+const GRADE_BOUNDARIES = [
+  { grade: 'A', min: 85, color: 'text-emerald-500', bg: 'bg-emerald-500/10' },
+  { grade: 'B', min: 70, color: 'text-sky-500', bg: 'bg-sky-500/10' },
+  { grade: 'C', min: 55, color: 'text-amber-500', bg: 'bg-amber-500/10' },
+  { grade: 'D', min: 40, color: 'text-orange-500', bg: 'bg-orange-500/10' },
+  { grade: 'F', min: 0, color: 'text-rose-500', bg: 'bg-rose-500/10' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function displayName(m: DataMember): string {
+  return m.authorName ?? `${m.ccHotId.slice(0, 12)}...`;
+}
+
+function matchArticle(cited: string, article: string): boolean {
+  const parts = article.split(/[,§\s]+/).filter(Boolean);
+  return parts.every((part) => cited.includes(part));
+}
+
+function heatmapColor(count: number): string {
+  if (count === 0) return 'bg-muted/50 text-muted-foreground';
+  if (count <= 2) return 'bg-sky-500/15 text-sky-600 dark:text-sky-400';
+  if (count <= 5) return 'bg-sky-500/30 text-sky-700 dark:text-sky-300';
+  return 'bg-sky-500/50 text-sky-800 dark:text-sky-200 font-medium';
+}
+
+// ---------------------------------------------------------------------------
+// Article Citation Heatmap
+// ---------------------------------------------------------------------------
+
+function CitationHeatmap({
+  members,
+  citations,
+}: {
+  members: DataMember[];
+  citations: CitationData[];
+}) {
+  // Build citation count map: memberId -> article -> count
+  const heatmapData = useMemo(() => {
+    const memberCounts = new Map<string, Map<string, number>>();
+
+    for (const c of citations) {
+      if (!memberCounts.has(c.ccHotId)) {
+        memberCounts.set(c.ccHotId, new Map());
+      }
+      const articleMap = memberCounts.get(c.ccHotId)!;
+      for (const cited of c.citedArticles) {
+        for (const knownArticle of KNOWN_ARTICLES) {
+          if (matchArticle(cited, knownArticle)) {
+            articleMap.set(knownArticle, (articleMap.get(knownArticle) ?? 0) + 1);
+          }
+        }
+      }
+    }
+
+    return memberCounts;
+  }, [citations]);
+
+  // Only show members who have at least one citation
+  const membersWithData = useMemo(
+    () => members.filter((m) => heatmapData.has(m.ccHotId)),
+    [members, heatmapData],
+  );
+
+  if (membersWithData.length === 0) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-card/30 p-5 text-center">
+        <p className="text-sm text-muted-foreground">No article citation data available yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/30 p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <BookOpen className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">Article Citation Heatmap</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        How often each CC member cites specific constitutional articles across their rationales.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="text-left py-2 pr-3 font-medium text-muted-foreground min-w-[120px]">
+                Member
+              </th>
+              {KNOWN_ARTICLES.map((article) => (
+                <th
+                  key={article}
+                  className="text-center py-2 px-1.5 font-medium text-muted-foreground whitespace-nowrap"
+                >
+                  {article.replace('Article ', 'Art. ').replace(', §', ' §')}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {membersWithData.map((member) => {
+              const articleMap = heatmapData.get(member.ccHotId);
+              return (
+                <tr key={member.ccHotId} className="border-b last:border-0">
+                  <td className="py-2 pr-3">
+                    <Link
+                      href={`/governance/committee/${encodeURIComponent(member.ccHotId)}`}
+                      className="text-xs font-medium hover:text-primary transition-colors truncate block max-w-[140px]"
+                      title={displayName(member)}
+                    >
+                      {displayName(member)}
+                    </Link>
+                  </td>
+                  {KNOWN_ARTICLES.map((article) => {
+                    const count = articleMap?.get(article) ?? 0;
+                    return (
+                      <td key={article} className="py-2 px-1.5 text-center">
+                        <span
+                          className={cn(
+                            'inline-flex h-7 w-10 items-center justify-center rounded text-xs tabular-nums',
+                            heatmapColor(count),
+                          )}
+                        >
+                          {count > 0 ? count : '·'}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Heatmap legend */}
+      <div className="flex items-center gap-3 text-[10px] text-muted-foreground pt-2 border-t border-border/30">
+        <span>Intensity:</span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-5 rounded bg-muted/50" /> 0
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-5 rounded bg-sky-500/15" /> 1-2
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-5 rounded bg-sky-500/30" /> 3-5
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-3 w-5 rounded bg-sky-500/50" /> 6+
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Data Export Section
+// ---------------------------------------------------------------------------
+
+function DataExportButtons({ members }: { members: DataMember[] }) {
+  const generateCSV = useCallback(() => {
+    const headers = [
+      'Member Name',
+      'Hot Key ID',
+      'Fidelity Score',
+      'Grade',
+      'Participation',
+      'Constitutional Grounding',
+      'Reasoning Quality',
+      'Votes Cast',
+      'Eligible Proposals',
+      'Rationale Rate',
+    ];
+
+    const rows = members.map((m) => [
+      m.authorName ?? '',
+      m.ccHotId,
+      m.fidelityScore?.toString() ?? '',
+      m.fidelityGrade ?? '',
+      m.participationScore?.toString() ?? '',
+      m.constitutionalGroundingScore?.toString() ?? '',
+      m.reasoningQualityScore?.toString() ?? '',
+      m.votesCast?.toString() ?? '',
+      m.eligibleProposals?.toString() ?? '',
+      m.rationaleProvisionRate != null ? `${Math.round(m.rationaleProvisionRate)}%` : '',
+    ]);
+
+    const csvContent = [
+      headers.join(','),
+      ...rows.map((r) => r.map((c) => `"${c}"`).join(',')),
+    ].join('\n');
+
+    downloadFile(csvContent, 'cc-members-fidelity.csv', 'text/csv');
+  }, [members]);
+
+  const generateJSON = useCallback(() => {
+    const data = members.map((m) => ({
+      memberName: m.authorName,
+      hotKeyId: m.ccHotId,
+      fidelityScore: m.fidelityScore,
+      grade: m.fidelityGrade,
+      participation: m.participationScore,
+      constitutionalGrounding: m.constitutionalGroundingScore,
+      reasoningQuality: m.reasoningQualityScore,
+      votesCast: m.votesCast,
+      eligibleProposals: m.eligibleProposals,
+      rationaleRate: m.rationaleProvisionRate,
+    }));
+
+    downloadFile(JSON.stringify(data, null, 2), 'cc-members-fidelity.json', 'application/json');
+  }, [members]);
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/30 p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <Download className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">Data Export</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Download CC member fidelity scores and metrics for research and analysis.
+      </p>
+
+      <div className="flex gap-3">
+        <button
+          onClick={generateCSV}
+          className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-card/50 px-4 py-2.5 text-sm font-medium hover:bg-muted/60 transition-colors"
+        >
+          <FileText className="h-4 w-4" />
+          Export CSV
+        </button>
+        <button
+          onClick={generateJSON}
+          className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-card/50 px-4 py-2.5 text-sm font-medium hover:bg-muted/60 transition-colors"
+        >
+          <FileJson className="h-4 w-4" />
+          Export JSON
+        </button>
+      </div>
+
+      <p className="text-[10px] text-muted-foreground">
+        {members.length} members &middot; Scores updated with each governance action sync
+      </p>
+    </div>
+  );
+}
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ---------------------------------------------------------------------------
+// Methodology Section
+// ---------------------------------------------------------------------------
+
+function FullMethodology() {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/30 p-5 space-y-6">
+      <div className="flex items-center gap-2">
+        <Scale className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-base font-semibold">Full Scoring Methodology</h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        The Constitutional Fidelity Score measures how well a CC member fulfills their
+        constitutional role — not how often they agree with DReps. It is a composite of three
+        weighted pillars.
+      </p>
+
+      {/* Composite formula */}
+      <div className="rounded-lg border border-border/40 bg-muted/20 p-4 space-y-2">
+        <h3 className="text-sm font-semibold">Composite Score</h3>
+        <p className="text-xs text-muted-foreground font-mono">
+          Fidelity = (Participation × 0.30) + (Constitutional Grounding × 0.40) + (Reasoning Quality
+          × 0.30)
+        </p>
+        <p className="text-xs text-muted-foreground">Range: 0-100</p>
+      </div>
+
+      {/* Grade boundaries */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold">Grade Boundaries</h3>
+        <div className="flex gap-2 flex-wrap">
+          {GRADE_BOUNDARIES.map((g) => (
+            <span
+              key={g.grade}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium',
+                g.bg,
+                g.color,
+                'border-current/20',
+              )}
+            >
+              <span className="font-bold">{g.grade}</span>
+              <span className="text-muted-foreground">
+                {g.grade === 'F' ? '< 40' : `>= ${g.min}`}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Pillar 1 */}
+      <div className="rounded-lg border border-border/40 p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Vote className="h-4 w-4 text-sky-500" />
+          <h3 className="text-sm font-semibold">Pillar 1: Participation (30%)</h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Measures the CC member&apos;s vote rate on proposals they were eligible to vote on.
+        </p>
+        <div className="bg-muted/20 rounded-md p-3">
+          <p className="text-xs font-mono text-muted-foreground">
+            Participation Score = (Votes Cast / Eligible Proposals) × 100
+          </p>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Eligible proposals are determined by the member&apos;s authorization period — only
+          proposals created while the member was an active CC member count.
+        </p>
+      </div>
+
+      {/* Pillar 2 */}
+      <div className="rounded-lg border border-border/40 p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <BookOpen className="h-4 w-4 text-emerald-500" />
+          <h3 className="text-sm font-semibold">Pillar 2: Constitutional Grounding (40%)</h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Measures how well the member grounds their votes in the Cardano Constitution. Composed of
+          two sub-scores:
+        </p>
+        <div className="bg-muted/20 rounded-md p-3 space-y-2">
+          <p className="text-xs font-mono text-muted-foreground">
+            Constitutional Grounding = (Rationale Provision × 0.35) + (Article Coverage × 0.65)
+          </p>
+          <p className="text-xs text-muted-foreground">
+            <strong>Rationale Provision</strong> — Percentage of votes that include a CIP-136
+            rationale document.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            <strong>Article Coverage</strong> — How well cited articles match the expected
+            constitutional articles for each proposal type. Average coverage across all votes with
+            rationales.
+          </p>
+        </div>
+
+        {/* Expected articles table */}
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium">Expected Articles per Proposal Type</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b text-muted-foreground">
+                  <th className="text-left py-1.5 pr-3 font-medium">Proposal Type</th>
+                  <th className="text-left py-1.5 font-medium">Expected Articles</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(EXPECTED_ARTICLES).map(([type, articles]) => (
+                  <tr key={type} className="border-b last:border-0">
+                    <td className="py-1.5 pr-3 font-mono">{type}</td>
+                    <td className="py-1.5 text-muted-foreground">{articles.join(', ')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Pillar 3 */}
+      <div className="rounded-lg border border-border/40 p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-violet-500" />
+          <h3 className="text-sm font-semibold">Pillar 3: Reasoning Quality (30%)</h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          AI-assessed depth and quality of constitutional analysis in vote rationales. Each
+          rationale is scored on:
+        </p>
+        <ul className="text-xs text-muted-foreground space-y-1 list-disc pl-4">
+          <li>Depth of constitutional argument (not just mentioning articles)</li>
+          <li>Logical coherence and structured reasoning</li>
+          <li>Consideration of counterarguments</li>
+          <li>Precedent discussion where applicable</li>
+        </ul>
+        <div className="bg-muted/20 rounded-md p-3">
+          <p className="text-xs font-mono text-muted-foreground">
+            Reasoning Quality = Average AI score across all rationales (0-100)
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Fallback when AI scoring unavailable: Article Coverage score is used as a proxy.
+          </p>
+        </div>
+      </div>
+
+      {/* Data sources */}
+      <div className="rounded-lg border border-border/40 p-4 space-y-2">
+        <h3 className="text-sm font-semibold">Data Sources</h3>
+        <ul className="text-xs text-muted-foreground space-y-1 list-disc pl-4">
+          <li>
+            <strong>Votes:</strong> On-chain CC votes via Koios API, synced every epoch
+          </li>
+          <li>
+            <strong>Rationales:</strong> CIP-136 rationale documents fetched from member-provided
+            URLs
+          </li>
+          <li>
+            <strong>Proposals:</strong> Governance actions from Koios with type classification
+          </li>
+          <li>
+            <strong>AI Scoring:</strong> Reasoning quality assessed via LLM analysis of rationale
+            text
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export function CCDataExport({ members, citations }: CCDataExportProps) {
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className="space-y-6"
+    >
+      {/* Back link */}
+      <motion.div variants={fadeInUp}>
+        <Link
+          href="/governance/committee"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to Committee
+        </Link>
+      </motion.div>
+
+      {/* Title */}
+      <motion.div variants={fadeInUp}>
+        <h1 className="text-2xl font-bold">Data & Methodology</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Full scoring methodology, article citation analysis, and data export for researchers.
+        </p>
+      </motion.div>
+
+      {/* Section 1: Citation Heatmap */}
+      <motion.div variants={fadeInUp}>
+        <CitationHeatmap members={members} citations={citations} />
+      </motion.div>
+
+      {/* Section 2: Data Export */}
+      <motion.div variants={fadeInUp}>
+        <DataExportButtons members={members} />
+      </motion.div>
+
+      {/* Section 3: Full Methodology */}
+      <motion.div variants={fadeInUp}>
+        <FullMethodology />
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/components/cc/CCMemberProfileClient.tsx
+++ b/components/cc/CCMemberProfileClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, Suspense } from 'react';
 import Link from 'next/link';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { motion } from 'framer-motion';
 import {
   Vote,
@@ -12,9 +13,15 @@ import {
   Scale,
   ChevronLeft,
   ChevronRight,
+  ChevronDown,
+  ArrowRight,
+  ArrowLeft,
+  TrendingUp,
+  Filter,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import dynamic from 'next/dynamic';
 
@@ -23,6 +30,8 @@ const CCTransparencyTrend = dynamic(
     import('@/components/cc/CCTransparencyTrend').then((m) => ({ default: m.CCTransparencyTrend })),
   { ssr: false, loading: () => <div className="h-48 animate-pulse bg-muted rounded-xl" /> },
 );
+import { CCRecentVotes } from '@/components/cc/CCRecentVotes';
+import { CCConstitutionalReasoning } from '@/components/cc/CCConstitutionalReasoning';
 import { CopyableAddress } from '@/components/CopyableAddress';
 import {
   interpretFidelityScore,
@@ -32,13 +41,13 @@ import {
   interpretPillarStrengthWeakness,
 } from '@/lib/cc/interpretations';
 import { staggerContainer, fadeInUp } from '@/lib/animations';
-import type { CCFidelitySnapshot } from '@/lib/data';
+import type { CCFidelitySnapshot, CCProposalFidelitySnapshot } from '@/lib/data';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-interface EnrichedVote {
+export interface EnrichedVote {
   proposalTxHash: string;
   proposalIndex: number;
   vote: string;
@@ -65,6 +74,7 @@ interface ProfileData {
   fidelityGrade: string | null;
   status: string | null;
   expirationEpoch: number | null;
+  authorizationEpoch: number | null;
   rank: number | null;
   totalScored: number;
   totalVotes: number;
@@ -83,6 +93,7 @@ interface ProfileData {
   pillarScores: PillarScores | null;
   enrichedVotes: EnrichedVote[];
   fidelityHistory: CCFidelitySnapshot[];
+  proposalFidelityHistory?: CCProposalFidelitySnapshot[];
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +271,27 @@ function KeyStats({ data }: { data: ProfileData }) {
 }
 
 // ---------------------------------------------------------------------------
+// Term Context Line
+// ---------------------------------------------------------------------------
+
+function TermContext({ data }: { data: ProfileData }) {
+  const parts: string[] = [];
+  if (data.authorizationEpoch != null) {
+    parts.push(`Authorized since epoch ${data.authorizationEpoch}`);
+  }
+  if (data.expirationEpoch != null) {
+    parts.push(`Term expires epoch ${data.expirationEpoch}`);
+  }
+  if (parts.length === 0) return null;
+  return (
+    <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+      <ShieldCheck className="h-3 w-3 shrink-0" />
+      {parts.join(' \u2022 ')}
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // PillarBar (reused from old page, adapted)
 // ---------------------------------------------------------------------------
 
@@ -302,65 +334,131 @@ function PillarBar({
 }
 
 // ---------------------------------------------------------------------------
-// Overview Tab
+// Pillar Breakdown (extracted for reuse between overview and deep)
 // ---------------------------------------------------------------------------
 
-function OverviewTab({ data }: { data: ProfileData }) {
+function PillarBreakdown({ data }: { data: ProfileData }) {
+  if (!data.pillarScores || data.fidelityScore == null) return null;
   return (
-    <div className="space-y-6">
-      {/* Pillar breakdown */}
-      {data.pillarScores && data.fidelityScore != null && (
-        <div className="space-y-3">
-          <h3 className="text-sm font-semibold flex items-center gap-2">
-            <Scale className="h-4 w-4" />
-            Constitutional Fidelity Breakdown
-          </h3>
-          <div className="grid gap-4 sm:grid-cols-3">
-            <PillarBar
-              icon={<Vote className="h-3.5 w-3.5" />}
-              label="Participation"
-              weight="30%"
-              score={data.pillarScores.participation}
-              delay={0}
-            />
-            <PillarBar
-              icon={<BookOpen className="h-3.5 w-3.5" />}
-              label="Constitutional Grounding"
-              weight="40%"
-              score={data.pillarScores.constitutionalGrounding}
-              delay={0.1}
-            />
-            <PillarBar
-              icon={<Sparkles className="h-3.5 w-3.5" />}
-              label="Reasoning Quality"
-              weight="30%"
-              score={data.pillarScores.reasoningQuality}
-              delay={0.2}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Fidelity trend */}
-      <CCTransparencyTrend history={data.fidelityHistory} />
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold flex items-center gap-2">
+        <Scale className="h-4 w-4" />
+        Constitutional Fidelity Breakdown
+      </h3>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <PillarBar
+          icon={<Vote className="h-3.5 w-3.5" />}
+          label="Participation"
+          weight="30%"
+          score={data.pillarScores.participation}
+          delay={0}
+        />
+        <PillarBar
+          icon={<BookOpen className="h-3.5 w-3.5" />}
+          label="Constitutional Grounding"
+          weight="40%"
+          score={data.pillarScores.constitutionalGrounding}
+          delay={0.1}
+        />
+        <PillarBar
+          icon={<Sparkles className="h-3.5 w-3.5" />}
+          label="Reasoning Quality"
+          weight="30%"
+          score={data.pillarScores.reasoningQuality}
+          delay={0.2}
+        />
+      </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Voting Record Tab (paginated)
+// Voting Record Tab (paginated, with filters for Level 3)
 // ---------------------------------------------------------------------------
 
 function VotingRecordTab({ votes }: { votes: EnrichedVote[] }) {
   const [page, setPage] = useState(0);
-  const totalPages = Math.ceil(votes.length / VOTES_PER_PAGE);
+  const [typeFilter, setTypeFilter] = useState<string>('all');
+  const [alignmentFilter, setAlignmentFilter] = useState<'all' | 'aligned' | 'diverged'>('all');
+
+  // Available proposal types
+  const proposalTypes = useMemo(() => {
+    const types = new Set(votes.map((v) => v.proposalType));
+    return Array.from(types).sort();
+  }, [votes]);
+
+  // Filtered votes
+  const filteredVotes = useMemo(() => {
+    let result = votes;
+    if (typeFilter !== 'all') {
+      result = result.filter((v) => v.proposalType === typeFilter);
+    }
+    if (alignmentFilter !== 'all') {
+      result = result.filter((v) => {
+        if (!v.drepMajority || v.drepMajority === 'Abstain') return false;
+        const isAligned = v.vote === v.drepMajority;
+        return alignmentFilter === 'aligned' ? isAligned : !isAligned;
+      });
+    }
+    return result;
+  }, [votes, typeFilter, alignmentFilter]);
+
+  const totalPages = Math.ceil(filteredVotes.length / VOTES_PER_PAGE);
   const pageVotes = useMemo(
-    () => votes.slice(page * VOTES_PER_PAGE, (page + 1) * VOTES_PER_PAGE),
-    [votes, page],
+    () => filteredVotes.slice(page * VOTES_PER_PAGE, (page + 1) * VOTES_PER_PAGE),
+    [filteredVotes, page],
   );
+
+  // Reset page when filters change
+  useEffect(() => {
+    setPage(0);
+  }, [typeFilter, alignmentFilter]);
 
   return (
     <div className="space-y-3">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+        <div className="relative">
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="appearance-none rounded-lg border border-border/60 bg-card/30 px-3 py-1.5 pr-7 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="all">All types</option>
+            {proposalTypes.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground pointer-events-none" />
+        </div>
+        <div className="relative">
+          <select
+            value={alignmentFilter}
+            onChange={(e) => setAlignmentFilter(e.target.value as typeof alignmentFilter)}
+            className="appearance-none rounded-lg border border-border/60 bg-card/30 px-3 py-1.5 pr-7 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="all">All alignment</option>
+            <option value="aligned">Aligned with DReps</option>
+            <option value="diverged">Diverged from DReps</option>
+          </select>
+          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground pointer-events-none" />
+        </div>
+        {(typeFilter !== 'all' || alignmentFilter !== 'all') && (
+          <button
+            onClick={() => {
+              setTypeFilter('all');
+              setAlignmentFilter('all');
+            }}
+            className="text-[10px] text-muted-foreground hover:text-foreground transition-colors underline"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
       <div className="overflow-x-auto rounded-xl border border-border/60">
         <table className="w-full text-sm">
           <thead>
@@ -447,6 +545,13 @@ function VotingRecordTab({ votes }: { votes: EnrichedVote[] }) {
                 </tr>
               );
             })}
+            {pageVotes.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No votes match the current filters.
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
@@ -456,7 +561,8 @@ function VotingRecordTab({ votes }: { votes: EnrichedVote[] }) {
         <div className="flex items-center justify-between px-1">
           <p className="text-xs text-muted-foreground">
             Showing {page * VOTES_PER_PAGE + 1}-
-            {Math.min((page + 1) * VOTES_PER_PAGE, votes.length)} of {votes.length} votes
+            {Math.min((page + 1) * VOTES_PER_PAGE, filteredVotes.length)} of {filteredVotes.length}{' '}
+            votes
           </p>
           <div className="flex items-center gap-1">
             <button
@@ -484,7 +590,7 @@ function VotingRecordTab({ votes }: { votes: EnrichedVote[] }) {
 }
 
 // ---------------------------------------------------------------------------
-// Alignment Tab
+// Alignment Tab (enhanced with principled vs silent divergence)
 // ---------------------------------------------------------------------------
 
 function AlignmentTab({ data }: { data: ProfileData }) {
@@ -511,14 +617,18 @@ function AlignmentTab({ data }: { data: ProfileData }) {
     });
   }, [data.enrichedVotes]);
 
-  // Tension list: votes where this member diverged from DRep majority
-  const tensions = useMemo(
-    () =>
-      data.enrichedVotes.filter(
-        (v) => v.drepMajority && v.drepMajority !== 'Abstain' && v.vote !== v.drepMajority,
-      ),
-    [data.enrichedVotes],
-  );
+  // Split diverged votes into principled (has rationale) vs silent (no rationale)
+  const { principledDivergences, silentDivergences } = useMemo(() => {
+    const diverged = data.enrichedVotes.filter(
+      (v) => v.drepMajority && v.drepMajority !== 'Abstain' && v.vote !== v.drepMajority,
+    );
+    return {
+      principledDivergences: diverged.filter((v) => v.hasRationale),
+      silentDivergences: diverged.filter((v) => !v.hasRationale),
+    };
+  }, [data.enrichedVotes]);
+
+  const totalDivergences = principledDivergences.length + silentDivergences.length;
 
   return (
     <div className="space-y-6">
@@ -568,38 +678,53 @@ function AlignmentTab({ data }: { data: ProfileData }) {
         </div>
       )}
 
-      {/* Tension list */}
-      {tensions.length > 0 && (
+      {/* Principled vs Silent Divergence */}
+      {totalDivergences > 0 && (
         <div className="space-y-3">
-          <h3 className="text-sm font-semibold">Diverged from DRep Majority ({tensions.length})</h3>
-          <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
-            {tensions.map((v) => (
-              <Link
-                key={`${v.proposalTxHash}-${v.proposalIndex}`}
-                href={`/proposal/${v.proposalTxHash}/${v.proposalIndex}`}
-                className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-muted/40 transition-colors"
-              >
-                <span className="text-sm truncate">
-                  {v.proposalTitle ?? `${v.proposalTxHash.slice(0, 12)}\u2026`}
-                </span>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Badge
-                    variant="outline"
-                    className={
-                      v.vote === 'Yes'
-                        ? 'text-emerald-500 border-emerald-500/40'
-                        : v.vote === 'No'
-                          ? 'text-rose-500 border-rose-500/40'
-                          : 'text-amber-500 border-amber-500/40'
-                    }
-                  >
-                    {v.vote}
-                  </Badge>
-                  <span className="text-[10px] text-muted-foreground">vs {v.drepMajority}</span>
-                </div>
-              </Link>
-            ))}
+          <h3 className="text-sm font-semibold">
+            Diverged from DRep Majority ({totalDivergences})
+          </h3>
+          <div className="grid gap-3 sm:grid-cols-2 mb-3">
+            <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-3 text-center space-y-1">
+              <p className="text-lg font-bold tabular-nums text-emerald-500">
+                {principledDivergences.length}
+              </p>
+              <p className="text-[10px] text-muted-foreground">Principled (with rationale)</p>
+            </div>
+            <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-3 text-center space-y-1">
+              <p className="text-lg font-bold tabular-nums text-amber-500">
+                {silentDivergences.length}
+              </p>
+              <p className="text-[10px] text-muted-foreground">Silent (no rationale)</p>
+            </div>
           </div>
+
+          {/* Principled divergences */}
+          {principledDivergences.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-emerald-500 flex items-center gap-1.5">
+                <BookOpen className="h-3 w-3" />
+                Principled Divergences
+              </h4>
+              <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+                {principledDivergences.map((v) => (
+                  <DivergenceRow key={`${v.proposalTxHash}-${v.proposalIndex}`} vote={v} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Silent divergences */}
+          {silentDivergences.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-amber-500">Silent Divergences</h4>
+              <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+                {silentDivergences.map((v) => (
+                  <DivergenceRow key={`${v.proposalTxHash}-${v.proposalIndex}`} vote={v} />
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -659,11 +784,164 @@ function AlignmentTab({ data }: { data: ProfileData }) {
   );
 }
 
+/** Shared divergence row used in both principled/silent lists */
+function DivergenceRow({ vote: v }: { vote: EnrichedVote }) {
+  return (
+    <Link
+      href={`/proposal/${v.proposalTxHash}/${v.proposalIndex}`}
+      className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-muted/40 transition-colors"
+    >
+      <span className="text-sm truncate">
+        {v.proposalTitle ?? `${v.proposalTxHash.slice(0, 12)}\u2026`}
+      </span>
+      <div className="flex items-center gap-2 shrink-0">
+        <Badge
+          variant="outline"
+          className={
+            v.vote === 'Yes'
+              ? 'text-emerald-500 border-emerald-500/40'
+              : v.vote === 'No'
+                ? 'text-rose-500 border-rose-500/40'
+                : 'text-amber-500 border-amber-500/40'
+          }
+        >
+          {v.vote}
+        </Badge>
+        <span className="text-[10px] text-muted-foreground">vs {v.drepMajority}</span>
+      </div>
+    </Link>
+  );
+}
+
 // ---------------------------------------------------------------------------
-// Main Client Component
+// Level 2: Overview Mode (default)
 // ---------------------------------------------------------------------------
 
-export function CCMemberProfileClient({ data }: { data: ProfileData }) {
+function OverviewMode({
+  data,
+  onViewFullRecord,
+}: {
+  data: ProfileData;
+  onViewFullRecord: () => void;
+}) {
+  return (
+    <div className="space-y-6">
+      {/* Term context */}
+      <TermContext data={data} />
+
+      {/* Pillar bars */}
+      <PillarBreakdown data={data} />
+
+      {/* Compact trend sparkline */}
+      <div className="[&_.card]:border-0 [&_.card]:bg-transparent [&_.card]:shadow-none [&_[style*='height']]:!h-32">
+        <CCTransparencyTrend
+          history={data.fidelityHistory}
+          proposalSnapshots={data.proposalFidelityHistory}
+        />
+      </div>
+
+      {/* Recent votes */}
+      <CCRecentVotes votes={data.enrichedVotes} maxVotes={5} />
+
+      {/* View full record button */}
+      <motion.div variants={fadeInUp} className="flex justify-center pt-2">
+        <Button variant="outline" onClick={onViewFullRecord} className="gap-2">
+          View full record
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </motion.div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Level 3: Deep Analysis Mode
+// ---------------------------------------------------------------------------
+
+function DeepMode({ data, onBackToOverview }: { data: ProfileData; onBackToOverview: () => void }) {
+  return (
+    <div className="space-y-6">
+      {/* Navigation */}
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBackToOverview} className="gap-1.5 -ml-2">
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to overview
+        </Button>
+        <Link
+          href={`/governance/committee/compare?members=${encodeURIComponent(data.ccHotId)}`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Compare with others
+        </Link>
+      </div>
+
+      {/* Full tabbed interface */}
+      <Tabs defaultValue="votes">
+        <TabsList variant="line" className="w-full justify-start">
+          <TabsTrigger value="votes">
+            Voting Record
+            <span className="ml-1 text-[10px] text-muted-foreground tabular-nums">
+              ({data.enrichedVotes.length})
+            </span>
+          </TabsTrigger>
+          <TabsTrigger value="reasoning">Constitutional Reasoning</TabsTrigger>
+          <TabsTrigger value="alignment">Alignment</TabsTrigger>
+          <TabsTrigger value="trend">
+            <TrendingUp className="h-3.5 w-3.5 mr-1" />
+            Trend & Context
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="votes" className="pt-4">
+          <VotingRecordTab votes={data.enrichedVotes} />
+        </TabsContent>
+
+        <TabsContent value="reasoning" className="pt-4">
+          <CCConstitutionalReasoning votes={data.enrichedVotes} />
+        </TabsContent>
+
+        <TabsContent value="alignment" className="pt-4">
+          <AlignmentTab data={data} />
+        </TabsContent>
+
+        <TabsContent value="trend" className="pt-4">
+          <div className="space-y-6">
+            <TermContext data={data} />
+            <CCTransparencyTrend
+              history={data.fidelityHistory}
+              proposalSnapshots={data.proposalFidelityHistory}
+            />
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inner component that uses useSearchParams (needs Suspense boundary)
+// ---------------------------------------------------------------------------
+
+function CCMemberProfileInner({ data }: { data: ProfileData }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [depth, setDepth] = useState<'overview' | 'deep'>(
+    searchParams.get('depth') === 'deep' ? 'deep' : 'overview',
+  );
+
+  const updateDepth = (newDepth: 'overview' | 'deep') => {
+    setDepth(newDepth);
+    const params = new URLSearchParams(searchParams.toString());
+    if (newDepth === 'deep') {
+      params.set('depth', 'deep');
+    } else {
+      params.delete('depth');
+    }
+    const query = params.toString();
+    router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
+  };
+
   return (
     <motion.div
       variants={staggerContainer}
@@ -681,33 +959,37 @@ export function CCMemberProfileClient({ data }: { data: ProfileData }) {
         <KeyStats data={data} />
       </motion.div>
 
-      {/* Tabbed Content */}
+      {/* Depth-dependent content */}
       <motion.div variants={fadeInUp}>
-        <Tabs defaultValue="overview">
-          <TabsList variant="line" className="w-full justify-start">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="votes">
-              Voting Record
-              <span className="ml-1 text-[10px] text-muted-foreground tabular-nums">
-                ({data.enrichedVotes.length})
-              </span>
-            </TabsTrigger>
-            <TabsTrigger value="alignment">Alignment</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="overview" className="pt-4">
-            <OverviewTab data={data} />
-          </TabsContent>
-
-          <TabsContent value="votes" className="pt-4">
-            <VotingRecordTab votes={data.enrichedVotes} />
-          </TabsContent>
-
-          <TabsContent value="alignment" className="pt-4">
-            <AlignmentTab data={data} />
-          </TabsContent>
-        </Tabs>
+        {depth === 'overview' ? (
+          <OverviewMode data={data} onViewFullRecord={() => updateDepth('deep')} />
+        ) : (
+          <DeepMode data={data} onBackToOverview={() => updateDepth('overview')} />
+        )}
       </motion.div>
     </motion.div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Client Component (with Suspense for useSearchParams)
+// ---------------------------------------------------------------------------
+
+export function CCMemberProfileClient({ data }: { data: ProfileData }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="space-y-6">
+          <div className="h-32 animate-pulse bg-muted rounded-xl" />
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="h-28 animate-pulse bg-muted rounded-xl" />
+            <div className="h-28 animate-pulse bg-muted rounded-xl" />
+            <div className="h-28 animate-pulse bg-muted rounded-xl" />
+          </div>
+        </div>
+      }
+    >
+      <CCMemberProfileInner data={data} />
+    </Suspense>
   );
 }

--- a/components/cc/CCRecentVotes.tsx
+++ b/components/cc/CCRecentVotes.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { BookOpen } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { EnrichedVote } from '@/components/cc/CCMemberProfileClient';
+
+interface CCRecentVotesProps {
+  votes: EnrichedVote[];
+  maxVotes?: number;
+}
+
+export function CCRecentVotes({ votes, maxVotes = 5 }: CCRecentVotesProps) {
+  const recentVotes = votes.slice(0, maxVotes);
+
+  if (recentVotes.length === 0) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-card/30 px-4 py-5 text-center">
+        <p className="text-sm text-muted-foreground">No votes recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold">Recent Votes</h3>
+      <div className="rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+        {recentVotes.map((v) => (
+          <Link
+            key={`${v.proposalTxHash}-${v.proposalIndex}`}
+            href={`/proposal/${v.proposalTxHash}/${v.proposalIndex}`}
+            className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-muted/40 transition-colors"
+          >
+            <span className="text-sm truncate min-w-0 flex-1">
+              {v.proposalTitle ?? 'Untitled Proposal'}
+            </span>
+            <div className="flex items-center gap-2 shrink-0">
+              <BookOpen
+                className={`h-3.5 w-3.5 ${v.hasRationale ? 'text-emerald-500' : 'text-muted-foreground/30'}`}
+              />
+              <Badge
+                variant="outline"
+                className={
+                  v.vote === 'Yes'
+                    ? 'text-emerald-500 border-emerald-500/40'
+                    : v.vote === 'No'
+                      ? 'text-rose-500 border-rose-500/40'
+                      : 'text-amber-500 border-amber-500/40'
+                }
+              >
+                {v.vote}
+              </Badge>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/cc/CCTransparencyTrend.tsx
+++ b/components/cc/CCTransparencyTrend.tsx
@@ -9,7 +9,7 @@ import { TrendingUp } from 'lucide-react';
 import { useChartDimensions } from '@/lib/charts/useChartDimensions';
 import { GlowFilter } from '@/lib/charts/GlowDefs';
 import { chartTheme } from '@/lib/charts/theme';
-import type { CCFidelitySnapshot } from '@/lib/data';
+import type { CCFidelitySnapshot, CCProposalFidelitySnapshot } from '@/lib/data';
 
 const PILLAR_KEYS = ['Participation', 'Grounding', 'Reasoning'] as const;
 const PILLAR_COLORS = [
@@ -20,26 +20,39 @@ const PILLAR_COLORS = [
 
 interface CCTransparencyTrendProps {
   history: CCFidelitySnapshot[];
+  /** Proposal-anchored snapshots — used instead of epoch-based when available */
+  proposalSnapshots?: CCProposalFidelitySnapshot[];
 }
 
-export function CCTransparencyTrend({ history }: CCTransparencyTrendProps) {
+export function CCTransparencyTrend({ history, proposalSnapshots }: CCTransparencyTrendProps) {
   const [showPillars, setShowPillars] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const { containerRef, dimensions } = useChartDimensions(250);
   const { width, innerWidth, innerHeight, margin } = dimensions;
 
-  const chartData = useMemo(
-    () =>
-      history.map((s) => ({
-        label: `E${s.epochNo}`,
-        epochNo: s.epochNo,
+  // Prefer proposal-anchored snapshots when available (event-driven scoring)
+  const useProposalMode = (proposalSnapshots?.length ?? 0) >= 2;
+
+  const chartData = useMemo(() => {
+    if (useProposalMode && proposalSnapshots) {
+      return proposalSnapshots.map((s, i) => ({
+        label: `P${i + 1}`,
+        epochNo: s.proposalEpoch,
         Index: s.fidelityScore,
         Participation: s.participationScore,
         Grounding: s.constitutionalGroundingScore,
         Reasoning: s.reasoningQualityScore,
-      })),
-    [history],
-  );
+      }));
+    }
+    return history.map((s) => ({
+      label: `E${s.epochNo}`,
+      epochNo: s.epochNo,
+      Index: s.fidelityScore,
+      Participation: s.participationScore,
+      Grounding: s.constitutionalGroundingScore,
+      Reasoning: s.reasoningQualityScore,
+    }));
+  }, [history, proposalSnapshots, useProposalMode]);
 
   const xScale = useMemo(
     () =>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default [
       '__tests__/**',
       'tests/**',
       'analytics/**',
+      '.claude/worktrees/**',
       '*.cjs',
     ],
   },

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -27,6 +27,12 @@ export interface CCHealthSummaryResponse {
   tensionCount: number;
 }
 
+export interface CCCommitteeStats {
+  totalProposalsReviewed: number;
+  avgRationaleRate: number | null;
+  totalCCVotes: number;
+}
+
 export interface CommitteeMemberQuickView {
   ccHotId: string;
   name: string | null;
@@ -42,7 +48,11 @@ export interface CommitteeMemberQuickView {
 }
 
 export function useCommitteeMembers() {
-  return useQuery<{ members: CommitteeMemberQuickView[]; health: CCHealthSummaryResponse }>({
+  return useQuery<{
+    members: CommitteeMemberQuickView[];
+    health: CCHealthSummaryResponse;
+    stats: CCCommitteeStats;
+  }>({
     queryKey: ['cc-members'],
     queryFn: () => fetchJson('/api/governance/committee'),
     staleTime: 120_000,

--- a/inngest/functions/sync-cc-rationales.ts
+++ b/inngest/functions/sync-cc-rationales.ts
@@ -133,6 +133,7 @@ export const syncCcRationales = inngest.createFunction(
           cc_cold_id: string;
           status: string;
           expiration_epoch: number;
+          authorization_epoch: number | null;
           has_script: boolean;
         }> = [];
 
@@ -145,6 +146,7 @@ export const syncCcRationales = inngest.createFunction(
                   cc_cold_id: m.cc_cold_id ?? null,
                   status: m.status ?? 'unknown',
                   expiration_epoch: m.expiration_epoch ?? null,
+                  authorization_epoch: m.start_epoch ?? null,
                   has_script: m.cc_hot_has_script ?? false,
                 });
               }
@@ -177,6 +179,7 @@ export const syncCcRationales = inngest.createFunction(
               author_name: authorMap.get(hotId) ?? null,
               status: m.status,
               expiration_epoch: m.expiration_epoch,
+              authorization_epoch: m.authorization_epoch,
               has_script: m.has_script,
               updated_at: new Date().toISOString(),
             },
@@ -337,7 +340,7 @@ export const syncCcRationales = inngest.createFunction(
       // Get proposals for eligible count and type lookups
       const { data: proposals } = await supabase
         .from('proposals')
-        .select('tx_hash, proposal_index, proposal_type, block_time');
+        .select('tx_hash, proposal_index, proposal_type, block_time, proposed_epoch');
 
       // Get rationales
       const { data: rationales } = await supabase
@@ -368,10 +371,26 @@ export const syncCcRationales = inngest.createFunction(
         });
       }
 
-      // Total eligible proposals (all proposals in the system)
-      const totalEligibleProposals = new Set(
+      // Global fallback eligible count
+      const globalEligibleProposals = new Set(
         proposals.map((p) => `${p.tx_hash}:${p.proposal_index}`),
       ).size;
+
+      // Fetch cc_members authorization/expiration epochs for per-member eligibility
+      const { data: ccMembers } = await supabase
+        .from('cc_members')
+        .select('cc_hot_id, authorization_epoch, expiration_epoch');
+
+      const memberEpochMap = new Map<
+        string,
+        { authorization_epoch: number | null; expiration_epoch: number | null }
+      >();
+      for (const m of ccMembers ?? []) {
+        memberEpochMap.set(m.cc_hot_id, {
+          authorization_epoch: m.authorization_epoch,
+          expiration_epoch: m.expiration_epoch,
+        });
+      }
 
       // Group votes by member
       const memberVotes = new Map<string, CCMemberVoteData[]>();
@@ -389,12 +408,24 @@ export const syncCcRationales = inngest.createFunction(
 
       let scored = 0;
       for (const [ccHotId, mvotes] of memberVotes) {
+        // Per-member eligible proposals based on authorization/expiration epochs
+        const memberEligible = proposals.filter((p) => {
+          const epochs = memberEpochMap.get(ccHotId);
+          if (!epochs?.authorization_epoch || !p.proposed_epoch) return true; // fallback
+          if (p.proposed_epoch < epochs.authorization_epoch) return false;
+          if (epochs.expiration_epoch && p.proposed_epoch > epochs.expiration_epoch) return false;
+          return true;
+        });
+        const memberEligibleCount = new Set(
+          memberEligible.map((p) => `${p.tx_hash}:${p.proposal_index}`),
+        ).size;
+
         const result = computeFullConstitutionalFidelity({
           ccHotId,
           votes: mvotes,
           proposalMap,
           rationaleMap,
-          totalEligibleProposals,
+          totalEligibleProposals: memberEligibleCount || globalEligibleProposals,
         });
 
         // Update cc_members with Constitutional Fidelity Score
@@ -476,11 +507,164 @@ export const syncCcRationales = inngest.createFunction(
       return { scored, epoch: currentEpoch };
     });
 
+    // Step 5: Create proposal-anchored fidelity snapshots for terminal proposals
+    const proposalSnapshotResult = await step.run('snapshot-proposal-scores', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get current epoch
+      const { data: stats } = await supabase
+        .from('governance_stats')
+        .select('current_epoch')
+        .eq('id', 1)
+        .single();
+      const currentEpoch = stats?.current_epoch ?? 0;
+
+      // Fetch proposals that have reached a terminal state
+      const { data: allProposals } = await supabase
+        .from('proposals')
+        .select(
+          'tx_hash, proposal_index, proposed_epoch, ratified_epoch, dropped_epoch, enacted_epoch, expired_epoch, expiration_epoch',
+        );
+
+      if (!allProposals?.length) return { snapshotted: 0 };
+
+      const terminalProposals = allProposals.filter(
+        (p) =>
+          p.ratified_epoch != null ||
+          p.dropped_epoch != null ||
+          p.enacted_epoch != null ||
+          p.expired_epoch != null ||
+          (p.expiration_epoch != null && p.expiration_epoch <= currentEpoch),
+      );
+
+      if (terminalProposals.length === 0) return { snapshotted: 0 };
+
+      // Fetch existing snapshots to skip already-snapshotted proposals
+      const { data: existingSnapshots } = await supabase
+        .from('cc_fidelity_proposal_snapshots')
+        .select('cc_hot_id, proposal_tx_hash, proposal_index');
+
+      const existingKeys = new Set(
+        (existingSnapshots ?? []).map(
+          (s) => `${s.cc_hot_id}:${s.proposal_tx_hash}:${s.proposal_index}`,
+        ),
+      );
+
+      // Fetch CC votes on terminal proposals
+      const { data: ccVotes } = await supabase
+        .from('cc_votes')
+        .select('cc_hot_id, proposal_tx_hash, proposal_index');
+
+      // Fetch current cumulative fidelity scores from cc_members
+      const { data: members } = await supabase
+        .from('cc_members')
+        .select(
+          'cc_hot_id, fidelity_score, participation_score, constitutional_grounding_score, rationale_quality_score, votes_cast, eligible_proposals',
+        );
+
+      const memberScoreMap = new Map<
+        string,
+        {
+          fidelity_score: number | null;
+          participation_score: number | null;
+          constitutional_grounding_score: number | null;
+          rationale_quality_score: number | null;
+          votes_cast: number | null;
+          eligible_proposals: number | null;
+        }
+      >();
+      for (const m of members ?? []) {
+        memberScoreMap.set(m.cc_hot_id, {
+          fidelity_score: m.fidelity_score,
+          participation_score: m.participation_score,
+          constitutional_grounding_score: m.constitutional_grounding_score,
+          rationale_quality_score: m.rationale_quality_score,
+          votes_cast: m.votes_cast,
+          eligible_proposals: m.eligible_proposals,
+        });
+      }
+
+      // Build set of terminal proposal keys
+      const terminalKeys = new Set(
+        terminalProposals.map((p) => `${p.tx_hash}:${p.proposal_index}`),
+      );
+      const terminalEpochMap = new Map<string, number | null>();
+      for (const p of terminalProposals) {
+        terminalEpochMap.set(`${p.tx_hash}:${p.proposal_index}`, p.proposed_epoch);
+      }
+
+      // For each CC vote on a terminal proposal, create a snapshot if not already exists
+      let snapshotted = 0;
+      const rows: Array<{
+        cc_hot_id: string;
+        proposal_tx_hash: string;
+        proposal_index: number;
+        proposal_epoch: number | null;
+        fidelity_score: number | null;
+        participation_score: number | null;
+        constitutional_grounding_score: number | null;
+        reasoning_quality_score: number | null;
+        votes_cast: number | null;
+        eligible_proposals: number | null;
+        snapshotted_at: string;
+      }> = [];
+
+      for (const v of ccVotes ?? []) {
+        const pKey = `${v.proposal_tx_hash}:${v.proposal_index}`;
+        if (!terminalKeys.has(pKey)) continue;
+
+        const snapKey = `${v.cc_hot_id}:${v.proposal_tx_hash}:${v.proposal_index}`;
+        if (existingKeys.has(snapKey)) continue;
+
+        const scores = memberScoreMap.get(v.cc_hot_id);
+        if (!scores) continue;
+
+        rows.push({
+          cc_hot_id: v.cc_hot_id,
+          proposal_tx_hash: v.proposal_tx_hash,
+          proposal_index: v.proposal_index,
+          proposal_epoch: terminalEpochMap.get(pKey) ?? null,
+          fidelity_score: scores.fidelity_score,
+          participation_score: scores.participation_score,
+          constitutional_grounding_score: scores.constitutional_grounding_score,
+          reasoning_quality_score: scores.rationale_quality_score,
+          votes_cast: scores.votes_cast,
+          eligible_proposals: scores.eligible_proposals,
+          snapshotted_at: new Date().toISOString(),
+        });
+      }
+
+      // Batch upsert in chunks of 50
+      for (let i = 0; i < rows.length; i += 50) {
+        const batch = rows.slice(i, i + 50);
+        const { error } = await supabase
+          .from('cc_fidelity_proposal_snapshots')
+          .upsert(batch, { onConflict: 'cc_hot_id,proposal_tx_hash,proposal_index' });
+
+        if (error) {
+          logger.error('[sync-cc-rationales] Proposal snapshot upsert failed', {
+            error: error.message,
+            batch: i,
+          });
+        } else {
+          snapshotted += batch.length;
+        }
+      }
+
+      logger.info('[sync-cc-rationales] Proposal fidelity snapshots created', {
+        snapshotted,
+        terminalProposals: terminalProposals.length,
+      });
+
+      return { snapshotted };
+    });
+
     return {
       rationales: fetchResult,
       members: memberResult,
       scores: scoreResult,
       transparency: transparencyResult,
+      proposalSnapshots: proposalSnapshotResult,
     };
   },
 );

--- a/lib/cc/fidelityScore.ts
+++ b/lib/cc/fidelityScore.ts
@@ -65,7 +65,7 @@ export function computeRationaleProvision(totalVotes: number, votesWithRationale
 // ---------------------------------------------------------------------------
 
 /** Expected articles per proposal type (simplified mapping). */
-const EXPECTED_ARTICLES: Record<string, string[]> = {
+export const EXPECTED_ARTICLES: Record<string, string[]> = {
   TreasuryWithdrawals: ['Article II, § 6', 'Article II, § 7'],
   ParameterChange: ['Article II, § 6', 'Article III'],
   HardForkInitiation: ['Article II, § 6', 'Article III, § 6'],

--- a/lib/cc/interpretations.ts
+++ b/lib/cc/interpretations.ts
@@ -282,6 +282,22 @@ export function generateMemberVerdict(input: MemberVerdictInput): string {
 }
 
 // ---------------------------------------------------------------------------
+// Term Context
+// ---------------------------------------------------------------------------
+
+export function interpretTermContext(
+  authorizationEpoch: number | null,
+  expirationEpoch: number | null,
+  eligibleProposals: number,
+  totalProposals: number,
+): string {
+  if (authorizationEpoch == null) return 'Authorization epoch unknown.';
+  const expStr = expirationEpoch != null ? `, term ends epoch ${expirationEpoch}` : '';
+  if (totalProposals === 0) return `Authorized since epoch ${authorizationEpoch}${expStr}.`;
+  return `Authorized since epoch ${authorizationEpoch}${expStr}. ${eligibleProposals} of ${totalProposals} total proposals fell within their term.`;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1039,6 +1039,7 @@ export interface CCMemberFidelity {
   authorName: string | null;
   status: string | null;
   expirationEpoch: number | null;
+  authorizationEpoch: number | null;
   fidelityScore: number | null;
   fidelityGrade: string | null;
   participationScore: number | null;
@@ -1060,7 +1061,7 @@ export async function getCCMembersFidelity(): Promise<CCMemberFidelity[]> {
     const { data, error } = await supabase
       .from('cc_members')
       .select(
-        'cc_hot_id, author_name, status, expiration_epoch, fidelity_score, fidelity_grade, participation_score, rationale_quality_score, constitutional_grounding_score, rationale_provision_rate, avg_article_coverage, avg_reasoning_quality, votes_cast, eligible_proposals',
+        'cc_hot_id, author_name, status, expiration_epoch, authorization_epoch, fidelity_score, fidelity_grade, participation_score, rationale_quality_score, constitutional_grounding_score, rationale_provision_rate, avg_article_coverage, avg_reasoning_quality, votes_cast, eligible_proposals',
       )
       .order('fidelity_score', { ascending: false, nullsFirst: false });
 
@@ -1070,6 +1071,7 @@ export async function getCCMembersFidelity(): Promise<CCMemberFidelity[]> {
       authorName: m.author_name,
       status: m.status,
       expirationEpoch: m.expiration_epoch,
+      authorizationEpoch: m.authorization_epoch,
       fidelityScore: m.fidelity_score,
       fidelityGrade: m.fidelity_grade,
       participationScore: m.participation_score,
@@ -1088,6 +1090,54 @@ export async function getCCMembersFidelity(): Promise<CCMemberFidelity[]> {
 
 /** @deprecated Use getCCMembersFidelity */
 export const getCCMembersTransparency = getCCMembersFidelity;
+
+// ============================================================================
+// CC PROPOSAL FIDELITY SNAPSHOTS
+// ============================================================================
+
+export interface CCProposalFidelitySnapshot {
+  proposalTxHash: string;
+  proposalIndex: number;
+  proposalEpoch: number;
+  fidelityScore: number;
+  participationScore: number;
+  constitutionalGroundingScore: number;
+  reasoningQualityScore: number;
+  votesCast: number;
+  eligibleProposals: number;
+}
+
+export async function getCCProposalFidelityHistory(
+  ccHotId: string,
+): Promise<CCProposalFidelitySnapshot[]> {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('cc_fidelity_proposal_snapshots')
+      .select(
+        'proposal_tx_hash, proposal_index, proposal_epoch, fidelity_score, participation_score, constitutional_grounding_score, reasoning_quality_score, votes_cast, eligible_proposals',
+      )
+      .eq('cc_hot_id', ccHotId)
+      .order('proposal_epoch', { ascending: true, nullsFirst: false });
+
+    if (error || !data) return [];
+    return data
+      .filter((s) => s.proposal_epoch != null && s.fidelity_score != null)
+      .map((s) => ({
+        proposalTxHash: s.proposal_tx_hash,
+        proposalIndex: s.proposal_index,
+        proposalEpoch: s.proposal_epoch!,
+        fidelityScore: s.fidelity_score!,
+        participationScore: s.participation_score ?? 0,
+        constitutionalGroundingScore: s.constitutional_grounding_score ?? 0,
+        reasoningQualityScore: s.reasoning_quality_score ?? 0,
+        votesCast: s.votes_cast ?? 0,
+        eligibleProposals: s.eligible_proposals ?? 0,
+      }));
+  } catch {
+    return [];
+  }
+}
 
 // ============================================================================
 // CC HEALTH SUMMARY & MEMBER VERDICTS

--- a/types/database.ts
+++ b/types/database.ts
@@ -564,8 +564,51 @@ export type Database = {
         };
         Relationships: [];
       };
+      cc_fidelity_proposal_snapshots: {
+        Row: {
+          cc_hot_id: string;
+          constitutional_grounding_score: number | null;
+          eligible_proposals: number | null;
+          fidelity_score: number | null;
+          participation_score: number | null;
+          proposal_epoch: number | null;
+          proposal_index: number;
+          proposal_tx_hash: string;
+          reasoning_quality_score: number | null;
+          snapshotted_at: string | null;
+          votes_cast: number | null;
+        };
+        Insert: {
+          cc_hot_id: string;
+          constitutional_grounding_score?: number | null;
+          eligible_proposals?: number | null;
+          fidelity_score?: number | null;
+          participation_score?: number | null;
+          proposal_epoch?: number | null;
+          proposal_index: number;
+          proposal_tx_hash: string;
+          reasoning_quality_score?: number | null;
+          snapshotted_at?: string | null;
+          votes_cast?: number | null;
+        };
+        Update: {
+          cc_hot_id?: string;
+          constitutional_grounding_score?: number | null;
+          eligible_proposals?: number | null;
+          fidelity_score?: number | null;
+          participation_score?: number | null;
+          proposal_epoch?: number | null;
+          proposal_index?: number;
+          proposal_tx_hash?: string;
+          reasoning_quality_score?: number | null;
+          snapshotted_at?: string | null;
+          votes_cast?: number | null;
+        };
+        Relationships: [];
+      };
       cc_members: {
         Row: {
+          authorization_epoch: number | null;
           author_name: string | null;
           avg_article_coverage: number | null;
           avg_reasoning_quality: number | null;
@@ -586,6 +629,7 @@ export type Database = {
           votes_cast: number | null;
         };
         Insert: {
+          authorization_epoch?: number | null;
           author_name?: string | null;
           avg_article_coverage?: number | null;
           avg_reasoning_quality?: number | null;
@@ -606,6 +650,7 @@ export type Database = {
           votes_cast?: number | null;
         };
         Update: {
+          authorization_epoch?: number | null;
           author_name?: string | null;
           avg_article_coverage?: number | null;
           avg_reasoning_quality?: number | null;


### PR DESCRIPTION
## Summary
- Fix vote eligibility to scope per member's authorization term instead of all-time proposals
- Add proposal-anchored fidelity snapshots for event-driven trend visualization
- Restructure CC pages into 4 progressive disclosure levels (list → overview → deep → comparative)
- New pages: `/governance/committee/compare` and `/governance/committee/data`

## Impact
- **What changed**: CC members are no longer penalized for proposals before their term. Profile page has L2 overview and L3 deep analysis. New comparison and data export pages.
- **User-facing**: Yes — fairer scores, richer profile experience, new comparison and methodology pages
- **Risk**: Medium — scoring logic change + new pages, but backward-compatible (null authorization_epoch falls back to global count)
- **Scope**: sync-cc-rationales.ts, lib/data.ts, CC components, committee API route, hooks/queries, new pages, eslint config, types

## Test plan
- [ ] Verify CC member scores update correctly after next sync (authorization_epoch scoping)
- [ ] Profile page loads in L2 overview mode by default
- [ ] `?depth=deep` shows L3 tabbed interface
- [ ] `/governance/committee/compare` renders member comparison
- [ ] `/governance/committee/data` shows methodology and export
- [ ] Aggregate stats (proposals reviewed, avg rationale rate) display on list page

🤖 Generated with [Claude Code](https://claude.com/claude-code)