### PR TITLE
feat: add treasury ambient intelligence across app

### DIFF
--- a/__tests__/matching/confidence.test.ts
+++ b/__tests__/matching/confidence.test.ts
@@ -53,6 +53,7 @@ describe('calculateProgressiveConfidence', () => {
       proposalTypesVoted: 4,
       engagementActionCount: 10,
       hasDelegation: true,
+      treasuryJudgmentCount: 5,
     };
     const result = calculateProgressiveConfidence(inputs);
     expect(result.overall).toBe(100);
@@ -76,7 +77,7 @@ describe('calculateProgressiveConfidence', () => {
     expect(fullQuiz.overall - noQuiz.overall).toBe(20);
   });
 
-  it('poll votes contribute up to 40 points', () => {
+  it('poll votes contribute up to 35 points', () => {
     const noPoll = calculateProgressiveConfidence({
       quizAnswerCount: 0,
       pollVoteCount: 0,
@@ -91,7 +92,7 @@ describe('calculateProgressiveConfidence', () => {
       engagementActionCount: 0,
       hasDelegation: false,
     });
-    expect(fullPoll.overall - noPoll.overall).toBe(40);
+    expect(fullPoll.overall - noPoll.overall).toBe(35);
   });
 
   it('delegation contributes exactly 15 points', () => {
@@ -115,23 +116,24 @@ describe('calculateProgressiveConfidence', () => {
   it('suggests next action based on highest potential gain', () => {
     const result = calculateProgressiveConfidence({
       quizAnswerCount: 3, // maxed
-      pollVoteCount: 0, // empty → 40 point gap (highest)
+      pollVoteCount: 0, // empty → 35 point gap (highest)
       proposalTypesVoted: 0,
       engagementActionCount: 0,
       hasDelegation: false,
     });
     expect(result.nextAction).not.toBeNull();
     expect(result.nextAction!.type).toBe('vote_proposals');
-    expect(result.nextAction!.potentialGain).toBe(40);
+    expect(result.nextAction!.potentialGain).toBe(35);
   });
 
   it('returns null next action when all sources are maxed', () => {
     const result = calculateProgressiveConfidence({
-      quizAnswerCount: 3,
+      quizAnswerCount: 4,
       pollVoteCount: 15,
       proposalTypesVoted: 4,
       engagementActionCount: 10,
       hasDelegation: true,
+      treasuryJudgmentCount: 5,
     });
     expect(result.nextAction).toBeNull();
   });
@@ -143,6 +145,7 @@ describe('calculateProgressiveConfidence', () => {
       proposalTypesVoted: 2,
       engagementActionCount: 3,
       hasDelegation: true,
+      treasuryJudgmentCount: 2,
     });
     const keys = result.sources.map((s) => s.key);
     expect(keys).toContain('quizAnswers');
@@ -150,15 +153,60 @@ describe('calculateProgressiveConfidence', () => {
     expect(keys).toContain('proposalDiversity');
     expect(keys).toContain('engagement');
     expect(keys).toContain('delegation');
+    expect(keys).toContain('treasuryJudgment');
+  });
+
+  it('treasury judgment contributes up to 10 points', () => {
+    const noTreasury = calculateProgressiveConfidence({
+      quizAnswerCount: 0,
+      pollVoteCount: 0,
+      proposalTypesVoted: 0,
+      engagementActionCount: 0,
+      hasDelegation: false,
+      treasuryJudgmentCount: 0,
+    });
+    const fullTreasury = calculateProgressiveConfidence({
+      quizAnswerCount: 0,
+      pollVoteCount: 0,
+      proposalTypesVoted: 0,
+      engagementActionCount: 0,
+      hasDelegation: false,
+      treasuryJudgmentCount: 5,
+    });
+    expect(fullTreasury.overall - noTreasury.overall).toBe(10);
+  });
+
+  it('treasury judgment defaults to 0 when omitted', () => {
+    const withoutField = calculateProgressiveConfidence({
+      quizAnswerCount: 0,
+      pollVoteCount: 0,
+      proposalTypesVoted: 0,
+      engagementActionCount: 0,
+      hasDelegation: false,
+    });
+    const withZero = calculateProgressiveConfidence({
+      quizAnswerCount: 0,
+      pollVoteCount: 0,
+      proposalTypesVoted: 0,
+      engagementActionCount: 0,
+      hasDelegation: false,
+      treasuryJudgmentCount: 0,
+    });
+    expect(withoutField.overall).toBe(withZero.overall);
+    const treasurySource = withoutField.sources.find((s) => s.key === 'treasuryJudgment');
+    expect(treasurySource).toBeDefined();
+    expect(treasurySource!.score).toBe(0);
+    expect(treasurySource!.active).toBe(false);
   });
 
   it('caps input at target (no extra credit)', () => {
     const result = calculateProgressiveConfidence({
-      quizAnswerCount: 10, // way over target of 3
+      quizAnswerCount: 10, // way over target of 4
       pollVoteCount: 100, // way over target of 15
       proposalTypesVoted: 20,
       engagementActionCount: 100,
       hasDelegation: true,
+      treasuryJudgmentCount: 50, // way over target of 5
     });
     expect(result.overall).toBe(100); // still 100, not higher
   });

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -121,6 +121,7 @@ import { SegmentGate } from '@/components/shared/SegmentGate';
 import { computeTrustSignals } from '@/components/governada/profiles/TrustSignals';
 import { DRepProfileClient } from '@/components/governada/profiles/DRepProfileClient';
 import { ActivityHeatmap } from '@/components/ActivityHeatmap';
+import { getDRepTreasuryTrackRecord } from '@/lib/treasury';
 
 interface DRepDetailPageProps {
   params: Promise<{ drepId: string }>;
@@ -371,6 +372,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
   let spoAlignPct: number | null = null;
   let openProposals: Awaited<ReturnType<typeof getOpenProposalsForDRep>> = [];
   let endorsementCount = 0;
+  let treasuryRecord: Awaited<ReturnType<typeof getDRepTreasuryTrackRecord>> | null = null;
 
   // Wrap each secondary fetch with an 8-second timeout so a single slow fetch
   // cannot block the entire page render. Timed-out fetches return their default value.
@@ -402,6 +404,7 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     spoAlignPct,
     openProposals,
     endorsementCount,
+    treasuryRecord,
   ] = await Promise.all([
     withTimeout(getScoreHistory(drep.drepId), [], 'scoreHistory'),
     withTimeout(getDRepPercentile(drep.drepScore), 0, 'percentile'),
@@ -412,9 +415,14 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     withTimeout(getSpoAlignment(drep.votes), null, 'spoAlignPct'),
     withTimeout(getOpenProposalsForDRep(drep.drepId), [], 'openProposals'),
     withTimeout(getEndorsementCount('drep', drep.drepId), 0, 'endorsementCount'),
+    withTimeout(getDRepTreasuryTrackRecord(drep.drepId), null, 'treasuryRecord'),
   ]);
 
   const pendingProposalCount = openProposals.length;
+
+  // Treasury stewardship signals — summary-level only
+  const treasuryJudgmentScore = treasuryRecord?.judgmentScore ?? null;
+  const treasuryProposalCount = treasuryRecord?.totalProposals ?? 0;
 
   // Check if viewer is authenticated (hide certain elements for anonymous visitors)
   let isViewerAuthenticated = false;
@@ -640,6 +648,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         votingPowerFormatted={formatAda(drep.votingPower)}
         totalVotes={drep.totalVotes}
         rationaleRate={drep.rationaleRate}
+        treasuryJudgmentScore={treasuryJudgmentScore}
+        treasuryProposalCount={treasuryProposalCount}
       />
 
       {/* ── Trust Card — governance participants view (preserved for governance depth) ── */}
@@ -657,6 +667,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           noVotes={drep.noVotes}
           abstainVotes={drep.abstainVotes}
           drepId={drep.drepId}
+          treasuryJudgmentScore={treasuryJudgmentScore}
+          treasuryProposalCount={treasuryProposalCount}
         />
       </SegmentGate>
 

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -251,6 +251,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         currentEpoch={currentEpoch}
         withdrawalAmount={proposal.withdrawalAmount}
         blockTime={proposal.blockTime}
+        treasuryBalanceAda={treasury?.balanceAda ?? null}
       />
 
       {/* 1-line summary — answers "what is this?" above the fold */}
@@ -298,6 +299,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
           noCount={proposal.noCount}
           abstainCount={proposal.abstainCount}
           historicalContext={historicalContext}
+          nclUtilization={nclUtilization}
         />
       </ProposalDepthSection>
 

--- a/components/governada/profiles/DRepProfileClient.tsx
+++ b/components/governada/profiles/DRepProfileClient.tsx
@@ -50,6 +50,8 @@ export interface DRepProfileClientProps {
   votingPowerFormatted: string;
   totalVotes: number;
   rationaleRate: number;
+  treasuryJudgmentScore: number | null;
+  treasuryProposalCount: number;
 }
 
 /* ─── Alignment fetcher ───────────────────────────────── */
@@ -100,6 +102,8 @@ export function DRepProfileClient({
   votingPowerFormatted,
   totalVotes,
   rationaleRate,
+  treasuryJudgmentScore,
+  treasuryProposalCount,
 }: DRepProfileClientProps) {
   const { delegatedDrep } = useSegment();
 
@@ -227,6 +231,8 @@ export function DRepProfileClient({
             endorsementCount={endorsementCount}
             delegationTrend={trendLabel}
             onMatchComplete={handleMatchComplete}
+            treasuryJudgmentScore={treasuryJudgmentScore}
+            treasuryProposalCount={treasuryProposalCount}
           />
         )
       ) : (
@@ -237,6 +243,8 @@ export function DRepProfileClient({
           endorsementCount={endorsementCount}
           delegationTrend={trendLabel}
           onMatchComplete={handleMatchComplete}
+          treasuryJudgmentScore={treasuryJudgmentScore}
+          treasuryProposalCount={treasuryProposalCount}
         />
       )}
 

--- a/components/governada/profiles/DiscoveryMode.tsx
+++ b/components/governada/profiles/DiscoveryMode.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
-import { Users, TrendingUp, TrendingDown, Minus, Heart } from 'lucide-react';
+import { Users, TrendingUp, TrendingDown, Minus, Heart, ShieldCheck } from 'lucide-react';
 import { InlineQuickMatch } from './InlineQuickMatch';
 import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import type { AlignmentScores } from '@/lib/drepIdentity';
@@ -16,6 +16,8 @@ interface DiscoveryModeProps {
   endorsementCount: number;
   delegationTrend: 'growing' | 'stable' | 'declining';
   onMatchComplete: (alignment: AlignmentScores) => void;
+  treasuryJudgmentScore: number | null;
+  treasuryProposalCount: number;
   className?: string;
 }
 
@@ -36,6 +38,8 @@ export function DiscoveryMode({
   endorsementCount,
   delegationTrend,
   onMatchComplete,
+  treasuryJudgmentScore,
+  treasuryProposalCount,
   className,
 }: DiscoveryModeProps) {
   const { isAtLeast } = useGovernanceDepth();
@@ -86,6 +90,16 @@ export function DiscoveryMode({
               {endorsementCount}
             </span>{' '}
             citizen endorsements
+          </div>
+        )}
+
+        {treasuryJudgmentScore !== null && treasuryProposalCount > 0 && (
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <ShieldCheck className="h-4 w-4 text-primary/70" />
+            <span className="font-medium text-foreground tabular-nums">
+              {treasuryJudgmentScore}%
+            </span>{' '}
+            delivery on approved spending
           </div>
         )}
       </div>

--- a/components/governada/profiles/TrustCard.tsx
+++ b/components/governada/profiles/TrustCard.tsx
@@ -4,7 +4,15 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
-import { Shield, ChevronDown, ChevronUp, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import {
+  Shield,
+  ChevronDown,
+  ChevronUp,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Landmark,
+} from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { spring } from '@/lib/animations';
@@ -47,6 +55,8 @@ interface TrustCardProps {
   noVotes: number;
   abstainVotes: number;
   drepId: string;
+  treasuryJudgmentScore: number | null;
+  treasuryProposalCount: number;
 }
 
 function TrustMetric({
@@ -110,6 +120,8 @@ export function TrustCard({
   noVotes,
   abstainVotes,
   drepId,
+  treasuryJudgmentScore,
+  treasuryProposalCount,
 }: TrustCardProps) {
   const { segment } = useSegment();
   const isAnonymous = segment === 'anonymous';
@@ -215,6 +227,14 @@ export function TrustCard({
                 label="Citizen Endorsements"
                 value={endorsementCount.toLocaleString()}
                 tooltip="Number of citizens who have endorsed this DRep across governance competencies"
+              />
+            )}
+            {treasuryJudgmentScore !== null && treasuryProposalCount > 0 && (
+              <TrustMetric
+                label="Treasury Stewardship"
+                value={`${treasuryJudgmentScore}% delivery`}
+                subtext={`on ${treasuryProposalCount} spending proposal${treasuryProposalCount !== 1 ? 's' : ''}`}
+                tooltip="Delivery rate of treasury proposals this DRep voted to approve"
               />
             )}
           </>

--- a/components/governada/proposals/CompactHeader.tsx
+++ b/components/governada/proposals/CompactHeader.tsx
@@ -11,6 +11,7 @@ interface CompactHeaderProps {
   currentEpoch: number;
   withdrawalAmount: number | null;
   blockTime: number | null;
+  treasuryBalanceAda?: number | null;
 }
 
 function formatTreasuryCompact(amount: number): string {
@@ -38,6 +39,7 @@ export function CompactHeader({
   currentEpoch,
   withdrawalAmount,
   blockTime,
+  treasuryBalanceAda,
 }: CompactHeaderProps) {
   const theme = getProposalTheme(proposalType);
   const TypeIcon = theme.icon;
@@ -101,6 +103,10 @@ export function CompactHeader({
               className="text-xs tabular-nums font-semibold text-amber-400 border-amber-400/30"
             >
               &#x20B3; {formatTreasuryCompact(withdrawalAmount / 1_000_000)} ADA
+              {proposalType === 'TreasuryWithdrawals' &&
+                treasuryBalanceAda != null &&
+                treasuryBalanceAda > 0 &&
+                ` · ${((withdrawalAmount / 1_000_000 / treasuryBalanceAda) * 100).toFixed(2)}% of treasury`}
             </Badge>
           )}
 

--- a/components/governada/proposals/LivingBrief.tsx
+++ b/components/governada/proposals/LivingBrief.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { getRelevantArticles } from '@/lib/constitution';
 import { getVotingBodies } from '@/lib/governance/votingBodies';
 import type { ProposalBriefContent } from '@/lib/proposalBrief';
+import type { NclUtilization } from '@/lib/treasury';
 
 interface LivingBriefProps {
   brief: ProposalBriefContent | null;
@@ -47,6 +48,7 @@ interface LivingBriefProps {
   noCount: number;
   abstainCount: number;
   historicalContext: string | null;
+  nclUtilization?: NclUtilization | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +206,7 @@ export function LivingBrief({
   noCount,
   abstainCount,
   historicalContext,
+  nclUtilization,
 }: LivingBriefProps) {
   const briefUrl = `https://governada.io/proposal/${encodeURIComponent(txHash)}/${proposalIndex}`;
   const shareText = `Living Brief on this Cardano governance proposal via @Governada`;
@@ -303,6 +306,7 @@ export function LivingBrief({
         historicalContext={historicalContext}
         rationaleCount={rationaleCount}
         rationales={rationales}
+        nclUtilization={nclUtilization ?? null}
       />
     );
   }
@@ -403,6 +407,7 @@ function FirstLook({
   historicalContext,
   rationaleCount,
   rationales,
+  nclUtilization,
 }: {
   aiSummary: string | null;
   proposalType: string;
@@ -412,6 +417,7 @@ function FirstLook({
   historicalContext: string | null;
   rationaleCount: number;
   rationales: LivingBriefProps['rationales'];
+  nclUtilization: NclUtilization | null;
 }) {
   const totalVotes = yesCount + noCount + abstainCount;
   const articles = getRelevantArticles(proposalType);
@@ -455,9 +461,31 @@ function FirstLook({
         )}
 
         {/* 2. Scale & Context (treasury proposals only) */}
-        {historicalContext && (
+        {(historicalContext || nclUtilization) && proposalType === 'TreasuryWithdrawals' && (
           <SectionCard icon={TrendingUp} title="Scale & Context">
-            <p className="text-sm text-foreground/80">{historicalContext}</p>
+            {historicalContext && <p className="text-sm text-foreground/80">{historicalContext}</p>}
+            {nclUtilization && (
+              <div className="space-y-1.5 pt-1">
+                <p className="text-sm text-foreground/80">
+                  If approved, budget utilization rises from{' '}
+                  {Math.round(nclUtilization.utilizationPct)}% to{' '}
+                  {Math.round(nclUtilization.projectedUtilizationPct)}%.
+                </p>
+                {nclUtilization.projectedUtilizationPct > 80 && (
+                  <p className="text-sm font-medium text-amber-500">
+                    Projected utilization exceeds 80% of the budget period limit — elevated
+                    stewardship scrutiny expected.
+                  </p>
+                )}
+                {nclUtilization.epochsRemaining > 0 &&
+                  nclUtilization.epochsRemaining * (5 / 30.44) < 24 && (
+                    <p className="text-sm text-foreground/70">
+                      {Math.round(nclUtilization.epochsRemaining * (5 / 30.44))} months remaining in
+                      the current budget period.
+                    </p>
+                  )}
+              </div>
+            )}
           </SectionCard>
         )}
 

--- a/components/hub/HubCardConfig.ts
+++ b/components/hub/HubCardConfig.ts
@@ -24,6 +24,7 @@ export type CardId =
   | 'drep-score'
   | 'spo-governance-score'
   | 'spo-delegators'
+  | 'treasury-pulse'
   | 'discovery-match'
   | 'discovery-explore';
 
@@ -62,6 +63,13 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
     conditional: false,
     href: '/governance/health',
   },
+  'treasury-pulse': {
+    id: 'treasury-pulse',
+    type: 'status',
+    priority: 4,
+    conditional: false,
+    href: '/governance/treasury',
+  },
   alert: {
     id: 'alert',
     type: 'action',
@@ -72,7 +80,7 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
   briefing: {
     id: 'briefing',
     type: 'status',
-    priority: 4,
+    priority: 5,
     conditional: true,
     href: '/governance/briefing',
   },
@@ -143,10 +151,24 @@ export const CARD_DEFINITIONS: Record<CardId, HubCardDefinition> = {
 /** Which cards each persona sees, in render order (action > status > engagement > discovery) */
 export const PERSONA_CARDS: Record<UserSegment, CardId[]> = {
   anonymous: ['discovery-match', 'discovery-explore'],
-  citizen: ['alert', 'representation', 'coverage', 'governance-health', 'briefing', 'engagement'],
-  drep: ['drep-action-queue', 'drep-delegators', 'drep-score', 'governance-health'],
-  spo: ['spo-governance-score', 'spo-delegators', 'governance-health'],
-  cc: ['representation', 'coverage', 'governance-health', 'engagement'],
+  citizen: [
+    'alert',
+    'representation',
+    'coverage',
+    'governance-health',
+    'treasury-pulse',
+    'briefing',
+    'engagement',
+  ],
+  drep: [
+    'drep-action-queue',
+    'drep-delegators',
+    'drep-score',
+    'governance-health',
+    'treasury-pulse',
+  ],
+  spo: ['spo-governance-score', 'spo-delegators', 'governance-health', 'treasury-pulse'],
+  cc: ['representation', 'coverage', 'governance-health', 'treasury-pulse', 'engagement'],
 };
 
 /** Sort cards by type priority, then by card priority within type */

--- a/components/hub/HubCardRenderer.tsx
+++ b/components/hub/HubCardRenderer.tsx
@@ -18,6 +18,7 @@ import {
 } from './cards/StatusCard';
 import { CoverageCard } from './cards/CoverageCard';
 import { BriefingCard } from './cards/BriefingCard';
+import { TreasuryPulseCard } from './cards/TreasuryPulseCard';
 import { CommunityConsensus } from './CommunityConsensus';
 
 /** Map card IDs to their React components */
@@ -33,6 +34,7 @@ const CARD_COMPONENTS: Record<CardId, React.ComponentType> = {
   'spo-governance-score': SPOGovernanceScoreCard,
   'spo-delegators': SPODelegatorsCard,
   briefing: BriefingCard,
+  'treasury-pulse': TreasuryPulseCard,
   'discovery-match': DiscoveryMatchCard,
   'discovery-explore': DiscoveryExploreCard,
 };

--- a/components/hub/cards/TreasuryPulseCard.tsx
+++ b/components/hub/cards/TreasuryPulseCard.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Landmark, ChevronDown, ChevronUp } from 'lucide-react';
+import { useState } from 'react';
+import { useTreasuryCurrent, useTreasuryNcl } from '@/hooks/queries';
+import { HubCard, HubCardSkeleton, HubCardError, type CardUrgency } from './HubCard';
+
+interface TreasuryCurrentData {
+  balance: number;
+  epoch: number;
+  runwayMonths: number;
+  burnRatePerEpoch: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  healthScore: number | null;
+  pendingCount: number;
+  pendingTotalAda: number;
+}
+
+function formatAda(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(2)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(0)}K`;
+  return ada.toFixed(0);
+}
+
+function getHealthStatus(score: number | null): {
+  label: string;
+  urgency: CardUrgency;
+  dotClass: string;
+} {
+  if (score === null) {
+    return { label: 'Unknown', urgency: 'default', dotClass: 'bg-muted-foreground' };
+  }
+  if (score >= 70) {
+    return { label: 'Healthy', urgency: 'default', dotClass: 'bg-emerald-500' };
+  }
+  if (score >= 40) {
+    return { label: 'Attention', urgency: 'warning', dotClass: 'bg-amber-500' };
+  }
+  return { label: 'Critical', urgency: 'critical', dotClass: 'bg-red-500' };
+}
+
+function formatRunway(months: number): string {
+  if (months >= 999) return '10yr+ runway';
+  if (months >= 24) return `${Math.floor(months / 12)}yr+ runway`;
+  return `${months}mo runway`;
+}
+
+/**
+ * TreasuryPulseCard — Compact treasury health indicator for the Hub.
+ *
+ * JTBD: "Is the Cardano treasury in good shape?"
+ * Status dot + headline + two key stats. Click to expand narrative.
+ * Stewardship framing: community resource, budget utilization, not "you own X".
+ */
+export function TreasuryPulseCard() {
+  const [expanded, setExpanded] = useState(false);
+
+  const {
+    data: currentRaw,
+    isLoading: currentLoading,
+    isError: currentError,
+    refetch: refetchCurrent,
+  } = useTreasuryCurrent();
+
+  const { data: nclRaw } = useTreasuryNcl();
+
+  if (currentLoading) return <HubCardSkeleton />;
+  if (currentError)
+    return <HubCardError message="Couldn't load treasury" onRetry={() => refetchCurrent()} />;
+
+  const current = currentRaw as TreasuryCurrentData | undefined;
+  if (!current) return null;
+
+  const { label, urgency, dotClass } = getHealthStatus(current.healthScore);
+  const ncl = nclRaw as
+    | { ncl: { utilizationPct: number; period: { nclAda: number } } | null }
+    | undefined;
+  const nclPct = ncl?.ncl ? Math.round(ncl.ncl.utilizationPct) : null;
+
+  // Build narrative for expanded state
+  const narrativeParts: string[] = [];
+  const trendWord =
+    current.trend === 'growing'
+      ? 'growing'
+      : current.trend === 'shrinking'
+        ? 'declining'
+        : 'stable';
+  narrativeParts.push(
+    `The Cardano treasury holds ₳${formatAda(current.balance)} and is ${trendWord}.`,
+  );
+  if (nclPct !== null && ncl?.ncl) {
+    narrativeParts.push(
+      `${nclPct}% of the ₳${formatAda(ncl.ncl.period.nclAda)} budget period limit has been used.`,
+    );
+  }
+  if (current.pendingCount > 0) {
+    narrativeParts.push(
+      `${current.pendingCount} proposal${current.pendingCount !== 1 ? 's' : ''} pending, totaling ₳${formatAda(current.pendingTotalAda)}.`,
+    );
+  }
+  const narrative = narrativeParts.join(' ');
+
+  return (
+    <HubCard
+      href="/governance/treasury"
+      urgency={urgency}
+      label={`Treasury: ${label}, balance ₳${formatAda(current.balance)}`}
+    >
+      <div className="space-y-2">
+        {/* Header: status dot + headline */}
+        <div className="flex items-center gap-2">
+          <Landmark className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Treasury
+          </span>
+          <span className={`h-2 w-2 rounded-full shrink-0 ${dotClass}`} aria-hidden />
+          <span className="text-xs font-semibold text-foreground">{label}</span>
+        </div>
+
+        {/* Key stats */}
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span className="text-sm font-medium text-foreground">₳{formatAda(current.balance)}</span>
+          {nclPct !== null && (
+            <span className="text-xs text-muted-foreground">&middot; {nclPct}% of budget used</span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            &middot; {formatRunway(current.runwayMonths)}
+          </span>
+        </div>
+
+        {/* Pending count (if any) */}
+        {current.pendingCount > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {current.pendingCount} proposal{current.pendingCount !== 1 ? 's' : ''} pending
+          </p>
+        )}
+
+        {/* Expandable narrative */}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
+          className="flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          {expanded ? (
+            <>
+              Less <ChevronUp className="h-3 w-3" />
+            </>
+          ) : (
+            <>
+              More <ChevronDown className="h-3 w-3" />
+            </>
+          )}
+        </button>
+
+        {expanded && (
+          <p className="text-xs leading-relaxed text-muted-foreground border-t border-border pt-2">
+            {narrative}
+          </p>
+        )}
+      </div>
+    </HubCard>
+  );
+}

--- a/lib/ghi/components.ts
+++ b/lib/ghi/components.ts
@@ -10,6 +10,7 @@
  */
 
 import { createClient } from '@/lib/supabase';
+import { calculateTreasuryHealthScore } from '@/lib/treasury';
 import { computeEDI, type EDIResult } from './ediMetrics';
 
 // ---------------------------------------------------------------------------
@@ -494,7 +495,28 @@ export async function computeCCConstitutionalFidelity({
 }
 
 // ---------------------------------------------------------------------------
-// 2H. System Stability (10%)
+// 2H. Treasury Health (8%)
+// ---------------------------------------------------------------------------
+
+export async function computeTreasuryHealth(_input: ComponentInput): Promise<ComponentScore> {
+  const health = await calculateTreasuryHealthScore();
+  if (!health) return { raw: 0 };
+
+  return {
+    raw: health.score,
+    detail: {
+      balanceTrend: health.components.balanceTrend,
+      withdrawalVelocity: health.components.withdrawalVelocity,
+      incomeStability: health.components.incomeStability,
+      pendingLoad: health.components.pendingLoad,
+      runwayAdequacy: health.components.runwayAdequacy,
+      nclDiscipline: health.components.nclDiscipline,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2I. System Stability (10%)
 // ---------------------------------------------------------------------------
 
 export async function computeSystemStability({

--- a/lib/ghi/index.ts
+++ b/lib/ghi/index.ts
@@ -17,6 +17,7 @@ import {
   computeCCConstitutionalFidelity,
   computePowerDistribution,
   computeSystemStability,
+  computeTreasuryHealth,
   type ComponentInput,
 } from './components';
 import type { EDIResult } from './ediMetrics';
@@ -99,6 +100,7 @@ export async function computeGHI(): Promise<GHIComputeResult> {
     ccFidelity,
     power,
     stability,
+    treasuryHealth,
   ] = await Promise.all([
     computeDRepParticipation(input),
     computeSPOParticipation(input),
@@ -107,6 +109,7 @@ export async function computeGHI(): Promise<GHIComputeResult> {
     computeCCConstitutionalFidelity(input),
     computePowerDistribution(input),
     computeSystemStability(input),
+    computeTreasuryHealth(input),
   ]);
 
   // Citizen engagement: only compute if flag is on
@@ -126,6 +129,7 @@ export async function computeGHI(): Promise<GHIComputeResult> {
     'CC Constitutional Fidelity': calibrate(ccFidelity.raw, CALIBRATION.ccConstitutionalFidelity),
     'Power Distribution': calibrate(power.raw, CALIBRATION.powerDistribution),
     'System Stability': calibrate(stability.raw, CALIBRATION.systemStability),
+    'Treasury Health': calibrate(treasuryHealth.raw, CALIBRATION.treasuryHealth),
   };
 
   const components: GHIComponent[] = Object.entries(calibrated).map(([name, value]) => {

--- a/lib/matching/confidence.ts
+++ b/lib/matching/confidence.ts
@@ -3,10 +3,11 @@
  *
  * Confidence grows as the user provides more data sources:
  * - Quiz answers (Quick Match 3-question quiz): 20% max
- * - Poll votes (Governance DNA Quiz real-proposal votes): 40% max
+ * - Poll votes (Governance DNA Quiz real-proposal votes): 35% max
  * - Proposal type diversity (votes spanning different proposal types): 10% max
- * - Engagement signals (sentiment, endorsements, concern flags, etc.): 15% max
+ * - Engagement signals (sentiment, endorsements, concern flags, etc.): 10% max
  * - Delegation confirmation (active delegation to any DRep): 15% max
+ * - Treasury judgment (accountability poll votes on funded proposals): 10% max
  *
  * Total max: 100%
  */
@@ -35,7 +36,8 @@ export type ConfidenceSourceKey =
   | 'pollVotes'
   | 'proposalDiversity'
   | 'engagement'
-  | 'delegation';
+  | 'delegation'
+  | 'treasuryJudgment';
 
 export interface ConfidenceBreakdown {
   /** Overall confidence score (0-100) */
@@ -48,7 +50,13 @@ export interface ConfidenceBreakdown {
 
 export interface ConfidenceAction {
   /** Action type for routing */
-  type: 'take_quiz' | 'vote_proposals' | 'diversify_votes' | 'engage' | 'delegate';
+  type:
+    | 'take_quiz'
+    | 'vote_proposals'
+    | 'diversify_votes'
+    | 'engage'
+    | 'delegate'
+    | 'treasury_engage';
   /** Short description */
   label: string;
   /** Longer description */
@@ -63,10 +71,11 @@ export interface ConfidenceAction {
 
 const WEIGHTS = {
   quizAnswers: 20,
-  pollVotes: 40,
+  pollVotes: 35,
   proposalDiversity: 10,
-  engagement: 15,
+  engagement: 10,
   delegation: 15,
+  treasuryJudgment: 10,
 } as const;
 
 const TARGETS = {
@@ -75,6 +84,7 @@ const TARGETS = {
   proposalDiversity: 4, // 4 out of 6 proposal types
   engagement: 10, // 10 engagement actions
   delegation: 1, // 1 active delegation
+  treasuryJudgment: 5, // 5 treasury accountability judgments
 } as const;
 
 /* ─── Input data ───────────────────────────────────────── */
@@ -90,6 +100,8 @@ export interface ConfidenceInputs {
   engagementActionCount: number;
   /** Whether user has an active DRep delegation */
   hasDelegation: boolean;
+  /** Number of treasury accountability judgments (poll votes on funded proposal outcomes) */
+  treasuryJudgmentCount?: number;
 }
 
 /* ─── Core calculation ─────────────────────────────────── */
@@ -148,6 +160,19 @@ export function calculateProgressiveConfidence(inputs: ConfidenceInputs): Confid
       current: inputs.hasDelegation ? 1 : 0,
       target: TARGETS.delegation,
       active: inputs.hasDelegation,
+    },
+    {
+      key: 'treasuryJudgment',
+      label: 'Treasury judgment',
+      score: sourceScore(
+        inputs.treasuryJudgmentCount ?? 0,
+        TARGETS.treasuryJudgment,
+        WEIGHTS.treasuryJudgment,
+      ),
+      maxScore: WEIGHTS.treasuryJudgment,
+      current: Math.min(inputs.treasuryJudgmentCount ?? 0, TARGETS.treasuryJudgment),
+      target: TARGETS.treasuryJudgment,
+      active: (inputs.treasuryJudgmentCount ?? 0) > 0,
     },
   ];
 
@@ -223,6 +248,16 @@ function getNextAction(
           label: 'Delegate to a DRep',
           description: 'Confirm your governance values by delegating to a DRep who represents you.',
           href: '/governance/representatives',
+          potentialGain: gap,
+        });
+        break;
+      case 'treasuryJudgment':
+        actions.push({
+          type: 'treasury_engage',
+          label: 'Rate treasury outcomes',
+          description:
+            'Judge whether funded proposals delivered on their promises to sharpen your fiscal alignment.',
+          href: '/governance/treasury',
           potentialGain: gap,
         });
         break;

--- a/lib/proposalBrief.ts
+++ b/lib/proposalBrief.ts
@@ -79,6 +79,7 @@ export interface BriefGenerationInput {
   concernFlags: string[];
   constitutionalArticles: string[];
   historicalContext: string | null;
+  treasuryHealthContext: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -293,6 +294,85 @@ export async function assembleProposalBriefInput(
       }
     }
 
+    // Treasury health context for TreasuryWithdrawals (best-effort, parallel fetch)
+    let treasuryHealthContext: string | null = null;
+    if (proposal.proposalType === 'TreasuryWithdrawals' && proposal.withdrawalAmount) {
+      try {
+        const {
+          getNclUtilization,
+          findSimilarProposals,
+          calculateRunwayMonths,
+          calculateBurnRate,
+          getTreasuryBalance,
+          getTreasuryTrend,
+        } = await import('@/lib/treasury');
+
+        const [ncl, balance, trend, similar] = await Promise.all([
+          getNclUtilization(),
+          getTreasuryBalance(),
+          getTreasuryTrend(30),
+          findSimilarProposals(
+            proposal.title || '',
+            proposal.withdrawalAmount / 1_000_000,
+            proposal.treasuryTier ?? null,
+            txHash,
+          ),
+        ]);
+
+        const parts: string[] = [];
+
+        if (balance) {
+          parts.push(
+            `Treasury balance: ${balance.balanceAda.toLocaleString()} ADA (epoch ${balance.epoch}).`,
+          );
+        }
+
+        if (trend.length >= 2) {
+          const burnRate = calculateBurnRate(trend, 10);
+          if (burnRate > 0 && balance) {
+            const runway = calculateRunwayMonths(balance.balanceAda, burnRate);
+            parts.push(
+              `Burn rate: ~${Math.round(burnRate).toLocaleString()} ADA/epoch. Runway: ${runway === Infinity ? '10+ years' : `${Math.round(runway)} months`}.`,
+            );
+          }
+        }
+
+        if (ncl) {
+          parts.push(
+            `NCL budget utilization: ${Math.round(ncl.utilizationPct)}% enacted, ${Math.round(ncl.projectedUtilizationPct)}% projected (including pending). ${ncl.epochsRemaining} epochs remaining in budget period.`,
+          );
+          if (ncl.projectedUtilizationPct > 80) {
+            parts.push(
+              'Warning: projected utilization exceeds 80% of budget period limit — elevated stewardship scrutiny warranted.',
+            );
+          }
+        }
+
+        if (similar.length > 0) {
+          const enacted = similar.filter((s) => s.outcome === 'enacted');
+          const rejected = similar.filter(
+            (s) => s.outcome === 'dropped' || s.outcome === 'expired',
+          );
+          if (enacted.length > 0) {
+            parts.push(
+              `${enacted.length} similar proposal${enacted.length !== 1 ? 's' : ''} enacted previously (${enacted.map((s) => `"${s.title}" at ${s.withdrawalAda.toLocaleString()} ADA`).join('; ')}).`,
+            );
+          }
+          if (rejected.length > 0) {
+            parts.push(
+              `${rejected.length} similar proposal${rejected.length !== 1 ? 's' : ''} rejected or expired (${rejected.map((s) => `"${s.title}"`).join('; ')}).`,
+            );
+          }
+        }
+
+        if (parts.length > 0) {
+          treasuryHealthContext = parts.join(' ');
+        }
+      } catch {
+        // Non-critical
+      }
+    }
+
     // Citizen sentiment (best-effort)
     let citizenSentiment: number | null = null;
     try {
@@ -329,6 +409,7 @@ export async function assembleProposalBriefInput(
       concernFlags,
       constitutionalArticles: articles.map((a) => `${a.id}: ${a.text}`),
       historicalContext,
+      treasuryHealthContext,
     };
   } catch (err) {
     logger.error('[ProposalBrief] Context assembly failed', { txHash, error: err });
@@ -411,6 +492,7 @@ ${abstainRationales || '  (none provided)'}
 ${input.citizenSentiment != null ? `## Citizen Sentiment: ${input.citizenSentiment}/100` : ''}
 ${input.concernFlags.length > 0 ? `## Community Concerns: ${input.concernFlags.join(', ')}` : ''}
 ${input.historicalContext ? `## Historical Context: ${input.historicalContext}` : ''}
+${input.treasuryHealthContext ? `## Treasury Health Context\n${input.treasuryHealthContext}` : ''}
 ${input.constitutionalArticles.length > 0 ? `## Relevant Constitutional Articles:\n${input.constitutionalArticles.map((a) => `  - ${a}`).join('\n')}` : ''}
 
 Return JSON with this exact structure:

--- a/lib/scoring/calibration.ts
+++ b/lib/scoring/calibration.ts
@@ -513,6 +513,12 @@ export const GHI_CALIBRATION = {
     targetHigh: 75,
     ceiling: 90,
   },
+  treasuryHealth: {
+    floor: 20,
+    targetLow: 40,
+    targetHigh: 70,
+    ceiling: 90,
+  },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -522,19 +528,21 @@ export const GHI_CALIBRATION = {
 /**
  * GHI component weights (must sum to 1.0).
  *
- * Engagement (35%): DRep Participation (15%) + SPO Participation (10%) + Citizen Engagement (10%)
- * Quality (40%): Deliberation Quality (15%) + Governance Effectiveness (15%) + CC Constitutional Fidelity (10%)
- * Resilience (25%): Power Distribution (15%) + System Stability (10%)
+ * Engagement (32%): DRep Participation (14%) + SPO Participation (9%) + Citizen Engagement (9%)
+ * Quality (37%): Deliberation Quality (14%) + Governance Effectiveness (14%) + CC Constitutional Fidelity (9%)
+ * Resilience (23%): Power Distribution (14%) + System Stability (9%)
+ * Sustainability (8%): Treasury Health (8%)
  */
 export const GHI_COMPONENT_WEIGHTS = {
-  'DRep Participation': 0.15,
-  'SPO Participation': 0.1,
-  'Citizen Engagement': 0.1,
-  'Deliberation Quality': 0.15,
-  'Governance Effectiveness': 0.15,
-  'CC Constitutional Fidelity': 0.1,
-  'Power Distribution': 0.15,
-  'System Stability': 0.1,
+  'DRep Participation': 0.14,
+  'SPO Participation': 0.09,
+  'Citizen Engagement': 0.09,
+  'Deliberation Quality': 0.14,
+  'Governance Effectiveness': 0.14,
+  'CC Constitutional Fidelity': 0.09,
+  'Power Distribution': 0.14,
+  'System Stability': 0.09,
+  'Treasury Health': 0.08,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- Distribute treasury context into existing surfaces (proposals, DRep profiles, Hub, GHI, matching) instead of keeping it siloed in `/governance/treasury`
- Stewardship framing throughout ("budget X% used", "Y% delivery on approved spending") — never personal share amounts
- Treasury health becomes a first-class governance signal: 9th GHI component, matching confidence signal, trust metric

## Changes

### Proposal Page (Living Brief Path)
- CompactHeader shows `₳X · Y% of treasury` for withdrawal proposals
- FirstLook "Scale & Context" adds NCL budget impact, 80% threshold warning, runway context
- AI brief generation includes treasury health context (NCL, runway, similar proposal outcomes)

### DRep Profile (Decision Engine)
- TrustCard: "Treasury Stewardship: X% delivery on approved spending" signal
- DiscoveryMode: delivery track record in social proof section
- Server-side treasury record fetch with 8s timeout + null fallback

### Hub
- New TreasuryPulseCard: health dot (green/amber/red), balance, NCL %, runway, expandable narrative
- Registered for citizen/drep/spo/cc personas

### Backend
- GHI: Treasury Health as 9th component (8% weight, proportional rebalance of existing 8)
- Matching confidence: treasuryJudgment source (10%, backward-compatible default 0)

## Impact
- **What changed**: Treasury intelligence woven into 5 existing app surfaces + 2 backend systems
- **User-facing**: Yes — treasury context appears on proposals, DRep profiles, and Hub without visiting /governance/treasury
- **Risk**: Low — all changes are additive, treasury data fetch has timeout fallbacks, matching defaults backward-compatible
- **Scope**: 16 files (4 pages/routes, 7 components, 3 lib modules, 1 test, 1 new component)

## Test plan
- [ ] Verify CompactHeader shows treasury % on TreasuryWithdrawals proposals
- [ ] Verify FirstLook Scale & Context section shows NCL impact
- [ ] Verify DRep TrustCard shows treasury stewardship (for DReps with treasury votes)
- [ ] Verify DiscoveryMode shows delivery stat in social proof
- [ ] Verify TreasuryPulseCard renders on Hub for authenticated users
- [ ] Verify GHI score includes Treasury Health component
- [ ] Verify matching confidence tests pass (16/16)
- [ ] Verify treasury fetch timeout doesn't break DRep profile when treasury API is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)