### PR TITLE
fix: streamline mobile wallet connection and fix tour overlay interaction

### DIFF
--- a/components/WalletConnectModal.tsx
+++ b/components/WalletConnectModal.tsx
@@ -38,6 +38,17 @@ type Step = 'connect' | 'sign' | 'push' | 'success';
 
 const PREFERRED_WALLETS = ['eternl', 'lace', 'nami', 'typhon', 'vespr'];
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 640);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+  return isMobile;
+}
+
 function sortWallets(wallets: string[]): string[] {
   return [...wallets].sort((a, b) => {
     const aIdx = PREFERRED_WALLETS.indexOf(a.toLowerCase());
@@ -67,6 +78,7 @@ export function WalletConnectModal({
     disconnect,
   } = useWallet();
 
+  const isMobile = useIsMobile();
   const [step, setStep] = useState<Step>('connect');
   const [authenticating, setAuthenticating] = useState(false);
   const [pushRequested, setPushRequested] = useState(false);
@@ -84,23 +96,35 @@ export function WalletConnectModal({
     posthog.capture('wallet_selected', { wallet_name: walletName });
     clearError();
     setSelectedWallet(walletName);
-    await connect(walletName);
+    try {
+      await connect(walletName);
+    } catch {
+      // connect() sets error state internally via categorizeError;
+      // this catch prevents unhandled promise rejections from surfacing as silent failures
+    }
   };
 
   // Auto-authenticate once wallet connects — skip the manual sign step.
-  // The wallet extension will prompt the user to sign immediately after connection.
+  // On mobile: stay on "connect" step visually (shows inline loading) to reduce perceived steps.
+  // On desktop: advance to "sign" step for the full verification UI.
   useEffect(() => {
     if (connected && address && !error && step === 'connect') {
-      setStep('sign');
+      if (!isMobile) setStep('sign');
       // Auto-trigger authentication so user doesn't land in connected-but-not-authenticated state
       (async () => {
         clearError();
         setAuthenticating(true);
-        const success = await authenticate();
-        setAuthenticating(false);
-        if (success) {
-          posthog.capture('wallet_authenticated', { wallet_name: selectedWallet });
-          setStep(skipPushPrompt ? 'success' : 'push');
+        try {
+          const success = await authenticate();
+          if (success) {
+            posthog.capture('wallet_authenticated', { wallet_name: selectedWallet });
+            // On mobile, skip push prompt entirely to reduce steps
+            setStep(skipPushPrompt || isMobile ? 'success' : 'push');
+          }
+        } catch {
+          // authenticate() sets error state internally; no additional handling needed
+        } finally {
+          setAuthenticating(false);
         }
       })();
     }
@@ -110,7 +134,11 @@ export function WalletConnectModal({
   const handleTryAgain = async () => {
     clearError();
     if (selectedWallet) {
-      await connect(selectedWallet);
+      try {
+        await connect(selectedWallet);
+      } catch {
+        // connect() sets error state internally
+      }
     }
   };
 
@@ -124,12 +152,16 @@ export function WalletConnectModal({
   const handleSign = async () => {
     clearError();
     setAuthenticating(true);
-    const success = await authenticate();
-    setAuthenticating(false);
-
-    if (success) {
-      posthog.capture('wallet_authenticated', { wallet_name: selectedWallet });
-      setStep(skipPushPrompt ? 'success' : 'push');
+    try {
+      const success = await authenticate();
+      if (success) {
+        posthog.capture('wallet_authenticated', { wallet_name: selectedWallet });
+        setStep(skipPushPrompt || isMobile ? 'success' : 'push');
+      }
+    } catch {
+      // authenticate() sets error state internally
+    } finally {
+      setAuthenticating(false);
     }
   };
 
@@ -160,6 +192,15 @@ export function WalletConnectModal({
     setTimeout(() => setStep('connect'), 300);
   };
 
+  // On mobile, auto-close after success to reduce friction
+  useEffect(() => {
+    if (step === 'success' && isMobile) {
+      const timer = setTimeout(handleClose, 1500);
+      return () => clearTimeout(timer);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- handleClose is stable enough for this effect
+  }, [step, isMobile]);
+
   const shortenAddress = (addr: string) => `${addr.slice(0, 8)}...${addr.slice(-6)}`;
 
   return (
@@ -177,51 +218,64 @@ export function WalletConnectModal({
               </DialogDescription>
             </DialogHeader>
 
-            <div className="p-2.5 bg-blue-50 dark:bg-blue-950/30 rounded-lg border border-blue-200 dark:border-blue-900 text-xs text-blue-700 dark:text-blue-300 flex items-start gap-2">
-              <Shield className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-              <span>
-                Read-only signature verification. We never request transactions or access to your
-                funds.
-              </span>
-            </div>
-
-            <div className="space-y-2 py-2">
-              {availableWallets.length > 0 ? (
-                sortWallets(availableWallets).map((walletName) => (
-                  <Button
-                    key={walletName}
-                    variant="outline"
-                    className="w-full justify-start gap-2 h-12"
-                    onClick={() => handleWalletSelect(walletName)}
-                    disabled={connecting}
-                  >
-                    {connecting ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <Wallet className="h-4 w-4" />
-                    )}
-                    <span className="capitalize">{walletName}</span>
-                  </Button>
-                ))
-              ) : (
-                <div className="text-center py-6 space-y-4">
-                  <div className="text-muted-foreground">
-                    <Wallet className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                    <p className="font-medium text-foreground">No Cardano wallets detected</p>
-                    <p className="text-sm mt-1">
-                      You need a Cardano wallet extension to connect. We&apos;ll help you get set
-                      up.
-                    </p>
-                  </div>
-                  <Button asChild className="w-full">
-                    <Link href="/get-started" onClick={() => onOpenChange(false)}>
-                      <ExternalLink className="h-4 w-4 mr-2" />
-                      Get started with a wallet
-                    </Link>
-                  </Button>
+            {/* Mobile: show inline loading state during auto-authentication */}
+            {isMobile && authenticating ? (
+              <div className="py-8 text-center space-y-3">
+                <Loader2 className="h-8 w-8 animate-spin mx-auto text-primary" />
+                <p className="text-sm text-muted-foreground">
+                  Verifying ownership — check your wallet app...
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="p-2.5 bg-blue-50 dark:bg-blue-950/30 rounded-lg border border-blue-200 dark:border-blue-900 text-xs text-blue-700 dark:text-blue-300 flex items-start gap-2">
+                  <Shield className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <span>
+                    Read-only signature verification. We never request transactions or access to
+                    your funds.
+                  </span>
                 </div>
-              )}
-            </div>
+
+                <div className="space-y-2 py-2">
+                  {availableWallets.length > 0 ? (
+                    sortWallets(availableWallets).map((walletName) => (
+                      <Button
+                        key={walletName}
+                        variant="outline"
+                        className="w-full justify-start gap-2 h-12"
+                        onClick={() => handleWalletSelect(walletName)}
+                        disabled={connecting}
+                      >
+                        {connecting ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Wallet className="h-4 w-4" />
+                        )}
+                        <span className="capitalize">{walletName}</span>
+                      </Button>
+                    ))
+                  ) : (
+                    <div className="text-center py-6 space-y-4">
+                      <div className="text-muted-foreground">
+                        <Wallet className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                        <p className="font-medium text-foreground">No Cardano wallets detected</p>
+                        <p className="text-sm mt-1">
+                          {isMobile
+                            ? 'Open this page in your wallet app\u2019s built-in browser (Eternl, Lace, etc.) to connect.'
+                            : 'You need a Cardano wallet extension to connect. We\u2019ll help you get set up.'}
+                        </p>
+                      </div>
+                      <Button asChild className="w-full">
+                        <Link href="/get-started" onClick={() => onOpenChange(false)}>
+                          <ExternalLink className="h-4 w-4 mr-2" />
+                          Get started with a wallet
+                        </Link>
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
 
             {error && (
               <div className="space-y-3">
@@ -283,9 +337,9 @@ export function WalletConnectModal({
               <div className="p-3 bg-blue-50 dark:bg-blue-950/30 rounded-lg border border-blue-200 dark:border-blue-900 text-sm">
                 <p className="font-medium text-blue-800 dark:text-blue-200 mb-1">What to expect:</p>
                 <ul className="text-blue-700 dark:text-blue-300 space-y-1 text-xs">
-                  <li>• Your wallet will show &quot;Sign in to Governada&quot;</li>
-                  <li>• This is free — no ADA will be sent</li>
-                  <li>• You can ignore the technical hex codes</li>
+                  <li>&bull; Your wallet will show &quot;Sign in to Governada&quot;</li>
+                  <li>&bull; This is free — no ADA will be sent</li>
+                  <li>&bull; You can ignore the technical hex codes</li>
                 </ul>
               </div>
 

--- a/components/discovery/SpotlightOverlay.tsx
+++ b/components/discovery/SpotlightOverlay.tsx
@@ -33,7 +33,8 @@ interface TargetRect {
 const PADDING = 8; // px around target element
 const TOOLTIP_GAP = 12; // px between target and tooltip
 const RETRY_INTERVAL_MS = 300;
-const MAX_RETRIES = 10; // 10 * 300ms = 3s max wait for DOM
+const MAX_RETRIES = 15; // 15 * 300ms = 4.5s max wait for DOM (more time for mobile)
+const SCROLL_SETTLE_MS = 400; // wait for scrollIntoView to finish before measuring
 
 export function SpotlightOverlay({
   step,
@@ -68,8 +69,10 @@ export function SpotlightOverlay({
         });
         const spaceBelow = window.innerHeight - rect.bottom;
         const spaceAbove = rect.top;
-        setTooltipPosition(spaceBelow > 200 || spaceBelow > spaceAbove ? 'bottom' : 'top');
-      }, 300);
+        // On small screens (mobile), require less space for the tooltip
+        const minSpace = window.innerWidth < 640 ? 140 : 200;
+        setTooltipPosition(spaceBelow > minSpace || spaceBelow > spaceAbove ? 'bottom' : 'top');
+      }, SCROLL_SETTLE_MS);
     };
 
     const findTarget = () => {
@@ -128,21 +131,26 @@ export function SpotlightOverlay({
     height: targetRect.height + PADDING * 2,
   };
 
-  // Tooltip position
+  // Tooltip position — clamp within viewport, especially on mobile
+  const isMobileViewport = typeof window !== 'undefined' && window.innerWidth < 640;
   const tooltipStyle: React.CSSProperties = {
     position: 'absolute',
-    left: Math.max(16, Math.min(cutout.left, window.innerWidth - 320)),
-    maxWidth: 'min(320px, calc(100vw - 32px))',
+    left: isMobileViewport ? 16 : Math.max(16, Math.min(cutout.left, window.innerWidth - 320)),
+    maxWidth: isMobileViewport ? window.innerWidth - 32 : 320,
     ...(tooltipPosition === 'bottom'
-      ? { top: cutout.top + cutout.height + TOOLTIP_GAP }
-      : { top: cutout.top - TOOLTIP_GAP, transform: 'translateY(-100%)' }),
+      ? { top: Math.min(cutout.top + cutout.height + TOOLTIP_GAP, window.innerHeight - 160) }
+      : { top: Math.max(cutout.top - TOOLTIP_GAP, 16), transform: 'translateY(-100%)' }),
   };
 
   const overlay = (
-    <div className="fixed inset-0 z-[60]" role="dialog" aria-label="Guided tour">
-      {/* Backdrop with cutout */}
+    <div
+      className="fixed inset-0 z-[60] pointer-events-none"
+      role="dialog"
+      aria-label="Guided tour"
+    >
+      {/* Backdrop with cutout — pointer-events-auto so clicks on dark area advance */}
       <div
-        className="absolute inset-0 bg-black/50 transition-all duration-300"
+        className="absolute inset-0 bg-black/50 transition-all duration-300 pointer-events-auto"
         onClick={onNext}
         style={{
           clipPath: `polygon(
@@ -168,7 +176,7 @@ export function SpotlightOverlay({
         }}
       />
 
-      {/* Tooltip card */}
+      {/* Tooltip card — pointer-events-auto so buttons are tappable on mobile */}
       <AnimatePresence mode="wait">
         <motion.div
           key={step.id}
@@ -178,7 +186,7 @@ export function SpotlightOverlay({
           exit={{ opacity: 0, y: -10 }}
           transition={spring.smooth}
           style={tooltipStyle}
-          className="rounded-xl border border-white/[0.08] bg-card/95 backdrop-blur-xl shadow-2xl p-4 space-y-3"
+          className="rounded-xl border border-white/[0.08] bg-card/95 backdrop-blur-xl shadow-2xl p-4 space-y-3 pointer-events-auto"
         >
           <div className="flex items-start justify-between gap-2">
             <div>
@@ -188,8 +196,11 @@ export function SpotlightOverlay({
               </p>
             </div>
             <button
-              onClick={onSkip}
-              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors p-1"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSkip();
+              }}
+              className="shrink-0 text-muted-foreground hover:text-foreground transition-colors p-2 -m-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
               aria-label="End tour"
             >
               <X className="h-4 w-4" />
@@ -213,17 +224,27 @@ export function SpotlightOverlay({
               ))}
             </div>
 
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-2">
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={onSkip}
-                className="h-7 text-xs text-muted-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSkip();
+                }}
+                className="h-9 text-xs text-muted-foreground min-w-[44px]"
               >
                 <SkipForward className="h-3 w-3 mr-1" />
                 Skip
               </Button>
-              <Button size="sm" onClick={onNext} className="h-7 text-xs">
+              <Button
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNext();
+                }}
+                className="h-9 text-xs min-w-[44px]"
+              >
                 {stepIndex < totalSteps - 1 ? (
                   <>
                     Next


### PR DESCRIPTION
## Summary
- **Mobile wallet connection**: Reduced from 4 steps to 2 — inline loading during auto-auth, skip push prompt, auto-close on success. Mobile-specific guidance when no wallets detected.
- **Error handling**: All async wallet handlers wrapped in try/catch to prevent silent failures and unhandled promise rejections.
- **Tour overlay**: Fixed pointer-events so tooltip buttons are tappable on mobile. Increased touch targets to 44px, clamped tooltip within viewport, extended target retry window from 3s to 4.5s.

## Impact
- **What changed**: Mobile wallet connection is now 2 steps instead of 4; tour overlay controls work on mobile
- **User-facing**: Yes — mobile users get a streamlined connect flow and can interact with guided tour controls
- **Risk**: Low — desktop flow unchanged, only mobile-specific behavior added
- **Scope**: `WalletConnectModal.tsx`, `SpotlightOverlay.tsx`

## Test plan
- [ ] Connect wallet on mobile — verify 2-step flow (select wallet → success)
- [ ] Connect wallet on desktop — verify 4-step flow unchanged
- [ ] Trigger error (reject in wallet) — verify error message shows with retry options
- [ ] Open connect modal on mobile with no wallets — verify in-app browser guidance
- [ ] Start a guided tour on mobile — verify tooltip buttons (Next, Skip, Close) are tappable
- [ ] Start a multi-page tour — verify overlay renders after navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)