### PR TITLE
feat: DRep Decision Engine — profile page rebuild

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -1,14 +1,15 @@
 /**
- * DRep Detail Page — Chapter-based progressive disclosure.
+ * DRep Detail Page — Decision Engine layout.
  *
- * Ch1 "The Story" (Hero): Name, score, personality, AI narrative (above fold).
- * Ch2 "Trust at a Glance" (TrustCard): Unified trust metrics, citizen sentiment.
- * Ch3 "The Record" (RecordSummaryCard): Treasury track record + delivery outcomes.
- * Ch4 "Trajectory" (TrajectoryCard): Score evolution + delegation momentum.
- * Ch5 "Detailed Analysis" (DRepDetailedAnalysis): Gated deep-dive — treasury stance,
- *      philosophy, endorsements, similar DReps, tabbed analysis.
+ * Two rendering modes based on viewer alignment data:
+ * - Decision Engine: alignment-first (viewer has quiz/vote data)
+ * - Discovery Mode: quiz-first (viewer has no alignment data)
  *
- * Anonymous: Ch1 + Ch2 (core only). Citizen+: All chapters. Governance: Ch5 expanded.
+ * Server component handles data fetching; DRepProfileClient manages
+ * the Decision/Discovery toggle client-side.
+ *
+ * Evidence layer (heatmap, record, trajectory, detailed analysis) is
+ * depth-gated and rendered below the Decision Engine / Discovery Mode.
  */
 
 import { notFound } from 'next/navigation';
@@ -58,18 +59,11 @@ const MilestoneBadges = nextDynamic(
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
 );
 import { GovernancePhilosophyEditor } from '@/components/GovernancePhilosophyEditor';
-const SimilarDReps = nextDynamic(
-  () => import('@/components/governada/profiles/SimilarDReps').then((m) => m.SimilarDReps),
-  { loading: () => <div className="h-20 animate-pulse bg-muted rounded-lg" /> },
-);
-import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
 import { DRepDetailedAnalysis } from '@/components/drep/DRepDetailedAnalysis';
 import { DelegationImpactPreview } from '@/components/drep/DelegationImpactPreview';
 import { TrustCard } from '@/components/governada/profiles/TrustCard';
-import { RecordSummaryCard } from '@/components/governada/profiles/RecordSummaryCard';
-import { TrajectoryCard } from '@/components/governada/profiles/TrajectoryCard';
 const CitizenEndorsements = nextDynamic(
   () => import('@/components/engagement/CitizenEndorsements').then((m) => m.CitizenEndorsements),
   { loading: () => <div className="h-20 animate-pulse bg-muted rounded-lg" /> },
@@ -124,6 +118,9 @@ import { createClient } from '@/lib/supabase';
 import { BASE_URL } from '@/lib/constants';
 import { Suspense } from 'react';
 import { SegmentGate } from '@/components/shared/SegmentGate';
+import { computeTrustSignals } from '@/components/governada/profiles/TrustSignals';
+import { DRepProfileClient } from '@/components/governada/profiles/DRepProfileClient';
+import { ActivityHeatmap } from '@/components/ActivityHeatmap';
 
 interface DRepDetailPageProps {
   params: Promise<{ drepId: string }>;
@@ -488,6 +485,17 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     governanceIdentity: drep.governanceIdentity,
   });
 
+  // Compute trust signals server-side for the hero
+  const trustSignals = computeTrustSignals({
+    effectiveParticipation: drep.effectiveParticipation,
+    rationaleRate: drep.rationaleRate,
+    reliabilityStreak: drep.reliabilityStreak,
+    reliabilityRecency: drep.reliabilityRecency,
+    delegatorCount: drep.delegatorCount,
+    profileCompleteness: drep.profileCompleteness,
+    metadataHashVerified: drep.metadataHashVerified,
+  });
+
   // Phase B: Statements tab — shows vote explanations, positions, epoch updates, and Q&A
   // For DRep owners, also shows a "Write Statement" button
   const statementsContent = <DRepStatementsTab drepId={drep.drepId} />;
@@ -537,10 +545,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       />
 
       {/* ════════════════════════════════════════════
-          VP1 — "The Story" (above fold)
+          HERO — Slimmed with TrustSignals for citizens
           ════════════════════════════════════════════ */}
-
-      {/* ── Chapter 1: The Story (Hero) ── */}
       <DRepProfileHero
         name={drepName}
         score={drep.drepScore}
@@ -551,6 +557,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         traitTags={traitTags}
         isActive={drep.isActive}
         matchScore={matchScore}
+        trustSignals={trustSignals}
+        tier={tierProgress.currentTier}
         narrative={generateDRepNarrative({
           name: drepName,
           participationRate: drep.effectiveParticipation,
@@ -573,7 +581,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         <WatchEntityButton entityType="drep" entityId={drep.drepId} />
       </DRepProfileHero>
 
-      {/* 3. Tier Progress + Momentum — governance participants only */}
+      {/* Tier Progress + Momentum — governance participants only */}
       {isViewerAuthenticated && tierProgress.pointsToNext != null && (
         <SegmentGate show={['drep', 'spo', 'cc']}>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-4 sm:px-5 py-3">
@@ -606,21 +614,45 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         </SegmentGate>
       )}
 
-      {/* ── Chapter 2: Trust at a Glance ── */}
-      <TrustCard
-        score={drep.drepScore}
-        percentile={percentile}
-        identityLabel={identityLabel}
-        participationRate={drep.effectiveParticipation}
-        rationaleRate={drep.rationaleRate}
-        spoAlignPct={spoAlignPct}
-        endorsementCount={endorsementCount}
-        totalVotes={drep.totalVotes}
-        yesVotes={drep.yesVotes}
-        noVotes={drep.noVotes}
-        abstainVotes={drep.abstainVotes}
+      {/* ════════════════════════════════════════════
+          DECISION ENGINE / DISCOVERY MODE
+          Client component manages the toggle between modes.
+          Evidence layer (heatmap, record, trajectory) is inside.
+          ════════════════════════════════════════════ */}
+      <DRepProfileClient
         drepId={drep.drepId}
+        drepName={drepName}
+        drepScore={drep.drepScore}
+        delegatorCount={drep.delegatorCount}
+        endorsementCount={endorsementCount}
+        participationRate={drep.effectiveParticipation}
+        tier={tierProgress.currentTier}
+        scoreHistory={scoreHistory}
+        delegationTrend={delegationTrend}
+        currentScore={drep.drepScore}
+        scoreMomentum={drep.scoreMomentum}
+        votingPowerFormatted={formatAda(drep.votingPower)}
+        totalVotes={drep.totalVotes}
+        rationaleRate={drep.rationaleRate}
       />
+
+      {/* ── Trust Card — governance participants view (preserved for governance depth) ── */}
+      <SegmentGate show={['drep', 'spo', 'cc']}>
+        <TrustCard
+          score={drep.drepScore}
+          percentile={percentile}
+          identityLabel={identityLabel}
+          participationRate={drep.effectiveParticipation}
+          rationaleRate={drep.rationaleRate}
+          spoAlignPct={spoAlignPct}
+          endorsementCount={endorsementCount}
+          totalVotes={drep.totalVotes}
+          yesVotes={drep.yesVotes}
+          noVotes={drep.noVotes}
+          abstainVotes={drep.abstainVotes}
+          drepId={drep.drepId}
+        />
+      </SegmentGate>
 
       {/* ── Delegation Impact Preview — undelegated citizens only ── */}
       <DelegationImpactPreview
@@ -632,7 +664,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         delegatorCount={drep.delegatorCount}
       />
 
-      {/* 5. Identity metadata row — governance participants only */}
+      {/* Identity metadata row — governance participants only */}
       <SegmentGate show={['drep', 'spo', 'cc']}>
         <div className="flex items-center gap-2 sm:gap-3 flex-wrap text-sm text-muted-foreground overflow-hidden">
           {drep.ticker && (
@@ -691,24 +723,6 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         </div>
       </SegmentGate>
 
-      {/* ── Chapter 3: The Record — public data, visible to all ── */}
-      <RecordSummaryCard
-        drepId={drep.drepId}
-        totalVotes={drep.totalVotes}
-        participationRate={drep.effectiveParticipation}
-        rationaleRate={drep.rationaleRate}
-      />
-
-      {/* ── Chapter 4: Trajectory — public data, visible to all ── */}
-      <TrajectoryCard
-        scoreHistory={scoreHistory}
-        delegationTrend={delegationTrend}
-        currentScore={drep.drepScore}
-        scoreMomentum={drep.scoreMomentum}
-        delegatorCount={drep.delegatorCount}
-        votingPowerFormatted={formatAda(drep.votingPower)}
-      />
-
       {/* ── Citizen Endorsements — visible to all (social proof) ── */}
       <CitizenEndorsements entityType="drep" entityId={drep.drepId} />
 
@@ -720,7 +734,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         references={drep.metadata?.references as Array<{ uri: string; label?: string }> | undefined}
       />
 
-      {/* 7. Dashboard wrapper — hidden for anonymous (claim prompt confuses non-DReps) */}
+      {/* Dashboard wrapper — hidden for anonymous (claim prompt confuses non-DReps) */}
       <SegmentGate hide={['anonymous']}>
         <Suspense fallback={null}>
           <DRepDashboardWrapper drepId={drep.drepId} drepName={drepName} isClaimed={isClaimed} />
@@ -741,9 +755,6 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
 
         {/* Citizen Endorsements — interactive version for detailed analysis */}
         <CitizenEndorsements entityType="drep" entityId={drep.drepId} />
-
-        {/* Similar DReps */}
-        <SimilarDReps drepId={drep.drepId} />
 
         {/* ════════════════════════════════════════════
             VP2 — "The Record" (below fold, tabbed)

--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -17,6 +17,7 @@ import { cn } from '@/lib/utils';
 import { Users, TrendingUp, Award } from 'lucide-react';
 import { MatchContextBadge } from '@/components/matching/MatchContextBadge';
 import { useSegment } from '@/components/providers/SegmentProvider';
+import { TrustSignals, type TrustSignal } from '@/components/governada/profiles/TrustSignals';
 
 interface DRepProfileHeroProps {
   name: string;
@@ -30,6 +31,10 @@ interface DRepProfileHeroProps {
   matchScore?: number | null;
   narrative?: string | null;
   narrativeAccentColor?: string;
+  /** Trust signals for the Decision Engine display */
+  trustSignals?: TrustSignal[];
+  /** Tier label (e.g. 'Gold', 'Silver') */
+  tier?: string;
   children?: React.ReactNode;
 }
 
@@ -45,6 +50,8 @@ export function DRepProfileHero({
   matchScore,
   narrative,
   narrativeAccentColor,
+  trustSignals,
+  tier,
   children,
 }: DRepProfileHeroProps) {
   const { segment } = useSegment();
@@ -87,6 +94,11 @@ export function DRepProfileHero({
                 </p>
               )}
             </div>
+
+            {/* Trust Signals — replaces raw score for citizens */}
+            {trustSignals && tier && !isGovernanceParticipant && (
+              <TrustSignals tier={tier} signals={trustSignals} />
+            )}
 
             {/* AI narrative summary — above the fold */}
             {narrative && (
@@ -151,14 +163,16 @@ export function DRepProfileHero({
             {children && <div className="pt-2 flex flex-wrap gap-2">{children}</div>}
           </motion.div>
 
-          {/* Right: Signature visuals — radar for governance participants, score for others */}
+          {/* Right: Signature visuals — radar for governance participants, trust signals already shown for citizens */}
           <motion.div
             className="flex items-center justify-center lg:justify-end"
             variants={fadeInUp}
           >
             {isGovernanceParticipant ? (
               <GovernanceRadar alignments={alignments} size="full" centerScore={score} />
-            ) : (
+            ) : // For citizens: no big score number — TrustSignals shown inline above
+            // Show a compact tier + personality visual instead
+            trustSignals && tier ? null : (
               <div className="flex flex-col items-center justify-center px-6">
                 <div
                   className="text-6xl font-bold font-mono tabular-nums"

--- a/components/governada/profiles/AlignmentCard.tsx
+++ b/components/governada/profiles/AlignmentCard.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import type { ProposalAlignmentResult } from '@/lib/matching/proposalAlignment';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+interface AlignmentCardProps {
+  result: ProposalAlignmentResult;
+  type: 'agreement' | 'disagreement';
+  className?: string;
+}
+
+/* ─── Vote badge styling ──────────────────────────────── */
+
+const VOTE_BADGE: Record<string, { className: string }> = {
+  Yes: {
+    className: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
+  },
+  No: { className: 'bg-rose-500/15 text-rose-600 dark:text-rose-400 border-rose-500/30' },
+  Abstain: { className: 'bg-muted text-muted-foreground border-border' },
+};
+
+/* ─── Component ───────────────────────────────────────── */
+
+export function AlignmentCard({ result, type, className }: AlignmentCardProps) {
+  const borderColor =
+    type === 'agreement'
+      ? 'border-l-emerald-500 dark:border-l-emerald-400'
+      : 'border-l-amber-500 dark:border-l-amber-400';
+
+  const voteBadge = VOTE_BADGE[result.drepVote] ?? VOTE_BADGE.Abstain;
+
+  const isHighConfidence = result.stanceConfidence >= 60;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border/50 border-l-[3px] bg-card/50 px-4 py-3 space-y-1.5',
+        borderColor,
+        className,
+      )}
+    >
+      {/* Proposal title */}
+      <p className="text-sm font-medium text-foreground leading-snug line-clamp-2">
+        {result.proposalTitle}
+      </p>
+
+      {/* Badges row: vote + dimension */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className={cn('text-[10px] px-1.5 py-0', voteBadge.className)}>
+          {result.drepVote}
+        </Badge>
+        <span className="text-[10px] text-muted-foreground">{result.dimension}</span>
+      </div>
+
+      {/* Reason */}
+      <p className="text-xs text-muted-foreground leading-relaxed">{result.reason}</p>
+
+      {/* Confidence indicator */}
+      <p className="text-[10px] text-muted-foreground/70">
+        {isHighConfidence ? 'High confidence' : 'Approximate'}
+      </p>
+    </div>
+  );
+}

--- a/components/governada/profiles/DRepProfileClient.tsx
+++ b/components/governada/profiles/DRepProfileClient.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import type { AlignmentSummary } from '@/lib/matching/proposalAlignment';
+import type { DelegationSimulation } from '@/lib/matching/delegationSimulation';
+import type { TrustSignal } from './TrustSignals';
+import { loadMatchProfile, saveMatchProfile, type StoredMatchProfile } from '@/lib/matchStore';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { DepthGate } from '@/components/providers/DepthGate';
+import { DecisionEngine } from './DecisionEngine';
+import { DiscoveryMode } from './DiscoveryMode';
+import { ActivityHeatmap } from '@/components/ActivityHeatmap';
+import { RecordSummaryCard } from './RecordSummaryCard';
+import { TrajectoryCard } from './TrajectoryCard';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+interface AlignmentResponse {
+  alignment: AlignmentSummary | null;
+  simulation: DelegationSimulation | null;
+  comparison: null;
+  trustSignals: TrustSignal[];
+}
+
+export interface DRepProfileClientProps {
+  drepId: string;
+  drepName: string;
+  drepScore: number;
+  delegatorCount: number;
+  endorsementCount: number;
+  participationRate: number;
+  tier: string;
+  /** Data for the evidence layer */
+  scoreHistory: { date: string; score: number }[];
+  delegationTrend: { epoch: number; votingPowerAda: number; delegatorCount: number }[];
+  currentScore: number;
+  scoreMomentum: number | null;
+  votingPowerFormatted: string;
+  totalVotes: number;
+  rationaleRate: number;
+}
+
+/* ─── Alignment fetcher ───────────────────────────────── */
+
+async function fetchAlignment(
+  drepId: string,
+  userAlignment: AlignmentScores,
+): Promise<AlignmentResponse> {
+  const res = await fetch(`/api/drep/${encodeURIComponent(drepId)}/alignment`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userAlignment }),
+  });
+  if (!res.ok) throw new Error(`Alignment API error: ${res.status}`);
+  return res.json();
+}
+
+/* ─── Delegation trend classifier ─────────────────────── */
+
+function classifyDelegationTrend(
+  trend: { epoch: number; delegatorCount: number }[],
+): 'growing' | 'stable' | 'declining' {
+  if (trend.length < 2) return 'stable';
+  const latest = trend[trend.length - 1];
+  const previous = trend[trend.length - 2];
+  if (!latest || !previous || previous.delegatorCount === 0) return 'stable';
+  const change =
+    ((latest.delegatorCount - previous.delegatorCount) / previous.delegatorCount) * 100;
+  if (change > 5) return 'growing';
+  if (change < -5) return 'declining';
+  return 'stable';
+}
+
+/* ─── Component ───────────────────────────────────────── */
+
+export function DRepProfileClient({
+  drepId,
+  drepName,
+  drepScore: _drepScore,
+  delegatorCount,
+  endorsementCount,
+  participationRate,
+  tier,
+  scoreHistory,
+  delegationTrend,
+  currentScore,
+  scoreMomentum,
+  votingPowerFormatted,
+  totalVotes,
+  rationaleRate,
+}: DRepProfileClientProps) {
+  const { delegatedDrep } = useSegment();
+
+  // Check localStorage for existing quiz results
+  const [localAlignment, setLocalAlignment] = useState<AlignmentScores | null>(() => {
+    if (typeof window === 'undefined') return null;
+    const profile = loadMatchProfile();
+    return profile?.userAlignments ?? null;
+  });
+
+  // Hash alignment for stable cache key
+  const alignmentHash = useMemo(() => {
+    if (!localAlignment) return null;
+    return JSON.stringify(localAlignment);
+  }, [localAlignment]);
+
+  // Fetch alignment data from API when user has alignment scores
+  const { data: alignmentData, isLoading: alignmentLoading } = useQuery<AlignmentResponse>({
+    queryKey: ['drep-alignment', drepId, alignmentHash],
+    queryFn: () => fetchAlignment(drepId, localAlignment!),
+    enabled: !!localAlignment,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  // Handle quiz completion — transition from Discovery to Decision Engine
+  const handleMatchComplete = useCallback((alignment: AlignmentScores) => {
+    // Save to localStorage (match existing pattern)
+    saveMatchProfile({
+      userAlignments: alignment,
+      personalityLabel: '',
+      identityColor: '',
+      matchType: 'drep',
+      answers: {},
+      timestamp: Date.now(),
+    } satisfies StoredMatchProfile);
+
+    // Update local state to trigger Decision Engine mode
+    setLocalAlignment(alignment);
+  }, []);
+
+  // Determine rendering mode
+  const hasAlignment = !!localAlignment;
+  const hasAlignmentData = !!alignmentData?.alignment;
+
+  // Build comparison data for ComparisonStrip
+  // TODO: In the future, fetch comparison DRep data from the API
+  // For now, comparison is null (the strip will not render)
+  const comparisonDrep = null;
+  const comparisonType = delegatedDrep ? ('current_drep' as const) : null;
+
+  const viewingDrepData = {
+    drepId,
+    name: drepName,
+    alignment: alignmentData?.alignment?.overallAlignment ?? null,
+    participationRate,
+    tier,
+  };
+
+  const trendLabel = classifyDelegationTrend(delegationTrend);
+
+  return (
+    <div className="space-y-6">
+      {/* ── Decision Engine or Discovery Mode ── */}
+      {hasAlignment ? (
+        alignmentLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            <span className="ml-2 text-sm text-muted-foreground">Calculating alignment...</span>
+          </div>
+        ) : hasAlignmentData ? (
+          <DecisionEngine
+            drepId={drepId}
+            drepName={drepName}
+            alignment={alignmentData!.alignment!}
+            simulation={alignmentData!.simulation}
+            comparisonDrep={comparisonDrep}
+            comparisonType={comparisonType}
+            viewingDrepData={viewingDrepData}
+          />
+        ) : (
+          // Has alignment but API returned no data (e.g., DRep has no classified votes)
+          <DiscoveryMode
+            drepId={drepId}
+            drepName={drepName}
+            delegatorCount={delegatorCount}
+            endorsementCount={endorsementCount}
+            delegationTrend={trendLabel}
+            onMatchComplete={handleMatchComplete}
+          />
+        )
+      ) : (
+        <DiscoveryMode
+          drepId={drepId}
+          drepName={drepName}
+          delegatorCount={delegatorCount}
+          endorsementCount={endorsementCount}
+          delegationTrend={trendLabel}
+          onMatchComplete={handleMatchComplete}
+        />
+      )}
+
+      {/* ── Evidence Layer (depth-gated) ── */}
+      <DepthGate minDepth="informed">
+        <ActivityHeatmap drepId={drepId} />
+      </DepthGate>
+
+      <DepthGate minDepth="informed">
+        <RecordSummaryCard
+          drepId={drepId}
+          totalVotes={totalVotes}
+          participationRate={participationRate}
+          rationaleRate={rationaleRate}
+        />
+      </DepthGate>
+
+      <DepthGate minDepth="engaged">
+        <TrajectoryCard
+          scoreHistory={scoreHistory}
+          delegationTrend={delegationTrend}
+          currentScore={currentScore}
+          scoreMomentum={scoreMomentum}
+          delegatorCount={delegatorCount}
+          votingPowerFormatted={votingPowerFormatted}
+        />
+      </DepthGate>
+    </div>
+  );
+}

--- a/components/governada/profiles/DecisionEngine.tsx
+++ b/components/governada/profiles/DecisionEngine.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Target } from 'lucide-react';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import { DepthGate } from '@/components/providers/DepthGate';
+import { AlignmentCard } from './AlignmentCard';
+import { ComparisonStrip } from './ComparisonStrip';
+import { DelegationSimulationView } from './DelegationSimulationView';
+import type { AlignmentSummary } from '@/lib/matching/proposalAlignment';
+import type { DelegationSimulation } from '@/lib/matching/delegationSimulation';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+interface DecisionEngineProps {
+  drepId: string;
+  drepName: string;
+  alignment: AlignmentSummary;
+  simulation: DelegationSimulation | null;
+  comparisonDrep: {
+    drepId: string;
+    name: string;
+    alignment: number | null;
+    participationRate: number;
+    tier: string;
+  } | null;
+  comparisonType: 'current_drep' | 'top_match' | null;
+  /** Viewing DRep data for the comparison strip */
+  viewingDrepData: {
+    drepId: string;
+    name: string;
+    alignment: number | null;
+    participationRate: number;
+    tier: string;
+  };
+  className?: string;
+}
+
+/* ─── Depth-based card limits ─────────────────────────── */
+
+function getCardLimits(isAtLeast: (t: 'hands_off' | 'informed' | 'engaged' | 'deep') => boolean): {
+  agreements: number;
+  disagreements: number;
+} {
+  if (isAtLeast('deep')) return { agreements: Infinity, disagreements: Infinity };
+  if (isAtLeast('engaged')) return { agreements: 3, disagreements: 2 };
+  if (isAtLeast('informed')) return { agreements: 2, disagreements: 2 };
+  // hands_off: show alignment header + 1 top agreement only
+  return { agreements: 1, disagreements: 0 };
+}
+
+/* ─── Component ───────────────────────────────────────── */
+
+export function DecisionEngine({
+  drepId: _drepId,
+  drepName: _drepName,
+  alignment,
+  simulation,
+  comparisonDrep,
+  comparisonType,
+  viewingDrepData,
+  className,
+}: DecisionEngineProps) {
+  const { isAtLeast } = useGovernanceDepth();
+  const limits = getCardLimits(isAtLeast);
+
+  const visibleAgreements = alignment.topAgreements.slice(
+    0,
+    limits.agreements === Infinity ? undefined : limits.agreements,
+  );
+  const visibleDisagreements = alignment.topDisagreements.slice(
+    0,
+    limits.disagreements === Infinity ? undefined : limits.disagreements,
+  );
+
+  return (
+    <div className={cn('space-y-5', className)}>
+      {/* ── Alignment Header ── */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <Target className="h-4 w-4 text-primary" />
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Alignment with You
+          </span>
+        </div>
+
+        {alignment.overallAlignment !== null && (
+          <div className="space-y-1">
+            <p className="text-2xl font-bold tabular-nums text-foreground">
+              {alignment.overallAlignment}%{' '}
+              <span className="text-base font-normal text-muted-foreground">aligned with you</span>
+            </p>
+            <p className="text-xs text-muted-foreground">{alignment.confidenceLabel}</p>
+          </div>
+        )}
+
+        {/* Narrative */}
+        {alignment.narrative && (
+          <p className="text-sm text-muted-foreground leading-relaxed">{alignment.narrative}</p>
+        )}
+
+        {/* ── Agreement Cards ── */}
+        {visibleAgreements.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Where you agree
+            </p>
+            <div className="space-y-2">
+              {visibleAgreements.map((result) => (
+                <AlignmentCard key={result.proposalId} result={result} type="agreement" />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Disagreement Cards ── */}
+        {visibleDisagreements.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Where you differ
+            </p>
+            <div className="space-y-2">
+              {visibleDisagreements.map((result) => (
+                <AlignmentCard key={result.proposalId} result={result} type="disagreement" />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* ── Comparison Strip ── */}
+      <DepthGate minDepth="informed">
+        <ComparisonStrip
+          viewingDrep={viewingDrepData}
+          comparisonDrep={comparisonDrep}
+          comparisonType={comparisonType}
+        />
+      </DepthGate>
+
+      {/* ── Delegation Simulation ── */}
+      {simulation && simulation.totalProposals > 0 && (
+        <DepthGate minDepth="engaged">
+          <DelegationSimulationView simulation={simulation} />
+        </DepthGate>
+      )}
+    </div>
+  );
+}

--- a/components/governada/profiles/DelegationSimulationView.tsx
+++ b/components/governada/profiles/DelegationSimulationView.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronUp, Vote, CheckCircle2, Clock, XCircle } from 'lucide-react';
+import type { DelegationSimulation, SimulatedVote } from '@/lib/matching/delegationSimulation';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+interface DelegationSimulationViewProps {
+  simulation: DelegationSimulation;
+  className?: string;
+}
+
+/* ─── Vote outcome styling ────────────────────────────── */
+
+const OUTCOME_BADGE: Record<string, { className: string; icon: typeof CheckCircle2 }> = {
+  Enacted: {
+    className: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
+    icon: CheckCircle2,
+  },
+  Expired: {
+    className: 'bg-rose-500/15 text-rose-600 dark:text-rose-400 border-rose-500/30',
+    icon: XCircle,
+  },
+  Dropped: {
+    className: 'bg-rose-500/15 text-rose-600 dark:text-rose-400 border-rose-500/30',
+    icon: XCircle,
+  },
+  Pending: {
+    className: 'bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/30',
+    icon: Clock,
+  },
+};
+
+const VOTE_BADGE: Record<string, string> = {
+  Yes: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30',
+  No: 'bg-rose-500/15 text-rose-600 dark:text-rose-400 border-rose-500/30',
+  Abstain: 'bg-muted text-muted-foreground border-border',
+};
+
+const ALIGNMENT_INDICATOR: Record<string, { label: string; className: string }> = {
+  agree: { label: 'Aligned', className: 'text-emerald-600 dark:text-emerald-400' },
+  disagree: { label: 'Differs', className: 'text-amber-600 dark:text-amber-400' },
+  neutral: { label: 'Neutral', className: 'text-muted-foreground' },
+};
+
+/* ─── Single vote row ────────────────────────────────── */
+
+function SimulatedVoteRow({ vote }: { vote: SimulatedVote }) {
+  const outcome = OUTCOME_BADGE[vote.outcome] ?? OUTCOME_BADGE.Pending;
+  const OutcomeIcon = outcome.icon;
+  const voteBadge = VOTE_BADGE[vote.drepVote] ?? VOTE_BADGE.Abstain;
+  const alignmentInfo = vote.alignmentWithUser ? ALIGNMENT_INDICATOR[vote.alignmentWithUser] : null;
+
+  return (
+    <div className="flex items-start gap-3 py-2 border-b border-border/30 last:border-b-0">
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <p className="text-xs font-medium text-foreground truncate">{vote.proposalTitle}</p>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className={cn('text-[10px] px-1.5 py-0', voteBadge)}>
+            {vote.drepVote}
+          </Badge>
+          <Badge variant="outline" className={cn('text-[10px] px-1.5 py-0', outcome.className)}>
+            <OutcomeIcon className="h-2.5 w-2.5 mr-0.5" />
+            {vote.outcome}
+          </Badge>
+          {vote.deliveryStatus && vote.deliveryStatus !== 'in_progress' && (
+            <span className="text-[10px] text-muted-foreground">
+              {vote.deliveryStatus === 'delivered'
+                ? 'Delivered'
+                : vote.deliveryStatus === 'partial'
+                  ? 'Partial'
+                  : 'Not delivered'}
+            </span>
+          )}
+          {alignmentInfo && (
+            <span className={cn('text-[10px] font-medium', alignmentInfo.className)}>
+              {alignmentInfo.label}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Main component ──────────────────────────────────── */
+
+export function DelegationSimulationView({ simulation, className }: DelegationSimulationViewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { isAtLeast } = useGovernanceDepth();
+
+  // Deep depth shows full list, engaged shows summary only
+  const showFullList = isAtLeast('deep');
+
+  const alignmentPct =
+    simulation.totalClassifiedVotes > 0
+      ? Math.round((simulation.alignedVoteCount / simulation.totalClassifiedVotes) * 100)
+      : null;
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-5 space-y-4',
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Vote className="h-4 w-4 text-primary" />
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          If You Had Delegated
+        </span>
+      </div>
+
+      {/* Period */}
+      <p className="text-xs text-muted-foreground">{simulation.periodLabel}</p>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="rounded-lg border border-border/50 bg-card/50 p-3 text-center">
+          <p className="text-xs text-muted-foreground">Proposals</p>
+          <p className="text-lg font-bold tabular-nums">{simulation.totalProposals}</p>
+        </div>
+        <div className="rounded-lg border border-border/50 bg-card/50 p-3 text-center">
+          <p className="text-xs text-muted-foreground">DRep Voted</p>
+          <p className="text-lg font-bold tabular-nums">
+            {simulation.drepVotedOn}
+            {simulation.totalProposals > 0 && (
+              <span className="text-xs font-normal text-muted-foreground ml-1">
+                ({Math.round((simulation.drepVotedOn / simulation.totalProposals) * 100)}%)
+              </span>
+            )}
+          </p>
+        </div>
+        {alignmentPct !== null && (
+          <div className="rounded-lg border border-border/50 bg-card/50 p-3 text-center">
+            <p className="text-xs text-muted-foreground">Aligned</p>
+            <p className="text-lg font-bold tabular-nums">
+              {simulation.alignedVoteCount}
+              <span className="text-xs font-normal text-muted-foreground ml-1">
+                ({alignmentPct}%)
+              </span>
+            </p>
+          </div>
+        )}
+        {simulation.enactedCount > 0 && (
+          <div className="rounded-lg border border-border/50 bg-card/50 p-3 text-center">
+            <p className="text-xs text-muted-foreground">Enacted</p>
+            <p className="text-lg font-bold tabular-nums">
+              {simulation.enactedCount}
+              {simulation.deliverySuccessRate !== null && (
+                <span className="text-xs font-normal text-muted-foreground ml-1">
+                  ({simulation.deliverySuccessRate}% delivered)
+                </span>
+              )}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Delivery coverage note */}
+      {simulation.deliveryCoverage && (
+        <p className="text-[10px] text-muted-foreground">{simulation.deliveryCoverage}</p>
+      )}
+
+      {/* Expandable vote list — deep depth only */}
+      {showFullList && simulation.simulatedVotes.length > 0 && (
+        <div className="space-y-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded(!expanded)}
+            className="gap-1.5 text-xs text-muted-foreground hover:text-foreground p-0 h-auto"
+          >
+            {expanded ? (
+              <>
+                <ChevronUp className="h-3.5 w-3.5" />
+                Hide proposals
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3.5 w-3.5" />
+                Show all {simulation.simulatedVotes.length} proposals
+              </>
+            )}
+          </Button>
+
+          {expanded && (
+            <div className="max-h-96 overflow-y-auto border border-border/30 rounded-lg px-3">
+              {simulation.simulatedVotes.map((vote) => (
+                <SimulatedVoteRow key={vote.proposalId} vote={vote} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/governada/profiles/DiscoveryMode.tsx
+++ b/components/governada/profiles/DiscoveryMode.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Users, TrendingUp, TrendingDown, Minus, Heart } from 'lucide-react';
+import { InlineQuickMatch } from './InlineQuickMatch';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+/* ─── Types ───────────────────────────────────────────── */
+
+interface DiscoveryModeProps {
+  drepId: string;
+  drepName: string;
+  delegatorCount: number;
+  endorsementCount: number;
+  delegationTrend: 'growing' | 'stable' | 'declining';
+  onMatchComplete: (alignment: AlignmentScores) => void;
+  className?: string;
+}
+
+/* ─── Trend display ───────────────────────────────────── */
+
+const TREND_CONFIG = {
+  growing: { icon: TrendingUp, label: 'Growing this epoch', className: 'text-emerald-500' },
+  stable: { icon: Minus, label: 'Stable this epoch', className: 'text-muted-foreground' },
+  declining: { icon: TrendingDown, label: 'Declining this epoch', className: 'text-amber-500' },
+} as const;
+
+/* ─── Component ───────────────────────────────────────── */
+
+export function DiscoveryMode({
+  drepId,
+  drepName,
+  delegatorCount,
+  endorsementCount,
+  delegationTrend,
+  onMatchComplete,
+  className,
+}: DiscoveryModeProps) {
+  const { isAtLeast } = useGovernanceDepth();
+
+  // Deep depth users are assumed to have alignment data already;
+  // don't show quiz for them (per depth gating table)
+  if (isAtLeast('deep')) return null;
+
+  const trend = TREND_CONFIG[delegationTrend];
+  const TrendIcon = trend.icon;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* ── Inline Quick Match ── */}
+      <InlineQuickMatch drepName={drepName} drepId={drepId} onMatchComplete={onMatchComplete} />
+
+      {/* ── Social Proof Section ── */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md px-5 py-4 space-y-2">
+        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Users className="h-4 w-4 text-primary/70" />
+            <span className="font-medium text-foreground tabular-nums">
+              {delegatorCount.toLocaleString()}
+            </span>{' '}
+            citizens have delegated
+          </span>
+          <span className={cn('flex items-center gap-1', trend.className)}>
+            <TrendIcon className="h-3.5 w-3.5" />
+            <span className="text-xs">{trend.label}</span>
+          </span>
+        </div>
+
+        {endorsementCount > 0 && (
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Heart className="h-4 w-4 text-primary/70" />
+            <span className="font-medium text-foreground tabular-nums">
+              {endorsementCount}
+            </span>{' '}
+            citizen endorsements
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Rebuild DRep profile page with two rendering modes: Decision Engine (alignment-first) and Discovery Mode (quiz-first)
- New components: DecisionEngine, DiscoveryMode, AlignmentCard, DelegationSimulationView, DRepProfileClient
- Slimmed hero with TrustSignals replacing raw score display for citizens
- Depth-gated progressive disclosure across all sections
- Client-side transition from Discovery to Decision Engine on quiz completion
- Score display moved to DRep dashboard only (accountability flywheel preserved)

## Impact
- **What changed**: Major DRep profile page restructure — alignment leads, score qualifies
- **User-facing**: Yes — citizens see fundamentally different profile experience
- **Risk**: Medium — major page restructure, but all data fetching preserved
- **Scope**: 5 new files, 2 major modifications (page.tsx, hero), several minor modifications

## Test plan
- [ ] Decision Engine mode renders with alignment data
- [ ] Discovery Mode renders without alignment data
- [ ] Quiz completion transitions to Decision Engine
- [ ] Depth gating works at all 4 levels
- [ ] DRep owner still sees dashboard features
- [ ] Governance participants see full detail
- [ ] Mobile responsive
- [ ] `npm run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)