### PR TITLE
fix: decouple Railway health check from external API availability

### DIFF
--- a/app/api/health/deep/route.ts
+++ b/app/api/health/deep/route.ts
@@ -65,11 +65,13 @@ export const GET = withRouteHandler(
       probeRedis(),
     ]);
 
-    const allHealthy =
-      supabase.status === 'healthy' && koios.status === 'healthy' && redis.status === 'healthy';
+    // Supabase is critical — pages read from it. Redis is nice-to-have (rate-limit
+    // falls back to in-memory). Koios is background-only (Inngest sync jobs).
+    const coreHealthy = supabase.status === 'healthy';
+    const allHealthy = coreHealthy && koios.status === 'healthy' && redis.status === 'healthy';
 
     return NextResponse.json({
-      status: allHealthy ? 'healthy' : 'degraded',
+      status: allHealthy ? 'healthy' : coreHealthy ? 'degraded' : 'critical',
       dependencies: { supabase, koios, redis },
       timestamp: new Date().toISOString(),
     });

--- a/app/api/health/ready/route.ts
+++ b/app/api/health/ready/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Lightweight readiness probe for Railway health checks.
+ *
+ * Only verifies the Next.js server can handle requests.
+ * Does NOT call external services (Koios, Redis) — those are
+ * checked by /api/health/deep for monitoring, not deploy gating.
+ */
+export function GET() {
+  return NextResponse.json({ status: 'ok' }, { status: 200 });
+}

--- a/railway.toml
+++ b/railway.toml
@@ -20,7 +20,7 @@ watchPaths = [
 ]
 
 [deploy]
-healthcheckPath = "/api/health/deep"
+healthcheckPath = "/api/health/ready"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- Railway deploy was failing when Koios (external Cardano API) was unreachable at container startup
- Koios is only used by background Inngest sync jobs — pages serve from Supabase cache
- Created `/api/health/ready` — zero-dependency readiness probe for Railway
- Pointed `railway.toml` to `/api/health/ready` instead of `/api/health/deep`
- Updated `/api/health/deep` to distinguish critical deps (Supabase) from informational ones (Koios, Redis) for monitoring

## Impact
- **What changed**: Railway health check no longer depends on external API availability
- **User-facing**: No — infra resilience improvement
- **Risk**: Low — readiness probe is trivially simple, deep health check is monitoring-only
- **Scope**: `railway.toml`, `app/api/health/ready/route.ts` (new), `app/api/health/deep/route.ts`

## Why this keeps happening
The `/api/health/deep` endpoint required ALL dependencies (Supabase + Koios + Redis) to be healthy. Koios is an external API we don't control. Any transient slowness at the exact moment Railway probes = failed deploy. This is a design flaw — deploy readiness should only check things we control.

## Test plan
- [ ] CI passes (lint, types, tests, build)
- [ ] `curl /api/health/ready` returns `{"status":"ok"}` with 200
- [ ] `curl /api/health/deep` returns meaningful status even if Koios is down
- [ ] Railway deploy succeeds regardless of Koios availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)