### PR TITLE
fix: paginate vote loading to prevent PostgREST row truncation

### DIFF
--- a/inngest/functions/sync-drep-scores.ts
+++ b/inngest/functions/sync-drep-scores.ts
@@ -23,7 +23,7 @@ import {
   type ProposalVotingSummary,
   type DRepProfileData,
 } from '@/lib/scoring';
-import { batchUpsert, SyncLogger, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
+import { batchUpsert, fetchAll, SyncLogger, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 
 export const syncDrepScores = inngest.createFunction(
@@ -58,34 +58,36 @@ export const syncDrepScores = inngest.createFunction(
         // ── Step 1: Load all data ──────────────────────────────────────
         const s1 = Date.now();
 
-        const [
-          { data: drepRows },
-          { data: voteRows },
-          { data: proposalRows },
-          { data: summaryRows },
-        ] = await Promise.all([
-          supabase
-            .from('dreps')
-            .select('id, info, metadata, metadata_hash_verified, anchor_hash')
-            .range(0, 99999),
-          supabase
-            .from('drep_votes')
-            .select(
-              'drep_id, proposal_tx_hash, proposal_index, vote, block_time, epoch_no, rationale_quality',
-            )
-            .range(0, 99999),
-          supabase
-            .from('proposals')
-            .select(
-              'tx_hash, proposal_index, proposal_type, treasury_tier, withdrawal_amount, block_time, proposed_epoch, expired_epoch, ratified_epoch, dropped_epoch',
-            )
-            .range(0, 99999),
-          supabase
-            .from('proposal_voting_summary')
-            .select(
-              'proposal_tx_hash, proposal_index, drep_yes_vote_power, drep_no_vote_power, drep_abstain_vote_power',
-            )
-            .range(0, 99999),
+        // Use fetchAll to paginate past PostgREST row limits.
+        // drep_votes (15K+ rows) was silently truncated by .range(0, 99999),
+        // causing 384+ DReps to get 0 scores despite having votes.
+        const [drepRows, voteRows, proposalRows, summaryRows] = await Promise.all([
+          fetchAll(
+            supabase
+              .from('dreps')
+              .select('id, info, metadata, metadata_hash_verified, anchor_hash'),
+          ),
+          fetchAll(
+            supabase
+              .from('drep_votes')
+              .select(
+                'drep_id, proposal_tx_hash, proposal_index, vote, block_time, epoch_no, rationale_quality',
+              ),
+          ),
+          fetchAll(
+            supabase
+              .from('proposals')
+              .select(
+                'tx_hash, proposal_index, proposal_type, treasury_tier, withdrawal_amount, block_time, proposed_epoch, expired_epoch, ratified_epoch, dropped_epoch',
+              ),
+          ),
+          fetchAll(
+            supabase
+              .from('proposal_voting_summary')
+              .select(
+                'proposal_tx_hash, proposal_index, drep_yes_vote_power, drep_no_vote_power, drep_abstain_vote_power',
+              ),
+          ),
         ]);
 
         if (!drepRows?.length || !voteRows?.length) {
@@ -270,16 +272,17 @@ export const syncDrepScores = inngest.createFunction(
         const s4 = Date.now();
         const drepIds = [...drepVotes.keys()];
 
-        const { data: historyRows } = await supabase
-          .from('drep_score_history')
-          .select('drep_id, snapshot_date, score')
-          .in('drep_id', drepIds)
-          .gte('snapshot_date', new Date(Date.now() - 14 * 86400000).toISOString().slice(0, 10))
-          .order('snapshot_date', { ascending: true })
-          .range(0, 99999);
+        const historyRows = await fetchAll(
+          supabase
+            .from('drep_score_history')
+            .select('drep_id, snapshot_date, score')
+            .in('drep_id', drepIds)
+            .gte('snapshot_date', new Date(Date.now() - 14 * 86400000).toISOString().slice(0, 10))
+            .order('snapshot_date', { ascending: true }),
+        );
 
         const scoreHistory = new Map<string, { date: string; score: number }[]>();
-        for (const h of historyRows || []) {
+        for (const h of historyRows) {
           if (!scoreHistory.has(h.drep_id)) scoreHistory.set(h.drep_id, []);
           scoreHistory.get(h.drep_id)!.push({ date: h.snapshot_date, score: h.score });
         }
@@ -305,11 +308,9 @@ export const syncDrepScores = inngest.createFunction(
 
         // Load existing tiers BEFORE writing new scores so we can detect changes
         const drepIdList = [...finalScores.keys()];
-        const { data: priorDreps } = await supabase
-          .from('dreps')
-          .select('id, score, current_tier')
-          .in('id', drepIdList)
-          .range(0, 99999);
+        const priorDreps = await fetchAll(
+          supabase.from('dreps').select('id, score, current_tier').in('id', drepIdList),
+        );
 
         const oldTierMap = new Map<string, { score: number; tier: string | null }>();
         for (const d of priorDreps || []) {

--- a/inngest/functions/sync-spo-scores.ts
+++ b/inngest/functions/sync-spo-scores.ts
@@ -1,7 +1,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { SyncLogger, batchUpsert, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
+import { SyncLogger, batchUpsert, fetchAll, errMsg, emitPostHog, capMsg } from '@/lib/sync-utils';
 import {
   computeSpoScores,
   computeProposalMarginMultipliers,
@@ -132,29 +132,35 @@ export const syncSpoScores = inngest.createFunction(
       const syncLog = new SyncLogger(supabase, 'spo_scores');
       await syncLog.start();
 
-      const [
-        { data: voteRows },
-        { data: proposalRows },
-        { data: classificationRows },
-        { data: statsRow },
-        { data: poolRows },
-      ] = await Promise.all([
-        supabase
-          .from('spo_votes')
-          .select('pool_id, proposal_tx_hash, proposal_index, vote, block_time, epoch'),
-        supabase
-          .from('proposals')
-          .select(
-            'tx_hash, proposal_index, proposal_type, treasury_tier, withdrawal_amount, block_time, proposed_epoch, expired_epoch, ratified_epoch, dropped_epoch',
-          ),
-        supabase.from('proposal_classifications').select('*'),
-        supabase.from('governance_stats').select('current_epoch').eq('id', 1).single(),
-        supabase
-          .from('pools')
-          .select(
-            'pool_id, ticker, pool_name, governance_statement, homepage_url, social_links, metadata_hash_verified, delegator_count',
-          ),
+      // Use fetchAll to paginate past PostgREST row limits
+      const [voteRows, proposalRows, classificationRows, poolRows] = await Promise.all([
+        fetchAll(
+          supabase
+            .from('spo_votes')
+            .select('pool_id, proposal_tx_hash, proposal_index, vote, block_time, epoch'),
+        ),
+        fetchAll(
+          supabase
+            .from('proposals')
+            .select(
+              'tx_hash, proposal_index, proposal_type, treasury_tier, withdrawal_amount, block_time, proposed_epoch, expired_epoch, ratified_epoch, dropped_epoch',
+            ),
+        ),
+        fetchAll(supabase.from('proposal_classifications').select('*')),
+        fetchAll(
+          supabase
+            .from('pools')
+            .select(
+              'pool_id, ticker, pool_name, governance_statement, homepage_url, social_links, metadata_hash_verified, delegator_count',
+            ),
+        ),
       ]);
+
+      const { data: statsRow } = await supabase
+        .from('governance_stats')
+        .select('current_epoch')
+        .eq('id', 1)
+        .single();
 
       const currentEpoch =
         statsRow?.current_epoch ?? blockTimeToEpoch(Math.floor(Date.now() / 1000));


### PR DESCRIPTION
## Summary
- **Root cause**: `sync-drep-scores` and `sync-spo-scores` loaded votes with `.range(0, 99999)`, which is silently capped by PostgREST's `max_rows` setting. With 15,810+ DRep votes, the query was truncated.
- **Impact**: 384 DReps received 0 raw scores despite having 10-83 votes each. Even "active" DReps got artificially low Effective Participation (e.g., 17% raw for a DRep who voted on 90/93 proposals). This cascaded to low composite scores across the platform.
- **Fix**: Switches all large-table loads to the existing `fetchAll()` paginated helper (already in `sync-utils.ts`) that fetches in 1000-row pages until exhaustion.

## Impact
- **What changed**: Inngest score sync functions now use paginated data loading instead of single ranged queries
- **User-facing**: Yes — DRep and SPO scores will rise significantly to reflect actual governance participation. ~384 DReps will go from 0 to their correct scores.
- **Risk**: Low — uses existing, tested `fetchAll()` utility. No schema changes. Scoring logic unchanged.
- **Scope**: `inngest/functions/sync-drep-scores.ts`, `inngest/functions/sync-spo-scores.ts`

## Test plan
- [ ] CI passes (lint, types, tests)
- [ ] After merge + deploy, trigger DRep score resync via Inngest
- [ ] Verify composite_avg in snapshot_completeness_log rises from 12 to ~50+
- [ ] Verify top DRep scores reach 80+ range
- [ ] Verify 384 previously-zero DReps now have proper scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)