### PR TITLE
feat: alignment-weighted default sort for DRep discover

### DIFF
--- a/components/governada/cards/GovernadaDRepCard.tsx
+++ b/components/governada/cards/GovernadaDRepCard.tsx
@@ -165,6 +165,15 @@ export function GovernadaDRepCard({
           </div>
         )}
 
+        {/* ── Limited track record warning for Emerging DReps (score < 30) ── */}
+        {score < 30 && (
+          <div className="mb-3">
+            <span className="text-[10px] font-medium text-amber-600 dark:text-amber-400/80 bg-amber-500/10 px-1.5 py-0.5 rounded-full">
+              Limited track record
+            </span>
+          </div>
+        )}
+
         {/* ── Footer stats + CTA ──────────────────────────────────── */}
         <div className="mt-auto flex items-center justify-between pt-2 border-t border-border/30">
           <div className="flex items-center gap-2.5 text-[10px] text-muted-foreground">

--- a/components/governada/discover/GovernadaDRepBrowse.tsx
+++ b/components/governada/discover/GovernadaDRepBrowse.tsx
@@ -378,7 +378,9 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
   });
   const [sortMode, setSortMode] = useState<SortMode>(() => {
     if (typeof window === 'undefined') return 'score';
-    return sortParam === 'match' && loadMatchProfile() ? 'match' : 'score';
+    // Default to match sort when user has alignment data (WS-7)
+    if (sortParam === 'score') return 'score';
+    return loadMatchProfile() ? 'match' : 'score';
   });
 
   const deferredSearch = useDeferredValue(filters.search);
@@ -450,7 +452,7 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
       }
     }
 
-    // Sort by match compatibility if enabled and profile exists
+    // Sort by blended alignment+score when match mode active (WS-7)
     if (sortMode === 'match' && matchProfile) {
       const userAlign = matchProfile.userAlignments;
       result = [...result].sort((a, b) => {
@@ -470,10 +472,12 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
           innovation: b.alignmentInnovation,
           transparency: b.alignmentTransparency,
         };
-        const distDiff =
-          alignmentDistance(userAlign, aAlign) - alignmentDistance(userAlign, bAlign);
-        if (distDiff !== 0) return distDiff;
-        return (b.drepScore ?? 0) - (a.drepScore ?? 0);
+        // Blended score: alignment × 0.7 + normalizedScore × 0.3
+        const aMatchPct = distanceToMatchScore(alignmentDistance(userAlign, aAlign));
+        const bMatchPct = distanceToMatchScore(alignmentDistance(userAlign, bAlign));
+        const aBlended = (aMatchPct / 100) * 0.7 + ((a.drepScore ?? 0) / 100) * 0.3;
+        const bBlended = (bMatchPct / 100) * 0.7 + ((b.drepScore ?? 0) / 100) * 0.3;
+        return bBlended - aBlended;
       });
     }
 
@@ -594,7 +598,7 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
                     )}
                   >
                     <Sparkles className="h-3 w-3" />
-                    {sortMode === 'match' ? 'Sorted by match' : 'Sort by match'}
+                    {sortMode === 'match' ? 'Best Match' : 'Governance Score'}
                   </button>
                   {sortMode === 'match' && (
                     <span className="text-[10px] text-muted-foreground hidden sm:inline">


### PR DESCRIPTION
## Summary
- Default sort on DRep browse/discover now uses alignment-weighted scoring when viewer has Quick Match data
- Blended formula: alignment x 0.7 + score x 0.3 (DReps aligned with viewer surface first)
- Falls back to score-only sort when no alignment data
- "Best Match" label when alignment active, "Governance Score" otherwise
- "Limited track record" indicator for DReps with score < 30

## Impact
- **What changed**: Sort logic in DRep browse
- **User-facing**: Yes -- DReps sorted by alignment match for users who took the quiz
- **Risk**: Low -- additive sort option, existing sort preserved as fallback
- **Scope**: 2 modified files

## Test plan
- [ ] Without quiz data: sorts by score (existing behavior)
- [ ] With quiz data: sorts by blended alignment+score
- [ ] "Limited track record" shows for low-score DReps
- [ ] `npm run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)