### PR TITLE
fix: restrict tier celebrations to authenticated profile owners

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -545,7 +545,6 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         entityType="drep"
         entityId={drep.drepId}
         entityName={drepName}
-        enabled
         ogImageUrl={`/api/og/wrapped/drep/${encodeURIComponent(drep.drepId)}`}
         shareUrl={`https://governada.io/drep/${encodeURIComponent(drep.drepId)}`}
       />

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -726,7 +726,7 @@ export default async function PoolProfilePage({ params }: PageProps) {
           entityType="spo"
           entityId={poolId}
           entityName={displayName}
-          enabled
+          claimedBy={claimedBy}
           ogImageUrl={`/api/og/staking/${encodeURIComponent(poolId)}`}
           shareUrl={`https://governada.io/pool/${encodeURIComponent(poolId)}`}
         />

--- a/components/governada/shared/TierCelebrationManager.tsx
+++ b/components/governada/shared/TierCelebrationManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useWallet } from '@/utils/wallet-context';
 import { CelebrationOverlay } from './CelebrationOverlay';
 
 interface TierChange {
@@ -24,7 +25,8 @@ interface TierCelebrationManagerProps {
   entityType: 'drep' | 'spo';
   entityId: string;
   entityName: string;
-  enabled: boolean;
+  /** For SPO profiles: the userId that claimed this pool */
+  claimedBy?: string | null;
   ogImageUrl?: string;
   shareUrl?: string;
 }
@@ -33,15 +35,20 @@ export function TierCelebrationManager({
   entityType,
   entityId,
   entityName,
-  enabled,
+  claimedBy,
   ogImageUrl,
   shareUrl,
 }: TierCelebrationManagerProps) {
+  const { isAuthenticated, ownDRepId, userId } = useWallet();
   const [change, setChange] = useState<TierChange | null>(null);
   const [milestone, setMilestone] = useState<{ score: number } | null>(null);
 
+  const isOwner =
+    isAuthenticated &&
+    (entityType === 'drep' ? ownDRepId === entityId : !!claimedBy && userId === claimedBy);
+
   useEffect(() => {
-    if (!enabled) return;
+    if (!isOwner) return;
 
     const storageKey = `tier_celebration_seen_${entityType}_${entityId}`;
     const lastVisit = localStorage.getItem(storageKey);
@@ -76,7 +83,7 @@ export function TierCelebrationManager({
         }
       })
       .catch(() => {});
-  }, [enabled, entityType, entityId]);
+  }, [isOwner, entityType, entityId]);
 
   const handleDismiss = () => {
     const storageKey = `tier_celebration_seen_${entityType}_${entityId}`;


### PR DESCRIPTION
## Summary
- Tier celebration overlays (confetti + tier change banner) were showing for **all visitors** on DRep and SPO profile pages, including anonymous users
- Now only fires when the authenticated wallet owner views **their own** profile: DRep pages check `ownDRepId === entityId`, SPO pages check `userId === claimedBy`

## Impact
- **What changed**: TierCelebrationManager now uses `useWallet()` to gate on profile ownership instead of an always-true `enabled` prop
- **User-facing**: Yes — anonymous users and non-owners no longer see celebration overlays on others' profiles
- **Risk**: Low — only affects celebration display, no data changes
- **Scope**: 3 files: TierCelebrationManager.tsx, drep/[drepId]/page.tsx, pool/[poolId]/page.tsx

## Test plan
- [ ] Visit a DRep profile page without a wallet connected — no celebration
- [ ] Visit an SPO profile page without a wallet connected — no celebration
- [ ] Connect wallet and visit another DRep's profile — no celebration
- [ ] Connect wallet and visit your own DRep profile after a tier change — celebration shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)