### PR TITLE
feat: inline Quick Match widget + decentralization question

### DIFF
--- a/__tests__/matching/confidence.test.ts
+++ b/__tests__/matching/confidence.test.ts
@@ -48,7 +48,7 @@ describe('calculateProgressiveConfidence', () => {
 
   it('returns 100 for all maxed inputs', () => {
     const inputs: ConfidenceInputs = {
-      quizAnswerCount: 3,
+      quizAnswerCount: 4,
       pollVoteCount: 15,
       proposalTypesVoted: 4,
       engagementActionCount: 10,
@@ -67,7 +67,7 @@ describe('calculateProgressiveConfidence', () => {
       hasDelegation: false,
     });
     const fullQuiz = calculateProgressiveConfidence({
-      quizAnswerCount: 3,
+      quizAnswerCount: 4,
       pollVoteCount: 0,
       proposalTypesVoted: 0,
       engagementActionCount: 0,

--- a/__tests__/matching/quickMatchHelpers.test.ts
+++ b/__tests__/matching/quickMatchHelpers.test.ts
@@ -6,8 +6,13 @@ import { buildAlignmentFromAnswers, ANSWER_VECTORS } from '@/lib/matching/answer
 // The pure functions we CAN test directly are in answerVectors.ts.
 
 describe('ANSWER_VECTORS', () => {
-  it('has entries for all 3 question IDs', () => {
-    expect(Object.keys(ANSWER_VECTORS)).toEqual(['treasury', 'protocol', 'transparency']);
+  it('has entries for all 4 question IDs', () => {
+    expect(Object.keys(ANSWER_VECTORS)).toEqual([
+      'treasury',
+      'protocol',
+      'transparency',
+      'decentralization',
+    ]);
   });
 
   it('treasury has 3 options', () => {

--- a/app/api/governance/quick-match/route.ts
+++ b/app/api/governance/quick-match/route.ts
@@ -1,7 +1,10 @@
 /**
- * Quick Match API — converts 3 value-based answers into an alignment vector
- * and matches against DRep (or SPO) alignment scores using Euclidean distance.
+ * Quick Match API — converts value-based answers (3 required + 1 optional) into an alignment
+ * vector and matches against DRep (or SPO) alignment scores using Euclidean distance.
  * No wallet/auth required. Supports match_type: 'drep' | 'spo'.
+ *
+ * Required: treasury, protocol, transparency
+ * Optional: decentralization (added in WS-5a for complete 6D coverage)
  */
 
 import { NextResponse } from 'next/server';
@@ -133,6 +136,7 @@ export const POST = withRouteHandler(async (request) => {
     treasury?: string;
     protocol?: string;
     transparency?: string;
+    decentralization?: string;
     match_type?: 'drep' | 'spo';
   };
   try {
@@ -141,7 +145,7 @@ export const POST = withRouteHandler(async (request) => {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { treasury, protocol, transparency, match_type = 'drep' } = body;
+  const { treasury, protocol, transparency, decentralization, match_type = 'drep' } = body;
 
   if (!treasury || !ANSWER_VECTORS.treasury[treasury]) {
     return NextResponse.json({ error: 'Invalid treasury answer' }, { status: 400 });
@@ -151,6 +155,10 @@ export const POST = withRouteHandler(async (request) => {
   }
   if (!transparency || !ANSWER_VECTORS.transparency[transparency]) {
     return NextResponse.json({ error: 'Invalid transparency answer' }, { status: 400 });
+  }
+  // Decentralization is optional — validate only if provided
+  if (decentralization && !ANSWER_VECTORS.decentralization[decentralization]) {
+    return NextResponse.json({ error: 'Invalid decentralization answer' }, { status: 400 });
   }
 
   // Build user alignment vector from answers
@@ -163,11 +171,18 @@ export const POST = withRouteHandler(async (request) => {
     transparency: 50,
   };
 
-  for (const [, dimScores] of [
+  const answerPairs: [string, Partial<AlignmentScores>][] = [
     ['treasury', ANSWER_VECTORS.treasury[treasury]],
     ['protocol', ANSWER_VECTORS.protocol[protocol]],
     ['transparency', ANSWER_VECTORS.transparency[transparency]],
-  ] as [string, Partial<AlignmentScores>][]) {
+  ];
+
+  // Add decentralization answer if provided (backward compatible — old clients omit it)
+  if (decentralization && ANSWER_VECTORS.decentralization[decentralization]) {
+    answerPairs.push(['decentralization', ANSWER_VECTORS.decentralization[decentralization]]);
+  }
+
+  for (const [, dimScores] of answerPairs) {
     for (const dim of DIMENSIONS) {
       if (dimScores[dim] !== undefined) {
         userAlignments[dim] = dimScores[dim]!;
@@ -176,6 +191,7 @@ export const POST = withRouteHandler(async (request) => {
   }
 
   const supabase = getSupabaseAdmin();
+  const quizAnswerCount = decentralization ? 4 : 3;
 
   if (match_type === 'spo') {
     // SPO matching — query pools table with behavioral data
@@ -229,9 +245,9 @@ export const POST = withRouteHandler(async (request) => {
     const dominant = getDominantDimension(userAlignments);
     const identityColor = getIdentityColor(dominant);
 
-    // Baseline confidence from 3 quiz answers
+    // Baseline confidence from quiz answers (3 required + optional decentralization)
     const spoConfidenceBreakdown = calculateProgressiveConfidence({
-      quizAnswerCount: 3,
+      quizAnswerCount,
       pollVoteCount: 0,
       proposalTypesVoted: 0,
       engagementActionCount: 0,
@@ -242,6 +258,7 @@ export const POST = withRouteHandler(async (request) => {
       treasury,
       protocol,
       transparency,
+      decentralization: decentralization ?? null,
       match_type: 'spo',
       personality_label: personalityLabel,
       top_match_score: ranked[0]?.matchScore ?? null,
@@ -338,9 +355,9 @@ export const POST = withRouteHandler(async (request) => {
   const dominant = getDominantDimension(userAlignments);
   const identityColor = getIdentityColor(dominant);
 
-  // Baseline confidence from 3 quiz answers (no other data yet for anonymous users)
+  // Baseline confidence from quiz answers (3 required + optional decentralization)
   const confidenceBreakdown = calculateProgressiveConfidence({
-    quizAnswerCount: 3,
+    quizAnswerCount,
     pollVoteCount: 0,
     proposalTypesVoted: 0,
     engagementActionCount: 0,
@@ -351,6 +368,7 @@ export const POST = withRouteHandler(async (request) => {
     treasury,
     protocol,
     transparency,
+    decentralization: decentralization ?? null,
     match_type: 'drep',
     personality_label: personalityLabel,
     top_match_score: topRanked[0]?.matchScore ?? null,

--- a/components/governada/match/QuickMatchFlow.tsx
+++ b/components/governada/match/QuickMatchFlow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
@@ -22,6 +22,9 @@ import {
   Users,
   Share2,
   Check,
+  Globe,
+  Crown,
+  Minus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -48,8 +51,7 @@ import { buildAlignmentFromAnswers } from '@/lib/matching/answerVectors';
 import type { ConfidenceBreakdown } from '@/lib/matching/confidence';
 import { generateMatchNarrative } from '@/lib/matching/matchNarrative';
 import { MatchConfidenceCTA } from '@/components/matching/MatchConfidenceCTA';
-import { saveMatchProfile, loadMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
-import { emitDiscoveryEvent } from '@/lib/discovery/events';
+import { loadMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
 import {
   webShare,
   canWebShare,
@@ -57,36 +59,12 @@ import {
   trackShare,
   buildMatchResultUrl,
 } from '@/lib/share';
-
-/* ─── Types ─────────────────────────────────────────────── */
-
-interface MatchResult {
-  drepId: string;
-  drepName: string | null;
-  drepScore: number;
-  matchScore: number;
-  identityColor: string;
-  personalityLabel: string;
-  alignments: AlignmentScores;
-  agreeDimensions: string[];
-  differDimensions: string[];
-  // Enriched behavioral data
-  voteCount?: number;
-  participationPct?: number;
-  rationaleRate?: number;
-  delegatorCount?: number;
-  tier?: string | null;
-  signatureInsight?: string | null;
-}
-
-interface QuickMatchResponse {
-  matches: MatchResult[];
-  nearMisses?: MatchResult[];
-  userAlignments: AlignmentScores;
-  personalityLabel: string;
-  identityColor: string;
-  confidenceBreakdown?: ConfidenceBreakdown;
-}
+import {
+  useQuickMatch,
+  type QuickMatchResponse,
+  type MatchResult,
+  type QuickMatchAnswers,
+} from '@/hooks/useQuickMatch';
 
 /* ─── Question definitions ──────────────────────────────── */
 
@@ -180,138 +158,136 @@ const QUESTIONS: Question[] = [
       },
     ],
   },
+  {
+    id: 'decentralization',
+    title: 'How should voting power be distributed?',
+    subtitle:
+      'Governance power distribution shapes who influences Cardano\u2019s future direction.',
+    options: [
+      {
+        value: 'spread_widely',
+        label: 'Spread Widely',
+        description: 'No single entity should have outsized influence. Distribute power broadly.',
+        icon: Globe,
+      },
+      {
+        value: 'concentrated',
+        label: 'Concentrated',
+        description: 'Focus power among the most active and qualified participants.',
+        icon: Crown,
+      },
+      {
+        value: 'current_fine',
+        label: 'Current Is Fine',
+        description: 'The current distribution works. Focus energy on other issues.',
+        icon: Minus,
+      },
+    ],
+  },
 ];
 
 /* ─── Component ─────────────────────────────────────────── */
 
-type Step = 'intro' | 0 | 1 | 2 | 'loading' | 'results' | 'error';
+const TOTAL_QUESTIONS = QUESTIONS.length;
+type Step = 'intro' | 0 | 1 | 2 | 3 | 'loading' | 'results' | 'error';
 type MatchType = 'drep' | 'spo';
 
 export function QuickMatchFlow() {
   const [step, setStep] = useState<Step>('intro');
-  const [answers, setAnswers] = useState<Record<string, string>>({});
   const [selected, setSelected] = useState<string | null>(null);
-  const [drepResults, setDrepResults] = useState<QuickMatchResponse | null>(null);
-  const [spoResults, setSpoResults] = useState<QuickMatchResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [storedProfile, setStoredProfile] = useState<StoredMatchProfile | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const posthog = usePostHog();
 
+  const {
+    state: matchState,
+    setAnswer: setMatchAnswer,
+    submit,
+    reset: resetMatch,
+  } = useQuickMatch({
+    onComplete: () => {
+      setStep('results');
+    },
+  });
+
   const partialIdentityColor = useMemo(() => {
-    if (Object.keys(answers).length === 0) return 'hsl(var(--primary))';
-    const partial = buildAlignmentFromAnswers(answers);
+    const answerEntries = Object.entries(matchState.answers).filter(([, v]) => v);
+    if (answerEntries.length === 0) return 'hsl(var(--primary))';
+    const answersRecord: Record<string, string> = {};
+    for (const [k, v] of answerEntries) {
+      if (v) answersRecord[k] = v;
+    }
+    const partial = buildAlignmentFromAnswers(answersRecord);
     const dominant = getDominantDimension(partial);
     return getIdentityColor(dominant).hex;
-  }, [answers]);
+  }, [matchState.answers]);
 
   // Load stored match profile on mount
   useEffect(() => {
     setStoredProfile(loadMatchProfile());
   }, []);
 
-  const fetchBothMatches = useCallback(async (finalAnswers: Record<string, string>) => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const fetchOne = async (type: MatchType) => {
-      const res = await fetch('/api/governance/quick-match', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          treasury: finalAnswers.treasury,
-          protocol: finalAnswers.protocol,
-          transparency: finalAnswers.transparency,
-          match_type: type,
-        }),
-        signal: controller.signal,
-      });
-      if (!res.ok) throw new Error(`Server error: ${res.status}`);
-      return res.json() as Promise<QuickMatchResponse>;
-    };
-
-    try {
-      const [drepData, spoData] = await Promise.all([fetchOne('drep'), fetchOne('spo')]);
-      setDrepResults(drepData);
-      setSpoResults(spoData);
-      setStep('results');
-      emitDiscoveryEvent('match_completed');
-
-      // Funnel: match completed + results viewed
-      trackFunnel(FUNNEL_EVENTS.MATCH_COMPLETED, {
-        personality: drepData.personalityLabel,
-        drep_matches: drepData.matches.length,
-        spo_matches: spoData.matches.length,
-      });
-      trackFunnel(FUNNEL_EVENTS.MATCH_RESULT_VIEWED, {
-        top_match_score: drepData.matches[0]?.matchScore ?? 0,
-      });
-
-      // Mark quick match as completed for authenticated users
-      const token = getStoredSession();
-      if (token) {
-        fetch('/api/governance/quick-match/mark-completed', {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${token}` },
-        }).catch(() => {});
-      }
-
-      // Persist match profile (use DRep data for user alignments — same for both)
-      saveMatchProfile({
-        userAlignments: drepData.userAlignments,
-        personalityLabel: drepData.personalityLabel,
-        identityColor: drepData.identityColor,
-        matchType: 'drep',
-        answers: finalAnswers,
-        timestamp: Date.now(),
-      });
-      setStoredProfile(null);
-    } catch (err: unknown) {
-      if (err instanceof Error && err.name === 'AbortError') return;
-      setError(err instanceof Error ? err.message : 'Something went wrong');
+  // Transition to error state when hook reports an error
+  useEffect(() => {
+    if (matchState.error && step === 'loading') {
       setStep('error');
     }
-  }, []);
+  }, [matchState.error, step]);
 
   const handleAnswer = useCallback(
     (questionId: string, value: string) => {
       setSelected(value);
-      const newAnswers = { ...answers, [questionId]: value };
-      setAnswers(newAnswers);
+      setMatchAnswer(questionId, value);
 
       // Auto-advance after brief feedback
       setTimeout(() => {
         setSelected(null);
         const currentQ = typeof step === 'number' ? step : -1;
-        if (currentQ < 2) {
-          setStep((currentQ + 1) as 0 | 1 | 2);
+        if (currentQ < TOTAL_QUESTIONS - 1) {
+          setStep((currentQ + 1) as 0 | 1 | 2 | 3);
         } else {
-          // All questions answered — fetch both DRep and SPO matches
+          // All questions answered — submit via hook
           setStep('loading');
-          fetchBothMatches(newAnswers);
+          const newAnswers = { ...matchState.answers, [questionId]: value } as QuickMatchAnswers;
+          submit(newAnswers);
         }
       }, 350);
     },
-    [answers, step, fetchBothMatches],
+    [matchState.answers, step, setMatchAnswer, submit],
   );
 
   const restart = useCallback(() => {
     setStep('intro');
-    setAnswers({});
     setSelected(null);
-    setDrepResults(null);
-    setSpoResults(null);
-    setError(null);
-  }, []);
+    resetMatch();
+  }, [resetMatch]);
+
+  const fetchStoredResults = useCallback(
+    (profile: StoredMatchProfile) => {
+      for (const [k, v] of Object.entries(profile.answers)) {
+        setMatchAnswer(k, v);
+      }
+      setStep('loading');
+      submit(profile.answers as QuickMatchAnswers);
+    },
+    [setMatchAnswer, submit],
+  );
 
   const goBack = useCallback(() => {
     if (typeof step === 'number' && step > 0) {
-      setStep((step - 1) as 0 | 1 | 2);
+      setStep((step - 1) as 0 | 1 | 2 | 3);
     } else if (step === 0) {
       setStep('intro');
     }
   }, [step]);
+
+  // Build answers record for loading screen
+  const answersRecord = useMemo(() => {
+    const record: Record<string, string> = {};
+    for (const [k, v] of Object.entries(matchState.answers)) {
+      if (v) record[k] = v;
+    }
+    return record;
+  }, [matchState.answers]);
 
   return (
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
@@ -332,10 +308,10 @@ export function QuickMatchFlow() {
                 role="progressbar"
                 aria-valuenow={typeof step === 'number' ? step + 1 : 0}
                 aria-valuemin={1}
-                aria-valuemax={3}
-                aria-label={`Question ${typeof step === 'number' ? step + 1 : 0} of 3`}
+                aria-valuemax={TOTAL_QUESTIONS}
+                aria-label={`Question ${typeof step === 'number' ? step + 1 : 0} of ${TOTAL_QUESTIONS}`}
               >
-                {[0, 1, 2].map((i) => (
+                {Array.from({ length: TOTAL_QUESTIONS }, (_, i) => (
                   <div key={i} className="h-1 flex-1 rounded-full overflow-hidden bg-muted">
                     <div
                       className={cn(
@@ -348,7 +324,7 @@ export function QuickMatchFlow() {
                 ))}
               </div>
               <span className="text-xs text-muted-foreground tabular-nums" aria-hidden="true">
-                {step + 1}/3
+                {step + 1}/{TOTAL_QUESTIONS}
               </span>
             </div>
           </div>
@@ -367,9 +343,7 @@ export function QuickMatchFlow() {
             storedProfile={storedProfile}
             onViewPrevious={() => {
               if (storedProfile) {
-                setAnswers(storedProfile.answers);
-                setStep('loading');
-                fetchBothMatches(storedProfile.answers);
+                fetchStoredResults(storedProfile);
               }
             }}
           />
@@ -381,11 +355,15 @@ export function QuickMatchFlow() {
             onSelect={(value) => handleAnswer(QUESTIONS[step].id, value)}
           />
         )}
-        {step === 'loading' && <LoadingScreen answers={answers} />}
-        {step === 'results' && drepResults && spoResults && (
-          <ResultsScreen drepResults={drepResults} spoResults={spoResults} onRestart={restart} />
+        {step === 'loading' && <LoadingScreen answers={answersRecord} />}
+        {step === 'results' && matchState.drepResult && matchState.spoResult && (
+          <ResultsScreen
+            drepResults={matchState.drepResult}
+            spoResults={matchState.spoResult}
+            onRestart={restart}
+          />
         )}
-        {step === 'error' && <ErrorScreen message={error} onRetry={restart} />}
+        {step === 'error' && <ErrorScreen message={matchState.error} onRetry={restart} />}
       </div>
     </div>
   );
@@ -412,8 +390,8 @@ function IntroScreen({
           Build Your Governance Team
         </h1>
         <p className="text-muted-foreground text-base sm:text-lg leading-relaxed">
-          Answer 3 questions about what you care about and see who votes like you. We&apos;ll match
-          you with DReps and SPOs who share your vision. Under 60 seconds.
+          Answer 4 quick questions about what you care about and see who votes like you. We&apos;ll
+          match you with DReps and SPOs who share your vision. Under 60 seconds.
         </p>
         <p className="text-xs text-muted-foreground/80 max-w-md mx-auto">
           Your governance team votes on proposals and secures the network on your behalf.{' '}

--- a/components/governada/profiles/InlineQuickMatch.tsx
+++ b/components/governada/profiles/InlineQuickMatch.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import { usePostHog } from 'posthog-js/react';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import { useQuickMatch } from '@/hooks/useQuickMatch';
+
+/* ─── Types ─────────────────────────────────────────────── */
+
+interface InlineQuickMatchProps {
+  drepName: string;
+  drepId: string;
+  onMatchComplete: (alignment: AlignmentScores) => void;
+  className?: string;
+}
+
+/* ─── Question definitions (compact) ────────────────────── */
+
+interface InlineQuestion {
+  id: string;
+  label: string;
+  options: { value: string; label: string }[];
+}
+
+const INLINE_QUESTIONS: InlineQuestion[] = [
+  {
+    id: 'treasury',
+    label: 'Treasury management',
+    options: [
+      { value: 'conservative', label: 'Conservative' },
+      { value: 'growth', label: 'Growth' },
+      { value: 'balanced', label: 'Balanced' },
+    ],
+  },
+  {
+    id: 'protocol',
+    label: 'Protocol changes should prioritize...',
+    options: [
+      { value: 'caution', label: 'Caution' },
+      { value: 'innovation', label: 'Innovation' },
+      { value: 'case_by_case', label: 'Case by case' },
+    ],
+  },
+  {
+    id: 'transparency',
+    label: 'How important is DRep transparency?',
+    options: [
+      { value: 'essential', label: 'Essential' },
+      { value: 'nice_to_have', label: 'Nice to have' },
+      { value: 'doesnt_matter', label: "Doesn't matter" },
+    ],
+  },
+  {
+    id: 'decentralization',
+    label: 'Voting power distribution',
+    options: [
+      { value: 'spread_widely', label: 'Spread widely' },
+      { value: 'concentrated', label: 'Concentrated' },
+      { value: 'current_fine', label: 'Current is fine' },
+    ],
+  },
+];
+
+/* ─── Component ─────────────────────────────────────────── */
+
+export function InlineQuickMatch({
+  drepName,
+  drepId,
+  onMatchComplete,
+  className,
+}: InlineQuickMatchProps) {
+  const posthog = usePostHog();
+
+  const { state, setAnswer, submit } = useQuickMatch({
+    drepId,
+    onComplete: (drepResult) => {
+      posthog?.capture('quick_match_completed_inline', {
+        source: 'drep_profile',
+        drepId,
+      });
+      onMatchComplete(drepResult.userAlignments);
+    },
+  });
+
+  const handleSubmit = useCallback(() => {
+    submit();
+  }, [submit]);
+
+  return (
+    <Card className={cn('border-border/50 bg-card/50', className)}>
+      <CardContent className="p-5 sm:p-6 space-y-5">
+        {/* Header */}
+        <p className="text-sm font-medium text-foreground">
+          See how <span className="text-primary font-semibold">{drepName}</span> aligns with your
+          governance values
+        </p>
+
+        {/* Questions */}
+        <div className="space-y-4">
+          {INLINE_QUESTIONS.map((q) => (
+            <InlineQuestionRow
+              key={q.id}
+              question={q}
+              selected={state.answers[q.id as keyof typeof state.answers] ?? null}
+              onSelect={(value) => setAnswer(q.id, value)}
+              disabled={state.isSubmitting}
+            />
+          ))}
+        </div>
+
+        {/* Error */}
+        {state.error && (
+          <p className="text-sm text-destructive" role="alert">
+            {state.error}
+          </p>
+        )}
+
+        {/* Submit */}
+        <Button
+          onClick={handleSubmit}
+          disabled={!state.isComplete || state.isSubmitting}
+          className="w-full"
+          size="sm"
+        >
+          {state.isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Calculating alignment...
+            </>
+          ) : (
+            <>See my alignment with {drepName} &rarr;</>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* ─── Question row ──────────────────────────────────────── */
+
+function InlineQuestionRow({
+  question,
+  selected,
+  onSelect,
+  disabled,
+}: {
+  question: InlineQuestion;
+  selected: string | null;
+  onSelect: (value: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <fieldset className="space-y-1.5" disabled={disabled}>
+      <legend className="text-xs font-medium text-muted-foreground">{question.label}</legend>
+      <div className="flex flex-wrap gap-2">
+        {question.options.map((opt) => {
+          const isSelected = selected === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onSelect(opt.value)}
+              aria-pressed={isSelected}
+              className={cn(
+                'px-3 py-1.5 rounded-full text-xs font-medium transition-all',
+                'border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1',
+                isSelected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-background text-muted-foreground hover:border-primary/40 hover:text-foreground',
+                disabled && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/docs/strategy/plans/constitutional-intelligence.md
+++ b/docs/strategy/plans/constitutional-intelligence.md
@@ -1,0 +1,1187 @@
+# Constitutional Intelligence — Implementation Plan
+
+> **Status**: DRAFT — Awaiting founder approval
+> **Origin**: `/explore-feature Committee pages` (2026-03-14)
+> **Goal**: Transform the CC pages from an accountability dashboard into the world's first Constitutional Intelligence platform — combining relational dynamics visualization ("The Chamber") with AI-powered constitutional interpretation tracking, reasoning quality analysis, and predictive intelligence.
+
+---
+
+## Vision Summary
+
+The Constitutional Committee is a 7-10 member body with disproportionate power — a CC rejection blocks governance actions even with overwhelming DRep/SPO support. Today, Governada scores individual CC members on 3 pillars and ranks them. This is already ahead of every competitor. But it treats members as isolated entities and ignores the most valuable intelligence: **how members relate to each other, how they interpret the constitution, and how those interpretations evolve.**
+
+This plan builds two layers simultaneously:
+
+1. **The Chamber** (Computational) — Agreement heatmap, bloc detection, constitutional personality archetypes, composition timeline. Shows the CC as a living system of relationships.
+2. **Constitutional Intelligence** (AI) — Rationale deep analysis, interpretation tracking, precedent graph, reasoning quality scoring, predictive signals, AI briefings. Understands _what the constitution means_ based on how it's being applied.
+
+Together, these make Governada the **case law tracker for Cardano** — something that doesn't exist for any blockchain governance body, and is competitive with what Harvard Law Review and legal scholars do for the Supreme Court.
+
+### Core Principles
+
+1. **Relationships first, scores second.** With 7-10 members, the heatmap reveals more than any ranked list.
+2. **Interpretation > citation.** "Did they cite Article II §6?" is table stakes. "How did they interpret Article II §6, and does that conflict with how they interpreted it last month?" is intelligence.
+3. **Forward-looking, not just historical.** Predictive signals about upcoming governance actions make Governada essential _before_ decisions happen.
+4. **Accessible to citizens, deep enough for researchers.** AI briefings make constitutional interpretation understandable to anyone. Raw data and methodology remain available for depth users.
+5. **Compounding moat.** Every CC decision makes the interpretation tracker, precedent graph, and prediction model more valuable. Competitors launching later can never catch up on accumulated intelligence.
+
+### The "Holy Shit" Moments
+
+These are the specific experiences that create the launch reaction:
+
+- **The Heatmap**: "I can see how the entire CC works together in one glance — who agrees, who clashes, where the blocs are."
+- **The Key Finding**: "Governada's AI caught that Member X has never cited Article III despite voting on 4 hard fork proposals that require it."
+- **The Interpretation Divergence**: "Members A and B read Article II §6 completely differently — that's why treasury proposals always split 5-2."
+- **The Precedent Alert**: "This CC decision contradicts their own precedent from 3 months ago. Governada flagged it automatically."
+- **The Prediction**: "Governada predicted this 5-2 split two weeks ago based on interpretation patterns."
+- **The Briefing**: A 4-sentence paragraph that makes a citizen actually understand what the CC is doing and why it matters.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    DATA PIPELINE (Inngest)                       │
+│                                                                 │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────────┐  │
+│  │ syncCcVotes   │    │ syncCcRatio- │    │ NEW: analyzeCc-  │  │
+│  │ (existing)    │───▶│ nales        │───▶│ Rationales       │  │
+│  │               │    │ (existing)   │    │ (AI analysis)    │  │
+│  └──────────────┘    └──────────────┘    └──────────────────┘  │
+│                                                  │              │
+│                           ┌──────────────────────┤              │
+│                           ▼                      ▼              │
+│  ┌──────────────────────────┐  ┌──────────────────────────┐    │
+│  │ NEW: computeCcRelations  │  │ NEW: trackInterpretation │    │
+│  │ (agreement matrix,       │  │ History (per-article,    │    │
+│  │  blocs, personalities)   │  │  precedent links)        │    │
+│  └──────────────────────────┘  └──────────────────────────┘    │
+│                           │                      │              │
+│                           ▼                      ▼              │
+│                  ┌──────────────────────────┐                   │
+│                  │ NEW: generateCcBriefing  │                   │
+│                  │ (epoch briefings,        │                   │
+│                  │  member dossiers,        │                   │
+│                  │  predictive signals)     │                   │
+│                  └──────────────────────────┘                   │
+└─────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    SUPABASE (new tables)                         │
+│                                                                 │
+│  cc_rationale_analysis     — AI-structured analysis per vote    │
+│  cc_agreement_matrix       — pairwise agreement percentages    │
+│  cc_bloc_assignments       — detected voting blocs             │
+│  cc_member_archetypes      — constitutional personality data   │
+│  cc_interpretation_history — per-member, per-article tracking  │
+│  cc_precedent_links        — decision-to-decision references   │
+│  cc_intelligence_briefs    — cached AI briefings               │
+│  cc_predictive_signals     — upcoming vote predictions         │
+└─────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    API LAYER                                     │
+│                                                                 │
+│  /api/governance/committee          — enhanced with relations   │
+│  /api/governance/committee/[id]     — NEW: member intelligence  │
+│  /api/governance/committee/briefing — NEW: AI briefings         │
+│  /api/governance/committee/predict  — NEW: predictive signals   │
+└─────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    FRONTEND                                      │
+│                                                                 │
+│  /governance/committee                                          │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  CCHealthVerdict (existing, enhanced with briefing)      │   │
+│  │  CCHeatmap (NEW — dominant element)                      │   │
+│  │  CCBlocBadges (NEW)                                      │   │
+│  │  CCMemberDirectory (existing list, demoted)              │   │
+│  │  Methodology (existing, collapsed)                       │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  /governance/committee/[id]                                     │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │  ProfileHero (enhanced: chamber position + personality)  │   │
+│  │  CCKeyFinding (NEW — AI-generated callout)               │   │
+│  │  KeyStats (existing, kept)                               │   │
+│  │  Overview: PillarBreakdown + Trend + RecentVotes         │   │
+│  │  Deep: Tabs + CCInterpretationProfile (NEW)              │   │
+│  │        + CCPairwiseAlignment (NEW)                       │   │
+│  │        + Enhanced VotingRecord (significance badges)     │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Database Schema
+
+### New Tables
+
+```sql
+-- 1. AI-structured analysis per CC rationale
+CREATE TABLE cc_rationale_analysis (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cc_hot_id TEXT NOT NULL,
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INT NOT NULL,
+
+  -- Interpretation extraction
+  interpretation_stance TEXT,          -- 'strict' | 'moderate' | 'broad' per article
+  key_arguments JSONB,                 -- [{claim, evidence, article_cited}]
+  logical_structure TEXT,              -- 'deductive' | 'analogical' | 'precedent-based' | 'textual'
+
+  -- Reasoning quality (AQuA-inspired)
+  rationality_score SMALLINT,          -- 0-100: evidence-based reasoning
+  reciprocity_score SMALLINT,          -- 0-100: engages with other CC arguments
+  clarity_score SMALLINT,              -- 0-100: clear, well-structured prose
+  deliberation_quality SMALLINT,       -- 0-100: weighted composite
+
+  -- Constitutional coverage
+  articles_analyzed JSONB,             -- [{article, interpretation, stance}]
+  novel_interpretation BOOLEAN DEFAULT FALSE,  -- flags new readings
+  contradicts_own_precedent BOOLEAN DEFAULT FALSE,
+
+  -- Key finding extraction
+  notable_finding TEXT,                -- 1-sentence AI-extracted finding
+  finding_severity TEXT,               -- 'info' | 'noteworthy' | 'concern' | 'critical'
+
+  -- Metadata
+  model_version TEXT NOT NULL,         -- track which Claude model generated this
+  analyzed_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE(cc_hot_id, proposal_tx_hash, proposal_index)
+);
+
+-- 2. Pairwise agreement matrix (recomputed after each new vote batch)
+CREATE TABLE cc_agreement_matrix (
+  member_a TEXT NOT NULL,
+  member_b TEXT NOT NULL,
+  agreement_pct NUMERIC(5,2),          -- 0.00-100.00
+  total_shared_proposals INT,          -- proposals both voted on
+  agreed_count INT,
+  disagreed_count INT,
+  -- Most recent disagreement for quick access
+  last_disagreement_proposal TEXT,
+  last_disagreement_index INT,
+  computed_at TIMESTAMPTZ DEFAULT NOW(),
+
+  PRIMARY KEY (member_a, member_b)
+);
+
+-- 3. Detected voting blocs
+CREATE TABLE cc_bloc_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  bloc_label TEXT NOT NULL,            -- 'Bloc A', 'Bloc B', or 'Independent'
+  cc_hot_id TEXT NOT NULL,
+  internal_agreement_pct NUMERIC(5,2), -- bloc's internal cohesion
+  member_count INT,                    -- total members in this bloc
+  computed_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE(cc_hot_id, computed_at)
+);
+
+-- 4. Constitutional personality archetypes
+CREATE TABLE cc_member_archetypes (
+  cc_hot_id TEXT PRIMARY KEY,
+  archetype_label TEXT NOT NULL,       -- 'Treasury Guardian', 'Consensus Builder', etc.
+  archetype_description TEXT,          -- 1-2 sentence explanation
+  strictness_score NUMERIC(5,2),       -- 0-100 (low=permissive, high=strict)
+  specialization JSONB,                -- {proposalType: approvalRate} showing focus areas
+  independence_profile TEXT,           -- 'independent' | 'consensus-leaning' | 'bloc-aligned'
+  -- Relationships
+  most_aligned_member TEXT,
+  most_aligned_pct NUMERIC(5,2),
+  most_divergent_member TEXT,
+  most_divergent_pct NUMERIC(5,2),
+  -- Sole dissenter stats
+  sole_dissenter_count INT DEFAULT 0,
+  sole_dissenter_proposals JSONB,      -- [{tx_hash, index, proposal_title}]
+  computed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- 5. Per-member, per-article interpretation history
+CREATE TABLE cc_interpretation_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cc_hot_id TEXT NOT NULL,
+  article TEXT NOT NULL,               -- 'Article II, § 6', etc.
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INT NOT NULL,
+  epoch INT,
+
+  interpretation_stance TEXT,          -- 'strict' | 'moderate' | 'broad'
+  interpretation_summary TEXT,         -- 1-sentence: how they read this article here
+  consistent_with_prior BOOLEAN,       -- matches their previous reading?
+  drift_note TEXT,                     -- if inconsistent, explain the shift
+
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE(cc_hot_id, article, proposal_tx_hash, proposal_index)
+);
+
+-- 6. Decision-to-decision precedent links
+CREATE TABLE cc_precedent_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_tx_hash TEXT NOT NULL,        -- the later decision
+  source_index INT NOT NULL,
+  target_tx_hash TEXT NOT NULL,        -- the earlier decision it references/follows
+  target_index INT NOT NULL,
+  relationship TEXT NOT NULL,          -- 'follows' | 'extends' | 'narrows' | 'contradicts' | 'distinguishes'
+  shared_articles JSONB,               -- articles both decisions interpret
+  explanation TEXT,                     -- AI-generated: why these are linked
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE(source_tx_hash, source_index, target_tx_hash, target_index)
+);
+
+-- 7. Cached AI briefings
+CREATE TABLE cc_intelligence_briefs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  brief_type TEXT NOT NULL,            -- 'committee_epoch' | 'member_dossier' | 'decision_analysis'
+  reference_id TEXT NOT NULL,          -- epoch number, cc_hot_id, or proposal key
+  persona_variant TEXT DEFAULT 'default', -- 'citizen' | 'drep' | 'researcher' | 'default'
+
+  headline TEXT,                       -- 1-line hook
+  executive_summary TEXT,              -- 3-4 sentence overview
+  key_findings JSONB,                  -- [{finding, severity, evidence_link}]
+  what_changed TEXT,                   -- "What changed this epoch" bullets
+  full_narrative TEXT,                 -- complete briefing text (markdown)
+  citations JSONB,                     -- [{claim, source_type, source_id}]
+
+  -- Staleness tracking
+  input_hash TEXT,                     -- hash of source data; regenerate if changed
+  model_version TEXT NOT NULL,
+  generated_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ,             -- force refresh after this time
+
+  UNIQUE(brief_type, reference_id, persona_variant)
+);
+
+-- 8. Predictive signals for upcoming governance actions
+CREATE TABLE cc_predictive_signals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INT NOT NULL,
+
+  predicted_outcome TEXT,              -- 'approve' | 'reject' | 'split'
+  predicted_split JSONB,               -- {yes: [member_ids], no: [member_ids], uncertain: [member_ids]}
+  confidence SMALLINT,                 -- 0-100
+  reasoning TEXT,                      -- AI explanation of prediction basis
+  key_article TEXT,                    -- constitutional article most likely to drive the decision
+  tension_flag BOOLEAN DEFAULT FALSE,  -- true if prediction suggests CC-DRep divergence
+
+  -- Tracking
+  actual_outcome TEXT,                 -- filled after vote completes
+  prediction_accurate BOOLEAN,         -- did we get it right?
+  model_version TEXT NOT NULL,
+  predicted_at TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE(proposal_tx_hash, proposal_index)
+);
+```
+
+### Indexes
+
+```sql
+CREATE INDEX idx_rationale_analysis_member ON cc_rationale_analysis(cc_hot_id);
+CREATE INDEX idx_rationale_analysis_proposal ON cc_rationale_analysis(proposal_tx_hash, proposal_index);
+CREATE INDEX idx_interpretation_member_article ON cc_interpretation_history(cc_hot_id, article);
+CREATE INDEX idx_precedent_source ON cc_precedent_links(source_tx_hash, source_index);
+CREATE INDEX idx_precedent_target ON cc_precedent_links(target_tx_hash, target_index);
+CREATE INDEX idx_briefs_lookup ON cc_intelligence_briefs(brief_type, reference_id, persona_variant);
+CREATE INDEX idx_predictions_proposal ON cc_predictive_signals(proposal_tx_hash, proposal_index);
+```
+
+---
+
+## Inngest Functions
+
+### Function 1: `analyzeCcRationales` (AI Analysis Pipeline)
+
+**Trigger**: Runs after `syncCcRationales` completes (event-driven via `cc/rationales.synced`)
+**Concurrency**: `{ scope: 'cc-analysis', limit: 1 }`
+
+**Steps**:
+
+1. **`find-unanalyzed`** — Query `cc_rationales` LEFT JOIN `cc_rationale_analysis` to find rationales not yet analyzed.
+
+2. **`analyze-batch`** — For each unanalyzed rationale (batch of 5):
+   - Fetch the rationale text, cited articles, proposal type, and proposal title
+   - Fetch the CC member's prior interpretation history for the same articles (from `cc_interpretation_history`)
+   - Call Claude with structured prompt (see Prompt Engineering section below)
+   - Parse response into `cc_rationale_analysis` row
+   - Extract per-article interpretations into `cc_interpretation_history` rows
+   - Detect if this contradicts the member's own prior interpretation of the same article
+
+3. **`link-precedents`** — For each analyzed rationale:
+   - Find prior CC decisions on the same proposal type
+   - Find prior decisions citing the same constitutional articles
+   - Call Claude to classify the relationship (follows/extends/narrows/contradicts/distinguishes)
+   - Insert into `cc_precedent_links`
+
+4. **`emit-completion`** — Emit `cc/analysis.completed` event for downstream functions
+
+**Error handling**: If Claude API fails, mark rationale as `analysis_pending` and retry on next run. Never block the pipeline.
+
+### Function 2: `computeCcRelations` (Computational Intelligence)
+
+**Trigger**: Runs after `syncSpoAndCcVotes` completes (event-driven via `cc/votes.synced`), AND on schedule `0 */6 * * *` (every 6 hours as safety net)
+**Concurrency**: `{ scope: 'cc-relations', limit: 1 }`
+
+**Steps**:
+
+1. **`compute-agreement-matrix`** — For all pairs of active CC members:
+
+   ```sql
+   SELECT
+     a.cc_hot_id AS member_a,
+     b.cc_hot_id AS member_b,
+     COUNT(*) AS total_shared,
+     SUM(CASE WHEN a.vote = b.vote THEN 1 ELSE 0 END) AS agreed
+   FROM cc_votes a
+   JOIN cc_votes b ON a.proposal_tx_hash = b.proposal_tx_hash
+     AND a.proposal_index = b.proposal_index
+     AND a.cc_hot_id < b.cc_hot_id
+   GROUP BY a.cc_hot_id, b.cc_hot_id
+   ```
+
+   Upsert into `cc_agreement_matrix`.
+
+2. **`detect-blocs`** — Apply agglomerative clustering on agreement matrix:
+   - Convert agreement percentages to distance matrix (100 - agreement%)
+   - Use single-linkage clustering with threshold: members with ≥80% internal agreement form a bloc
+   - Only label a cluster as a "bloc" if it has ≥2 members AND internal agreement ≥80%
+   - Members not in any bloc are labeled "Independent"
+   - Upsert into `cc_bloc_assignments`
+
+3. **`compute-archetypes`** — For each active CC member:
+   - Calculate strictness_score: `100 - approval_rate` (low approval = strict constitutional guardian)
+   - Compute specialization from vote distribution by proposal type
+   - Identify most-aligned and most-divergent peers from agreement matrix
+   - Count sole dissenter instances (only CC member to vote differently from the rest)
+   - Classify independence_profile from bloc assignment + divergence patterns
+   - Generate archetype_label using rule-based classification (see Archetype Rules below)
+   - Upsert into `cc_member_archetypes`
+
+4. **`emit-completion`** — Emit `cc/relations.computed` event
+
+### Function 3: `generateCcBriefing` (AI Briefings)
+
+**Trigger**: Event-driven via `cc/analysis.completed` AND `cc/relations.computed` (waits for both), PLUS schedule at epoch boundaries
+**Concurrency**: `{ scope: 'cc-briefing', limit: 1 }`
+
+**Steps**:
+
+1. **`generate-committee-briefing`** — Create/update the committee-level epoch briefing:
+   - Gather: health summary, agreement matrix, bloc assignments, recent rationale analyses, interpretation drift events, precedent links
+   - Hash all inputs; skip regeneration if hash matches existing brief
+   - Call Claude to generate: headline, executive_summary, key_findings, what_changed
+   - Generate persona variants (citizen gets plain language, researcher gets detailed analysis)
+   - Upsert into `cc_intelligence_briefs` with `brief_type='committee_epoch'`
+
+2. **`generate-member-dossiers`** — For each active CC member:
+   - Gather: member data, archetype, interpretation history, sole dissenter list, pairwise alignment, notable findings from rationale analyses
+   - Determine the single most notable "Key Finding" (highest severity from `cc_rationale_analysis.notable_finding` OR interpretation contradictions OR blind spots)
+   - Call Claude to generate member dossier: executive summary, key finding callout, behavioral patterns, constitutional interpretation profile
+   - Upsert into `cc_intelligence_briefs` with `brief_type='member_dossier'`
+
+3. **`generate-predictions`** — For each pending/active proposal that CC can vote on:
+   - Check if CC members have already voted (skip if vote complete)
+   - Gather: proposal type, relevant constitutional articles, each CC member's interpretation history for those articles, bloc assignments, historical voting patterns on similar proposal types
+   - Call Claude to predict: likely outcome, predicted member-by-member votes, confidence, reasoning
+   - Upsert into `cc_predictive_signals`
+
+4. **`backfill-prediction-accuracy`** — For proposals with predictions where CC voting is now complete:
+   - Compare predicted outcome to actual outcome
+   - Update `actual_outcome` and `prediction_accurate` fields
+   - This builds the accuracy track record over time
+
+---
+
+## Prompt Engineering
+
+### Prompt 1: Rationale Analysis
+
+```
+You are a constitutional law analyst for Cardano's governance system.
+
+Analyze this CC member's rationale for their vote on a governance action.
+
+## Context
+- CC Member: {{authorName}} ({{ccHotId}})
+- Proposal: {{proposalTitle}} (Type: {{proposalType}})
+- Vote: {{vote}}
+- Expected constitutional articles for this proposal type: {{expectedArticles}}
+
+## Prior Interpretation History
+This member has previously interpreted these articles as follows:
+{{priorInterpretations}}
+
+## Rationale Text
+{{rationaleText}}
+
+## Cited Articles
+{{citedArticles}}
+
+## Instructions
+Analyze this rationale and return a JSON object with these fields:
+
+1. **interpretation_stance** (per cited article): 'strict' | 'moderate' | 'broad'
+   - strict: narrow, textual reading limiting the article's scope
+   - moderate: balanced interpretation following established precedent
+   - broad: expansive reading extending the article's application
+
+2. **key_arguments**: Array of {claim, evidence, article_cited} — the 2-4 core arguments
+
+3. **logical_structure**: 'deductive' | 'analogical' | 'precedent-based' | 'textual'
+
+4. **rationality_score** (0-100): Is the reasoning evidence-based and logically sound?
+   - 90-100: Rigorous legal reasoning with clear evidence chain
+   - 70-89: Solid reasoning with minor gaps
+   - 50-69: Reasoning present but weak evidence or logical gaps
+   - 0-49: Assertion without substantiation
+
+5. **reciprocity_score** (0-100): Does the rationale engage with other perspectives?
+   - 90-100: Directly addresses counterarguments or other CC members' positions
+   - 70-89: Acknowledges alternative interpretations
+   - 50-69: Single-perspective but thorough
+   - 0-49: No engagement with alternatives
+
+6. **clarity_score** (0-100): Is the prose clear, well-structured, and accessible?
+
+7. **articles_analyzed**: Array of {article, interpretation, stance} for EACH article cited
+
+8. **novel_interpretation** (boolean): Does this represent a new reading of any article
+   not seen in this member's prior history?
+
+9. **contradicts_own_precedent** (boolean): Does this interpretation conflict with their
+   prior interpretation of the same article? Only true if a clear reversal.
+
+10. **notable_finding** (string): The single most noteworthy thing about this rationale.
+    Be specific and concrete. Examples:
+    - "First time this member has cited Article IV in a treasury context"
+    - "Contradicts their own strict reading of Article II §6 from Epoch 520"
+    - "Only CC member to argue this proposal violates Article III §6"
+    If nothing notable: null
+
+11. **finding_severity**: 'info' | 'noteworthy' | 'concern' | 'critical'
+
+Return ONLY valid JSON matching this schema. No commentary.
+```
+
+### Prompt 2: Precedent Classification
+
+```
+You are a constitutional precedent analyst for Cardano's governance.
+
+Classify the relationship between two CC decisions that involve the same
+constitutional articles.
+
+## Later Decision (Source)
+- Proposal: {{sourceTitle}} ({{sourceType}}, Epoch {{sourceEpoch}})
+- CC Outcome: {{sourceOutcome}}
+- Key articles cited: {{sourceArticles}}
+- Key interpretation: {{sourceInterpretation}}
+
+## Earlier Decision (Target)
+- Proposal: {{targetTitle}} ({{targetType}}, Epoch {{targetEpoch}})
+- CC Outcome: {{targetOutcome}}
+- Key articles cited: {{targetArticles}}
+- Key interpretation: {{targetInterpretation}}
+
+## Classify the relationship as ONE of:
+- **follows**: Later decision applies the same interpretation as the earlier one
+- **extends**: Later decision builds on the earlier interpretation, applying it to a new context
+- **narrows**: Later decision limits the scope of the earlier interpretation
+- **contradicts**: Later decision directly conflicts with the earlier interpretation
+- **distinguishes**: Later decision acknowledges the earlier one but argues it doesn't apply here
+
+Return JSON: {relationship, shared_articles, explanation}
+- explanation: 1-2 sentences explaining WHY this relationship exists
+```
+
+### Prompt 3: Committee Briefing
+
+```
+You are the governance intelligence analyst for Governada, the constitutional
+intelligence platform for Cardano.
+
+Write a committee briefing for the current epoch.
+
+## Committee State
+- Active members: {{memberCount}}
+- Average fidelity: {{avgFidelity}}
+- Health status: {{healthStatus}}
+- Trend: {{trend}}
+
+## Voting Blocs
+{{blocSummary}}
+
+## Recent Decisions (this epoch)
+{{recentDecisions}}
+
+## Interpretation Developments
+- New interpretations: {{novelInterpretations}}
+- Precedent contradictions: {{contradictions}}
+- Interpretation drift events: {{driftEvents}}
+
+## Tensions
+- CC-DRep divergences: {{tensions}}
+
+## Persona: {{persona}}
+{{personaGuidance}}
+
+## Instructions
+Generate a briefing with:
+
+1. **headline** (max 12 words): The single most important thing about the CC right now.
+   Not generic ("CC continues governance work"). Specific ("First CC split on treasury
+   since Epoch 510 signals interpretation shift").
+
+2. **executive_summary** (3-4 sentences): What's happening, why it matters, what to watch.
+   Write for {{persona}} audience. Citizens need plain language and significance.
+   Researchers need precision and data references.
+
+3. **key_findings** (2-4 items): Array of {finding, severity, evidence_link}
+   - Each finding must reference specific proposals, members, or articles
+   - severity: 'info' | 'noteworthy' | 'concern' | 'critical'
+   - evidence_link: description of the data source (e.g., "cc_rationale for Member X on Proposal Y")
+
+4. **what_changed** (2-3 bullets): What's different since last epoch. Specific, not generic.
+
+Return JSON matching this schema. Every claim must be grounded in the provided data.
+Do not invent information.
+```
+
+### Prompt 4: Member Dossier
+
+```
+You are writing an intelligence dossier on a CC member for Governada.
+
+## Member Profile
+- Name: {{authorName}}
+- Score: {{fidelityScore}}/100 (Grade {{fidelityGrade}})
+- Rank: {{rank}}/{{totalMembers}}
+- Term: Epoch {{authorizationEpoch}} – {{expirationEpoch}}
+- Archetype: {{archetypeLabel}} — {{archetypeDescription}}
+
+## Chamber Position
+- Most aligned with: {{mostAlignedMember}} ({{mostAlignedPct}}%)
+- Most divergent from: {{mostDivergentMember}} ({{mostDivergentPct}}%)
+- Bloc assignment: {{blocLabel}} ({{blocInternalAgreement}}% internal cohesion)
+- Sole dissenter: {{soleDissenterCount}} times
+
+## Pillar Scores
+- Participation: {{participationScore}}/100
+- Constitutional Grounding: {{groundingScore}}/100
+- Reasoning Quality: {{reasoningScore}}/100
+
+## Key Rationale Findings
+{{rationaleFindings}}
+
+## Interpretation History
+{{interpretationHistory}}
+
+## Contradictions / Drift
+{{contradictions}}
+
+## Instructions
+Write a dossier with:
+
+1. **executive_summary** (1 paragraph): Who this person is as a constitutional guardian.
+   Lead with their defining characteristic, not their score. Reference their archetype
+   and chamber position. Mention their strongest and weakest accountability dimension.
+
+2. **key_finding** (1 sentence): The single most notable fact about this member.
+   Must be concrete and surprising. Not "has good participation" but "is the only
+   CC member who has never cited Article III despite voting on 4 hard fork proposals."
+
+3. **behavioral_patterns** (2-3 sentences): What patterns emerge from their voting
+   history? Are they fast or slow voters? Do they specialize in certain proposal types?
+   Do they drift or stay consistent?
+
+4. **constitutional_profile** (2-3 sentences): How do they interpret the constitution?
+   Are they strict or broad? On which articles? Has their interpretation shifted?
+
+Return JSON: {executive_summary, key_finding, behavioral_patterns, constitutional_profile}
+Every claim must reference specific data from the context provided.
+```
+
+### Prompt 5: Predictive Signal
+
+```
+You are predicting how the CC will vote on an upcoming governance action.
+
+## Proposal
+- Title: {{proposalTitle}}
+- Type: {{proposalType}}
+- Key constitutional articles: {{relevantArticles}}
+
+## CC Members' Relevant History
+{{memberHistories}}
+
+## Bloc Dynamics
+{{blocSummary}}
+
+## Instructions
+Predict:
+1. **predicted_outcome**: 'approve' | 'reject' | 'split' (non-unanimous either way)
+2. **predicted_split**: {yes: [member_names], no: [member_names], uncertain: [member_names]}
+3. **confidence**: 0-100 (be honest — with <10 data points per member, confidence should rarely exceed 75)
+4. **reasoning**: 2-3 sentences explaining the prediction basis. Reference specific prior votes and interpretations.
+5. **key_article**: The constitutional article most likely to drive divergence.
+6. **tension_flag**: true if predicted CC outcome diverges from likely DRep majority.
+
+Return JSON. Mark members as 'uncertain' when their history on this proposal type is insufficient.
+```
+
+---
+
+## Archetype Classification Rules
+
+Deterministic first pass (AI can override with nuance in dossier generation):
+
+| Archetype                 | Rule                                                             | Description                                                  |
+| ------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Treasury Guardian**     | Strictness ≥ 70 AND TreasuryWithdrawals approval rate < 50%      | Conservative on spending, demands fiscal evidence            |
+| **Consensus Builder**     | In largest bloc AND sole_dissenter_count = 0                     | Rarely breaks from majority, prioritizes committee unity     |
+| **Constitutional Purist** | Article coverage ≥ 90% AND interpretation_stance mostly 'strict' | Narrow textual reader, high citation standards               |
+| **Independent Voice**     | Not in any bloc AND sole_dissenter_count ≥ 2                     | Votes against the group with rationale, principled dissenter |
+| **Pragmatic Interpreter** | interpretation_stance mostly 'broad' AND approval rate ≥ 70%     | Reads constitution expansively, tends to approve             |
+| **Silent Voter**          | Rationale provision rate < 40%                                   | Votes but rarely explains why — accountability red flag      |
+| **New Guardian**          | Authorization epoch within last 2 epochs                         | Too new to classify — watch for emerging patterns            |
+
+Fallback: "Active Member" if no rule matches.
+
+---
+
+## Workstreams
+
+### WS-1: Database Schema & Migrations
+
+**What**: Create all 8 new tables with indexes and RLS policies.
+
+**Files**:
+
+- **NEW**: Supabase migration via MCP
+- **MODIFY**: `npm run gen:types` → commit updated `types/database.ts`
+
+**RLS**: All tables read-public (no auth required for read). Write restricted to service role only (Inngest functions).
+
+**Decision point**: None — execute directly.
+
+---
+
+### WS-2: Computational Intelligence Pipeline (Inngest)
+
+**What**: `computeCcRelations` function — agreement matrix, bloc detection, archetype classification. Pure computation, no AI calls.
+
+**Files**:
+
+- **NEW**: `inngest/functions/compute-cc-relations.ts`
+- **NEW**: `lib/cc/blocDetection.ts` — clustering algorithm
+- **NEW**: `lib/cc/archetypeClassification.ts` — rule-based archetype assignment
+- **MODIFY**: `app/api/inngest/route.ts` — register new function
+
+**Implementation details**:
+
+The bloc detection algorithm (single-linkage agglomerative clustering):
+
+```typescript
+// lib/cc/blocDetection.ts
+
+interface AgreementEntry {
+  memberA: string;
+  memberB: string;
+  agreementPct: number;
+}
+
+interface BlocAssignment {
+  blocLabel: string;
+  members: string[];
+  internalAgreementPct: number;
+}
+
+const BLOC_THRESHOLD = 80; // minimum internal agreement to form a bloc
+
+export function detectBlocs(agreements: AgreementEntry[]): BlocAssignment[] {
+  // Build adjacency: members connected if agreement >= threshold
+  const members = new Set<string>();
+  const edges = new Map<string, Set<string>>();
+
+  for (const { memberA, memberB, agreementPct } of agreements) {
+    members.add(memberA);
+    members.add(memberB);
+    if (agreementPct >= BLOC_THRESHOLD) {
+      if (!edges.has(memberA)) edges.set(memberA, new Set());
+      if (!edges.has(memberB)) edges.set(memberB, new Set());
+      edges.get(memberA)!.add(memberB);
+      edges.get(memberB)!.add(memberA);
+    }
+  }
+
+  // Find connected components (blocs)
+  const visited = new Set<string>();
+  const blocs: string[][] = [];
+
+  for (const member of members) {
+    if (visited.has(member)) continue;
+    const component: string[] = [];
+    const queue = [member];
+    while (queue.length > 0) {
+      const current = queue.pop()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+      component.push(current);
+      for (const neighbor of edges.get(current) ?? []) {
+        if (!visited.has(neighbor)) queue.push(neighbor);
+      }
+    }
+    blocs.push(component);
+  }
+
+  // Label blocs, compute internal agreement
+  let blocIndex = 0;
+  return blocs.map((members) => {
+    if (members.length < 2) {
+      return { blocLabel: 'Independent', members, internalAgreementPct: 100 };
+    }
+
+    // Compute average pairwise agreement within bloc
+    let totalAgreement = 0;
+    let pairCount = 0;
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const entry = agreements.find(
+          (a) =>
+            (a.memberA === members[i] && a.memberB === members[j]) ||
+            (a.memberA === members[j] && a.memberB === members[i]),
+        );
+        if (entry) {
+          totalAgreement += entry.agreementPct;
+          pairCount++;
+        }
+      }
+    }
+
+    blocIndex++;
+    return {
+      blocLabel: `Bloc ${String.fromCharCode(64 + blocIndex)}`,
+      members,
+      internalAgreementPct: pairCount > 0 ? totalAgreement / pairCount : 0,
+    };
+  });
+}
+```
+
+**Verification**: Run against current `cc_votes` data. Verify agreement matrix produces meaningful variance (not all 95%+). If variance is low, adjust bloc threshold.
+
+---
+
+### WS-3: AI Rationale Analysis Pipeline (Inngest)
+
+**What**: `analyzeCcRationales` function — deep AI analysis of each CC rationale, interpretation tracking, precedent linking.
+
+**Files**:
+
+- **NEW**: `inngest/functions/analyze-cc-rationales.ts`
+- **NEW**: `lib/cc/rationaleAnalysis.ts` — prompt construction + response parsing
+- **NEW**: `lib/cc/precedentLinker.ts` — precedent detection + classification
+- **MODIFY**: `inngest/functions/sync-cc-rationales.ts` — emit `cc/rationales.synced` event on completion
+- **MODIFY**: `app/api/inngest/route.ts` — register new function
+
+**Cost control**:
+
+- Use `MODELS.FAST` (Sonnet) for rationale analysis — sufficient quality, lower cost
+- Batch 5 rationales per step to stay within Inngest step duration limits
+- Cache: never re-analyze a rationale (unique constraint on table)
+- Estimated cost: ~$0.02 per rationale × ~50 rationales/epoch = ~$1/epoch
+
+**Error handling**: If a single rationale analysis fails, log the error and continue with the next. Mark failed rationales for retry on next run. The pipeline must never block on a single failure.
+
+---
+
+### WS-4: AI Briefing & Prediction Pipeline (Inngest)
+
+**What**: `generateCcBriefing` function — committee briefings, member dossiers, predictive signals.
+
+**Files**:
+
+- **NEW**: `inngest/functions/generate-cc-briefing.ts`
+- **NEW**: `lib/cc/briefingGenerator.ts` — prompt construction + response parsing
+- **NEW**: `lib/cc/predictiveSignals.ts` — prediction logic + prompt
+- **MODIFY**: `app/api/inngest/route.ts` — register new function
+
+**Staleness management**:
+
+- Hash all input data; skip regeneration if hash unchanged
+- Force regeneration at epoch boundaries regardless of hash
+- Member dossiers: regenerate when new rationale analysis available for that member
+- Predictions: regenerate when new CC votes observed for the proposal
+- TTL: briefs expire after 5 epochs (auto-cleaned)
+
+**Persona variants**:
+
+- `citizen`: Plain language, significance-focused, no jargon, shorter
+- `drep`: How CC decisions affect DRep governance, tension analysis
+- `researcher`: Full data references, methodology notes, longer
+- `default`: Balanced (used on public pages without persona detection)
+
+---
+
+### WS-5: API Layer
+
+**What**: Extend existing committee API and create new endpoints.
+
+**Files**:
+
+- **MODIFY**: `app/api/governance/committee/route.ts` — add agreement matrix, bloc data, archetype data to response
+- **NEW**: `app/api/governance/committee/[ccHotId]/route.ts` — member intelligence endpoint (dossier, pairwise alignment, interpretation history, key finding)
+- **NEW**: `app/api/governance/committee/briefing/route.ts` — committee briefing (persona-variant)
+- **NEW**: `app/api/governance/committee/predict/route.ts` — predictive signals for pending proposals
+- **MODIFY**: `hooks/queries.ts` — new TanStack Query hooks
+
+**Response shapes**:
+
+```typescript
+// Enhanced GET /api/governance/committee
+{
+  members: CommitteeMemberQuickView[],  // existing
+  health: CCHealthSummary,               // existing
+  stats: CCCommitteeStats,               // existing
+  // NEW:
+  agreementMatrix: {
+    memberA: string;
+    memberB: string;
+    agreementPct: number;
+    totalSharedProposals: number;
+  }[],
+  blocs: {
+    label: string;
+    members: string[];
+    internalAgreementPct: number;
+  }[],
+  archetypes: {
+    ccHotId: string;
+    label: string;
+    description: string;
+    mostAlignedMember: string | null;
+    mostDivergentMember: string | null;
+  }[],
+  briefing: {
+    headline: string;
+    executiveSummary: string;
+    keyFindings: { finding: string; severity: string }[];
+    whatChanged: string[];
+  } | null,
+}
+
+// NEW: GET /api/governance/committee/[ccHotId]
+{
+  dossier: {
+    executiveSummary: string;
+    keyFinding: string;
+    behavioralPatterns: string;
+    constitutionalProfile: string;
+  } | null,
+  chamberPosition: {
+    mostAligned: { name: string; pct: number };
+    mostDivergent: { name: string; pct: number };
+    blocLabel: string;
+    soleDissenterCount: number;
+    soleDissenterProposals: { txHash: string; index: number; title: string }[];
+  },
+  pairwiseAlignment: {
+    memberId: string;
+    memberName: string;
+    agreementPct: number;
+    sharedProposals: number;
+  }[],
+  interpretationHistory: {
+    article: string;
+    entries: {
+      proposalTitle: string;
+      epoch: number;
+      stance: string;
+      summary: string;
+      consistentWithPrior: boolean;
+    }[];
+  }[],
+  rationaleAnalyses: {
+    proposalTitle: string;
+    deliberationQuality: number;
+    notableFinding: string | null;
+    findingSeverity: string | null;
+  }[],
+}
+
+// NEW: GET /api/governance/committee/predict
+{
+  predictions: {
+    proposalTxHash: string;
+    proposalIndex: number;
+    proposalTitle: string;
+    predictedOutcome: string;
+    predictedSplit: { yes: string[]; no: string[]; uncertain: string[] };
+    confidence: number;
+    reasoning: string;
+    keyArticle: string;
+    tensionFlag: boolean;
+  }[],
+  accuracy: {
+    totalPredictions: number;
+    correct: number;
+    accuracyPct: number;
+  },
+}
+```
+
+---
+
+### WS-6: Frontend — The Chamber (Committee Overview)
+
+**What**: Rebuild `/governance/committee` with the heatmap as dominant element.
+
+**Files**:
+
+- **NEW**: `components/cc/CCHeatmap.tsx` — interactive agreement heatmap
+- **NEW**: `components/cc/CCBlocBadges.tsx` — detected bloc indicators
+- **NEW**: `components/cc/CCBriefingCard.tsx` — AI briefing display
+- **MODIFY**: `app/governance/committee/page.tsx` — restructure layout
+- **MODIFY**: `hooks/queries.ts` — update `useCommitteeMembers` hook for new data
+
+**Layout (top to bottom)**:
+
+1. **CCHealthVerdict** (existing) — enhanced with briefing headline replacing the static narrative. If briefing exists, show the AI headline. Otherwise fall back to the existing narrative.
+
+2. **CCBriefingCard** (new) — "What changed this epoch" bullets + key findings with severity badges. Collapsible full executive summary. Persona-adapted via `useSegment()`.
+
+3. **CCHeatmap** (new, DOMINANT) — Interactive N×N grid:
+   - Rows and columns = CC members (sorted by fidelity score)
+   - Cell color: gradient from deep green (95%+ agreement) through neutral (60-70%) to deep red (<40% agreement)
+   - Cell shows percentage on hover/tap
+   - Tap a cell → slide-out panel showing the specific proposals where those two members agreed/disagreed
+   - Diagonal cells show member's own fidelity score
+   - Mobile: horizontal scroll with sticky first column (member names)
+   - Accessible: screen reader support with aria labels ("Member A and Member B agree 87% of the time")
+
+4. **CCBlocBadges** (new) — Horizontal row of bloc indicators:
+   - "Bloc A: Member1, Member2, Member3 (92% internal agreement)"
+   - "Independent: Member4, Member5"
+   - Or: "No clear blocs — independent voting patterns" if no bloc meets threshold
+   - Each member name is a link to their profile
+
+5. **Member Directory** (existing `MemberRow`/`MemberCard`, demoted) — Below the fold. Each row enhanced with:
+   - Archetype badge (e.g., "Treasury Guardian" in a subtle chip)
+   - Keep: rank, grade, fidelity bar, narrative verdict
+
+6. **Methodology** (existing, collapsed) — Keep as-is
+
+**What to remove**:
+
+- 4 aggregate stat cards (Active Members, Proposals Reviewed, Avg Rationale Rate, Total Votes) — health verdict + heatmap convey this
+- CCInsightCard — replaced by CCBriefingCard which is more intelligent
+
+---
+
+### WS-7: Frontend — Enhanced Member Profile
+
+**What**: Enhance `/governance/committee/[id]` with chamber position, AI dossier, interpretation profile.
+
+**Files**:
+
+- **NEW**: `components/cc/CCKeyFinding.tsx` — prominent AI-generated callout
+- **NEW**: `components/cc/CCChamberPosition.tsx` — pairwise alignment summary
+- **NEW**: `components/cc/CCInterpretationProfile.tsx` — per-article interpretation history
+- **NEW**: `components/cc/CCDossierSummary.tsx` — AI executive summary
+- **MODIFY**: `components/cc/CCMemberProfileClient.tsx` — integrate new sections
+- **MODIFY**: `app/governance/committee/[ccHotId]/page.tsx` — fetch new data
+
+**Enhanced Hero**:
+
+- Existing: Name, grade badge, score card, status badges, term info
+- **ADD**: Archetype badge below name (e.g., "Treasury Guardian" with icon)
+- **ADD**: Chamber position line: "Agrees most with [Name] (94%) · Diverges most from [Name] (61%)"
+- **ADD**: Bloc assignment badge (if in a bloc): "Bloc A · 3 members"
+
+**New section after hero: CCKeyFinding** (above key stats):
+
+- Prominent callout card with left border accent (amber for noteworthy, red for concern)
+- Shows the AI-generated key finding: "Has never cited Article III despite voting on 4 hard fork proposals"
+- Small "Based on AI analysis" label with info tooltip explaining methodology
+- Falls back to deterministic finding (e.g., blind spot data) if no AI analysis yet
+
+**New section: CCDossierSummary** (between key stats and overview mode):
+
+- AI-generated executive summary paragraph (from `cc_intelligence_briefs`)
+- Collapsible "Full analysis" expanding to behavioral patterns + constitutional profile
+- Falls back gracefully to existing narrative verdict if dossier not yet generated
+
+**Overview mode enhancements**:
+
+- Recent votes: add significance badges on non-unanimous decisions
+- Add sole dissenter indicators (icon + "Only dissenter" badge) on relevant votes
+
+**Deep mode — new tabs**:
+
+- **"Chamber" tab** (new): CCChamberPosition showing pairwise alignment with every other CC member as horizontal bars + the proposals driving each relationship
+- **"Interpretation" tab** (new): CCInterpretationProfile showing per-article interpretation history as a timeline. Each entry: proposal name, epoch, stance (strict/moderate/broad), consistency indicator (green check if consistent, amber warning if drifted). Groups by article.
+- Existing tabs (Votes, Reasoning, Alignment, Trend) kept and enhanced with significance badges
+
+---
+
+### WS-8: Frontend — Predictions Panel
+
+**What**: Display predictive signals on committee and proposal pages.
+
+**Files**:
+
+- **NEW**: `components/cc/CCPredictions.tsx` — predictions for pending proposals
+- **MODIFY**: `app/governance/committee/page.tsx` — add predictions section (below heatmap, above directory)
+- **MODIFY**: Proposal pages (future integration point) — show predicted CC vote
+
+**Display**:
+
+- Section header: "Predicted CC Votes" with accuracy badge ("72% accurate on 18 predictions")
+- Each pending proposal card shows:
+  - Proposal title + type
+  - Predicted outcome badge (Approve/Reject/Split)
+  - Mini vote split: 7 small circles colored by prediction (green=yes, red=no, gray=uncertain)
+  - Confidence percentage
+  - Key article driving the prediction
+  - Tension flag if CC prediction diverges from DRep sentiment
+- Collapsible reasoning text per prediction
+- DepthGate: only show to `informed` and above (not `hands_off`)
+
+---
+
+## Chunk Execution Plan
+
+Organized for parallel execution. Each chunk = 1 PR.
+
+| Chunk | Workstream | Name                                                  | Priority | Effort | Depends On  | PR Group            |
+| ----- | ---------- | ----------------------------------------------------- | -------- | ------ | ----------- | ------------------- |
+| 1     | WS-1       | Database schema + migrations                          | P0       | M      | None        | A                   |
+| 2     | WS-2       | Computational pipeline (agreement, blocs, archetypes) | P0       | L      | Chunk 1     | B                   |
+| 3     | WS-3       | AI rationale analysis pipeline                        | P0       | L      | Chunk 1     | B (parallel with 2) |
+| 4     | WS-5       | API layer (enhanced committee + new endpoints)        | P0       | M      | Chunks 2, 3 | C                   |
+| 5     | WS-6       | Frontend: The Chamber (heatmap + blocs + briefing)    | P0       | L      | Chunk 4     | D                   |
+| 6     | WS-7       | Frontend: Enhanced member profile                     | P0       | L      | Chunk 4     | D (parallel with 5) |
+| 7     | WS-4       | AI briefing + prediction pipeline                     | P1       | L      | Chunks 2, 3 | E                   |
+| 8     | WS-8       | Frontend: Predictions panel                           | P1       | M      | Chunks 4, 7 | F                   |
+| 9     | —          | Data validation + backfill                            | P0       | M      | Chunks 2, 3 | B                   |
+| 10    | —          | Mobile polish + accessibility                         | P1       | M      | Chunks 5, 6 | G                   |
+
+**Parallelization opportunities**:
+
+- Chunks 2 + 3 run in parallel (both depend only on schema)
+- Chunks 5 + 6 run in parallel (both depend only on API)
+- Chunk 9 runs alongside 2+3 (validates data quality)
+
+**Critical path**: 1 → (2 || 3) → 4 → (5 || 6) → deploy
+
+**Total estimated effort**: ~4-5 weeks with parallel execution across 2 agents.
+
+---
+
+## Risk Assessment
+
+| Risk                                                           | Likelihood | Impact                              | Mitigation                                                                                                                                                                                             |
+| -------------------------------------------------------------- | ---------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Agreement matrix shows no variance (all members vote the same) | Medium     | High — heatmap becomes boring       | Run data validation FIRST (Chunk 9). If <20% of proposals have split votes, shift heatmap to show agreement on _rationale quality_ instead of just vote direction.                                     |
+| AI analysis quality inconsistent                               | Medium     | Medium — bad findings erode trust   | Use structured prompts with explicit scoring rubrics. Add `model_version` tracking. Human review first 10 analyses. Add "AI-generated" label on all AI content.                                        |
+| Claude API cost exceeds budget                                 | Low        | Low — total volume is tiny          | ~50 rationales/epoch × $0.02 = $1/epoch. Briefings + predictions add ~$0.50. Total: <$2/epoch. Cache aggressively.                                                                                     |
+| Predictions embarrassingly wrong                               | Medium     | Medium — undermines credibility     | Show accuracy track record prominently. Cap confidence at 75% for small sample sizes. Frame as "signal" not "forecast." Hide predictions until ≥10 historical predictions exist for accuracy baseline. |
+| Constitutional articles not standardized in rationale text     | High       | Medium — fuzzy matching needed      | Already handled by existing `EXPECTED_ARTICLES` fuzzy matching. AI analysis provides additional normalization.                                                                                         |
+| Mobile heatmap usability                                       | Medium     | Medium — 7×7 grid is tight on phone | Horizontal scroll with sticky names. Fallback on <640px: show as sorted list of "Strongest agreements" and "Notable divergences" instead of grid.                                                      |
+
+---
+
+## Success Metrics
+
+**Launch day**:
+
+- [ ] Heatmap renders with real agreement data for all active CC members
+- [ ] At least 1 bloc detected OR "Independent voting patterns" correctly displayed
+- [ ] All active members have archetype labels
+- [ ] AI analysis completed for ≥80% of existing rationales
+- [ ] Committee briefing generated with real findings
+- [ ] Member dossiers generated for all active members
+- [ ] At least 1 predictive signal generated for a pending proposal (if any exist)
+
+**30 days post-launch**:
+
+- [ ] Prediction accuracy tracking shows ≥60% on ≥5 predictions
+- [ ] No AI "hallucination" reports from community
+- [ ] Committee page engagement ≥ 2x current (PostHog: `governance_committee_viewed`)
+- [ ] Member profile depth: ≥30% of profile visitors reach deep mode (vs current baseline)
+- [ ] At least 1 community/media citation of Governada's constitutional intelligence
+
+**Long-term moat indicators**:
+
+- [ ] Interpretation history covers ≥3 epochs per CC member
+- [ ] Precedent graph has ≥10 linked decisions
+- [ ] Prediction accuracy improves over time (rolling 30-day window)
+- [ ] Community treats Governada as the authoritative source for CC accountability
+
+---
+
+## Migration Path from Current Implementation
+
+This is an enhancement, not a rewrite. The existing committee pages continue working throughout the build. New features are additive:
+
+1. **Heatmap** replaces ranked list as dominant element, but the list stays (demoted to "Member Directory")
+2. **CCHealthVerdict** stays — enhanced with AI headline when available
+3. **Member profile** keeps all existing sections — new sections (key finding, dossier, chamber position) are added above/between
+4. **Compare page** remains functional — becomes less important as pairwise data appears everywhere
+5. **Data page** remains functional — enhanced with new analysis data in exports
+6. **All existing scoring** (3-pillar fidelity) remains unchanged — AI analysis is additive intelligence on top
+
+No existing routes change. No existing components are deleted. The build is purely additive until launch, at which point the aggregate stat cards and CCInsightCard can be removed in a cleanup PR.
+
+---
+
+## Files Reference
+
+### New Files (20)
+
+| File                                              | Purpose                                        |
+| ------------------------------------------------- | ---------------------------------------------- |
+| `inngest/functions/compute-cc-relations.ts`       | Agreement matrix + bloc detection + archetypes |
+| `inngest/functions/analyze-cc-rationales.ts`      | AI rationale deep analysis                     |
+| `inngest/functions/generate-cc-briefing.ts`       | AI briefings + dossiers + predictions          |
+| `lib/cc/blocDetection.ts`                         | Clustering algorithm                           |
+| `lib/cc/archetypeClassification.ts`               | Rule-based archetype assignment                |
+| `lib/cc/rationaleAnalysis.ts`                     | AI prompt construction + response parsing      |
+| `lib/cc/precedentLinker.ts`                       | Precedent detection + classification           |
+| `lib/cc/briefingGenerator.ts`                     | Briefing prompt construction                   |
+| `lib/cc/predictiveSignals.ts`                     | Prediction logic + prompt                      |
+| `app/api/governance/committee/[ccHotId]/route.ts` | Member intelligence API                        |
+| `app/api/governance/committee/briefing/route.ts`  | Committee briefing API                         |
+| `app/api/governance/committee/predict/route.ts`   | Predictive signals API                         |
+| `components/cc/CCHeatmap.tsx`                     | Interactive agreement heatmap                  |
+| `components/cc/CCBlocBadges.tsx`                  | Bloc indicators                                |
+| `components/cc/CCBriefingCard.tsx`                | AI briefing display                            |
+| `components/cc/CCKeyFinding.tsx`                  | AI key finding callout                         |
+| `components/cc/CCChamberPosition.tsx`             | Pairwise alignment view                        |
+| `components/cc/CCInterpretationProfile.tsx`       | Article interpretation timeline                |
+| `components/cc/CCDossierSummary.tsx`              | AI executive summary                           |
+| `components/cc/CCPredictions.tsx`                 | Predictive signals panel                       |
+
+### Modified Files (8)
+
+| File                                          | Change                               |
+| --------------------------------------------- | ------------------------------------ |
+| `app/api/inngest/route.ts`                    | Register 3 new functions             |
+| `inngest/functions/sync-cc-rationales.ts`     | Emit completion event                |
+| `app/api/governance/committee/route.ts`       | Add relations + briefing to response |
+| `app/governance/committee/page.tsx`           | Restructure with heatmap + briefing  |
+| `app/governance/committee/[ccHotId]/page.tsx` | Fetch new intelligence data          |
+| `components/cc/CCMemberProfileClient.tsx`     | Integrate new sections + tabs        |
+| `hooks/queries.ts`                            | New hooks + enhanced types           |
+| `types/database.ts`                           | Regenerated after migration          |

--- a/docs/strategy/plans/drep-decision-engine.md
+++ b/docs/strategy/plans/drep-decision-engine.md
@@ -1,0 +1,772 @@
+# DRep Decision Engine — Implementation Plan
+
+> **Status**: APPROVED — Ready for execution
+> **Origin**: `/explore-feature DRep profiles` (2026-03-14)
+> **Goal**: Transform the DRep profile from an information display into a personalized delegation decision tool with decomposed trust signals — targeting a 10/10 citizen experience.
+
+---
+
+## Vision Summary
+
+The DRep profile's JTBD is "Decide if I should delegate to this DRep." Today it presents 8+ metrics across 5 chapters and asks citizens to synthesize their own answer. The Decision Engine makes the profile **viewer-relative**: alignment leads, decomposed score signals qualify, and the delegation decision is structured — not left as an exercise for the reader.
+
+### Core Principles
+
+1. **Alignment leads, score qualifies.** "87% aligned · votes on 85% of proposals, writes rationale on most votes" — not "Score: 74."
+2. **Show WHERE, not just HOW MUCH.** Per-proposal agreement/disagreement cards beat a single percentage.
+3. **No data → quiz IS the profile.** Visitors without alignment data get an inline 3-question Quick Match. The quiz isn't a detour — it's the entry experience.
+4. **Decompose the score into legible trust signals.** Citizens never see "Score: 74." They see specific behaviors: participation rate, rationale quality, consistency streak, delegation momentum.
+5. **Score stays the hero on the DRep dashboard.** Tiers, milestones, competitive positioning, and recommendations remain untouched on the owner-facing view. The accountability flywheel is preserved.
+6. **Ranking uses blended sort.** Browse/discover sort: `alignmentScore × 0.7 + normalizedScore × 0.3` for users with alignment data. Fallback: score descending.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    DRep Profile Page                     │
+│  (Server Component: data fetching + layout orchestration)│
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│  ┌─ Viewer has alignment data? ────────────────────┐    │
+│  │                                                  │    │
+│  │  YES                          NO                 │    │
+│  │  ┌──────────────────┐   ┌──────────────────┐    │    │
+│  │  │ Decision Engine   │   │ Discovery Mode   │    │    │
+│  │  │ (alignment-first) │   │ (quiz-first)     │    │    │
+│  │  └──────────────────┘   └──────────────────┘    │    │
+│  │                                                  │    │
+│  └──────────────────────────────────────────────────┘    │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │  Trust Signals (decomposed score — always shown)  │   │
+│  │  Participation · Rationale · Reliability · Growth │   │
+│  └──────────────────────────────────────────────────┘   │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │  Evidence Layer (depth-gated progressive detail)  │   │
+│  └──────────────────────────────────────────────────┘   │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Workstreams
+
+### WS-1: Per-Proposal Alignment Engine (Backend)
+
+**What**: Compute specific proposal-level agreement between a user's alignment profile and a DRep's actual votes. This powers the "biggest agreements / disagreements" cards — the Decision Engine's most powerful feature.
+
+**Why**: Today `dimensionAgreement.ts` computes per-DIMENSION agreement (e.g., "you both lean treasury conservative") but not per-PROPOSAL agreement ("on Proposal #287, this DRep voted YES — aligned with your stance on innovation"). The exploration identified this as the single most differentiating capability.
+
+**Files to create/modify**:
+
+- **NEW**: `lib/matching/proposalAlignment.ts` — Core computation
+- **MODIFY**: `lib/matching/dimensionAgreement.ts` — Export helpers for the new module
+- **MODIFY**: `app/api/drep/[drepId]/route.ts` or NEW: `app/api/drep/[drepId]/alignment/route.ts` — API endpoint
+
+**Implementation**:
+
+```typescript
+// lib/matching/proposalAlignment.ts
+
+interface ProposalAlignmentResult {
+  proposalId: string; // tx_hash#index
+  proposalTitle: string;
+  proposalType: string;
+  drepVote: 'Yes' | 'No' | 'Abstain';
+  predictedUserStance: 'Yes' | 'No' | 'Neutral';
+  stanceConfidence: number; // 0-100 — how confident we are in the prediction
+  agreement: 'agree' | 'disagree' | 'neutral';
+  reason: string; // "You both prioritize treasury conservation"
+  dimension: string; // Primary alignment dimension this touches
+}
+
+interface AlignmentSummary {
+  overallAlignment: number; // 0-100 (dimension-weighted)
+  confidence: number; // From user's progressive confidence
+  confidenceLabel: string; // "Based on 3 quiz answers" / "Based on 12 votes"
+  topAgreements: ProposalAlignmentResult[]; // Top 3 strongest agreements
+  topDisagreements: ProposalAlignmentResult[]; // Top 2 strongest disagreements
+  dimensionBreakdown: DimensionAgreement[]; // Per-dimension scores (existing)
+  narrative: string; // AI-generated 1-2 sentence summary
+}
+```
+
+**Algorithm**:
+
+1. Get user's alignment scores (from `user_governance_profiles` or quiz-derived via `buildAlignmentFromAnswers`)
+2. Get DRep's votes with proposal classifications (from `drep_votes` joined with `proposal_classifications`)
+3. For each classified proposal the DRep voted on:
+   - Identify the primary dimension(s) the proposal touches
+   - Predict user stance: if user's alignment on that dimension is >65 → "Yes tendency", <35 → "No tendency", else "Neutral"
+   - Compare with DRep's actual vote
+   - Score confidence based on how extreme the user's alignment is on that dimension
+4. Rank by confidence × recency → pick top 3 agreements and top 2 disagreements
+5. Generate narrative via `matchNarrative.ts` pattern (template-based, not AI — fast)
+
+**Key decisions**:
+
+- Prediction is probabilistic, not binary. Show confidence: "Likely aligned (high confidence)" vs. "Possibly aligned (based on limited data)"
+- Only classify proposals where the dimension signal is strong (classification score > 60). Skip ambiguous proposals.
+- Cache the alignment summary per (userId, drepId) pair with 1-epoch TTL
+
+**Effort**: M (1-2 days)
+
+---
+
+### WS-2: Delegation Simulation (Backend)
+
+**What**: "If you had delegated to this DRep 6 months ago, here's how your ADA would have voted." Shows each proposal with the DRep's vote, whether it was enacted, and delivery status.
+
+**Why**: Makes the abstract delegation decision tangible. Transforms "I think I agree with this person" into "here's the concrete record of what would have happened."
+
+**Files to create/modify**:
+
+- **NEW**: `lib/matching/delegationSimulation.ts` — Core simulation
+- **NEW or extend**: `app/api/drep/[drepId]/alignment/route.ts` — Include simulation data
+
+**Implementation**:
+
+```typescript
+interface SimulatedVote {
+  proposalId: string;
+  proposalTitle: string;
+  proposalType: string;
+  drepVote: 'Yes' | 'No' | 'Abstain';
+  outcome: 'Enacted' | 'Expired' | 'Dropped' | 'Pending';
+  deliveryStatus?: 'delivered' | 'partial' | 'not_delivered' | 'in_progress';
+  deliveryScore?: number;
+  alignmentWithUser: 'agree' | 'disagree' | 'neutral';
+  epoch: number;
+}
+
+interface DelegationSimulation {
+  periodLabel: string; // "Last 6 months (Epochs 470-485)"
+  totalProposals: number; // Proposals in period
+  drepVotedOn: number; // How many DRep voted on
+  participationRate: number; // drepVotedOn / totalProposals
+  enactedCount: number; // Proposals that passed
+  deliverySuccessRate: number; // % of enacted proposals that delivered
+  alignedVoteCount: number; // Votes aligned with user
+  totalClassifiedVotes: number; // Votes where alignment could be assessed
+  simulatedVotes: SimulatedVote[]; // Full list (most recent first)
+}
+```
+
+**Algorithm**:
+
+1. Fetch last 6 months of proposals + DRep's votes on them
+2. Join with proposal outcomes (delivery status, scores)
+3. For each vote, compute alignment with user (reuse WS-1 logic)
+4. Aggregate stats
+5. Return chronological list + summary
+
+**Effort**: M (1 day) — mostly composing existing data queries
+
+---
+
+### WS-3: Decomposed Trust Signals Component (Frontend)
+
+**What**: Replace the composite score number with legible behavioral indicators. This is the score repositioning — from headline to contextual trust signals.
+
+**Why**: "Score: 74" is opaque. "Votes on 85% of proposals · Writes rationale on most votes · Active 14 consecutive epochs · Growing delegation (+12% this epoch)" is legible and actionable.
+
+**Files to create/modify**:
+
+- **NEW**: `components/governada/profiles/TrustSignals.tsx` — The decomposed trust display
+- **MODIFY**: `components/DRepProfileHero.tsx` — Replace score prominence with trust signals
+- **REFERENCE**: `lib/scoring/calibration.ts` — Tier thresholds for badge
+
+**Design**:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Gold tier                                          │
+│                                                     │
+│  ✓ Votes on 85% of proposals    High participation  │
+│  ✓ Rationale on 70% of votes    Transparent         │
+│  ✓ Active 14 consecutive epochs Consistent          │
+│  ↑ Delegation growing (+12%)    Gaining trust       │
+│                                                     │
+│  ── Methodology ──────────────────── [expand] ──    │
+└─────────────────────────────────────────────────────┘
+```
+
+**Signal mapping from existing score pillars**:
+
+| Signal           | Source Data                                      | Thresholds                                                                                                   | Display                           |
+| ---------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| Participation    | `effectiveParticipation` (calibrated)            | ≥70: "Votes on most proposals", ≥40: "Votes regularly", <40: "Limited voting"                                | % + label                         |
+| Rationale        | `engagementQuality` → `rationaleRate`            | ≥60: "Writes rationale on most votes", ≥30: "Sometimes provides rationale", <30: "Rarely provides rationale" | % + label                         |
+| Reliability      | `reliability_streak` + `reliability_recency`     | streak ≥10: "Active X consecutive epochs", recency <7d: "Voted recently", gap >30d: "Inactive for X days"    | Streak + recency                  |
+| Delegation Trend | `drep_power_snapshots` (epoch-over-epoch)        | Growing (>5%), Stable (±5%), Declining (<-5%)                                                                | Direction + % change              |
+| Profile Quality  | `profileCompleteness` + `metadata_hash_verified` | ≥80: "Complete profile", verified: "Verified metadata"                                                       | Completeness + verification badge |
+
+**Depth behavior**:
+
+- `hands_off`: Tier badge only (single word: "Gold")
+- `informed`: Tier badge + top 2 signals (participation + reliability)
+- `engaged`: All 4-5 signals with labels
+- `deep`: All signals + expandable methodology (how each is computed)
+
+**Key rule**: The tier badge stays visible on ALL depth levels. It's the single-glance trust shorthand. The decomposed signals explain WHY they have that tier.
+
+**Effort**: M (1-2 days)
+
+---
+
+### WS-4: Decision Engine Profile Layout (Frontend — Core)
+
+**What**: Rebuild the DRep profile page layout to be viewer-relative. This is the largest workstream — the page restructuring.
+
+**Why**: The current chapter-based layout presents the same content to everyone. The Decision Engine adapts based on whether the viewer has alignment data.
+
+**Files to create/modify**:
+
+- **HEAVY MODIFY**: `app/drep/[drepId]/page.tsx` — Server component restructure
+- **NEW**: `components/governada/profiles/DecisionEngine.tsx` — Alignment-first view (viewer has data)
+- **NEW**: `components/governada/profiles/DiscoveryMode.tsx` — Quiz-first view (viewer has no data)
+- **NEW**: `components/governada/profiles/AlignmentCard.tsx` — Single agreement/disagreement card
+- **NEW**: `components/governada/profiles/ComparisonStrip.tsx` — "vs. your current DRep" or "vs. #1 match"
+- **NEW**: `components/governada/profiles/DelegationSimulationView.tsx` — Simulation results display
+- **MODIFY**: `components/DRepProfileHero.tsx` — Slimmed hero with trust signals
+- **MODIFY**: `components/governada/profiles/TrustCard.tsx` — Remove or repurpose (most content moves to trust signals + alignment cards)
+- **KEEP**: `components/governada/profiles/RecordSummaryCard.tsx` — Moves below alignment section
+- **KEEP**: `components/governada/profiles/TrajectoryCard.tsx` — Moves below alignment section
+- **REMOVE from public profile**: `components/ScoreCard.tsx` usage (stays on DRep dashboard only)
+- **REMOVE from public profile**: `components/governada/profiles/SimilarDReps.tsx` (replaced by comparison strip)
+
+#### Layout: Decision Engine Mode (viewer has alignment data)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  HERO (slimmed)                                         │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ [Name] · [Personality Label]        [Delegate CTA] │ │
+│  │ [One-line philosophy from metadata/prompt]          │ │
+│  │                                                     │ │
+│  │ ┌─ Trust Signals (WS-3) ────────────────────────┐  │ │
+│  │ │ Gold tier · 85% participation · Consistent     │  │ │
+│  │ └───────────────────────────────────────────────┘  │ │
+│  └────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  ALIGNMENT SECTION (the Decision Engine core)           │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ "87% aligned with you"                              │ │
+│  │ Based on 12 poll votes (high confidence)            │ │
+│  │                                                     │ │
+│  │ ┌─ Where you agree ────────────────────────────┐   │ │
+│  │ │ [AlignmentCard] Treasury: Both conservative   │   │ │
+│  │ │ [AlignmentCard] Security: Both prioritize     │   │ │
+│  │ │ [AlignmentCard] Proposal #287: Both voted Yes │   │ │
+│  │ └──────────────────────────────────────────────┘   │ │
+│  │                                                     │ │
+│  │ ┌─ Where you differ ───────────────────────────┐   │ │
+│  │ │ [AlignmentCard] Innovation: You support more  │   │ │
+│  │ │ [AlignmentCard] Proposal #301: Voted opposite │   │ │
+│  │ └──────────────────────────────────────────────┘   │ │
+│  └────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  COMPARISON STRIP (contextual)                          │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ "vs. Your Current DRep" [name]                      │ │
+│  │ Alignment: 87% vs 72% | Participation: 85% vs 60%  │ │
+│  │ [View full comparison →]                            │ │
+│  └────────────────────────────────────────────────────┘ │
+│  OR (if undelegated):                                   │
+│  │ "vs. Your #1 Match" [name]                          │ │
+├─────────────────────────────────────────────────────────┤
+│  DELEGATION SIMULATION (depth: engaged+)                │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ "If you had delegated 6 months ago..."              │ │
+│  │ 47 governance actions · DRep voted on 40 (85%)     │ │
+│  │ 28 aligned with your values · 8 differed · 4 ??   │ │
+│  │ Enacted: 23 · Delivered: 15 (65%)                   │ │
+│  │ [Show all proposals ↓]                              │ │
+│  └────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  EVIDENCE LAYER (depth-gated, below fold)               │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ Activity Heatmap (depth: informed+)                 │ │
+│  │ Record Summary (depth: informed+)                   │ │
+│  │ Trajectory (depth: engaged+)                        │ │
+│  │ Detailed Analysis (depth: deep) — voting record,    │ │
+│  │   alignment trajectory, DRep statements             │ │
+│  └────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### Layout: Discovery Mode (viewer has NO alignment data)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  HERO (same slimmed version)                            │
+│  [Name] · [Personality] · Trust Signals · [Delegate]    │
+├─────────────────────────────────────────────────────────┤
+│  INLINE QUICK MATCH                                     │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ "See how [Name] aligns with your governance values" │ │
+│  │                                                     │ │
+│  │ Q1: How should Cardano's treasury be managed?       │ │
+│  │   ○ Conservative  ○ Growth  ○ Balanced              │ │
+│  │                                                     │ │
+│  │ Q2: Protocol changes should prioritize...           │ │
+│  │   ○ Caution  ○ Innovation  ○ Case by case           │ │
+│  │                                                     │ │
+│  │ Q3: How important is DRep transparency?             │ │
+│  │   ○ Essential  ○ Nice to have  ○ Doesn't matter     │ │
+│  │                                                     │ │
+│  │ [See my alignment with {Name} →]                    │ │
+│  └────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  SOCIAL PROOF (while no alignment data)                 │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ X citizens have delegated · Growing this epoch      │ │
+│  │ Y citizen endorsements                              │ │
+│  └────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────┤
+│  EVIDENCE LAYER (same as Decision Engine mode)          │
+│  Activity Heatmap · Record Summary · Trajectory · etc.  │
+└─────────────────────────────────────────────────────────┘
+```
+
+**After quiz completion**: Page transitions to Decision Engine mode (client-side state update, no reload). The alignment section appears with results, quiz section collapses.
+
+**Depth gating on the Decision Engine profile**:
+
+| Section                           | hands_off       | informed         | engaged        | deep                                    |
+| --------------------------------- | --------------- | ---------------- | -------------- | --------------------------------------- |
+| Hero + Trust Signals              | Tier badge only | Tier + 2 signals | All signals    | All + methodology                       |
+| Alignment % + top agreement       | ✓ (if data)     | ✓                | ✓              | ✓                                       |
+| Full agreement/disagreement cards | —               | Top 2 each       | Top 3+2        | All classified                          |
+| Comparison strip                  | —               | ✓                | ✓              | ✓                                       |
+| Delegation simulation             | —               | —                | Summary only   | Full with proposal list                 |
+| Activity heatmap                  | —               | ✓                | ✓              | ✓                                       |
+| Record summary                    | —               | ✓                | ✓              | ✓                                       |
+| Trajectory                        | —               | —                | ✓              | ✓                                       |
+| Detailed analysis tabs            | —               | —                | —              | ✓ (voting record, alignment trajectory) |
+| Inline Quick Match                | ✓ (if no data)  | ✓ (if no data)   | ✓ (if no data) | — (assume has data)                     |
+
+**DRep/SPO/CC viewer behavior**: These users always see `deep` depth. The Decision Engine still works for them (they have alignment data from their own voting). The comparison strip shows "vs. your own voting record" instead of "vs. your current DRep."
+
+**Effort**: L (3-4 days)
+
+---
+
+### WS-5: Inline Quick Match Widget (Frontend)
+
+**What**: A compact, inline version of the 3-question Quick Match quiz that lives directly on the DRep profile page for visitors without alignment data.
+
+**Why**: Currently, to see alignment, a citizen must navigate to `/match`, complete the quiz, then come back to the DRep profile. This breaks flow. The quiz should be ON the profile — it IS the entry experience.
+
+**Files to create/modify**:
+
+- **NEW**: `components/governada/profiles/InlineQuickMatch.tsx` — Compact quiz widget
+- **MODIFY**: `components/governada/match/QuickMatchFlow.tsx` — Extract quiz logic into reusable hook
+- **NEW**: `hooks/useQuickMatch.ts` — Shared quiz state + API call logic
+
+**Implementation**:
+
+- Extract the core quiz logic (3 questions, answer mapping, API call) from `QuickMatchFlow.tsx` (1293 lines) into `useQuickMatch.ts` hook
+- `InlineQuickMatch.tsx` renders a compact 3-question form (no intro screen, no loading screen — all inline)
+- On submit: calls `/api/governance/quick-match`, saves profile to localStorage (existing pattern), and fires a callback (`onMatchComplete(alignmentData)`)
+- Parent component (`DiscoveryMode`) receives the callback and transitions to `DecisionEngine` view
+- PostHog event: `quick_match_completed_inline` with `{source: 'drep_profile', drepId}`
+
+**Design constraints**:
+
+- Must feel native to the profile, not like a popup or modal
+- All 3 questions visible at once (no step-by-step) — this is a fast inline widget, not a flow
+- Styled to match the profile's visual language (not the standalone match flow's style)
+- "See my alignment with [DRep Name] →" as the CTA — personalized, not generic
+
+**Effort**: M (1 day)
+
+---
+
+### WS-5a: Quiz Enhancement — Add Decentralization Question
+
+**What**: Add a 4th question to the Quick Match quiz covering decentralization — the only unaddressed alignment dimension. This fills the blind spot where all decentralization-related proposals produce "Neutral" predictions for quiz-only users.
+
+**Why**: The current 3-question quiz covers 5 of 6 dimensions. Decentralization defaults to 50 (neutral), making high-stakes proposals (NoConfidence, power distribution) invisible to the alignment engine for quiz-only users. One additional question gives complete 6-dimension coverage with minimal friction increase (~3 seconds).
+
+**Files to modify**:
+
+- **MODIFY**: `lib/matching/answerVectors.ts` — Add `decentralization` answer vector
+- **MODIFY**: `components/governada/match/QuickMatchFlow.tsx` — Add Q4 to flow
+- **MODIFY**: `components/governada/profiles/InlineQuickMatch.tsx` — Add Q4 to inline widget (built in WS-5)
+
+**New question**:
+
+> How should voting power be distributed in Cardano governance?
+>
+> - Spread widely — no single entity should have outsized influence (decentralization: 85)
+> - Concentrated among the most active/qualified participants (decentralization: 20)
+> - Current distribution is fine — focus on other issues (decentralization: 50)
+
+**Effort**: S (< 1 hour) — answer vector mapping + UI addition
+
+---
+
+### WS-6: Comparison Strip Component (Frontend)
+
+**What**: A contextual comparison bar that shows how this DRep compares to the viewer's current DRep or top match.
+
+**Why**: Delegation decisions are inherently comparative — "Should I delegate to THIS one instead of my current one?" The comparison strip answers this without leaving the page.
+
+**Files to create/modify**:
+
+- **NEW**: `components/governada/profiles/ComparisonStrip.tsx`
+- **NEW or extend**: `app/api/drep/[drepId]/alignment/route.ts` — Include comparison DRep data
+
+**Implementation**:
+
+```typescript
+interface ComparisonStripProps {
+  currentDrep: {
+    drepId: string;
+    name: string;
+    alignment: number; // Viewer's alignment with current DRep
+    participationRate: number;
+    tier: string;
+  };
+  viewingDrep: {
+    drepId: string;
+    name: string;
+    alignment: number; // Viewer's alignment with this DRep
+    participationRate: number;
+    tier: string;
+  };
+  comparisonType: 'current_drep' | 'top_match';
+}
+```
+
+**States**:
+
+- **Viewer is delegated**: "vs. Your Current DRep [Name]" — shows alignment %, participation, tier side-by-side
+- **Viewer is undelegated**: "vs. Your #1 Match [Name]" — shows the alternative
+- **Viewer is the DRep**: Hidden (no comparison needed)
+- **No alignment data**: Hidden (quiz hasn't been completed)
+
+**Link**: "View full comparison →" navigates to `/compare?dreps=current,viewing`
+
+**Effort**: S (0.5 day)
+
+---
+
+### WS-7: Browse/Discover Sort Order Update (Frontend + Backend)
+
+**What**: Update the default sort order on DRep browse/discover to use alignment-weighted scoring when viewer has alignment data.
+
+**Why**: Currently DReps sort by score descending. With the Decision Engine, the most relevant DReps should surface first — highest alignment + quality.
+
+**Files to modify**:
+
+- **MODIFY**: `components/governada/discover/GovernadaDRepBrowse.tsx` — Sort logic (lines 454-481)
+- **MODIFY**: `app/api/governance/leaderboard/route.ts` — API sort option
+- **MODIFY**: `components/DRepTableClient.tsx` — Default sort key
+
+**Implementation**:
+
+- When user has alignment profile (localStorage or DB), compute blended sort:
+  ```typescript
+  const blendedScore = (alignmentPct / 100) * 0.7 + (normalizedDRepScore / 100) * 0.3;
+  ```
+- Default sort label changes from "Governance Score" to "Best Match" (when alignment data available)
+- "Governance Score" remains as a selectable sort option
+- DRep cards in browse show both: match badge + tier badge (existing `MatchContextBadge` pattern)
+
+**Minimum score threshold**: DReps with score < 30 (Emerging, barely active) get a visual warning on the card: "Limited track record" — regardless of alignment score. This prevents ghost DReps from matching high.
+
+**Effort**: S (0.5 day)
+
+---
+
+### WS-8: DRep Dashboard Preservation + Enhancement (Frontend)
+
+**What**: Ensure the DRep owner dashboard retains score as the hero AND gets a new "How delegators see you" insight panel.
+
+**Why**: The accountability flywheel depends on DReps caring about their score. The dashboard is where that motivation lives. But now we can also show DReps how the Decision Engine presents them to citizens.
+
+**Files to modify**:
+
+- **MODIFY**: `components/DRepDashboard.tsx` — Add delegator alignment insight panel
+- **KEEP AS-IS**: `components/governada/identity/DRepScorecardView.tsx` — Score hero
+- **KEEP AS-IS**: All tier celebrations, competitive context, milestones, recommendations
+
+**New panel: "How Citizens See You"**:
+
+- Shows the DRep their own Trust Signals as citizens would see them
+- Shows aggregate alignment distribution: "X% of your delegators align with you on treasury, only Y% align on innovation"
+- Actionable insight: "Your weakest alignment dimension with delegators is [innovation]. Consider writing a rationale on the next innovation proposal to clarify your stance."
+
+**Effort**: M (1 day)
+
+---
+
+### WS-9: API Layer (Backend)
+
+**What**: New API endpoint that returns viewer-specific alignment data for a DRep profile.
+
+**Files to create**:
+
+- **NEW**: `app/api/drep/[drepId]/alignment/route.ts`
+
+**Implementation**:
+
+```typescript
+// GET /api/drep/[drepId]/alignment
+// Query params: ?source=quiz|profile (where alignment data comes from)
+// Auth: Optional (quiz data from localStorage, profile data from DB)
+
+// Request body (POST for quiz-based alignment):
+{
+  userAlignment?: AlignmentScores;  // From localStorage quiz results
+}
+
+// Response:
+{
+  alignment: AlignmentSummary;        // From WS-1
+  simulation: DelegationSimulation;   // From WS-2
+  comparison?: ComparisonData;        // From WS-6 (if viewer is delegated)
+  trustSignals: TrustSignal[];        // Decomposed score signals
+}
+```
+
+**Caching**:
+
+- Authenticated users: Cache per (userId, drepId) with 1-epoch TTL in Redis
+- Quiz-based (unauthenticated): Compute on-the-fly (lightweight, <100ms)
+- Trust signals: Computed from existing DB columns (no cache needed)
+
+**Effort**: M (1 day)
+
+---
+
+## Execution Plan
+
+### Phase 1: Foundation (WS-1, WS-2, WS-9) — Backend
+
+**Parallel-safe**: All three can be built simultaneously by separate agents.
+
+| WS   | Task                          | Dependencies                             | Effort       |
+| ---- | ----------------------------- | ---------------------------------------- | ------------ |
+| WS-1 | Per-proposal alignment engine | None                                     | M (1-2 days) |
+| WS-2 | Delegation simulation         | None (shares data queries with WS-1)     | M (1 day)    |
+| WS-9 | API endpoint                  | WS-1 + WS-2 outputs (can stub initially) | M (1 day)    |
+
+**Deliverable**: API endpoint returns alignment summary, simulation data, and trust signals for any (viewer, DRep) pair.
+
+**Validation**: Unit tests for alignment computation + API integration test.
+
+### Phase 2: Components (WS-3, WS-5, WS-6) — Frontend Components
+
+**Parallel-safe**: All three are independent components.
+
+| WS   | Task                       | Dependencies                     | Effort       |
+| ---- | -------------------------- | -------------------------------- | ------------ |
+| WS-3 | Trust Signals component    | None (reads existing DB columns) | M (1-2 days) |
+| WS-5 | Inline Quick Match widget  | Extract hook from QuickMatchFlow | M (1 day)    |
+| WS-6 | Comparison Strip component | WS-9 API for comparison data     | S (0.5 day)  |
+
+**Deliverable**: Three new standalone components, each tested independently.
+
+### Phase 3: Page Assembly (WS-4) — Integration
+
+**Sequential**: Depends on Phase 1 + Phase 2 components.
+
+| WS   | Task                           | Dependencies                 | Effort       |
+| ---- | ------------------------------ | ---------------------------- | ------------ |
+| WS-4 | Decision Engine profile layout | WS-1, WS-2, WS-3, WS-5, WS-6 | L (3-4 days) |
+
+**Deliverable**: The rebuilt DRep profile page with both Decision Engine and Discovery Mode layouts.
+
+### Phase 4: Polish (WS-7, WS-8) — Ecosystem Integration
+
+**Parallel-safe**: Independent from each other.
+
+| WS   | Task                        | Dependencies                  | Effort      |
+| ---- | --------------------------- | ----------------------------- | ----------- |
+| WS-7 | Browse/discover sort update | WS-1 alignment data available | S (0.5 day) |
+| WS-8 | DRep dashboard enhancement  | WS-3 trust signals component  | M (1 day)   |
+
+**Deliverable**: Full ecosystem integration — browse sorts by alignment, DRep dashboard shows delegator perspective.
+
+### Phase 5: Review & Refinement — Quality Gate
+
+**MANDATORY PAUSE BEFORE SHIPPING.**
+
+This phase exists to catch gaps, polish rough edges, and ensure the 10/10 target. Do NOT skip this phase to ship faster.
+
+#### Step 5a: Self-Audit (automated)
+
+Run `/audit-feature DRep profiles` against the rebuilt implementation. Score against:
+
+- **F1 JTBD**: Does the profile directly answer "should I delegate?"
+- **F2 Emotional Impact**: Does the viewer feel informed and confident?
+- **F3 Simplicity**: Can a citizen who knows nothing about governance understand the profile?
+- **F4 Differentiation**: Is this unlike anything in crypto governance?
+- **F5 Data Leverage**: Are we using all available data effectively?
+- **F6 Craft**: Is the visual quality, animation, and polish world-class?
+
+Target: Every dimension ≥ 8/10.
+
+#### Step 5b: Persona Walkthrough
+
+Manually trace the experience for each persona × state:
+
+| Persona | State                            | Expected Experience                                                            |
+| ------- | -------------------------------- | ------------------------------------------------------------------------------ |
+| Citizen | Anonymous, no quiz data          | Discovery Mode: hero + inline quiz + social proof                              |
+| Citizen | Has quiz data, undelegated       | Decision Engine: alignment + quiz confidence caveat + "vs. #1 match"           |
+| Citizen | Has quiz data + votes, delegated | Decision Engine: alignment (high confidence) + "vs. current DRep" + simulation |
+| Citizen | `hands_off` depth                | Minimal: tier badge + alignment % + delegate CTA                               |
+| Citizen | `deep` depth                     | Full: all sections expanded + detailed analysis tabs                           |
+| DRep    | Viewing own profile              | Score hero (dashboard) + "How citizens see you"                                |
+| DRep    | Viewing another DRep             | Decision Engine (their alignment from voting) + "vs. your record"              |
+| SPO     | Viewing a DRep                   | Decision Engine + governance-level signals                                     |
+| CC      | Viewing a DRep                   | Decision Engine + constitutional fidelity context                              |
+
+For each walkthrough, note:
+
+- Does the 5-second test pass? (Can you answer "should I delegate?" in 5 seconds?)
+- Is anything confusing, redundant, or missing?
+- Are depth gates working correctly?
+- Is the transition from Discovery → Decision Engine smooth?
+
+#### Step 5c: Edge Cases
+
+Test and fix:
+
+- **DRep with 0 votes**: Trust signals show "No voting history yet" — alignment section shows "Not enough data to assess alignment. This DRep hasn't voted yet."
+- **DRep with votes but no rationale**: Trust signal "Rarely provides rationale" + alignment still works from vote patterns
+- **User with quiz data but very low confidence**: Show confidence caveat prominently: "Based on 3 quiz answers — vote on proposals to improve accuracy"
+- **Inactive DRep**: Prominent "Inactive" badge on hero — alignment section includes warning "This DRep has been inactive for X epochs"
+- **DRep viewing themselves as if a citizen**: View As switcher should show Decision Engine from citizen perspective
+- **Mobile layout**: All sections must work on mobile. Comparison strip stacks vertically. Quiz renders cleanly.
+
+#### Step 5d: Performance Check
+
+- Profile page should load in < 2s (LCP)
+- Alignment computation should be < 200ms for cached, < 500ms for cold
+- No layout shift when quiz results load or when transitioning from Discovery → Decision Engine mode
+- Suspense boundaries on alignment section (show skeleton while loading)
+
+#### Step 5e: Gap Identification & Final Polish
+
+After steps 5a-5d, create a gap list. Common areas that may need attention:
+
+- **Transition animations**: Discovery → Decision Engine mode should feel smooth, not jarring
+- **Empty states**: Every section needs a considered empty state, not "No data"
+- **Confidence communication**: Is the citizen clear on WHY their alignment is "moderate confidence"?
+- **Share moments**: Is there a shareable alignment card? ("I'm 91% aligned with DRep Maria — here's where we agree")
+- **Accessibility**: Screen reader experience for alignment cards, trust signals, quiz
+- **OG image update**: Social preview should reflect the new profile (alignment + trust signals, not just score)
+
+Fix all gaps. Then ship.
+
+---
+
+## Files Summary
+
+### New Files (10)
+
+| File                                                         | Purpose                            | WS   |
+| ------------------------------------------------------------ | ---------------------------------- | ---- |
+| `lib/matching/proposalAlignment.ts`                          | Per-proposal alignment computation | WS-1 |
+| `lib/matching/delegationSimulation.ts`                       | Delegation simulation engine       | WS-2 |
+| `app/api/drep/[drepId]/alignment/route.ts`                   | Viewer-specific alignment API      | WS-9 |
+| `components/governada/profiles/TrustSignals.tsx`             | Decomposed score display           | WS-3 |
+| `components/governada/profiles/DecisionEngine.tsx`           | Alignment-first profile view       | WS-4 |
+| `components/governada/profiles/DiscoveryMode.tsx`            | Quiz-first profile view            | WS-4 |
+| `components/governada/profiles/AlignmentCard.tsx`            | Single agreement/disagreement card | WS-4 |
+| `components/governada/profiles/ComparisonStrip.tsx`          | Contextual DRep comparison         | WS-6 |
+| `components/governada/profiles/DelegationSimulationView.tsx` | Simulation results display         | WS-4 |
+| `hooks/useQuickMatch.ts`                                     | Shared quiz state + API logic      | WS-5 |
+| `components/governada/profiles/InlineQuickMatch.tsx`         | Compact inline quiz widget         | WS-5 |
+
+### Modified Files (7)
+
+| File                                                    | Change                                                                      | WS         |
+| ------------------------------------------------------- | --------------------------------------------------------------------------- | ---------- |
+| `app/drep/[drepId]/page.tsx`                            | Major restructure — Decision Engine vs Discovery Mode routing               | WS-4       |
+| `components/DRepProfileHero.tsx`                        | Slim down — remove score prominence, add trust signals slot                 | WS-3, WS-4 |
+| `components/governada/profiles/TrustCard.tsx`           | Remove or repurpose — most content moves to alignment cards + trust signals | WS-4       |
+| `components/governada/discover/GovernadaDRepBrowse.tsx` | Alignment-weighted sort default                                             | WS-7       |
+| `components/DRepTableClient.tsx`                        | Default sort key update                                                     | WS-7       |
+| `components/DRepDashboard.tsx`                          | Add "How citizens see you" panel                                            | WS-8       |
+| `components/governada/match/QuickMatchFlow.tsx`         | Extract quiz logic to shared hook                                           | WS-5       |
+
+### Removed from Public Profile (kept in codebase, used elsewhere)
+
+| Component             | Current Location         | New Location                   |
+| --------------------- | ------------------------ | ------------------------------ |
+| `ScoreCard.tsx`       | DRep profile + dashboard | Dashboard only                 |
+| `SimilarDReps.tsx`    | DRep profile             | Replaced by ComparisonStrip    |
+| Radar chart (in Hero) | DRep profile hero        | Match flow + compare page only |
+
+### Unchanged (kept as-is)
+
+| Component                       | Reason                                                  |
+| ------------------------------- | ------------------------------------------------------- |
+| `DRepScorecardView.tsx`         | DRep dashboard hero — score stays here                  |
+| `TierCelebrationManager.tsx`    | Tier celebrations — accountability flywheel             |
+| `CompetitiveContext.tsx`        | DRep competitive positioning — dashboard only           |
+| All milestone/notification code | Drives engagement loop                                  |
+| GHI computation pipeline        | Unchanged — measures ecosystem health                   |
+| Scoring engine (`lib/scoring/`) | Unchanged — computes scores for ranking, GHI, dashboard |
+
+---
+
+## Success Metrics
+
+| Metric                            | Current Baseline    | Target                             | How to Measure                                                      |
+| --------------------------------- | ------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| Profile → Delegation conversion   | Measure via PostHog | +25% lift                          | `drep_profile_viewed` → `delegation_started`                        |
+| Quick Match completion on profile | N/A (new)           | 40%+ of visitors without alignment | `quick_match_completed_inline` / `drep_profile_viewed_no_alignment` |
+| Time to delegation decision       | Unknown             | < 60 seconds                       | Session duration on profile before delegation                       |
+| DRep dashboard engagement         | Measure current     | No regression                      | Score check frequency, competitive context views                    |
+| Audit score (F1 JTBD)             | ~6/10               | 9+/10                              | `/audit-feature DRep profiles`                                      |
+
+---
+
+## Risk Registry
+
+| Risk                                                             | Likelihood | Impact | Mitigation                                                                                          |
+| ---------------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------- |
+| Per-proposal alignment predictions are noisy with quiz-only data | High       | Medium | Show confidence prominently; badge as "approximate" at <40% confidence                              |
+| Page load time increases with alignment computation              | Medium     | High   | Cache alignment per (user, drep) in Redis; Suspense boundaries                                      |
+| DReps feel their score is "hidden"                               | Medium     | Medium | Score still on dashboard; tier badge prominent on public profile; communicate change                |
+| Citizens skip the quiz (Discovery Mode abandonment)              | Medium     | Medium | Make quiz feel native (inline, 10-second completion); show social proof below as alternative signal |
+| Comparison strip loads slowly (needs 2nd DRep data)              | Low        | Medium | Preload comparison DRep data on server; skeleton loading                                            |
+| Breaking change for external badge/embed API consumers           | Low        | High   | Keep badge API unchanged (still shows score + tier); add alignment option as new param              |
+
+---
+
+## Estimated Total Effort
+
+| Phase               | Workstreams                             | Effort          | Parallelism                     |
+| ------------------- | --------------------------------------- | --------------- | ------------------------------- |
+| Phase 1: Foundation | WS-1, WS-2, WS-9                        | 3-4 days        | All parallel                    |
+| Phase 2: Components | WS-3, WS-5, WS-6                        | 2-3 days        | All parallel                    |
+| Phase 3: Assembly   | WS-4                                    | 3-4 days        | Sequential (depends on P1+P2)   |
+| Phase 4: Polish     | WS-7, WS-8                              | 1-2 days        | All parallel                    |
+| Phase 5: Review     | Audit + walkthrough + edge cases + gaps | 1-2 days        | Sequential                      |
+| **Total**           |                                         | **~10-15 days** | With parallelism: **~7-9 days** |
+
+---
+
+## Decision Log
+
+| Decision                                         | Rationale                                                              | Date       |
+| ------------------------------------------------ | ---------------------------------------------------------------------- | ---------- |
+| Alignment leads, score qualifies                 | JTBD is delegation decision; alignment answers it directly             | 2026-03-14 |
+| Score NOT blended into match %                   | Loses legibility; "match" should mean values alignment, not composite  | 2026-03-14 |
+| Score used in sort ranking (0.3 weight)          | Differentiates among similar-alignment DReps without confusing display | 2026-03-14 |
+| Decomposed trust signals replace composite score | "Votes on 85% of proposals" > "Score: 74" for citizen legibility       | 2026-03-14 |
+| DRep dashboard unchanged (score stays hero)      | Accountability flywheel must be preserved                              | 2026-03-14 |
+| Inline quiz on profile (not redirect to /match)  | Breaks flow to leave the profile; quiz IS the entry experience         | 2026-03-14 |
+| Mandatory review phase before shipping           | 10/10 target requires deliberate quality gate                          | 2026-03-14 |

--- a/hooks/useQuickMatch.ts
+++ b/hooks/useQuickMatch.ts
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import type { ConfidenceBreakdown } from '@/lib/matching/confidence';
+import { saveMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { trackFunnel, FUNNEL_EVENTS } from '@/lib/funnel';
+import { emitDiscoveryEvent } from '@/lib/discovery/events';
+
+/* ─── Types ─────────────────────────────────────────────── */
+
+export interface MatchResult {
+  drepId: string;
+  drepName: string | null;
+  drepScore: number;
+  matchScore: number;
+  identityColor: string;
+  personalityLabel: string;
+  alignments: AlignmentScores;
+  agreeDimensions: string[];
+  differDimensions: string[];
+  voteCount?: number;
+  participationPct?: number;
+  rationaleRate?: number;
+  delegatorCount?: number;
+  tier?: string | null;
+  signatureInsight?: string | null;
+}
+
+export interface QuickMatchResponse {
+  matches: MatchResult[];
+  nearMisses?: MatchResult[];
+  userAlignments: AlignmentScores;
+  personalityLabel: string;
+  identityColor: string;
+  confidenceBreakdown?: ConfidenceBreakdown;
+}
+
+export interface QuickMatchAnswers {
+  treasury?: 'conservative' | 'growth' | 'balanced';
+  protocol?: 'caution' | 'innovation' | 'case_by_case';
+  transparency?: 'essential' | 'nice_to_have' | 'doesnt_matter';
+  decentralization?: 'spread_widely' | 'concentrated' | 'current_fine';
+}
+
+export interface QuickMatchState {
+  answers: QuickMatchAnswers;
+  isComplete: boolean;
+  isSubmitting: boolean;
+  error: string | null;
+  drepResult: QuickMatchResponse | null;
+  spoResult: QuickMatchResponse | null;
+}
+
+export interface UseQuickMatchOptions {
+  onComplete?: (drepResult: QuickMatchResponse, spoResult: QuickMatchResponse) => void;
+  drepId?: string;
+}
+
+type MatchType = 'drep' | 'spo';
+
+/* ─── Hook ──────────────────────────────────────────────── */
+
+export function useQuickMatch(options?: UseQuickMatchOptions) {
+  const [answers, setAnswersState] = useState<QuickMatchAnswers>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [drepResult, setDrepResult] = useState<QuickMatchResponse | null>(null);
+  const [spoResult, setSpoResult] = useState<QuickMatchResponse | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const isComplete = Boolean(
+    answers.treasury && answers.protocol && answers.transparency && answers.decentralization,
+  );
+
+  const setAnswer = useCallback((question: string, answer: string) => {
+    setAnswersState((prev) => ({ ...prev, [question]: answer }));
+  }, []);
+
+  const submit = useCallback(
+    async (overrideAnswers?: QuickMatchAnswers) => {
+      const finalAnswers = overrideAnswers ?? answers;
+
+      // Require at least the original 3 questions for backward compatibility
+      if (!finalAnswers.treasury || !finalAnswers.protocol || !finalAnswers.transparency) {
+        setError('Please answer all required questions.');
+        return;
+      }
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setIsSubmitting(true);
+      setError(null);
+
+      const fetchOne = async (type: MatchType) => {
+        const res = await fetch('/api/governance/quick-match', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            treasury: finalAnswers.treasury,
+            protocol: finalAnswers.protocol,
+            transparency: finalAnswers.transparency,
+            decentralization: finalAnswers.decentralization,
+            match_type: type,
+          }),
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`Server error: ${res.status}`);
+        return res.json() as Promise<QuickMatchResponse>;
+      };
+
+      try {
+        const [drepData, spoData] = await Promise.all([fetchOne('drep'), fetchOne('spo')]);
+        setDrepResult(drepData);
+        setSpoResult(spoData);
+        emitDiscoveryEvent('match_completed');
+
+        // Funnel tracking
+        trackFunnel(FUNNEL_EVENTS.MATCH_COMPLETED, {
+          personality: drepData.personalityLabel,
+          drep_matches: drepData.matches.length,
+          spo_matches: spoData.matches.length,
+        });
+        trackFunnel(FUNNEL_EVENTS.MATCH_RESULT_VIEWED, {
+          top_match_score: drepData.matches[0]?.matchScore ?? 0,
+        });
+
+        // Mark quick match as completed for authenticated users
+        const token = getStoredSession();
+        if (token) {
+          fetch('/api/governance/quick-match/mark-completed', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+          }).catch(() => {});
+        }
+
+        // Persist match profile
+        const answersRecord: Record<string, string> = {};
+        for (const [k, v] of Object.entries(finalAnswers)) {
+          if (v) answersRecord[k] = v;
+        }
+        saveMatchProfile({
+          userAlignments: drepData.userAlignments,
+          personalityLabel: drepData.personalityLabel,
+          identityColor: drepData.identityColor,
+          matchType: 'drep',
+          answers: answersRecord,
+          timestamp: Date.now(),
+        } satisfies StoredMatchProfile);
+
+        options?.onComplete?.(drepData, spoData);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Something went wrong');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [answers, options],
+  );
+
+  const reset = useCallback(() => {
+    setAnswersState({});
+    setIsSubmitting(false);
+    setError(null);
+    setDrepResult(null);
+    setSpoResult(null);
+  }, []);
+
+  const state: QuickMatchState = {
+    answers,
+    isComplete,
+    isSubmitting,
+    error,
+    drepResult,
+    spoResult,
+  };
+
+  return { state, setAnswer, submit, reset };
+}

--- a/lib/matching/answerVectors.ts
+++ b/lib/matching/answerVectors.ts
@@ -21,6 +21,17 @@ export const ANSWER_VECTORS: Record<string, Record<string, Partial<AlignmentScor
     nice_to_have: { transparency: 55, decentralization: 50 },
     doesnt_matter: { transparency: 20, decentralization: 35 },
   },
+  decentralization: {
+    spread_widely: {
+      decentralization: 85,
+    },
+    concentrated: {
+      decentralization: 20,
+    },
+    current_fine: {
+      decentralization: 50,
+    },
+  },
 };
 
 /**

--- a/lib/matching/confidence.ts
+++ b/lib/matching/confidence.ts
@@ -70,7 +70,7 @@ const WEIGHTS = {
 } as const;
 
 const TARGETS = {
-  quizAnswers: 3, // 3 quick match questions
+  quizAnswers: 4, // 4 quick match questions (treasury, protocol, transparency, decentralization)
   pollVotes: 15, // 15 proposal votes for full confidence
   proposalDiversity: 4, // 4 out of 6 proposal types
   engagement: 10, // 10 engagement actions
@@ -182,7 +182,7 @@ function getNextAction(
             type: 'take_quiz',
             label: 'Take the Quick Match quiz',
             description:
-              'Answer 3 questions about your governance values to establish a baseline match profile.',
+              'Answer 4 questions about your governance values to establish a baseline match profile.',
             href: '/match',
             potentialGain: gap,
           });


### PR DESCRIPTION
## Summary
- Extract quiz logic into reusable `useQuickMatch` hook
- New `InlineQuickMatch` component — compact 4-question quiz for DRep profile pages
- Add 4th question (decentralization) to Quick Match quiz — fills the only blind spot in 6D alignment coverage
- Backward-compatible API update (decentralization answer is optional)
- QuickMatchFlow.tsx updated to use shared hook + new question

## Impact
- **What changed**: New hook + component, modified QuickMatchFlow + answerVectors + quick-match API
- **User-facing**: Yes — existing Quick Match flow now has 4 questions instead of 3
- **Risk**: Medium — modifies existing quiz flow, but backward compatible
- **Scope**: 2 new files, 3 modified files, 2 updated tests, 2 formatted docs

## Test plan
- [ ] Existing Quick Match flow works with 4 questions
- [ ] Quick Match flow works if user skips Q4 (backward compat)
- [ ] InlineQuickMatch renders all 4 questions inline
- [ ] Submit triggers API call and returns alignment
- [ ] `npm run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)