### PR TITLE
feat: Connected Graph with entity connections and explore path

### DIFF
--- a/app/api/entity-connections/route.ts
+++ b/app/api/entity-connections/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Entity Connections API — returns relationship data for the Connected Graph panel.
+ *
+ * Params: entityType (drep|proposal|pool|cc), entityId, optional viewerDrepId
+ * Returns up to 10 connections sorted by relevance (personal first).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getEntityConnections, type EntityType } from '@/lib/entityConnections';
+
+export const dynamic = 'force-dynamic';
+
+const VALID_TYPES = new Set(['drep', 'proposal', 'pool', 'cc']);
+
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const entityType = request.nextUrl.searchParams.get('type') as EntityType;
+  const entityId = request.nextUrl.searchParams.get('id');
+  const viewerDrepId = request.nextUrl.searchParams.get('viewerDrepId');
+
+  if (!entityType || !VALID_TYPES.has(entityType)) {
+    return NextResponse.json({ error: 'Invalid entity type' }, { status: 400 });
+  }
+  if (!entityId) {
+    return NextResponse.json({ error: 'Missing entity id' }, { status: 400 });
+  }
+
+  const connections = await getEntityConnections(entityType, entityId, viewerDrepId);
+
+  return NextResponse.json(
+    { connections },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800',
+      },
+    },
+  );
+});

--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -97,6 +97,7 @@ import { generateDRepNarrative } from '@/lib/narratives';
 import { SocialProofBadge } from '@/components/SocialProofBadge';
 import { WatchEntityButton } from '@/components/WatchEntityButton';
 import { PinButton } from '@/components/shared/PinButton';
+import { EntityPageConnections } from '@/components/shared/EntityPageConnections';
 import { ScoreDeepDive } from '@/components/ScoreDeepDive';
 import { DRepOutcomeSummary } from '@/components/governada/profiles/DRepOutcomeSummary';
 import { ScoreAnalysisGate } from '@/components/governada/profiles/ScoreAnalysisGate';
@@ -556,6 +557,12 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
           { label: 'Representatives', href: '/' },
           { label: drepName },
         ]}
+      />
+      <EntityPageConnections
+        entityType="drep"
+        entityId={drep.drepId}
+        entityLabel={drepName}
+        entityHref={`/drep/${encodeURIComponent(drep.drepId)}`}
       />
 
       {/* ════════════════════════════════════════════

--- a/app/governance/committee/[ccHotId]/page.tsx
+++ b/app/governance/committee/[ccHotId]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { Breadcrumb } from '@/components/shared/Breadcrumb';
 import { PinButton } from '@/components/shared/PinButton';
+import { EntityPageConnections } from '@/components/shared/EntityPageConnections';
 import { CCMemberProfileClient } from '@/components/cc/CCMemberProfileClient';
 
 export const dynamic = 'force-dynamic';
@@ -227,6 +228,12 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
           label={authorName ?? `CC ${decodedId.slice(0, 12)}\u2026`}
         />
       </div>
+      <EntityPageConnections
+        entityType="cc"
+        entityId={decodedId}
+        entityLabel={authorName ?? `CC ${decodedId.slice(0, 12)}\u2026`}
+        entityHref={`/governance/committee/${encodeURIComponent(decodedId)}`}
+      />
       <CCMemberProfileClient data={profileData} />
     </div>
   );

--- a/app/pool/[poolId]/page.tsx
+++ b/app/pool/[poolId]/page.tsx
@@ -54,6 +54,7 @@ const SpoProfileTabsV2 = nextDynamic(
 import { SpoProfileHero } from '@/components/governada/profiles/SpoProfileHero';
 import { WatchEntityButton } from '@/components/WatchEntityButton';
 import { PinButton } from '@/components/shared/PinButton';
+import { EntityPageConnections } from '@/components/shared/EntityPageConnections';
 import { PoolClaimCard } from '@/components/governada/profiles/PoolClaimCard';
 import { PoolProfileEditorGate } from '@/components/governada/profiles/PoolProfileEditorGate';
 import { FeatureGate } from '@/components/FeatureGate';
@@ -738,6 +739,12 @@ export default async function PoolProfilePage({ params }: PageProps) {
             { label: 'Pools', href: '/governance/pools' },
             { label: ticker ? `${displayName} [${ticker}]` : displayName },
           ]}
+        />
+        <EntityPageConnections
+          entityType="pool"
+          entityId={poolId}
+          entityLabel={displayName}
+          entityHref={`/pool/${encodeURIComponent(poolId)}`}
         />
 
         {/* Chapter 1: The Story — Hero */}

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -25,6 +25,7 @@ import { ConcernFlagBanner } from '@/components/engagement/ConcernFlagBanner';
 import { ProposalHeroV2 } from '@/components/governada/proposals/ProposalHeroV2';
 import { WatchEntityButton } from '@/components/WatchEntityButton';
 import { PinButton } from '@/components/shared/PinButton';
+import { EntityPageConnections } from '@/components/shared/EntityPageConnections';
 import { IntelligenceBriefing } from '@/components/governada/proposals/IntelligenceBriefing';
 import { DebateSection } from '@/components/governada/proposals/DebateSection';
 import { ProposalActionZone } from '@/components/governada/proposals/ProposalActionZone';
@@ -243,6 +244,12 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         <WatchEntityButton entityType="proposal" entityId={`${txHash}:${proposalIndex}`} />
         <PinButton type="proposal" id={`${txHash}/${proposalIndex}`} label={title} />
       </div>
+      <EntityPageConnections
+        entityType="proposal"
+        entityId={`${txHash}/${proposalIndex}`}
+        entityLabel={title}
+        entityHref={`/proposal/${txHash}/${proposalIndex}`}
+      />
 
       {/* Zone 1: Compact Header */}
       <CompactHeader
@@ -378,6 +385,12 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         <WatchEntityButton entityType="proposal" entityId={`${txHash}:${proposalIndex}`} />
         <PinButton type="proposal" id={`${txHash}/${proposalIndex}`} label={title} />
       </div>
+      <EntityPageConnections
+        entityType="proposal"
+        entityId={`${txHash}/${proposalIndex}`}
+        entityLabel={title}
+        entityHref={`/proposal/${txHash}/${proposalIndex}`}
+      />
 
       {/* Zone 1: Hero — type-specific gradient, verdict strip, prominent title */}
       <ProposalHeroV2

--- a/components/shared/EntityConnections.tsx
+++ b/components/shared/EntityConnections.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import {
+  User,
+  FileText,
+  Building2,
+  Shield,
+  Vote,
+  TrendingUp,
+  Users,
+  Link2,
+  ChevronRight,
+  Network,
+} from 'lucide-react';
+import { useEntityConnections } from '@/hooks/useEntityConnections';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { EntityType, EntityConnection } from '@/lib/entityConnections';
+
+const ICON_MAP = {
+  user: User,
+  'file-text': FileText,
+  building: Building2,
+  shield: Shield,
+  vote: Vote,
+  trending: TrendingUp,
+  users: Users,
+  link: Link2,
+} as const;
+
+function ConnectionItem({ connection }: { connection: EntityConnection }) {
+  const Icon = ICON_MAP[connection.icon] ?? Link2;
+
+  return (
+    <Link
+      href={connection.href}
+      className={cn(
+        'flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-accent/50',
+        connection.personalized && 'border-l-2 border-primary/50 bg-primary/5',
+      )}
+    >
+      <Icon className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm leading-snug truncate">{connection.label}</p>
+        {connection.sublabel && (
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">{connection.sublabel}</p>
+        )}
+      </div>
+      <ChevronRight className="h-3.5 w-3.5 mt-1 shrink-0 text-muted-foreground/30" />
+    </Link>
+  );
+}
+
+function ConnectionList({ connections }: { connections: EntityConnection[] }) {
+  if (connections.length === 0) return null;
+
+  return (
+    <div className="divide-y divide-border/30">
+      {connections.map((conn, idx) => (
+        <ConnectionItem key={`${conn.href}-${idx}`} connection={conn} />
+      ))}
+    </div>
+  );
+}
+
+interface EntityConnectionsProps {
+  entityType: EntityType;
+  entityId: string;
+}
+
+/**
+ * Connected Graph panel for entity pages.
+ *
+ * Desktop: Collapsible right-side panel (hidden by default, badge shows count).
+ * Mobile: "See connections" button → bottom sheet.
+ */
+export function EntityConnections({ entityType, entityId }: EntityConnectionsProps) {
+  const { t } = useTranslation();
+  const { data, isLoading } = useEntityConnections(entityType, entityId);
+  const [expanded, setExpanded] = useState(false);
+
+  const connections = data?.connections ?? [];
+
+  // Don't render anything while loading or if no connections
+  if (isLoading || connections.length === 0) return null;
+
+  const personalCount = connections.filter((c) => c.personalized).length;
+
+  return (
+    <>
+      {/* Desktop: collapsible panel */}
+      <div className="hidden lg:block">
+        {!expanded ? (
+          <Button variant="outline" size="sm" onClick={() => setExpanded(true)} className="gap-2">
+            <Network className="h-4 w-4" />
+            {connections.length} {t('connections')}
+            {personalCount > 0 && <span className="h-2 w-2 rounded-full bg-primary" />}
+          </Button>
+        ) : (
+          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md overflow-hidden w-72">
+            <div className="flex items-center justify-between px-4 pt-3 pb-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/60">
+                {t('Connected')}
+              </h3>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => setExpanded(false)}
+              >
+                {t('Hide')}
+              </Button>
+            </div>
+            <ConnectionList connections={connections} />
+          </div>
+        )}
+      </div>
+
+      {/* Mobile: sheet trigger */}
+      <div className="lg:hidden">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-2">
+              <Network className="h-4 w-4" />
+              {connections.length} {t('connections')}
+              {personalCount > 0 && <span className="h-2 w-2 rounded-full bg-primary" />}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="bottom" className="max-h-[70vh]">
+            <SheetHeader>
+              <SheetTitle>{t('Connected')}</SheetTitle>
+            </SheetHeader>
+            <div className="overflow-y-auto mt-4">
+              <ConnectionList connections={connections} />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  );
+}

--- a/components/shared/EntityPageConnections.tsx
+++ b/components/shared/EntityPageConnections.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useExplorePath } from '@/hooks/useExplorePath';
+import { EntityConnections } from './EntityConnections';
+import { ExplorePath } from './ExplorePath';
+import type { EntityType } from '@/lib/entityConnections';
+
+interface EntityPageConnectionsProps {
+  entityType: EntityType;
+  entityId: string;
+  entityLabel: string;
+  entityHref: string;
+}
+
+/**
+ * Wrapper that provides both EntityConnections panel and ExplorePath breadcrumb
+ * for entity pages. Automatically registers the entity visit in the explore path.
+ *
+ * Usage: Add <EntityPageConnections ... /> near the top of any entity page.
+ */
+export function EntityPageConnections({
+  entityType,
+  entityId,
+  entityLabel,
+  entityHref,
+}: EntityPageConnectionsProps) {
+  const { pushEntity } = useExplorePath();
+
+  useEffect(() => {
+    pushEntity(entityType, entityId, entityLabel, entityHref);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only register once on mount
+  }, [entityType, entityId]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ExplorePath />
+      <EntityConnections entityType={entityType} entityId={entityId} />
+    </div>
+  );
+}

--- a/components/shared/ExplorePath.tsx
+++ b/components/shared/ExplorePath.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronRight, X } from 'lucide-react';
+import { useExplorePath } from '@/hooks/useExplorePath';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+import { cn } from '@/lib/utils';
+
+/**
+ * Explore Path — client-side breadcrumb tracking entity page traversal.
+ * Only appears after 2+ entity page visits in a session.
+ * Replaces traditional breadcrumbs when active.
+ */
+export function ExplorePath() {
+  const { explorePath, showPath, goToStep, clearPath } = useExplorePath();
+  const { t } = useTranslation();
+
+  if (!showPath) return null;
+
+  return (
+    <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto scrollbar-none py-1">
+      {explorePath.map((step, idx) => {
+        const isLast = idx === explorePath.length - 1;
+        return (
+          <span key={`${step.type}-${step.id}`} className="flex items-center gap-1 shrink-0">
+            {idx > 0 && <ChevronRight className="h-3 w-3 text-muted-foreground/40" />}
+            {isLast ? (
+              <span className="font-medium text-foreground/70 truncate max-w-[120px]">
+                {step.label}
+              </span>
+            ) : (
+              <Link
+                href={step.href}
+                onClick={() => goToStep(idx)}
+                className={cn(
+                  'truncate max-w-[120px] hover:text-foreground transition-colors',
+                  'underline decoration-muted-foreground/30 underline-offset-2',
+                )}
+              >
+                {step.label}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+      <button
+        onClick={clearPath}
+        className="ml-1 rounded p-0.5 text-muted-foreground/40 hover:text-foreground/60 transition-colors shrink-0"
+        aria-label={t('Clear explore path')}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/hooks/useEntityConnections.ts
+++ b/hooks/useEntityConnections.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import type { EntityType, EntityConnection } from '@/lib/entityConnections';
+
+/**
+ * Fetch entity connections for the Connected Graph panel.
+ * Automatically includes viewer's DRep for personalization.
+ */
+export function useEntityConnections(entityType: EntityType, entityId: string) {
+  const { delegatedDrep } = useSegment();
+
+  const params = new URLSearchParams({
+    type: entityType,
+    id: entityId,
+  });
+  if (delegatedDrep) params.set('viewerDrepId', delegatedDrep);
+
+  return useQuery<{ connections: EntityConnection[] }>({
+    queryKey: ['entity-connections', entityType, entityId, delegatedDrep],
+    queryFn: async () => {
+      const res = await fetch(`/api/entity-connections?${params}`);
+      if (!res.ok) return { connections: [] };
+      return res.json();
+    },
+    staleTime: 15 * 60_000, // 15 minutes
+    enabled: !!entityId,
+  });
+}

--- a/hooks/useExplorePath.ts
+++ b/hooks/useExplorePath.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'governada_explore_path';
+const MAX_STEPS = 5;
+
+export interface ExploreStep {
+  type: 'drep' | 'proposal' | 'pool' | 'cc';
+  id: string;
+  label: string;
+  href: string;
+}
+
+function loadPath(): ExploreStep[] {
+  try {
+    if (typeof window === 'undefined') return [];
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePath(steps: ExploreStep[]) {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(steps));
+}
+
+/**
+ * Manages the Explore Path — a session-scoped breadcrumb tracking entity page traversal.
+ * Shows after 2+ entity hops. Max 5 steps.
+ */
+export function useExplorePath() {
+  const [path, setPath] = useState<ExploreStep[]>(() => loadPath());
+
+  const pushEntity = useCallback(
+    (type: ExploreStep['type'], id: string, label: string, href: string) => {
+      setPath((prev) => {
+        // Don't duplicate if already the last step
+        if (prev.length > 0 && prev[prev.length - 1].id === id) return prev;
+
+        // If already in path, truncate to that point (backtracking)
+        const existingIdx = prev.findIndex((s) => s.type === type && s.id === id);
+        if (existingIdx >= 0) {
+          const truncated = prev.slice(0, existingIdx + 1);
+          savePath(truncated);
+          return truncated;
+        }
+
+        const next = [...prev, { type, id, label, href }];
+        // Enforce max — drop oldest
+        if (next.length > MAX_STEPS) next.shift();
+        savePath(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clearPath = useCallback(() => {
+    setPath([]);
+    sessionStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  const goToStep = useCallback((index: number) => {
+    setPath((prev) => {
+      const truncated = prev.slice(0, index + 1);
+      savePath(truncated);
+      return truncated;
+    });
+  }, []);
+
+  return {
+    explorePath: path,
+    pushEntity,
+    clearPath,
+    goToStep,
+    /** Only show the path after 2+ entity visits */
+    showPath: path.length >= 2,
+  };
+}

--- a/lib/entityConnections.ts
+++ b/lib/entityConnections.ts
@@ -1,0 +1,378 @@
+/**
+ * Entity Connections — computes relationships between governance entities.
+ *
+ * Each entity page gets a Connected panel showing up to 10 related entities.
+ * Personal connections (viewer's DRep, viewer's alignment) are sorted first.
+ *
+ * Designed for server-side computation with 15-minute cache headers.
+ */
+
+import {
+  getVotesByDRepId,
+  getDRepById,
+  getVotesByProposal,
+  getSpoVotesByProposal,
+  getCcVotesByProposal,
+  getProposalByKey,
+  getCCFidelityHistory,
+  getCCMembersFidelity,
+  getProposalsByIds,
+} from '@/lib/data';
+import { findSimilarByClassification } from '@/lib/proposalSimilarity';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export type EntityType = 'drep' | 'proposal' | 'pool' | 'cc';
+
+export interface EntityConnection {
+  label: string;
+  sublabel?: string;
+  href: string;
+  icon: 'user' | 'file-text' | 'building' | 'shield' | 'vote' | 'trending' | 'users' | 'link';
+  /** True if this connection is personalized for the viewer */
+  personalized: boolean;
+}
+
+export async function getEntityConnections(
+  entityType: EntityType,
+  entityId: string,
+  viewerDrepId?: string | null,
+): Promise<EntityConnection[]> {
+  switch (entityType) {
+    case 'drep':
+      return getDRepConnections(entityId, viewerDrepId);
+    case 'proposal':
+      return getProposalConnections(entityId, viewerDrepId);
+    case 'pool':
+      return getPoolConnections(entityId);
+    case 'cc':
+      return getCCConnections(entityId);
+  }
+}
+
+// ── DRep Connections ──────────────────────────────────────────────────────
+
+async function getDRepConnections(
+  drepId: string,
+  viewerDrepId?: string | null,
+): Promise<EntityConnection[]> {
+  const connections: EntityConnection[] = [];
+
+  const [drep, votes] = await Promise.all([getDRepById(drepId), getVotesByDRepId(drepId)]);
+
+  if (!drep) return connections;
+
+  // Delegation stats
+  if (drep.delegatorCount != null && drep.delegatorCount > 0) {
+    const ada = drep.votingPowerLovelace
+      ? `${formatAdaShort(Number(drep.votingPowerLovelace))}`
+      : '';
+    connections.push({
+      label: `${drep.delegatorCount} delegators`,
+      sublabel: ada ? `${ada} delegated` : undefined,
+      href: `/workspace/delegators`,
+      icon: 'users',
+      personalized: false,
+    });
+  }
+
+  // Recent proposals voted on (up to 3)
+  const recentVotes = votes.slice(0, 3);
+  for (const vote of recentVotes) {
+    connections.push({
+      label: `Voted ${vote.vote}`,
+      sublabel: `Proposal ${vote.proposal_tx_hash.slice(0, 8)}...#${vote.proposal_index}`,
+      href: `/proposal/${vote.proposal_tx_hash}/${vote.proposal_index}`,
+      icon: 'vote',
+      personalized: false,
+    });
+  }
+
+  // Viewer alignment match (if viewer has a DRep)
+  if (viewerDrepId && viewerDrepId !== drepId) {
+    connections.unshift({
+      label: 'Your DRep',
+      sublabel: 'Compare alignment',
+      href: `/drep/${encodeURIComponent(viewerDrepId)}`,
+      icon: 'user',
+      personalized: true,
+    });
+  }
+
+  // Score context
+  if (drep.drepScore != null) {
+    connections.push({
+      label: `Score: ${Math.round(drep.drepScore)}`,
+      sublabel: drep.scoreMomentum
+        ? drep.scoreMomentum > 0
+          ? 'Trending up'
+          : drep.scoreMomentum < 0
+            ? 'Trending down'
+            : 'Stable'
+        : undefined,
+      href: `/you/drep`,
+      icon: 'trending',
+      personalized: false,
+    });
+  }
+
+  return connections.slice(0, 10);
+}
+
+// ── Proposal Connections ──────────────────────────────────────────────────
+
+async function getProposalConnections(
+  compositeId: string,
+  viewerDrepId?: string | null,
+): Promise<EntityConnection[]> {
+  const connections: EntityConnection[] = [];
+
+  // Parse composite ID: "txHash/index"
+  const parts = compositeId.split('/');
+  if (parts.length !== 2) return connections;
+  const [txHash, indexStr] = parts;
+  const proposalIndex = Number(indexStr);
+
+  const [proposal, drepVotes, spoVotes, ccVotes, similar] = await Promise.all([
+    getProposalByKey(txHash, proposalIndex),
+    getVotesByProposal(txHash, proposalIndex),
+    getSpoVotesByProposal(txHash, proposalIndex),
+    getCcVotesByProposal(txHash, proposalIndex),
+    findSimilarByClassification(txHash, proposalIndex, 3),
+  ]);
+
+  // Viewer's DRep vote (personalized, goes first)
+  if (viewerDrepId) {
+    const viewerVote = drepVotes.find((v) => v.drepId === viewerDrepId);
+    if (viewerVote) {
+      connections.push({
+        label: `Your DRep voted ${viewerVote.vote}`,
+        sublabel: viewerVote.drepName ?? viewerDrepId.slice(0, 12),
+        href: `/drep/${encodeURIComponent(viewerDrepId)}`,
+        icon: 'user',
+        personalized: true,
+      });
+    }
+  }
+
+  // Vote breakdown summary
+  const yesCount = proposal?.yesCount ?? drepVotes.filter((v) => v.vote === 'Yes').length;
+  const noCount = proposal?.noCount ?? drepVotes.filter((v) => v.vote === 'No').length;
+  const abstainCount =
+    proposal?.abstainCount ?? drepVotes.filter((v) => v.vote === 'Abstain').length;
+  connections.push({
+    label: `DRep votes: ${yesCount} Yes / ${noCount} No / ${abstainCount} Abstain`,
+    sublabel: `${drepVotes.length} DReps voted`,
+    href: `/proposal/${txHash}/${proposalIndex}`,
+    icon: 'vote',
+    personalized: false,
+  });
+
+  // SPO participation
+  if (spoVotes.length > 0) {
+    connections.push({
+      label: `${spoVotes.length} SPOs voted`,
+      href: `/proposal/${txHash}/${proposalIndex}`,
+      icon: 'building',
+      personalized: false,
+    });
+  }
+
+  // CC ruling
+  if (ccVotes.length > 0) {
+    const ccYes = ccVotes.filter((v) => v.vote === 'Yes').length;
+    const ccNo = ccVotes.filter((v) => v.vote === 'No').length;
+    connections.push({
+      label: `CC: ${ccYes} Yes / ${ccNo} No`,
+      sublabel: `${ccVotes.length} members voted`,
+      href: `/governance/committee`,
+      icon: 'shield',
+      personalized: false,
+    });
+  }
+
+  // Top voting DReps (first 3 with names)
+  const namedVoters = drepVotes.filter((v) => v.drepName).slice(0, 3);
+  for (const voter of namedVoters) {
+    connections.push({
+      label: `${voter.drepName} voted ${voter.vote}`,
+      href: `/drep/${encodeURIComponent(voter.drepId)}`,
+      icon: 'user',
+      personalized: false,
+    });
+  }
+
+  // Similar proposals
+  for (const sim of similar) {
+    connections.push({
+      label: sim.title?.slice(0, 50) ?? 'Related proposal',
+      sublabel: `${Math.round(sim.similarityScore * 100)}% similar`,
+      href: `/proposal/${sim.txHash}/${sim.index}`,
+      icon: 'file-text',
+      personalized: false,
+    });
+  }
+
+  return connections.slice(0, 10);
+}
+
+// ── Pool Connections ──────────────────────────────────────────────────────
+
+async function getPoolConnections(poolId: string): Promise<EntityConnection[]> {
+  const connections: EntityConnection[] = [];
+  const supabase = getSupabaseAdmin();
+
+  // Get pool info
+  const { data: pool } = await supabase
+    .from('pools')
+    .select('pool_id, pool_name, governance_score, active_stake')
+    .eq('pool_id', poolId)
+    .maybeSingle();
+
+  if (!pool) return connections;
+
+  // Governance score
+  if (pool.governance_score != null) {
+    connections.push({
+      label: `Gov Score: ${Math.round(pool.governance_score)}`,
+      href: `/pool/${encodeURIComponent(poolId)}`,
+      icon: 'trending',
+      personalized: false,
+    });
+  }
+
+  // Find proposals this pool voted on (via spo_votes table)
+  const { data: poolVotes } = await supabase
+    .from('spo_votes')
+    .select('proposal_tx_hash, proposal_index, vote')
+    .eq('pool_id', poolId)
+    .order('block_time', { ascending: false })
+    .limit(5);
+
+  if (poolVotes && poolVotes.length > 0) {
+    // Fetch proposal titles for the votes
+    const proposalIds = poolVotes.map((v) => ({
+      txHash: v.proposal_tx_hash,
+      index: v.proposal_index,
+    }));
+    const proposalMap = await getProposalsByIds(proposalIds);
+
+    for (const vote of poolVotes.slice(0, 3)) {
+      const proposal = proposalMap.get(vote.proposal_tx_hash);
+      connections.push({
+        label: `Voted ${vote.vote}`,
+        sublabel:
+          proposal?.title?.slice(0, 40) ?? `Proposal ${vote.proposal_tx_hash.slice(0, 8)}...`,
+        href: `/proposal/${vote.proposal_tx_hash}/${vote.proposal_index}`,
+        icon: 'vote',
+        personalized: false,
+      });
+    }
+  }
+
+  // Similar pools by governance score (within +/- 10 points)
+  if (pool.governance_score != null) {
+    const { data: similarPools } = await supabase
+      .from('pools')
+      .select('pool_id, pool_name, governance_score')
+      .neq('pool_id', poolId)
+      .gte('governance_score', pool.governance_score - 10)
+      .lte('governance_score', pool.governance_score + 10)
+      .order('governance_score', { ascending: false })
+      .limit(3);
+
+    for (const sim of similarPools ?? []) {
+      connections.push({
+        label: sim.pool_name ?? sim.pool_id.slice(0, 12),
+        sublabel: `Score: ${Math.round(sim.governance_score)}`,
+        href: `/pool/${encodeURIComponent(sim.pool_id)}`,
+        icon: 'building',
+        personalized: false,
+      });
+    }
+  }
+
+  return connections.slice(0, 10);
+}
+
+// ── CC Member Connections ─────────────────────────────────────────────────
+
+async function getCCConnections(ccHotId: string): Promise<EntityConnection[]> {
+  const connections: EntityConnection[] = [];
+
+  const [fidelityHistory, allMembers] = await Promise.all([
+    getCCFidelityHistory(ccHotId),
+    getCCMembersFidelity(),
+  ]);
+
+  const thisMember = allMembers.find((m) => m.ccHotId === ccHotId);
+
+  // Fidelity score
+  if (thisMember?.fidelityScore != null) {
+    connections.push({
+      label: `Fidelity: ${Math.round(thisMember.fidelityScore)}`,
+      sublabel: thisMember.fidelityGrade ?? undefined,
+      href: `/governance/committee/${encodeURIComponent(ccHotId)}`,
+      icon: 'shield',
+      personalized: false,
+    });
+  }
+
+  // Participation rate
+  if (
+    thisMember?.votesCast != null &&
+    thisMember?.eligibleProposals != null &&
+    thisMember.eligibleProposals > 0
+  ) {
+    const rate = Math.round((thisMember.votesCast / thisMember.eligibleProposals) * 100);
+    connections.push({
+      label: `${rate}% participation`,
+      sublabel: `${thisMember.votesCast} of ${thisMember.eligibleProposals} votes`,
+      href: `/governance/committee/${encodeURIComponent(ccHotId)}`,
+      icon: 'vote',
+      personalized: false,
+    });
+  }
+
+  // Other CC members (top 3 by fidelity, excluding self)
+  const otherMembers = allMembers.filter((m) => m.ccHotId !== ccHotId).slice(0, 3);
+  for (const member of otherMembers) {
+    connections.push({
+      label: member.authorName ?? member.ccHotId.slice(0, 12),
+      sublabel:
+        member.fidelityScore != null ? `Fidelity: ${Math.round(member.fidelityScore)}` : undefined,
+      href: `/governance/committee/${encodeURIComponent(member.ccHotId)}`,
+      icon: 'shield',
+      personalized: false,
+    });
+  }
+
+  // Recent fidelity trend
+  if (fidelityHistory.length >= 2) {
+    const latest = fidelityHistory[0];
+    const prev = fidelityHistory[1];
+    if (latest?.fidelityScore != null && prev?.fidelityScore != null) {
+      const delta = latest.fidelityScore - prev.fidelityScore;
+      if (Math.abs(delta) >= 1) {
+        connections.push({
+          label: delta > 0 ? 'Fidelity improving' : 'Fidelity declining',
+          sublabel: `${delta > 0 ? '+' : ''}${delta.toFixed(1)} since last epoch`,
+          href: `/governance/committee/${encodeURIComponent(ccHotId)}`,
+          icon: 'trending',
+          personalized: false,
+        });
+      }
+    }
+  }
+
+  return connections.slice(0, 10);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function formatAdaShort(lovelace: number): string {
+  const ada = lovelace / 1_000_000;
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B ₳`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(0)}M ₳`;
+  if (ada >= 1_000) return `${(ada / 1_000).toFixed(1)}K ₳`;
+  return `${Math.round(ada)} ₳`;
+}


### PR DESCRIPTION
## Summary
- **Entity Connections panel** on all 4 entity pages (DRep, Pool, Proposal, CC Member) showing up to 10 related entities with personal connections highlighted first
- **Explore Path** breadcrumb tracks entity page traversal in session (appears after 2+ hops, supports backtracking)
- **Server-side data layer** (`lib/entityConnections.ts`) computes connections using existing data functions

## Impact
- **What changed**: Entity pages are no longer dead ends — each shows related entities, vote breakdowns, similar entities, and personal connections
- **User-facing**: Yes — every entity profile now has a "connections" button revealing the governance relationship graph
- **Risk**: Low — additive feature, no existing behavior modified. API is read-only with 15-min cache.
- **Scope**: 11 files (7 new, 4 entity pages modified). No migrations, no Inngest changes.

## Test plan
- [ ] DRep profile shows connections (votes, delegators, score)
- [ ] Proposal page shows connections (DRep votes, CC ruling, similar proposals)
- [ ] Pool profile shows connections (gov score, votes, similar pools)
- [ ] CC member shows connections (fidelity, participation, other members)
- [ ] Personal connections highlighted (viewer DRep vote on proposal)
- [ ] Explore Path appears after visiting 2+ entity pages
- [ ] Mobile: bottom sheet for connections
- [ ] Desktop: collapsible inline panel
- [ ] Preflight passes (648 tests, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)