### PR TITLE
fix: Decision Engine audit fixes — comparison strip, simulation, trust signals, UX gaps

### DIFF
--- a/app/api/drep/[drepId]/alignment/route.ts
+++ b/app/api/drep/[drepId]/alignment/route.ts
@@ -358,11 +358,23 @@ export const POST = withRouteHandler(
         proposalIndex: v.proposal_index,
       }));
 
-      // Parallel data fetches
-      const [classifications, proposals, outcomes] = await Promise.all([
+      // Determine epoch window for total proposal count
+      const latestEpoch = Math.max(
+        ...drepVotes.filter((v) => v.epoch_no !== null).map((v) => v.epoch_no!),
+        0,
+      );
+      const cutoffEpoch = latestEpoch - 36; // DEFAULT_LOOKBACK_EPOCHS
+
+      // Parallel data fetches — include total proposal count for participation rate
+      const [classifications, proposals, outcomes, totalProposalCount] = await Promise.all([
         fetchClassifications(txHashes),
         getProposalsByIds(proposalIds),
         getProposalOutcomesBatch(outcomeKeys),
+        createClient()
+          .from('proposals')
+          .select('*', { count: 'exact', head: true })
+          .gte('proposed_epoch', cutoffEpoch)
+          .then((r) => r.count ?? null),
       ]);
 
       // Build VoteWithClassification array for WS-1
@@ -400,6 +412,7 @@ export const POST = withRouteHandler(
             outcomes,
             classifications,
             userAlignment,
+            totalProposalCount,
           }),
         ),
       ]);

--- a/app/api/drep/[drepId]/basic/route.ts
+++ b/app/api/drep/[drepId]/basic/route.ts
@@ -1,0 +1,36 @@
+/**
+ * DRep Basic Info API — lightweight endpoint for comparison data.
+ *
+ * GET /api/drep/[drepId]/basic
+ *
+ * Returns: { drepId, name, score, tier, participationRate }
+ * Used by ComparisonStrip to show the viewer's current DRep alongside
+ * the DRep being viewed.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+import { getDRepById } from '@/lib/data';
+import { getDRepPrimaryName } from '@/utils/display';
+import { computeTier } from '@/lib/scoring/tiers';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const drepId = request.nextUrl.pathname.split('/api/drep/')[1]?.split('/')[0];
+  if (!drepId) {
+    return NextResponse.json({ error: 'Missing drepId' }, { status: 400 });
+  }
+
+  const drep = await getDRepById(decodeURIComponent(drepId));
+  if (!drep) {
+    return NextResponse.json({ error: 'DRep not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    drepId: drep.drepId,
+    name: getDRepPrimaryName(drep),
+    score: drep.drepScore,
+    tier: computeTier(drep.drepScore),
+    participationRate: drep.effectiveParticipation ?? 0,
+  });
+}

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -486,12 +486,18 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
   });
 
   // Compute trust signals server-side for the hero
+  // Extract previous delegator count from delegation trend for the delegation_trend signal
+  const previousEpochData =
+    delegationTrend.length >= 2 ? delegationTrend[delegationTrend.length - 2] : null;
+  const previousDelegatorCount = previousEpochData?.delegatorCount ?? null;
+
   const trustSignals = computeTrustSignals({
     effectiveParticipation: drep.effectiveParticipation,
     rationaleRate: drep.rationaleRate,
     reliabilityStreak: drep.reliabilityStreak,
     reliabilityRecency: drep.reliabilityRecency,
     delegatorCount: drep.delegatorCount,
+    previousDelegatorCount,
     profileCompleteness: drep.profileCompleteness,
     metadataHashVerified: drep.metadataHashVerified,
   });
@@ -737,7 +743,16 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
       {/* Dashboard wrapper — hidden for anonymous (claim prompt confuses non-DReps) */}
       <SegmentGate hide={['anonymous']}>
         <Suspense fallback={null}>
-          <DRepDashboardWrapper drepId={drep.drepId} drepName={drepName} isClaimed={isClaimed} />
+          <DRepDashboardWrapper
+            drepId={drep.drepId}
+            drepName={drepName}
+            isClaimed={isClaimed}
+            trustSignals={trustSignals}
+            tier={tierProgress.currentTier}
+            delegatorCount={drep.delegatorCount}
+            participationRate={drep.effectiveParticipation}
+            rationaleRate={drep.rationaleRate}
+          />
         </Suspense>
       </SegmentGate>
 

--- a/components/DRepDashboardWrapper.tsx
+++ b/components/DRepDashboardWrapper.tsx
@@ -7,14 +7,35 @@ import { useSegment } from '@/components/providers/SegmentProvider';
 import { Button } from '@/components/ui/button';
 import { Sparkles, ArrowRight, Wallet, Share2, Check, Pencil } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
+import { CitizenViewPanel } from '@/components/governada/profiles/CitizenViewPanel';
+import type { TrustSignal } from '@/components/governada/profiles/TrustSignals';
 
 interface DRepDashboardWrapperProps {
   drepId: string;
   drepName: string;
   isClaimed: boolean;
+  /** Trust signals for CitizenViewPanel (shown to DRep owners) */
+  trustSignals?: TrustSignal[];
+  /** Tier label for CitizenViewPanel */
+  tier?: string;
+  /** Delegator count for CitizenViewPanel */
+  delegatorCount?: number;
+  /** Participation rate for CitizenViewPanel */
+  participationRate?: number;
+  /** Rationale rate for CitizenViewPanel */
+  rationaleRate?: number;
 }
 
-export function DRepDashboardWrapper({ drepId, drepName, isClaimed }: DRepDashboardWrapperProps) {
+export function DRepDashboardWrapper({
+  drepId,
+  drepName,
+  isClaimed,
+  trustSignals,
+  tier,
+  delegatorCount,
+  participationRate,
+  rationaleRate,
+}: DRepDashboardWrapperProps) {
   const { isAuthenticated, ownDRepId } = useWallet();
   const { segment } = useSegment();
   const [copied, setCopied] = useState(false);
@@ -53,24 +74,36 @@ export function DRepDashboardWrapper({ drepId, drepName, isClaimed }: DRepDashbo
 
   if (isOwner) {
     return (
-      <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5">
-        <div className="flex items-center gap-2 min-w-0">
-          <Sparkles className="h-4 w-4 text-primary shrink-0" />
-          <span className="text-sm font-medium truncate">Your DRep profile</span>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-2.5">
+          <div className="flex items-center gap-2 min-w-0">
+            <Sparkles className="h-4 w-4 text-primary shrink-0" />
+            <span className="text-sm font-medium truncate">Your DRep profile</span>
+          </div>
+          <div className="flex items-center gap-1.5 shrink-0">
+            {shareButton}
+            <Link href="/workspace">
+              <Button size="sm" variant="outline" className="gap-1.5 text-xs">
+                <Pencil className="h-3.5 w-3.5" /> Edit Profile
+              </Button>
+            </Link>
+            <Link href="/workspace">
+              <Button size="sm" className="gap-1.5 text-xs">
+                Open Workspace <ArrowRight className="h-3.5 w-3.5" />
+              </Button>
+            </Link>
+          </div>
         </div>
-        <div className="flex items-center gap-1.5 shrink-0">
-          {shareButton}
-          <Link href="/workspace">
-            <Button size="sm" variant="outline" className="gap-1.5 text-xs">
-              <Pencil className="h-3.5 w-3.5" /> Edit Profile
-            </Button>
-          </Link>
-          <Link href="/workspace">
-            <Button size="sm" className="gap-1.5 text-xs">
-              Open Workspace <ArrowRight className="h-3.5 w-3.5" />
-            </Button>
-          </Link>
-        </div>
+        {trustSignals && trustSignals.length > 0 && tier && (
+          <CitizenViewPanel
+            drepId={drepId}
+            trustSignals={trustSignals}
+            tier={tier}
+            delegatorCount={delegatorCount ?? 0}
+            participationRate={participationRate ?? 0}
+            rationaleRate={rationaleRate ?? 0}
+          />
+        )}
       </div>
     );
   }

--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -170,9 +170,18 @@ export function DRepProfileHero({
           >
             {isGovernanceParticipant ? (
               <GovernanceRadar alignments={alignments} size="full" centerScore={score} />
-            ) : // For citizens: no big score number — TrustSignals shown inline above
-            // Show a compact tier + personality visual instead
-            trustSignals && tier ? null : (
+            ) : trustSignals && tier ? (
+              // Citizens with trust signals: show tier + delegate CTA
+              <div className="flex flex-col items-center justify-center gap-3 px-6">
+                <div className="text-center">
+                  <div className="text-4xl font-bold" style={{ color: identityColor.hex }}>
+                    {tier}
+                  </div>
+                  <div className="text-sm text-muted-foreground mt-1">Governance Tier</div>
+                </div>
+                {children && <div className="flex flex-wrap gap-2">{children}</div>}
+              </div>
+            ) : (
               <div className="flex flex-col items-center justify-center px-6">
                 <div
                   className="text-6xl font-bold font-mono tabular-nums"

--- a/components/drep/DRepDetailedAnalysis.tsx
+++ b/components/drep/DRepDetailedAnalysis.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, type ReactNode } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -15,14 +16,18 @@ interface DRepDetailedAnalysisProps {
  *
  * - Citizens and anonymous users see a collapsed "Show detailed analysis" toggle.
  * - DReps, SPOs, CC members, and researchers see everything expanded by default.
+ * - Deep-depth citizens also see it expanded by default.
  *
  * When expanded, a sticky collapse bar appears at the top so users can easily
  * collapse and return to the core profile as they scroll through the analysis.
  */
 export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
   const { segment, isLoading } = useSegment();
+  const { isAtLeast } = useGovernanceDepth();
 
   const isDetailedSegment = segment === 'drep' || segment === 'spo' || segment === 'cc';
+  const isDeepCitizen = segment === 'citizen' && isAtLeast('deep');
+  const shouldAutoExpand = isDetailedSegment || isDeepCitizen;
 
   // User toggle: null = not yet toggled by user, use segment-derived default
   const [userToggled, setUserToggled] = useState<boolean | null>(null);
@@ -31,8 +36,8 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
   const [showStickyCollapse, setShowStickyCollapse] = useState(false);
   const gateRef = useRef<HTMLDivElement>(null);
 
-  // Derived expanded state: user toggle wins, else expand for confirmed detailed segments
-  const expanded = userToggled !== null ? userToggled : !isLoading && isDetailedSegment;
+  // Derived expanded state: user toggle wins, else expand for confirmed detailed segments or deep citizens
+  const expanded = userToggled !== null ? userToggled : !isLoading && shouldAutoExpand;
 
   // IntersectionObserver to show sticky collapse when the gate top scrolls out of viewport
   useEffect(() => {
@@ -59,8 +64,8 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
     gateRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };
 
-  // For confirmed detailed segments, render children directly (no gate)
-  if (!isLoading && isDetailedSegment) {
+  // For confirmed detailed segments or deep citizens, render children directly (no gate)
+  if (!isLoading && shouldAutoExpand) {
     return <>{children}</>;
   }
 

--- a/components/governada/profiles/DRepProfileClient.tsx
+++ b/components/governada/profiles/DRepProfileClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import type { AlignmentSummary } from '@/lib/matching/proposalAlignment';
 import type { DelegationSimulation } from '@/lib/matching/delegationSimulation';
@@ -23,6 +23,15 @@ interface AlignmentResponse {
   simulation: DelegationSimulation | null;
   comparison: null;
   trustSignals: TrustSignal[];
+}
+
+/** Lightweight DRep info for comparison strip */
+interface ComparisonDRepInfo {
+  drepId: string;
+  name: string;
+  score: number;
+  tier: string;
+  participationRate: number;
 }
 
 export interface DRepProfileClientProps {
@@ -115,6 +124,34 @@ export function DRepProfileClient({
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
+  // Fetch comparison DRep alignment (for ComparisonStrip) when viewer is delegated elsewhere
+  const { data: comparisonAlignmentData } = useQuery<AlignmentResponse | null>({
+    queryKey: ['drep-alignment-comparison', delegatedDrep, alignmentHash],
+    queryFn: async () => {
+      const res = await fetch(`/api/drep/${encodeURIComponent(delegatedDrep!)}/alignment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userAlignment: localAlignment }),
+      });
+      if (!res.ok) return null;
+      return res.json();
+    },
+    enabled: !!delegatedDrep && delegatedDrep !== drepId && !!localAlignment,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Fetch comparison DRep basic info (name, score, tier, participation rate)
+  const { data: comparisonDRepInfo } = useQuery<ComparisonDRepInfo | null>({
+    queryKey: ['drep-basic-info', delegatedDrep],
+    queryFn: async () => {
+      const res = await fetch(`/api/drep/${encodeURIComponent(delegatedDrep!)}/basic`);
+      if (!res.ok) return null;
+      return res.json();
+    },
+    enabled: !!delegatedDrep && delegatedDrep !== drepId,
+    staleTime: 10 * 60 * 1000,
+  });
+
   // Handle quiz completion — transition from Discovery to Decision Engine
   const handleMatchComplete = useCallback((alignment: AlignmentScores) => {
     // Save to localStorage (match existing pattern)
@@ -136,10 +173,17 @@ export function DRepProfileClient({
   const hasAlignmentData = !!alignmentData?.alignment;
 
   // Build comparison data for ComparisonStrip
-  // TODO: In the future, fetch comparison DRep data from the API
-  // For now, comparison is null (the strip will not render)
-  const comparisonDrep = null;
-  const comparisonType = delegatedDrep ? ('current_drep' as const) : null;
+  const comparisonDrep =
+    delegatedDrep && delegatedDrep !== drepId && comparisonDRepInfo
+      ? {
+          drepId: delegatedDrep,
+          name: comparisonDRepInfo.name,
+          alignment: comparisonAlignmentData?.alignment?.overallAlignment ?? null,
+          participationRate: comparisonDRepInfo.participationRate,
+          tier: comparisonDRepInfo.tier,
+        }
+      : null;
+  const comparisonType = comparisonDrep ? ('current_drep' as const) : null;
 
   const viewingDrepData = {
     drepId,
@@ -156,9 +200,13 @@ export function DRepProfileClient({
       {/* ── Decision Engine or Discovery Mode ── */}
       {hasAlignment ? (
         alignmentLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-primary" />
-            <span className="ml-2 text-sm text-muted-foreground">Calculating alignment...</span>
+          <div className={cn('space-y-4 animate-pulse')}>
+            <div className="h-8 w-48 rounded bg-muted" />
+            <div className="h-6 w-32 rounded bg-muted" />
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="h-24 rounded-lg bg-muted" />
+              <div className="h-24 rounded-lg bg-muted" />
+            </div>
           </div>
         ) : hasAlignmentData ? (
           <DecisionEngine

--- a/components/governada/profiles/DiscoveryMode.tsx
+++ b/components/governada/profiles/DiscoveryMode.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { Users, TrendingUp, TrendingDown, Minus, Heart } from 'lucide-react';
 import { InlineQuickMatch } from './InlineQuickMatch';
@@ -39,9 +40,20 @@ export function DiscoveryMode({
 }: DiscoveryModeProps) {
   const { isAtLeast } = useGovernanceDepth();
 
-  // Deep depth users are assumed to have alignment data already;
-  // don't show quiz for them (per depth gating table)
-  if (isAtLeast('deep')) return null;
+  // Deep depth users without alignment data — show a prompt to take the quiz
+  if (isAtLeast('deep') as boolean) {
+    return (
+      <div className={cn('rounded-lg border p-6 text-center', className)}>
+        <p className="text-muted-foreground">
+          Take the{' '}
+          <Link href="/match" className="underline">
+            Quick Match quiz
+          </Link>{' '}
+          to see how this DRep aligns with your governance values.
+        </p>
+      </div>
+    );
+  }
 
   const trend = TREND_CONFIG[delegationTrend];
   const TrendIcon = trend.icon;

--- a/lib/matching/delegationSimulation.ts
+++ b/lib/matching/delegationSimulation.ts
@@ -15,6 +15,7 @@ import { getVotesByDRepId, getProposalsByIds } from '@/lib/data';
 import type { ProposalOutcome } from '@/lib/proposalOutcomes';
 import { getProposalOutcomesBatch } from '@/lib/proposalOutcomes';
 import { predictUserStance, type VoteClassification } from './proposalAlignment';
+import { createClient } from '@/lib/supabase';
 
 /* ─── Constants ───────────────────────────────────────── */
 
@@ -57,6 +58,8 @@ export interface SimulationInput {
   userAlignment?: AlignmentScores | null;
   currentEpoch?: number;
   lookbackEpochs?: number;
+  /** Total proposals in the epoch window (from the proposals table). */
+  totalProposalCount?: number | null;
 }
 
 /* ─── Helpers ─────────────────────────────────────────── */
@@ -139,6 +142,7 @@ export function computeDelegationSimulation(input: SimulationInput): DelegationS
     userAlignment,
     currentEpoch,
     lookbackEpochs = DEFAULT_LOOKBACK_EPOCHS,
+    totalProposalCount,
   } = input;
 
   // Determine epoch window
@@ -228,8 +232,9 @@ export function computeDelegationSimulation(input: SimulationInput): DelegationS
   }
 
   // Aggregate stats
-  // totalProposals = how many unique proposals the DRep voted on in window
-  const totalProposals = drepVotedOn;
+  // totalProposals = actual proposals in the epoch window (from DB), falling back to drepVotedOn
+  const totalProposals =
+    totalProposalCount != null && totalProposalCount > 0 ? totalProposalCount : drepVotedOn;
   const participationRate = totalProposals > 0 ? drepVotedOn / totalProposals : 0;
 
   const deliverySuccessRate =
@@ -272,6 +277,8 @@ export async function fetchDelegationSimulation(
   userAlignment?: AlignmentScores | null,
   lookbackEpochs?: number,
 ): Promise<DelegationSimulation> {
+  const effectiveLookback = lookbackEpochs ?? DEFAULT_LOOKBACK_EPOCHS;
+
   // Fetch DRep votes (already ordered by block_time DESC)
   const drepVotes = await getVotesByDRepId(drepId);
 
@@ -280,9 +287,16 @@ export async function fetchDelegationSimulation(
       drepVotes: [],
       proposals: new Map(),
       outcomes: new Map(),
-      lookbackEpochs,
+      lookbackEpochs: effectiveLookback,
     });
   }
+
+  // Determine epoch window for total proposal count
+  const latestEpoch = Math.max(
+    ...drepVotes.filter((v) => v.epoch_no !== null).map((v) => v.epoch_no!),
+    0,
+  );
+  const cutoffEpoch = latestEpoch - effectiveLookback;
 
   // Build proposal ID list for batch fetches
   const proposalIds = drepVotes.map((v) => ({
@@ -295,10 +309,15 @@ export async function fetchDelegationSimulation(
     proposalIndex: v.proposal_index,
   }));
 
-  // Parallel data fetches
-  const [proposals, outcomes] = await Promise.all([
+  // Parallel data fetches — include total proposal count for the epoch window
+  const [proposals, outcomes, totalProposalResult] = await Promise.all([
     getProposalsByIds(proposalIds),
     getProposalOutcomesBatch(outcomeKeys),
+    createClient()
+      .from('proposals')
+      .select('*', { count: 'exact', head: true })
+      .gte('proposed_epoch', cutoffEpoch)
+      .then((r) => r.count ?? null),
   ]);
 
   return computeDelegationSimulation({
@@ -306,6 +325,7 @@ export async function fetchDelegationSimulation(
     proposals,
     outcomes,
     userAlignment,
-    lookbackEpochs,
+    lookbackEpochs: effectiveLookback,
+    totalProposalCount: totalProposalResult,
   });
 }


### PR DESCRIPTION
## Summary
Addresses all P0 and P1 findings from the Decision Engine pre-ship audit:

**P0 fixes:**
- Wire ComparisonStrip with real data for delegated users (fetch comparison DRep alignment)
- Fix delegation simulation totalProposals bug (was always = drepVotedOn, now queries actual total)
- Fix server-side trust signals missing delegation trend (pass previousDelegatorCount)

**P1 fixes:**
- Deep-depth citizens without alignment data now see a quiz prompt instead of blank gap
- Hero right column shows tier + CTA for citizens instead of empty space
- CitizenViewPanel wired into profile page for DRep owners
- Loading skeleton replaces spinner for alignment section
- DRepDetailedAnalysis auto-expands for deep-depth citizens

## Impact
- **What changed**: 8 bug fixes across the Decision Engine
- **User-facing**: Yes — comparison strip now visible, simulation stats correct, trust signals complete
- **Risk**: Medium — touches multiple components, but each fix is small and isolated
- **Scope**: ~9 files modified

## Test plan
- [ ] Delegated citizen sees ComparisonStrip with current DRep data
- [ ] Simulation shows realistic participation rate (not always 100%)
- [ ] Hero trust signals show delegation trend (not "unavailable")
- [ ] Deep citizen without alignment sees quiz prompt (not blank)
- [ ] Hero right column populated for citizens
- [ ] DRep owner sees CitizenViewPanel on their profile
- [ ] Alignment section shows skeleton while loading
- [ ] Deep citizen sees auto-expanded detailed analysis
- [ ] `npm run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)