### PR TITLE
fix: lazy-load meshsdk to prevent libsodium startup crash

### DIFF
--- a/app/api/auth/wallet/route.ts
+++ b/app/api/auth/wallet/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { checkSignature, DataSignature, resolveRewardAddress } from '@meshsdk/core';
+import type { DataSignature } from '@meshsdk/core';
 import { createSessionToken, SESSION_MAX_AGE_SECONDS } from '@/lib/supabaseAuth';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { verifyNonce } from '@/lib/nonce';
@@ -13,6 +13,10 @@ export const dynamic = 'force-dynamic';
 
 export const POST = withRouteHandler(
   async (request: NextRequest) => {
+    // Lazy-load @meshsdk/core to avoid libsodium initialization crash at server startup.
+    // The WASM/asm.js init in libsodium-wrappers-sumo fails in slim containers when loaded eagerly.
+    const { checkSignature, resolveRewardAddress } = await import('@meshsdk/core');
+
     const body = WalletAuthSchema.parse(await request.json());
     const { address, nonce, nonceSignature, signature, key } = body;
 


### PR DESCRIPTION
## Summary
- Convert top-level `@meshsdk/core` import in wallet auth API route to dynamic `await import()`
- Prevents `libsodium-wrappers-sumo` WASM initialization from running at server startup
- Fixes `unhandledRejection: Error: libsodium was not correctly initialized` crash on Railway deploy

## Impact
- **What changed**: Wallet auth route lazy-loads meshsdk only when called, instead of eagerly at server boot
- **User-facing**: No — wallet auth behavior unchanged, just loading timing
- **Risk**: Low — same code runs, just deferred. Type import preserved for compile-time safety
- **Scope**: `app/api/auth/wallet/route.ts` only

## Root Cause
The `node:20.18-slim` Docker image's standalone Next.js server eagerly loads API route modules at startup. The `@meshsdk/core` → `@meshsdk/provider` → `libsodium-wrappers-sumo` chain triggers WASM/asm.js initialization that fails in the slim container, producing an unhandled rejection that crashes Node.js 20.

## Test plan
- [ ] Preflight passes (confirmed locally)
- [ ] CI build succeeds
- [ ] Railway deploy starts without libsodium crash
- [ ] Wallet authentication still works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)