### PR TITLE
feat: DRep Decision Engine — alignment API + simulation engine

### DIFF
--- a/__tests__/matching/delegationSimulation.test.ts
+++ b/__tests__/matching/delegationSimulation.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/supabase', () => ({
+  createClient: () => ({}),
+  getSupabaseAdmin: () => ({}),
+}));
+
+import {
+  computeDelegationSimulation,
+  type SimulationInput,
+} from '@/lib/matching/delegationSimulation';
+import type { DRepVoteRow, CachedProposal } from '@/lib/data';
+import type { ProposalOutcome } from '@/lib/proposalOutcomes';
+
+/* ─── Helpers ─────────────────────────────────────────── */
+
+function makeVoteRow(overrides: Partial<DRepVoteRow> = {}): DRepVoteRow {
+  return {
+    vote_tx_hash: 'vtx_' + Math.random().toString(36).slice(2, 8),
+    drep_id: 'drep1abc',
+    proposal_tx_hash: 'tx_' + Math.random().toString(36).slice(2, 8),
+    proposal_index: 0,
+    vote: 'Yes',
+    epoch_no: 490,
+    block_time: Date.now(),
+    meta_url: null,
+    meta_hash: null,
+    rationale_quality: null,
+    ...overrides,
+  };
+}
+
+function makeProposal(txHash: string, index: number): CachedProposal {
+  return {
+    txHash,
+    proposalIndex: index,
+    title: `Proposal ${txHash.slice(0, 8)}`,
+    abstract: null,
+    aiSummary: null,
+    proposalType: 'TreasuryWithdrawals',
+    withdrawalAmount: null,
+    treasuryTier: null,
+    relevantPrefs: [],
+  };
+}
+
+function makeOutcome(txHash: string, index: number): ProposalOutcome {
+  return {
+    proposalTxHash: txHash,
+    proposalIndex: index,
+    deliveryStatus: 'delivered',
+    deliveryScore: 85,
+    totalPollResponses: 10,
+    deliveredCount: 8,
+    partialCount: 1,
+    notDeliveredCount: 1,
+    tooEarlyCount: 0,
+    wouldApproveAgainPct: 80,
+    milestonesTotal: 5,
+    milestonesCompleted: 4,
+    enactedEpoch: 480,
+    lastEvaluatedEpoch: 490,
+    epochsSinceEnactment: 10,
+  };
+}
+
+/* ─── computeDelegationSimulation ─────────────────────── */
+
+describe('computeDelegationSimulation', () => {
+  it('returns empty simulation for 0 votes', () => {
+    const result = computeDelegationSimulation({
+      drepVotes: [],
+      proposals: new Map(),
+      outcomes: new Map(),
+      currentEpoch: 500,
+    });
+
+    expect(result.drepVotedOn).toBe(0);
+    expect(result.totalProposals).toBe(0);
+    expect(result.participationRate).toBe(0);
+    expect(result.simulatedVotes.length).toBe(0);
+    expect(result.periodLabel).toContain('Epochs');
+  });
+
+  it('computes correct counts for 10 votes', () => {
+    const votes: DRepVoteRow[] = [];
+    const proposals = new Map<string, CachedProposal>();
+    const outcomes = new Map<string, ProposalOutcome>();
+
+    for (let i = 0; i < 10; i++) {
+      const txHash = `tx_${i.toString().padStart(3, '0')}`;
+      const vote = makeVoteRow({
+        proposal_tx_hash: txHash,
+        proposal_index: 0,
+        vote: i < 7 ? 'Yes' : 'No',
+        epoch_no: 480 + i,
+      });
+      votes.push(vote);
+      proposals.set(`${txHash}-0`, makeProposal(txHash, 0));
+    }
+
+    const result = computeDelegationSimulation({
+      drepVotes: votes,
+      proposals,
+      outcomes,
+      currentEpoch: 500,
+    });
+
+    expect(result.drepVotedOn).toBe(10);
+    expect(result.totalProposals).toBe(10);
+    expect(result.simulatedVotes.length).toBe(10);
+  });
+
+  it('computes participation rate correctly', () => {
+    const votes = [
+      makeVoteRow({ proposal_tx_hash: 'tx_a', proposal_index: 0, epoch_no: 490 }),
+      makeVoteRow({ proposal_tx_hash: 'tx_b', proposal_index: 0, epoch_no: 491 }),
+      makeVoteRow({ proposal_tx_hash: 'tx_c', proposal_index: 0, epoch_no: 492 }),
+    ];
+    const proposals = new Map<string, CachedProposal>();
+    votes.forEach((v) =>
+      proposals.set(`${v.proposal_tx_hash}-0`, makeProposal(v.proposal_tx_hash, 0)),
+    );
+
+    const result = computeDelegationSimulation({
+      drepVotes: votes,
+      proposals,
+      outcomes: new Map(),
+      currentEpoch: 500,
+    });
+
+    // DRep voted on 3 unique proposals out of 3 total
+    expect(result.participationRate).toBe(1);
+  });
+
+  it('aggregates delivery stats correctly', () => {
+    const txHash = 'tx_delivered';
+    const vote = makeVoteRow({
+      proposal_tx_hash: txHash,
+      proposal_index: 0,
+      epoch_no: 490,
+    });
+
+    const proposals = new Map<string, CachedProposal>();
+    proposals.set(`${txHash}-0`, makeProposal(txHash, 0));
+
+    const outcomes = new Map<string, ProposalOutcome>();
+    outcomes.set(`${txHash}-0`, makeOutcome(txHash, 0));
+
+    const result = computeDelegationSimulation({
+      drepVotes: [vote],
+      proposals,
+      outcomes,
+      currentEpoch: 500,
+    });
+
+    expect(result.enactedCount).toBe(1);
+    expect(result.deliverySuccessRate).toBe(100);
+    expect(result.deliveryCoverage).toContain('1 of 1');
+  });
+
+  it('shows correct period label', () => {
+    const result = computeDelegationSimulation({
+      drepVotes: [makeVoteRow({ epoch_no: 490 })],
+      proposals: new Map(),
+      outcomes: new Map(),
+      currentEpoch: 500,
+      lookbackEpochs: 36,
+    });
+
+    expect(result.periodLabel).toContain('464');
+    expect(result.periodLabel).toContain('500');
+    expect(result.periodLabel).toContain('6 months');
+  });
+
+  it('populates alignment field when user alignment is provided', () => {
+    const txHash = 'tx_aligned';
+    const vote = makeVoteRow({
+      proposal_tx_hash: txHash,
+      proposal_index: 0,
+      vote: 'Yes',
+      epoch_no: 490,
+    });
+
+    const proposals = new Map<string, CachedProposal>();
+    proposals.set(`${txHash}-0`, makeProposal(txHash, 0));
+
+    const classifications = new Map();
+    classifications.set(`${txHash}-0`, {
+      dimTreasuryConservative: 0.9,
+      dimTreasuryGrowth: 0.1,
+      dimDecentralization: 0.1,
+      dimSecurity: 0.1,
+      dimInnovation: 0.1,
+      dimTransparency: 0.1,
+    });
+
+    const result = computeDelegationSimulation({
+      drepVotes: [vote],
+      proposals,
+      outcomes: new Map(),
+      classifications,
+      userAlignment: {
+        treasuryConservative: 90,
+        treasuryGrowth: 50,
+        decentralization: 50,
+        security: 50,
+        innovation: 50,
+        transparency: 50,
+      },
+      currentEpoch: 500,
+    });
+
+    expect(result.simulatedVotes[0].alignmentWithUser).toBe('agree');
+    expect(result.alignedVoteCount).toBe(1);
+    expect(result.totalClassifiedVotes).toBe(1);
+  });
+
+  it('returns null delivery stats when no outcomes exist', () => {
+    const vote = makeVoteRow({ epoch_no: 490 });
+
+    const result = computeDelegationSimulation({
+      drepVotes: [vote],
+      proposals: new Map(),
+      outcomes: new Map(),
+      currentEpoch: 500,
+    });
+
+    expect(result.deliverySuccessRate).toBeNull();
+    expect(result.deliveryCoverage).toBeNull();
+  });
+});

--- a/__tests__/matching/proposalAlignment.test.ts
+++ b/__tests__/matching/proposalAlignment.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/supabase', () => ({
+  createClient: () => ({}),
+  getSupabaseAdmin: () => ({}),
+}));
+
+import {
+  predictUserStance,
+  computeProposalAlignment,
+  getProposalAlignmentReason,
+  type VoteWithClassification,
+} from '@/lib/matching/proposalAlignment';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+/* ─── Helpers ─────────────────────────────────────────── */
+
+function makeScores(overrides: Partial<AlignmentScores> = {}): AlignmentScores {
+  return {
+    treasuryConservative: 50,
+    treasuryGrowth: 50,
+    decentralization: 50,
+    security: 50,
+    innovation: 50,
+    transparency: 50,
+    ...overrides,
+  };
+}
+
+function makeVote(overrides: Partial<VoteWithClassification> = {}): VoteWithClassification {
+  return {
+    proposalId: 'tx123#0',
+    proposalTitle: 'Test Proposal',
+    proposalType: 'TreasuryWithdrawals',
+    vote: 'Yes',
+    epochNo: 500,
+    classification: {
+      dimTreasuryConservative: 0.8,
+      dimTreasuryGrowth: 0.2,
+      dimDecentralization: 0.1,
+      dimSecurity: 0.1,
+      dimInnovation: 0.1,
+      dimTransparency: 0.1,
+    },
+    ...overrides,
+  };
+}
+
+/* ─── predictUserStance ───────────────────────────────── */
+
+describe('predictUserStance', () => {
+  it('predicts Yes for high user score (>65)', () => {
+    const result = predictUserStance(80, 0.8);
+    expect(result.stance).toBe('Yes');
+    expect(result.confidence).toBe(60); // |80-50|*2
+  });
+
+  it('predicts No for low user score (<35)', () => {
+    const result = predictUserStance(20, 0.8);
+    expect(result.stance).toBe('No');
+    expect(result.confidence).toBe(60); // |20-50|*2
+  });
+
+  it('predicts Neutral for middle user score (35-65)', () => {
+    const result = predictUserStance(50, 0.8);
+    expect(result.stance).toBe('Neutral');
+    expect(result.confidence).toBe(0); // |50-50|*2
+  });
+
+  it('returns Neutral with 0 confidence when user is exactly 50', () => {
+    const result = predictUserStance(50, 0.8);
+    expect(result.stance).toBe('Neutral');
+    expect(result.confidence).toBe(0);
+  });
+
+  it('returns max confidence of 100 for extreme user score (100)', () => {
+    const result = predictUserStance(100, 0.8);
+    expect(result.stance).toBe('Yes');
+    expect(result.confidence).toBe(100);
+  });
+
+  it('returns max confidence of 100 for extreme user score (0)', () => {
+    const result = predictUserStance(0, 0.8);
+    expect(result.stance).toBe('No');
+    expect(result.confidence).toBe(100);
+  });
+
+  it('returns Neutral for classification below 0.6', () => {
+    const result = predictUserStance(90, 0.5);
+    expect(result.stance).toBe('Neutral');
+    expect(result.confidence).toBe(0);
+  });
+
+  it('defaults null user score to 50 (Neutral)', () => {
+    const result = predictUserStance(null, 0.8);
+    expect(result.stance).toBe('Neutral');
+    expect(result.confidence).toBe(0);
+  });
+});
+
+/* ─── computeProposalAlignment ────────────────────────── */
+
+describe('computeProposalAlignment', () => {
+  it('returns null for empty votes array', () => {
+    const result = computeProposalAlignment(makeScores(), []);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no proposals have qualifying classification', () => {
+    const vote = makeVote({
+      classification: {
+        dimTreasuryConservative: 0.3,
+        dimTreasuryGrowth: 0.2,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+    const result = computeProposalAlignment(makeScores(), [vote]);
+    expect(result).toBeNull();
+  });
+
+  it('produces agreement when user and DRep align on dimension', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const vote = makeVote({
+      vote: 'Yes',
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [vote]);
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements.length).toBe(1);
+    expect(result!.topAgreements[0].agreement).toBe('agree');
+  });
+
+  it('produces disagreement when user and DRep oppose on dimension', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const vote = makeVote({
+      vote: 'No',
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [vote]);
+    expect(result).not.toBeNull();
+    expect(result!.topDisagreements.length).toBe(1);
+    expect(result!.topDisagreements[0].agreement).toBe('disagree');
+  });
+
+  it('produces neutral for Abstain votes regardless of user stance', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const vote = makeVote({
+      vote: 'Abstain',
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [vote]);
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements.length).toBe(0);
+    expect(result!.topDisagreements.length).toBe(0);
+  });
+
+  it('produces all Neutral stances when user alignment is all 50', () => {
+    const userScores = makeScores();
+    const votes = [
+      makeVote({ proposalId: 'tx1#0', vote: 'Yes', epochNo: 500 }),
+      makeVote({ proposalId: 'tx2#0', vote: 'No', epochNo: 499 }),
+    ];
+
+    const result = computeProposalAlignment(userScores, votes);
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements.length).toBe(0);
+    expect(result!.topDisagreements.length).toBe(0);
+    expect(result!.confidence).toBeGreaterThanOrEqual(0);
+  });
+
+  it('caps top agreements at 3 and top disagreements at 2', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+
+    const agreements = Array.from({ length: 5 }, (_, i) =>
+      makeVote({
+        proposalId: `tx-agree-${i}#0`,
+        vote: 'Yes',
+        epochNo: 500 - i,
+        classification: {
+          dimTreasuryConservative: 0.9,
+          dimTreasuryGrowth: 0.1,
+          dimDecentralization: 0.1,
+          dimSecurity: 0.1,
+          dimInnovation: 0.1,
+          dimTransparency: 0.1,
+        },
+      }),
+    );
+
+    const disagreements = Array.from({ length: 4 }, (_, i) =>
+      makeVote({
+        proposalId: `tx-disagree-${i}#0`,
+        vote: 'No',
+        epochNo: 500 - i,
+        classification: {
+          dimTreasuryConservative: 0.9,
+          dimTreasuryGrowth: 0.1,
+          dimDecentralization: 0.1,
+          dimSecurity: 0.1,
+          dimInnovation: 0.1,
+          dimTransparency: 0.1,
+        },
+      }),
+    );
+
+    const result = computeProposalAlignment(userScores, [...agreements, ...disagreements]);
+
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements.length).toBe(3);
+    expect(result!.topDisagreements.length).toBe(2);
+  });
+
+  it('returns fewer than max when not enough results', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const vote = makeVote({
+      vote: 'Yes',
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [vote]);
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements.length).toBe(1);
+    expect(result!.topDisagreements.length).toBe(0);
+  });
+
+  it('favors recent proposals via recency weighting', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+
+    const recentVote = makeVote({
+      proposalId: 'tx-recent#0',
+      vote: 'Yes',
+      epochNo: 500,
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const oldVote = makeVote({
+      proposalId: 'tx-old#0',
+      vote: 'Yes',
+      epochNo: 400,
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [oldVote, recentVote], {
+      maxAgreements: 1,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.topAgreements[0].proposalId).toBe('tx-recent#0');
+  });
+
+  it('excludes proposals with classification below 0.6', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const lowClassVote = makeVote({
+      classification: {
+        dimTreasuryConservative: 0.5,
+        dimTreasuryGrowth: 0.2,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [lowClassVote]);
+    expect(result).toBeNull();
+  });
+
+  it('generates a narrative string', () => {
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const vote = makeVote({
+      vote: 'Yes',
+      classification: {
+        dimTreasuryConservative: 0.9,
+        dimTreasuryGrowth: 0.1,
+        dimDecentralization: 0.1,
+        dimSecurity: 0.1,
+        dimInnovation: 0.1,
+        dimTransparency: 0.1,
+      },
+    });
+
+    const result = computeProposalAlignment(userScores, [vote]);
+    expect(result).not.toBeNull();
+    expect(typeof result!.narrative).toBe('string');
+    expect(result!.narrative.length).toBeGreaterThan(0);
+  });
+
+  it('handles division safely with no agreements or disagreements', () => {
+    // All votes are Abstain -> all neutral
+    const userScores = makeScores({ treasuryConservative: 90 });
+    const votes = [
+      makeVote({ proposalId: 'tx1#0', vote: 'Abstain', epochNo: 500 }),
+      makeVote({ proposalId: 'tx2#0', vote: 'Abstain', epochNo: 499 }),
+    ];
+
+    const result = computeProposalAlignment(userScores, votes);
+    expect(result).not.toBeNull();
+    expect(result!.overallAlignment).not.toBeNaN();
+    expect(result!.topAgreements.length).toBe(0);
+    expect(result!.topDisagreements.length).toBe(0);
+  });
+});
+
+/* ─── getProposalAlignmentReason ──────────────────────── */
+
+describe('getProposalAlignmentReason', () => {
+  it('returns agree reason for known dimension', () => {
+    const reason = getProposalAlignmentReason('Treasury Conservative', 'agree');
+    expect(reason).toContain('fiscal conservatism');
+  });
+
+  it('returns disagree reason for known dimension', () => {
+    const reason = getProposalAlignmentReason('Innovation', 'disagree');
+    expect(reason).toContain('innovation');
+  });
+
+  it('returns fallback reason for unknown dimension', () => {
+    const reason = getProposalAlignmentReason('Unknown Dimension', 'agree');
+    expect(reason).toContain('Aligned');
+  });
+});

--- a/app/api/drep/[drepId]/alignment/route.ts
+++ b/app/api/drep/[drepId]/alignment/route.ts
@@ -1,0 +1,441 @@
+/**
+ * DRep Alignment API — Decision Engine Phase 1 (WS-9)
+ *
+ * POST /api/drep/[drepId]/alignment
+ *
+ * Orchestrates per-proposal alignment (WS-1), delegation simulation (WS-2),
+ * and decomposed trust signals into a single viewer-specific response.
+ *
+ * Auth: optional. Authenticated users get alignment from DB profile.
+ * Unauthenticated users POST their alignment scores in the request body.
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { createClient } from '@/lib/supabase';
+import { cached } from '@/lib/redis';
+import { getDRepById, getVotesByDRepId, getDRepDelegationTrend } from '@/lib/data';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import {
+  computeProposalAlignment,
+  type VoteWithClassification,
+  type VoteClassification,
+  type AlignmentSummary,
+} from '@/lib/matching/proposalAlignment';
+import {
+  computeDelegationSimulation,
+  type DelegationSimulation,
+} from '@/lib/matching/delegationSimulation';
+import { getProposalOutcomesBatch } from '@/lib/proposalOutcomes';
+import { getProposalsByIds } from '@/lib/data';
+import { getProposalDisplayTitle } from '@/utils/display';
+import { logger } from '@/lib/logger';
+import { createHash } from 'crypto';
+
+export const dynamic = 'force-dynamic';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+export interface TrustSignal {
+  key: 'participation' | 'rationale' | 'reliability' | 'delegation_trend' | 'profile_quality';
+  label: string;
+  value: number;
+  status: 'strong' | 'moderate' | 'weak';
+  detail?: string;
+}
+
+interface AlignmentResponse {
+  alignment: AlignmentSummary | null;
+  simulation: DelegationSimulation | null;
+  comparison: null;
+  trustSignals: TrustSignal[];
+}
+
+/* ─── Validation ──────────────────────────────────────── */
+
+const AlignmentScoresSchema = z
+  .object({
+    treasuryConservative: z.number().min(0).max(100).nullable().optional(),
+    treasuryGrowth: z.number().min(0).max(100).nullable().optional(),
+    decentralization: z.number().min(0).max(100).nullable().optional(),
+    security: z.number().min(0).max(100).nullable().optional(),
+    innovation: z.number().min(0).max(100).nullable().optional(),
+    transparency: z.number().min(0).max(100).nullable().optional(),
+  })
+  .optional();
+
+const RequestBodySchema = z
+  .object({
+    userAlignment: AlignmentScoresSchema,
+  })
+  .optional();
+
+/* ─── Trust Signal Computation ────────────────────────── */
+
+interface DRepTrustData {
+  effectiveParticipation: number;
+  rationaleRate: number;
+  reliabilityStreak: number;
+  reliabilityRecency: number;
+  profileCompleteness: number;
+  metadataHashVerified: boolean | null;
+  delegationTrend: { epoch: number; votingPowerAda: number }[];
+}
+
+function computeTrustSignals(data: DRepTrustData): TrustSignal[] {
+  const signals: TrustSignal[] = [];
+
+  // Participation
+  const participation = data.effectiveParticipation;
+  signals.push({
+    key: 'participation',
+    label:
+      participation >= 70
+        ? `Votes on ${Math.round(participation)}% of proposals`
+        : participation >= 40
+          ? `Votes on ${Math.round(participation)}% of proposals`
+          : `Limited voting (${Math.round(participation)}%)`,
+    value: participation,
+    status: participation >= 70 ? 'strong' : participation >= 40 ? 'moderate' : 'weak',
+  });
+
+  // Rationale
+  const rationaleRate = data.rationaleRate;
+  signals.push({
+    key: 'rationale',
+    label:
+      rationaleRate >= 60
+        ? 'Writes rationale on most votes'
+        : rationaleRate >= 30
+          ? 'Sometimes provides rationale'
+          : 'Rarely provides rationale',
+    value: rationaleRate,
+    status: rationaleRate >= 60 ? 'strong' : rationaleRate >= 30 ? 'moderate' : 'weak',
+  });
+
+  // Reliability
+  const { reliabilityStreak, reliabilityRecency } = data;
+  const reliabilityStatus: 'strong' | 'moderate' | 'weak' =
+    reliabilityStreak >= 10 ? 'strong' : reliabilityRecency <= 2 ? 'moderate' : 'weak';
+
+  signals.push({
+    key: 'reliability',
+    label:
+      reliabilityStreak >= 10
+        ? `Active ${reliabilityStreak} consecutive epochs`
+        : reliabilityRecency <= 2
+          ? 'Voted recently'
+          : `Inactive for ${reliabilityRecency} epochs`,
+    value: reliabilityStreak,
+    status: reliabilityStatus,
+  });
+
+  // Delegation trend
+  const trend = data.delegationTrend;
+  if (trend.length >= 2) {
+    const latest = trend[trend.length - 1];
+    const previous = trend[trend.length - 2];
+    const change =
+      previous.votingPowerAda > 0
+        ? ((latest.votingPowerAda - previous.votingPowerAda) / previous.votingPowerAda) * 100
+        : 0;
+
+    const trendStatus: 'strong' | 'moderate' | 'weak' =
+      change > 5 ? 'strong' : change > -5 ? 'moderate' : 'weak';
+
+    signals.push({
+      key: 'delegation_trend',
+      label:
+        change > 5
+          ? `Growing delegation (+${Math.round(change)}%)`
+          : change > -5
+            ? 'Stable delegation'
+            : `Declining delegation (${Math.round(change)}%)`,
+      value: Math.round(change),
+      status: trendStatus,
+      detail: `${latest.votingPowerAda.toLocaleString()} ADA delegated`,
+    });
+  } else {
+    signals.push({
+      key: 'delegation_trend',
+      label: 'Delegation trend unavailable',
+      value: 0,
+      status: 'weak',
+    });
+  }
+
+  // Profile quality
+  const { profileCompleteness, metadataHashVerified } = data;
+  const profileStatus: 'strong' | 'moderate' | 'weak' =
+    profileCompleteness >= 80 && metadataHashVerified
+      ? 'strong'
+      : profileCompleteness >= 50
+        ? 'moderate'
+        : 'weak';
+
+  signals.push({
+    key: 'profile_quality',
+    label:
+      profileCompleteness >= 80 && metadataHashVerified
+        ? 'Complete, verified profile'
+        : profileCompleteness >= 50
+          ? 'Partial profile'
+          : 'Minimal profile',
+    value: profileCompleteness,
+    status: profileStatus,
+    detail: metadataHashVerified ? 'Verified metadata' : undefined,
+  });
+
+  return signals;
+}
+
+/* ─── Data Helpers ────────────────────────────────────── */
+
+/**
+ * Fetch user alignment from DB profile (for authenticated users).
+ */
+async function fetchUserAlignmentFromDB(userId: string): Promise<AlignmentScores | null> {
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('user_governance_profiles')
+      .select('alignment_scores')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error || !data?.alignment_scores) return null;
+
+    const scores = data.alignment_scores as Record<string, number | null>;
+    return {
+      treasuryConservative: scores.treasuryConservative ?? null,
+      treasuryGrowth: scores.treasuryGrowth ?? null,
+      decentralization: scores.decentralization ?? null,
+      security: scores.security ?? null,
+      innovation: scores.innovation ?? null,
+      transparency: scores.transparency ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch proposal classifications for a set of proposals.
+ */
+async function fetchClassifications(txHashes: string[]): Promise<Map<string, VoteClassification>> {
+  if (txHashes.length === 0) return new Map();
+
+  try {
+    const supabase = createClient();
+    const { data, error } = await supabase
+      .from('proposal_classifications')
+      .select(
+        'proposal_tx_hash, proposal_index, dim_treasury_conservative, dim_treasury_growth, dim_decentralization, dim_security, dim_innovation, dim_transparency',
+      )
+      .in('proposal_tx_hash', txHashes);
+
+    if (error || !data) return new Map();
+
+    const map = new Map<string, VoteClassification>();
+    for (const row of data) {
+      const key = `${row.proposal_tx_hash}-${row.proposal_index}`;
+      map.set(key, {
+        dimTreasuryConservative: Number(row.dim_treasury_conservative) || 0,
+        dimTreasuryGrowth: Number(row.dim_treasury_growth) || 0,
+        dimDecentralization: Number(row.dim_decentralization) || 0,
+        dimSecurity: Number(row.dim_security) || 0,
+        dimInnovation: Number(row.dim_innovation) || 0,
+        dimTransparency: Number(row.dim_transparency) || 0,
+      });
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Hash alignment scores for cache key stability.
+ */
+function hashAlignment(alignment: AlignmentScores): string {
+  const str = JSON.stringify(alignment);
+  return createHash('sha256').update(str).digest('hex').slice(0, 12);
+}
+
+/* ─── Route Handler ───────────────────────────────────── */
+
+export const POST = withRouteHandler(
+  async (request, { requestId, userId }) => {
+    // 1. Parse drepId from URL
+    const drepId = request.nextUrl.pathname.split('/api/drep/')[1]?.split('/')[0];
+    if (!drepId) {
+      return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+    }
+
+    // 2. Parse and validate body
+    let body: z.infer<typeof RequestBodySchema> = undefined;
+    try {
+      const rawBody = await request.text();
+      if (rawBody) {
+        body = RequestBodySchema.parse(JSON.parse(rawBody));
+      }
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        const fields = err.issues.map((e) => `${String(e.path.join('.'))}: ${e.message}`);
+        return NextResponse.json({ error: 'Validation failed', details: fields }, { status: 400 });
+      }
+      // Non-JSON body -- treat as empty
+    }
+
+    // 3. Determine alignment source: DB profile > POST body > null
+    let userAlignment: AlignmentScores | null = null;
+
+    if (userId) {
+      userAlignment = await fetchUserAlignmentFromDB(userId);
+    }
+
+    if (!userAlignment && body?.userAlignment) {
+      userAlignment = {
+        treasuryConservative: body.userAlignment.treasuryConservative ?? null,
+        treasuryGrowth: body.userAlignment.treasuryGrowth ?? null,
+        decentralization: body.userAlignment.decentralization ?? null,
+        security: body.userAlignment.security ?? null,
+        innovation: body.userAlignment.innovation ?? null,
+        transparency: body.userAlignment.transparency ?? null,
+      };
+    }
+
+    // 4. Fetch DRep -- 404 if not found
+    const drep = await getDRepById(drepId);
+    if (!drep) {
+      return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
+    }
+
+    // 5. Compute trust signals (always, regardless of alignment)
+    const delegationTrend = await getDRepDelegationTrend(drepId);
+    const trustSignals = computeTrustSignals({
+      effectiveParticipation: drep.effectiveParticipation ?? 0,
+      rationaleRate: drep.rationaleRate ?? 0,
+      reliabilityStreak: drep.reliabilityStreak ?? 0,
+      reliabilityRecency: drep.reliabilityRecency ?? 0,
+      profileCompleteness: drep.profileCompleteness ?? 0,
+      metadataHashVerified: drep.metadataHashVerified ?? null,
+      delegationTrend,
+    });
+
+    // 6. If no alignment, return trust signals only
+    if (!userAlignment) {
+      const response: AlignmentResponse = {
+        alignment: null,
+        simulation: null,
+        comparison: null,
+        trustSignals,
+      };
+      return NextResponse.json(response);
+    }
+
+    // 7. Compute alignment and simulation (with caching for authenticated users)
+    const computeResult = async (): Promise<{
+      alignment: AlignmentSummary | null;
+      simulation: DelegationSimulation | null;
+    }> => {
+      // Fetch DRep votes
+      const drepVotes = await getVotesByDRepId(drepId);
+
+      if (drepVotes.length === 0) {
+        return { alignment: null, simulation: null };
+      }
+
+      // Unique tx hashes for batch fetches
+      const txHashes = [...new Set(drepVotes.map((v) => v.proposal_tx_hash))];
+      const proposalIds = drepVotes.map((v) => ({
+        txHash: v.proposal_tx_hash,
+        index: v.proposal_index,
+      }));
+      const outcomeKeys = drepVotes.map((v) => ({
+        txHash: v.proposal_tx_hash,
+        proposalIndex: v.proposal_index,
+      }));
+
+      // Parallel data fetches
+      const [classifications, proposals, outcomes] = await Promise.all([
+        fetchClassifications(txHashes),
+        getProposalsByIds(proposalIds),
+        getProposalOutcomesBatch(outcomeKeys),
+      ]);
+
+      // Build VoteWithClassification array for WS-1
+      const votesWithClassification: VoteWithClassification[] = drepVotes
+        .filter((v) => {
+          const key = `${v.proposal_tx_hash}-${v.proposal_index}`;
+          return classifications.has(key);
+        })
+        .map((v) => {
+          const key = `${v.proposal_tx_hash}-${v.proposal_index}`;
+          const proposal = proposals.get(key);
+          const classification = classifications.get(key)!;
+
+          return {
+            proposalId: key,
+            proposalTitle: getProposalDisplayTitle(
+              proposal?.title ?? null,
+              v.proposal_tx_hash,
+              v.proposal_index,
+            ),
+            proposalType: proposal?.proposalType ?? 'Unknown',
+            vote: v.vote,
+            epochNo: v.epoch_no ?? 0,
+            classification,
+          };
+        });
+
+      // Compute alignment (WS-1) and simulation (WS-2) in parallel
+      const [alignment, simulation] = await Promise.all([
+        Promise.resolve(computeProposalAlignment(userAlignment!, votesWithClassification)),
+        Promise.resolve(
+          computeDelegationSimulation({
+            drepVotes,
+            proposals,
+            outcomes,
+            classifications,
+            userAlignment,
+          }),
+        ),
+      ]);
+
+      return { alignment, simulation };
+    };
+
+    let result: { alignment: AlignmentSummary | null; simulation: DelegationSimulation | null };
+
+    // Use Redis cache for authenticated users
+    if (userId) {
+      const alignmentHash = hashAlignment(userAlignment);
+      const cacheKey = `align:${userId}:${drepId}:${alignmentHash}`;
+      // 1 epoch TTL ~ 5 days = 432,000 seconds
+      result = await cached(cacheKey, 432_000, computeResult);
+    } else {
+      result = await computeResult();
+    }
+
+    const response: AlignmentResponse = {
+      alignment: result.alignment,
+      simulation: result.simulation,
+      comparison: null,
+      trustSignals,
+    };
+
+    logger.info('Alignment API response', {
+      context: 'drep/alignment',
+      drepId,
+      hasAlignment: !!result.alignment,
+      hasSimulation: !!result.simulation,
+      trustSignalCount: trustSignals.length,
+      requestId,
+    });
+
+    return NextResponse.json(response);
+  },
+  { auth: 'optional', rateLimit: { max: 60, window: 60 } },
+);

--- a/lib/matching/delegationSimulation.ts
+++ b/lib/matching/delegationSimulation.ts
@@ -1,0 +1,311 @@
+/**
+ * Delegation simulation engine (WS-2).
+ *
+ * Answers: "If you had delegated to this DRep N months ago,
+ * here's how your ADA would have voted."
+ *
+ * Separates pure computation from data fetching:
+ * - `computeDelegationSimulation` is a pure function (testable without DB)
+ * - `fetchDelegationSimulation` orchestrates data fetching then calls the pure fn
+ */
+
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import type { DRepVoteRow, CachedProposal } from '@/lib/data';
+import { getVotesByDRepId, getProposalsByIds } from '@/lib/data';
+import type { ProposalOutcome } from '@/lib/proposalOutcomes';
+import { getProposalOutcomesBatch } from '@/lib/proposalOutcomes';
+import { predictUserStance, type VoteClassification } from './proposalAlignment';
+
+/* ─── Constants ───────────────────────────────────────── */
+
+/** Default lookback in epochs (~6 months at ~5 days/epoch). */
+const DEFAULT_LOOKBACK_EPOCHS = 36;
+
+/* ─── Types ───────────────────────────────────────────── */
+
+export interface SimulatedVote {
+  proposalId: string;
+  proposalTitle: string;
+  proposalType: string;
+  drepVote: 'Yes' | 'No' | 'Abstain';
+  outcome: 'Enacted' | 'Expired' | 'Dropped' | 'Pending';
+  deliveryStatus?: 'delivered' | 'partial' | 'not_delivered' | 'in_progress' | null;
+  deliveryScore?: number | null;
+  alignmentWithUser: 'agree' | 'disagree' | 'neutral' | null;
+  epoch: number;
+}
+
+export interface DelegationSimulation {
+  periodLabel: string;
+  totalProposals: number;
+  drepVotedOn: number;
+  participationRate: number;
+  enactedCount: number;
+  deliverySuccessRate: number | null;
+  deliveryCoverage: string | null;
+  alignedVoteCount: number;
+  totalClassifiedVotes: number;
+  simulatedVotes: SimulatedVote[];
+}
+
+/** Input data for pure computation. */
+export interface SimulationInput {
+  drepVotes: DRepVoteRow[];
+  proposals: Map<string, CachedProposal>;
+  outcomes: Map<string, ProposalOutcome>;
+  classifications?: Map<string, VoteClassification>;
+  userAlignment?: AlignmentScores | null;
+  currentEpoch?: number;
+  lookbackEpochs?: number;
+}
+
+/* ─── Helpers ─────────────────────────────────────────── */
+
+/**
+ * Determine proposal outcome from proposal metadata and outcome data.
+ */
+function resolveOutcome(
+  proposal: CachedProposal | undefined,
+  outcome: ProposalOutcome | undefined,
+): 'Enacted' | 'Expired' | 'Dropped' | 'Pending' {
+  // If we have delivery data, the proposal was enacted
+  if (outcome && outcome.deliveryStatus !== 'unknown') return 'Enacted';
+
+  if (!proposal) return 'Pending';
+
+  // Check proposal-level status indicators via available fields
+  // CachedProposal has: txHash, proposalIndex, title, abstract, aiSummary,
+  //   proposalType, withdrawalAmount, treasuryTier, relevantPrefs
+  // We don't have status fields on CachedProposal, so rely on outcome data
+  if (outcome) return 'Enacted';
+  return 'Pending';
+}
+
+/**
+ * Determine alignment between user stance and DRep vote for a single proposal.
+ */
+function computeVoteAlignment(
+  drepVote: 'Yes' | 'No' | 'Abstain',
+  userAlignment: AlignmentScores | null | undefined,
+  classification: VoteClassification | undefined,
+): 'agree' | 'disagree' | 'neutral' | null {
+  if (!userAlignment || !classification) return null;
+  if (drepVote === 'Abstain') return 'neutral';
+
+  // Find primary dimension (highest classification score)
+  const dimEntries: [string, number][] = [
+    ['treasuryConservative', classification.dimTreasuryConservative],
+    ['treasuryGrowth', classification.dimTreasuryGrowth],
+    ['decentralization', classification.dimDecentralization],
+    ['security', classification.dimSecurity],
+    ['innovation', classification.dimInnovation],
+    ['transparency', classification.dimTransparency],
+  ];
+
+  let bestDim: string | null = null;
+  let bestScore = 0;
+  for (const [dim, score] of dimEntries) {
+    if (score > bestScore) {
+      bestScore = score;
+      bestDim = dim;
+    }
+  }
+
+  if (!bestDim || bestScore < 0.6) return null;
+
+  const userScore = userAlignment[bestDim as keyof AlignmentScores];
+  const prediction = predictUserStance(userScore, bestScore);
+
+  if (prediction.stance === 'Neutral') return 'neutral';
+  if (prediction.stance === drepVote) return 'agree';
+  return 'disagree';
+}
+
+/* ─── Pure Computation ────────────────────────────────── */
+
+/**
+ * Compute a delegation simulation from pre-fetched data.
+ * Pure function -- no database access.
+ *
+ * @param input - All required data pre-fetched by the caller
+ * @returns DelegationSimulation result
+ */
+export function computeDelegationSimulation(input: SimulationInput): DelegationSimulation {
+  const {
+    drepVotes,
+    proposals,
+    outcomes,
+    classifications,
+    userAlignment,
+    currentEpoch,
+    lookbackEpochs = DEFAULT_LOOKBACK_EPOCHS,
+  } = input;
+
+  // Determine epoch window
+  const latestEpoch =
+    currentEpoch ??
+    (drepVotes.length > 0
+      ? Math.max(...drepVotes.filter((v) => v.epoch_no !== null).map((v) => v.epoch_no!))
+      : 0);
+  const startEpoch = latestEpoch - lookbackEpochs;
+
+  // Filter votes to the lookback window
+  const windowVotes = drepVotes.filter((v) => v.epoch_no !== null && v.epoch_no >= startEpoch);
+
+  // Build period label
+  const periodLabel = `Epochs ${startEpoch}\u2013${latestEpoch} (~${Math.round((lookbackEpochs * 5) / 30)} months)`;
+
+  if (windowVotes.length === 0) {
+    return {
+      periodLabel,
+      totalProposals: 0,
+      drepVotedOn: 0,
+      participationRate: 0,
+      enactedCount: 0,
+      deliverySuccessRate: null,
+      deliveryCoverage: null,
+      alignedVoteCount: 0,
+      totalClassifiedVotes: 0,
+      simulatedVotes: [],
+    };
+  }
+
+  // Count unique proposals in the window via the DRep's votes
+  const uniqueProposals = new Set(
+    windowVotes.map((v) => `${v.proposal_tx_hash}-${v.proposal_index}`),
+  );
+  const drepVotedOn = uniqueProposals.size;
+
+  // Build simulated votes (most recent first -- windowVotes inherits order from getVotesByDRepId)
+  const simulatedVotes: SimulatedVote[] = [];
+  let enactedCount = 0;
+  let deliveredCount = 0;
+  let deliveryEvaluatedCount = 0;
+  let alignedVoteCount = 0;
+  let totalClassifiedVotes = 0;
+
+  for (const vote of windowVotes) {
+    const proposalKey = `${vote.proposal_tx_hash}-${vote.proposal_index}`;
+    const proposal = proposals.get(proposalKey);
+    const outcome = outcomes.get(proposalKey);
+    const classification = classifications?.get(proposalKey);
+
+    const resolvedOutcome = resolveOutcome(proposal, outcome);
+    if (resolvedOutcome === 'Enacted') enactedCount++;
+
+    // Delivery tracking
+    let deliveryStatus: SimulatedVote['deliveryStatus'] = null;
+    let deliveryScore: number | null = null;
+    if (outcome) {
+      deliveryStatus = outcome.deliveryStatus === 'unknown' ? null : outcome.deliveryStatus;
+      deliveryScore = outcome.deliveryScore;
+      if (deliveryStatus && deliveryStatus !== 'in_progress') {
+        deliveryEvaluatedCount++;
+        if (deliveryStatus === 'delivered' || deliveryStatus === 'partial') {
+          deliveredCount++;
+        }
+      }
+    }
+
+    // Alignment computation
+    const alignmentWithUser = computeVoteAlignment(vote.vote, userAlignment, classification);
+    if (alignmentWithUser !== null) {
+      totalClassifiedVotes++;
+      if (alignmentWithUser === 'agree') alignedVoteCount++;
+    }
+
+    simulatedVotes.push({
+      proposalId: proposalKey,
+      proposalTitle: proposal?.title ?? `Proposal ${vote.proposal_tx_hash.slice(0, 8)}...`,
+      proposalType: proposal?.proposalType ?? 'Unknown',
+      drepVote: vote.vote,
+      outcome: resolvedOutcome,
+      deliveryStatus,
+      deliveryScore,
+      alignmentWithUser,
+      epoch: vote.epoch_no ?? 0,
+    });
+  }
+
+  // Aggregate stats
+  // totalProposals = how many unique proposals the DRep voted on in window
+  const totalProposals = drepVotedOn;
+  const participationRate = totalProposals > 0 ? drepVotedOn / totalProposals : 0;
+
+  const deliverySuccessRate =
+    deliveryEvaluatedCount > 0 ? Math.round((deliveredCount / deliveryEvaluatedCount) * 100) : null;
+
+  const deliveryCoverage =
+    enactedCount > 0
+      ? `${deliveryEvaluatedCount} of ${enactedCount} enacted proposals have delivery data`
+      : null;
+
+  return {
+    periodLabel,
+    totalProposals,
+    drepVotedOn,
+    participationRate,
+    enactedCount,
+    deliverySuccessRate,
+    deliveryCoverage,
+    alignedVoteCount,
+    totalClassifiedVotes,
+    simulatedVotes,
+  };
+}
+
+/* ─── Data-Fetching Orchestrator ──────────────────────── */
+
+/**
+ * Fetch data and compute delegation simulation for a DRep.
+ *
+ * Orchestrator function that handles all DB access, then delegates
+ * to the pure `computeDelegationSimulation`.
+ *
+ * @param drepId - DRep identifier
+ * @param userAlignment - Optional user alignment for per-vote alignment
+ * @param lookbackEpochs - How many epochs to look back (default: 36 ~ 6 months)
+ * @returns DelegationSimulation result
+ */
+export async function fetchDelegationSimulation(
+  drepId: string,
+  userAlignment?: AlignmentScores | null,
+  lookbackEpochs?: number,
+): Promise<DelegationSimulation> {
+  // Fetch DRep votes (already ordered by block_time DESC)
+  const drepVotes = await getVotesByDRepId(drepId);
+
+  if (drepVotes.length === 0) {
+    return computeDelegationSimulation({
+      drepVotes: [],
+      proposals: new Map(),
+      outcomes: new Map(),
+      lookbackEpochs,
+    });
+  }
+
+  // Build proposal ID list for batch fetches
+  const proposalIds = drepVotes.map((v) => ({
+    txHash: v.proposal_tx_hash,
+    index: v.proposal_index,
+  }));
+
+  const outcomeKeys = drepVotes.map((v) => ({
+    txHash: v.proposal_tx_hash,
+    proposalIndex: v.proposal_index,
+  }));
+
+  // Parallel data fetches
+  const [proposals, outcomes] = await Promise.all([
+    getProposalsByIds(proposalIds),
+    getProposalOutcomesBatch(outcomeKeys),
+  ]);
+
+  return computeDelegationSimulation({
+    drepVotes,
+    proposals,
+    outcomes,
+    userAlignment,
+    lookbackEpochs,
+  });
+}

--- a/lib/matching/dimensionAgreement.ts
+++ b/lib/matching/dimensionAgreement.ts
@@ -5,10 +5,10 @@
 
 import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
 
-const AGREE_THRESHOLD = 70;
-const DIFFER_THRESHOLD = 40;
+export const AGREE_THRESHOLD = 70;
+export const DIFFER_THRESHOLD = 40;
 
-const DIMENSION_LABELS: Record<AlignmentDimension, string> = {
+export const DIMENSION_LABELS: Record<AlignmentDimension, string> = {
   treasuryConservative: 'Treasury Conservative',
   treasuryGrowth: 'Treasury Growth',
   decentralization: 'Decentralization',
@@ -17,7 +17,7 @@ const DIMENSION_LABELS: Record<AlignmentDimension, string> = {
   transparency: 'Transparency',
 };
 
-const DIMENSIONS: AlignmentDimension[] = [
+export const DIMENSIONS: AlignmentDimension[] = [
   'treasuryConservative',
   'treasuryGrowth',
   'decentralization',

--- a/lib/matching/proposalAlignment.ts
+++ b/lib/matching/proposalAlignment.ts
@@ -1,0 +1,401 @@
+/**
+ * Per-proposal alignment engine (WS-1).
+ *
+ * Pure computation module: takes a user's alignment profile and a DRep's
+ * votes (enriched with proposal classifications), then produces
+ * per-proposal agreement/disagreement results plus an aggregate summary.
+ *
+ * No database access in core functions -- data fetching is the caller's
+ * responsibility (e.g. the alignment API route).
+ */
+
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import {
+  computeDimensionAgreement,
+  DIMENSIONS,
+  DIMENSION_LABELS,
+  type DimensionAgreementResult,
+} from './dimensionAgreement';
+import { generateMatchNarrative } from './matchNarrative';
+
+/* ─── Constants ───────────────────────────────────────── */
+
+/** Minimum classification score (0-1) for a proposal to qualify. */
+const MIN_CLASSIFICATION_SCORE = 0.6;
+
+/** Decay factor per epoch for recency weighting. */
+const RECENCY_DECAY = 0.1;
+
+/* ─── Types ───────────────────────────────────────────── */
+
+/** Per-proposal classification scores (0-1 scale, matching proposal_classifications table). */
+export interface VoteClassification {
+  dimTreasuryConservative: number;
+  dimTreasuryGrowth: number;
+  dimDecentralization: number;
+  dimSecurity: number;
+  dimInnovation: number;
+  dimTransparency: number;
+}
+
+/** A DRep vote enriched with proposal metadata and classification data. */
+export interface VoteWithClassification {
+  proposalId: string;
+  proposalTitle: string;
+  proposalType: string;
+  vote: 'Yes' | 'No' | 'Abstain';
+  epochNo: number;
+  classification: VoteClassification;
+}
+
+export interface ProposalAlignmentResult {
+  proposalId: string;
+  proposalTitle: string;
+  proposalType: string;
+  drepVote: 'Yes' | 'No' | 'Abstain';
+  predictedUserStance: 'Yes' | 'No' | 'Neutral';
+  stanceConfidence: number;
+  agreement: 'agree' | 'disagree' | 'neutral';
+  reason: string;
+  dimension: string;
+}
+
+export interface AlignmentSummary {
+  overallAlignment: number | null;
+  confidence: number;
+  confidenceLabel: string;
+  topAgreements: ProposalAlignmentResult[];
+  topDisagreements: ProposalAlignmentResult[];
+  dimensionBreakdown: DimensionAgreementResult;
+  narrative: string;
+}
+
+interface StancePrediction {
+  stance: 'Yes' | 'No' | 'Neutral';
+  confidence: number;
+}
+
+/* ─── Helpers ─────────────────────────────────────────── */
+
+/** Map from classification field to AlignmentDimension key. */
+const CLASSIFICATION_TO_DIMENSION: Record<string, AlignmentDimension> = {
+  dimTreasuryConservative: 'treasuryConservative',
+  dimTreasuryGrowth: 'treasuryGrowth',
+  dimDecentralization: 'decentralization',
+  dimSecurity: 'security',
+  dimInnovation: 'innovation',
+  dimTransparency: 'transparency',
+};
+
+/**
+ * Find the primary dimension for a proposal classification.
+ * Returns the dimension with the highest score >= MIN_CLASSIFICATION_SCORE,
+ * or null if none qualify. Ties broken by DIMENSIONS order.
+ */
+function findPrimaryDimension(classification: VoteClassification): AlignmentDimension | null {
+  let bestDim: AlignmentDimension | null = null;
+  let bestScore = -1;
+
+  const entries: [string, number][] = [
+    ['dimTreasuryConservative', classification.dimTreasuryConservative],
+    ['dimTreasuryGrowth', classification.dimTreasuryGrowth],
+    ['dimDecentralization', classification.dimDecentralization],
+    ['dimSecurity', classification.dimSecurity],
+    ['dimInnovation', classification.dimInnovation],
+    ['dimTransparency', classification.dimTransparency],
+  ];
+
+  for (const [field, score] of entries) {
+    if (score < MIN_CLASSIFICATION_SCORE) continue;
+    const dim = CLASSIFICATION_TO_DIMENSION[field];
+    if (!dim) continue;
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestDim = dim;
+    } else if (score === bestScore && bestDim !== null) {
+      // Tie-break: use DIMENSIONS order (lower index wins)
+      const currentIdx = DIMENSIONS.indexOf(dim);
+      const bestIdx = DIMENSIONS.indexOf(bestDim);
+      if (currentIdx < bestIdx) {
+        bestDim = dim;
+      }
+    }
+  }
+
+  return bestDim;
+}
+
+/* ─── Core Functions ──────────────────────────────────── */
+
+/**
+ * Predict a user's likely stance on a proposal given their alignment score
+ * on the relevant dimension and the proposal's classification score.
+ *
+ * @param userScore - User's alignment on the primary dimension (0-100, null defaults to 50)
+ * @param proposalDimensionScore - Proposal's classification score on that dimension (0-1)
+ * @returns Predicted stance and confidence level
+ */
+export function predictUserStance(
+  userScore: number | null,
+  proposalDimensionScore: number,
+): StancePrediction {
+  const score = userScore ?? 50;
+
+  // Only predict when the proposal is relevant enough
+  if (proposalDimensionScore < MIN_CLASSIFICATION_SCORE) {
+    return { stance: 'Neutral', confidence: 0 };
+  }
+
+  const confidence = Math.abs(score - 50) * 2; // 0 at 50, 100 at 0 or 100
+
+  if (score > 65) {
+    return { stance: 'Yes', confidence };
+  }
+  if (score < 35) {
+    return { stance: 'No', confidence };
+  }
+
+  return { stance: 'Neutral', confidence };
+}
+
+/**
+ * Determine agreement between predicted user stance and DRep's actual vote.
+ */
+function classifyAgreement(
+  predicted: 'Yes' | 'No' | 'Neutral',
+  drepVote: 'Yes' | 'No' | 'Abstain',
+): 'agree' | 'disagree' | 'neutral' {
+  // DRep Abstain is always neutral
+  if (drepVote === 'Abstain') return 'neutral';
+  // User Neutral is always neutral
+  if (predicted === 'Neutral') return 'neutral';
+  // Same direction = agree, opposite = disagree
+  if (predicted === drepVote) return 'agree';
+  return 'disagree';
+}
+
+/**
+ * Template-based reason strings for proposal alignment cards.
+ *
+ * @param dimension - The alignment dimension label (e.g. "Treasury Conservative")
+ * @param agreement - Whether user and DRep agree or disagree
+ * @returns Human-readable reason string
+ */
+export function getProposalAlignmentReason(
+  dimension: string,
+  agreement: 'agree' | 'disagree',
+): string {
+  const reasons: Record<string, Record<'agree' | 'disagree', string>> = {
+    'Treasury Conservative': {
+      agree: 'You both prioritize fiscal conservatism',
+      disagree: 'You differ on treasury spending caution',
+    },
+    'Treasury Growth': {
+      agree: 'You both support growth investment',
+      disagree: 'You differ on treasury growth strategy',
+    },
+    Decentralization: {
+      agree: 'You both value decentralization',
+      disagree: 'You differ on power distribution',
+    },
+    Security: {
+      agree: 'You both prioritize protocol security',
+      disagree: 'You differ on security priorities',
+    },
+    Innovation: {
+      agree: 'You both support innovation',
+      disagree: 'You differ on innovation priorities',
+    },
+    Transparency: {
+      agree: 'You both value transparency',
+      disagree: 'You differ on transparency expectations',
+    },
+  };
+
+  return (
+    reasons[dimension]?.[agreement] ??
+    `${agreement === 'agree' ? 'Aligned' : 'Differ'} on ${dimension}`
+  );
+}
+
+/**
+ * Compute per-proposal alignment between a user and a DRep.
+ *
+ * Pure computation -- no database access. The caller provides all data.
+ *
+ * @param userAlignment - User's alignment scores (0-100 per dimension)
+ * @param drepVotes - DRep's votes enriched with proposal classifications
+ * @param options - Optional limits for top agreements/disagreements
+ * @param currentEpoch - Current epoch number (for recency weighting)
+ * @returns AlignmentSummary or null if no computable alignment
+ */
+export function computeProposalAlignment(
+  userAlignment: AlignmentScores,
+  drepVotes: VoteWithClassification[],
+  options?: { maxAgreements?: number; maxDisagreements?: number },
+  currentEpoch?: number,
+): AlignmentSummary | null {
+  const maxAgreements = options?.maxAgreements ?? 3;
+  const maxDisagreements = options?.maxDisagreements ?? 2;
+
+  if (drepVotes.length === 0) return null;
+
+  // Process each vote: find primary dimension, predict stance, classify agreement
+  const processed: (ProposalAlignmentResult & {
+    score: number;
+    dimKey: AlignmentDimension;
+  })[] = [];
+
+  const latestEpoch = currentEpoch ?? Math.max(...drepVotes.map((v) => v.epochNo));
+
+  for (const vote of drepVotes) {
+    const primaryDim = findPrimaryDimension(vote.classification);
+    if (!primaryDim) continue; // Skip proposals without a qualifying dimension
+
+    const userScore = userAlignment[primaryDim];
+    const classificationField =
+      `dim${primaryDim.charAt(0).toUpperCase()}${primaryDim.slice(1)}` as keyof VoteClassification;
+    const proposalDimScore = vote.classification[classificationField];
+
+    const prediction = predictUserStance(userScore, proposalDimScore);
+    const agreement = classifyAgreement(prediction.stance, vote.vote);
+    const dimLabel = DIMENSION_LABELS[primaryDim];
+
+    const epochsAgo = Math.max(0, latestEpoch - vote.epochNo);
+    const recencyWeight = 1 / (1 + epochsAgo * RECENCY_DECAY);
+    const rankScore = prediction.confidence * recencyWeight;
+
+    const reason =
+      agreement === 'neutral'
+        ? vote.vote === 'Abstain'
+          ? 'DRep abstained on this proposal'
+          : 'Insufficient alignment signal on this dimension'
+        : getProposalAlignmentReason(dimLabel, agreement);
+
+    processed.push({
+      proposalId: vote.proposalId,
+      proposalTitle: vote.proposalTitle,
+      proposalType: vote.proposalType,
+      drepVote: vote.vote,
+      predictedUserStance: prediction.stance,
+      stanceConfidence: prediction.confidence,
+      agreement,
+      reason,
+      dimension: dimLabel,
+      score: rankScore,
+      dimKey: primaryDim,
+    });
+  }
+
+  // If no proposals were classifiable, return null
+  if (processed.length === 0) return null;
+
+  // Sort by ranking score descending
+  processed.sort((a, b) => b.score - a.score);
+
+  // Pick top agreements and disagreements
+  const agreements = processed.filter((p) => p.agreement === 'agree');
+  const disagreements = processed.filter((p) => p.agreement === 'disagree');
+
+  const topAgreements: ProposalAlignmentResult[] = agreements
+    .slice(0, maxAgreements)
+    .map(({ score: _s, dimKey: _d, ...rest }) => rest);
+
+  const topDisagreements: ProposalAlignmentResult[] = disagreements
+    .slice(0, maxDisagreements)
+    .map(({ score: _s, dimKey: _d, ...rest }) => rest);
+
+  // Compute dimension-level agreement using existing computeDimensionAgreement
+  // Build an approximate DRep alignment from their vote patterns
+  const drepScores = buildDRepAlignmentFromVotes(processed);
+  const dimensionBreakdown = computeDimensionAgreement(userAlignment, drepScores);
+
+  // Compute overall alignment as weighted average of dimension agreements
+  const dimValues = Object.values(dimensionBreakdown.dimensionAgreement);
+  const overallAlignment =
+    dimValues.length > 0
+      ? Math.round(dimValues.reduce((sum, v) => sum + v, 0) / dimValues.length)
+      : null;
+
+  // Confidence label based on data quality
+  const classifiedCount = processed.length;
+  const confidenceScore = Math.min(100, Math.round((classifiedCount / 15) * 100));
+  const confidenceLabel = getConfidenceLabel(confidenceScore);
+
+  // Generate narrative
+  const narrative = generateMatchNarrative({
+    agreeDimensions: dimensionBreakdown.agreeDimensions,
+    differDimensions: dimensionBreakdown.differDimensions,
+  });
+
+  return {
+    overallAlignment,
+    confidence: confidenceScore,
+    confidenceLabel,
+    topAgreements,
+    topDisagreements,
+    dimensionBreakdown,
+    narrative,
+  };
+}
+
+/* ─── Internal helpers ────────────────────────────────── */
+
+/**
+ * Build approximate DRep alignment scores from their classified votes.
+ * Used for dimension-level agreement computation.
+ */
+function buildDRepAlignmentFromVotes(
+  processed: { dimKey: AlignmentDimension; agreement: string; drepVote: string }[],
+): AlignmentScores {
+  const totals: Record<AlignmentDimension, number> = {
+    treasuryConservative: 0,
+    treasuryGrowth: 0,
+    decentralization: 0,
+    security: 0,
+    innovation: 0,
+    transparency: 0,
+  };
+  const counts: Record<AlignmentDimension, number> = {
+    treasuryConservative: 0,
+    treasuryGrowth: 0,
+    decentralization: 0,
+    security: 0,
+    innovation: 0,
+    transparency: 0,
+  };
+
+  for (const item of processed) {
+    const voteVal = item.drepVote === 'Yes' ? 100 : item.drepVote === 'No' ? 0 : 50;
+    totals[item.dimKey] += voteVal;
+    counts[item.dimKey]++;
+  }
+
+  const scores: AlignmentScores = {
+    treasuryConservative: null,
+    treasuryGrowth: null,
+    decentralization: null,
+    security: null,
+    innovation: null,
+    transparency: null,
+  };
+
+  for (const dim of DIMENSIONS) {
+    if (counts[dim] > 0) {
+      scores[dim] = Math.round(totals[dim] / counts[dim]);
+    }
+  }
+
+  return scores;
+}
+
+/**
+ * Generate a human-readable confidence label.
+ */
+function getConfidenceLabel(confidence: number): string {
+  if (confidence >= 70) return 'High confidence — based on many classified proposals';
+  if (confidence >= 40) return 'Moderate confidence — based on several classified proposals';
+  if (confidence > 0) return 'Low confidence — based on limited data';
+  return 'No data — cannot assess alignment';
+}


### PR DESCRIPTION
## Summary
- New per-proposal alignment engine (`lib/matching/proposalAlignment.ts`) — predicts user stance on each proposal a DRep voted on, surfaces top agreements/disagreements
- New delegation simulation (`lib/matching/delegationSimulation.ts`) — "If you had delegated 6 months ago, here's what happened"
- New alignment API endpoint (`/api/drep/[drepId]/alignment`) — orchestrates alignment + simulation + decomposed trust signals
- Additive exports from `dimensionAgreement.ts` (no breaking changes)

## Impact
- **What changed**: Backend foundation for the DRep Decision Engine profile redesign
- **User-facing**: No — backend-only, no UI changes yet
- **Risk**: Low — new files only, no modifications to existing functionality
- **Scope**: 3 new files, 1 minor modification, 0 migrations, 2 test files

## Test plan
- [x] Unit tests for proposalAlignment (23 cases covering all edge cases)
- [x] Unit tests for delegationSimulation (7 cases)
- [x] `npm run preflight` passes (644/644 tests, lint, types all green)
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)