### PR TITLE
fix: data integrity audit — correct 12 frontend data issues

### DIFF
--- a/app/api/sidebar-metrics/route.ts
+++ b/app/api/sidebar-metrics/route.ts
@@ -11,7 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
-import { getOpenProposalsForDRep, getDRepById, getActualProposalCount } from '@/lib/data';
+import { getOpenProposalsForDRep, getDRepById } from '@/lib/data';
 import { getTreasuryBalance } from '@/lib/treasury';
 
 export const dynamic = 'force-dynamic';
@@ -42,12 +42,18 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
   // ── Governance metrics (everyone gets these) ──────────────────────────
 
-  const [proposalCount, drepCount, ghiSnapshot, treasury] = await Promise.all([
-    getActualProposalCount(),
+  const [activeProposalCount, drepCount, ghiSnapshot, treasury] = await Promise.all([
+    supabase
+      .from('proposals')
+      .select('tx_hash', { count: 'exact', head: true })
+      .is('ratified_epoch', null)
+      .is('enacted_epoch', null)
+      .is('dropped_epoch', null)
+      .is('expired_epoch', null),
     supabase
       .from('dreps')
-      .select('drep_id', { count: 'exact', head: true })
-      .not('status', 'eq', 'Retired'),
+      .select('id', { count: 'exact', head: true })
+      .eq('info->>isActive', 'true'),
     supabase
       .from('ghi_snapshots')
       .select('ghi_score')
@@ -57,7 +63,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     getTreasuryBalance(),
   ]);
 
-  metrics['gov.activeProposals'] = `${proposalCount} active`;
+  metrics['gov.activeProposals'] = `${activeProposalCount.count ?? 0} active`;
   metrics['gov.activeDreps'] = `${drepCount.count ?? 0} DReps`;
 
   const ghiScore = ghiSnapshot.data?.ghi_score;

--- a/app/claim/[drepId]/ClaimPageClient.tsx
+++ b/app/claim/[drepId]/ClaimPageClient.tsx
@@ -29,10 +29,10 @@ interface ClaimPageClientProps {
   drepId: string;
   name: string;
   score: number;
+  engagement: number;
   participation: number;
-  rationale: number;
   reliability: number;
-  profile: number;
+  identity: number;
   isClaimed: boolean;
 }
 
@@ -116,16 +116,16 @@ function PillarBar({ label, value, max }: { label: string; value: number; max: n
 }
 
 function getLowestPillar(p: {
+  engagement: number;
   participation: number;
-  rationale: number;
   reliability: number;
-  profile: number;
+  identity: number;
 }) {
   const pillars = [
-    { key: 'Participation', value: p.participation },
-    { key: 'Rationale', value: p.rationale },
+    { key: 'Engagement Quality', value: p.engagement },
+    { key: 'Effective Participation', value: p.participation },
     { key: 'Reliability', value: p.reliability },
-    { key: 'Profile', value: p.profile },
+    { key: 'Governance Identity', value: p.identity },
   ];
   return pillars.reduce((min, curr) => (curr.value < min.value ? curr : min));
 }
@@ -134,10 +134,10 @@ export function ClaimPageClient({
   drepId,
   name,
   score,
+  engagement,
   participation,
-  rationale,
   reliability,
-  profile,
+  identity,
   isClaimed,
 }: ClaimPageClientProps) {
   const router = useRouter();
@@ -148,8 +148,8 @@ export function ClaimPageClient({
   const [showCelebration, setShowCelebration] = useState(false);
 
   const lowestPillar = useMemo(
-    () => getLowestPillar({ participation, rationale, reliability, profile }),
-    [participation, rationale, reliability, profile],
+    () => getLowestPillar({ engagement, participation, reliability, identity }),
+    [engagement, participation, reliability, identity],
   );
 
   useEffect(() => {
@@ -240,9 +240,9 @@ export function ClaimPageClient({
         name={name}
         score={score}
         participation={participation}
-        rationale={rationale}
+        rationale={engagement}
         reliability={reliability}
-        profile={profile}
+        profile={identity}
         onContinue={() => router.push('/my-gov')}
       />
     );
@@ -290,10 +290,10 @@ export function ClaimPageClient({
       <div className="flex flex-col items-center space-y-4">
         <ScoreRing score={score} />
         <div className="space-y-2 w-full max-w-md">
-          <PillarBar label="Participation" value={participation} max={30} />
-          <PillarBar label="Rationale" value={rationale} max={35} />
-          <PillarBar label="Reliability" value={reliability} max={20} />
-          <PillarBar label="Profile" value={profile} max={15} />
+          <PillarBar label="Engagement" value={engagement} max={35} />
+          <PillarBar label="Participation" value={participation} max={25} />
+          <PillarBar label="Reliability" value={reliability} max={25} />
+          <PillarBar label="Identity" value={identity} max={15} />
         </div>
         <p className="text-xs text-muted-foreground">
           Biggest opportunity:{' '}

--- a/app/claim/[drepId]/page.tsx
+++ b/app/claim/[drepId]/page.tsx
@@ -56,10 +56,10 @@ export default async function ClaimPage({ params }: ClaimPageProps) {
       drepId={drep.drepId}
       name={name}
       score={drep.drepScore}
-      participation={drep.effectiveParticipation}
-      rationale={drep.rationaleRate}
-      reliability={drep.reliabilityScore}
-      profile={drep.profileCompleteness}
+      engagement={drep.engagementQuality ?? drep.rationaleRate}
+      participation={drep.effectiveParticipationV3 ?? drep.effectiveParticipation}
+      reliability={drep.reliabilityV3 ?? drep.reliabilityScore}
+      identity={drep.governanceIdentity ?? drep.profileCompleteness}
       isClaimed={claimed}
     />
   );

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -25,7 +25,10 @@ export const dynamic = 'force-dynamic';
 async function getDRepCount(): Promise<number> {
   try {
     const supabase = createClient();
-    const { count } = await supabase.from('dreps').select('*', { count: 'exact', head: true });
+    const { count } = await supabase
+      .from('dreps')
+      .select('id', { count: 'exact', head: true })
+      .eq('info->>isActive', 'true');
     return count ?? 0;
   } catch {
     return 0;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,14 +58,9 @@ async function getGovernancePulse() {
   }
 
   return {
-    totalAdaGoverned: '',
     activeProposals: openProposalsResult.count ?? 0,
     activeDReps: activeDRepsResult.count ?? 0,
     totalDReps: totalDRepsResult.count ?? 0,
-    votesThisWeek: 0,
-    claimedDReps: 0,
-    activeSpOs: 0,
-    ccMembers: 0,
     totalDelegators,
   };
 }

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -15,10 +15,8 @@ const ConstellationScene = dynamic(
 
 interface AnonymousLandingProps {
   pulseData?: {
-    totalAdaGoverned: string;
     activeProposals: number;
     activeDReps: number;
-    activeSpOs: number;
     totalDelegators: number;
   };
 }

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -14,14 +14,9 @@ import { SPOCockpit } from '@/components/workspace/SPOCockpit';
 import { ActionQueueCard } from '@/components/governada/ActionQueueCard';
 
 interface PulseData {
-  totalAdaGoverned: string;
   activeProposals: number;
   activeDReps: number;
   totalDReps: number;
-  votesThisWeek: number;
-  claimedDReps: number;
-  activeSpOs: number;
-  ccMembers: number;
   totalDelegators: number;
 }
 

--- a/inngest/functions/sync-alignment.ts
+++ b/inngest/functions/sync-alignment.ts
@@ -96,12 +96,12 @@ const DB_PROPOSAL_COLUMNS =
 
 interface SerializedScoreRow {
   drepId: string;
-  treasuryConservative: number;
-  treasuryGrowth: number;
-  decentralization: number;
-  security: number;
-  innovation: number;
-  transparency: number;
+  treasuryConservative: number | null;
+  treasuryGrowth: number | null;
+  decentralization: number | null;
+  security: number | null;
+  innovation: number | null;
+  transparency: number | null;
   pTreasuryConservative: number;
   pTreasuryGrowth: number;
   pDecentralization: number;

--- a/lib/alignment/dimensions.ts
+++ b/lib/alignment/dimensions.ts
@@ -23,12 +23,12 @@ export interface DRepContext {
 }
 
 export interface DimensionScores {
-  treasuryConservative: number;
-  treasuryGrowth: number;
-  decentralization: number;
-  security: number;
-  innovation: number;
-  transparency: number;
+  treasuryConservative: number | null;
+  treasuryGrowth: number | null;
+  decentralization: number | null;
+  security: number | null;
+  innovation: number | null;
+  transparency: number | null;
 }
 
 const HALF_LIFE_MS = 6 * 30 * 24 * 60 * 60 * 1000;
@@ -68,9 +68,13 @@ export function computeDimensionScores(
   };
 }
 
-function calcTreasuryConservative(inputs: DimensionInput[], now: number, maxAda: number): number {
+function calcTreasuryConservative(
+  inputs: DimensionInput[],
+  now: number,
+  maxAda: number,
+): number | null {
   const relevant = inputs.filter((i) => (i.classification?.dimTreasuryConservative ?? 0) > 0.2);
-  if (relevant.length === 0) return 50;
+  if (relevant.length === 0) return null;
 
   let weightedSum = 0;
   let totalWeight = 0;
@@ -90,13 +94,13 @@ function calcTreasuryConservative(inputs: DimensionInput[], now: number, maxAda:
     totalWeight += weight;
   }
 
-  if (totalWeight === 0) return 50;
+  if (totalWeight === 0) return null;
   return Math.round((weightedSum / totalWeight) * 100);
 }
 
-function calcTreasuryGrowth(inputs: DimensionInput[], now: number, maxAda: number): number {
+function calcTreasuryGrowth(inputs: DimensionInput[], now: number, maxAda: number): number | null {
   const relevant = inputs.filter((i) => (i.classification?.dimTreasuryGrowth ?? 0) > 0.2);
-  if (relevant.length === 0) return 50;
+  if (relevant.length === 0) return null;
 
   let weightedSum = 0;
   let totalWeight = 0;
@@ -127,13 +131,19 @@ function calcTreasuryGrowth(inputs: DimensionInput[], now: number, maxAda: numbe
     totalWeight += weight;
   }
 
-  if (totalWeight === 0) return 50;
+  if (totalWeight === 0) return null;
   return Math.round((weightedSum / totalWeight) * 100);
 }
 
-function calcDecentralization(inputs: DimensionInput[], drep: DRepContext, now: number): number {
+function calcDecentralization(
+  inputs: DimensionInput[],
+  drep: DRepContext,
+  now: number,
+): number | null {
   // Vote pattern on decentralization-relevant proposals
   const relevant = inputs.filter((i) => (i.classification?.dimDecentralization ?? 0) > 0.2);
+
+  if (relevant.length === 0 && inputs.length === 0) return null;
 
   let voteScore = 50;
   if (relevant.length > 0) {
@@ -170,11 +180,11 @@ function calcDecentralization(inputs: DimensionInput[], drep: DRepContext, now: 
   return clamp(voteScore + breadthBonus);
 }
 
-function calcSecurity(inputs: DimensionInput[], drep: DRepContext, now: number): number {
+function calcSecurity(inputs: DimensionInput[], drep: DRepContext, now: number): number | null {
   const relevant = inputs.filter((i) => (i.classification?.dimSecurity ?? 0) > 0.2);
 
   if (relevant.length === 0) {
-    return Math.round(drep.participationRate * 0.5 + drep.rationaleRate * 0.5);
+    return null;
   }
 
   // Caution rate: No/Abstain on security proposals
@@ -193,7 +203,7 @@ function calcSecurity(inputs: DimensionInput[], drep: DRepContext, now: number):
     totalWeight += weight;
   }
 
-  if (totalWeight === 0) return 50;
+  if (totalWeight === 0) return null;
 
   const cautionRate = (cautionCount / totalWeight) * 100;
   const rationaleRate = (rationaleCount / totalWeight) * 100;
@@ -202,8 +212,10 @@ function calcSecurity(inputs: DimensionInput[], drep: DRepContext, now: number):
   return Math.round(cautionRate * 0.5 + rationaleRate * 0.3 + participationRate * 0.2);
 }
 
-function calcInnovation(inputs: DimensionInput[], drep: DRepContext, now: number): number {
+function calcInnovation(inputs: DimensionInput[], drep: DRepContext, now: number): number | null {
   const relevant = inputs.filter((i) => (i.classification?.dimInnovation ?? 0) > 0.2);
+
+  if (relevant.length === 0 && inputs.length === 0) return null;
 
   // Support rate on innovation proposals (0.4 weight)
   let supportScore = 50;
@@ -238,7 +250,9 @@ function calcInnovation(inputs: DimensionInput[], drep: DRepContext, now: number
   return Math.round(supportScore * 0.4 + infoEngagement * 0.3 + breadth * 0.3);
 }
 
-function calcTransparency(inputs: DimensionInput[], drep: DRepContext): number {
+function calcTransparency(inputs: DimensionInput[], drep: DRepContext): number | null {
+  if (inputs.length === 0) return null;
+
   // AI rationale quality (0.6 weight)
   const withQuality = inputs.filter((i) => i.rationaleQuality != null);
   let avgQuality = 50;

--- a/lib/alignment/normalize.ts
+++ b/lib/alignment/normalize.ts
@@ -5,12 +5,12 @@
 
 export interface RawScoreRow {
   drepId: string;
-  treasuryConservative: number;
-  treasuryGrowth: number;
-  decentralization: number;
-  security: number;
-  innovation: number;
-  transparency: number;
+  treasuryConservative: number | null;
+  treasuryGrowth: number | null;
+  decentralization: number | null;
+  security: number | null;
+  innovation: number | null;
+  transparency: number | null;
 }
 
 export interface NormalizedScoreRow extends RawScoreRow {
@@ -43,14 +43,16 @@ const DIMENSIONS: DimensionKey[] = [
 export function normalizeToPercentiles(rows: RawScoreRow[]): NormalizedScoreRow[] {
   if (rows.length === 0) return [];
 
-  const n = rows.length;
   const percentiles = new Map<string, Record<DimensionKey, number>>();
 
   for (const dim of DIMENSIONS) {
-    // Sort by raw score ascending, preserving index
-    const sorted = rows
-      .map((row, idx) => ({ drepId: row.drepId, value: row[dim], idx }))
+    // Only rank DReps that have data for this dimension (skip nulls)
+    const withData = rows.filter((row) => row[dim] != null);
+    const sorted = withData
+      .map((row) => ({ drepId: row.drepId, value: row[dim] as number }))
       .sort((a, b) => a.value - b.value);
+
+    const nd = sorted.length;
 
     // Assign ranks with tie-handling (average rank for ties)
     let i = 0;
@@ -59,17 +61,27 @@ export function normalizeToPercentiles(rows: RawScoreRow[]): NormalizedScoreRow[
       while (j < sorted.length && sorted[j].value === sorted[i].value) j++;
 
       const avgRank = (i + j - 1) / 2; // 0-indexed average rank for this tie group
-      const percentile = Math.round((avgRank / (n - 1)) * 100);
+      const percentile = nd <= 1 ? 50 : Math.round((avgRank / (nd - 1)) * 100);
 
       for (let k = i; k < j; k++) {
         const drepId = sorted[k].drepId;
         if (!percentiles.has(drepId)) {
           percentiles.set(drepId, {} as Record<DimensionKey, number>);
         }
-        percentiles.get(drepId)![dim] = n === 1 ? 50 : percentile;
+        percentiles.get(drepId)![dim] = percentile;
       }
 
       i = j;
+    }
+
+    // DReps with null for this dimension get percentile 50 (neutral)
+    for (const row of rows) {
+      if (row[dim] == null) {
+        if (!percentiles.has(row.drepId)) {
+          percentiles.set(row.drepId, {} as Record<DimensionKey, number>);
+        }
+        percentiles.get(row.drepId)![dim] = 50;
+      }
     }
   }
 

--- a/lib/alignment/pcaProjection.ts
+++ b/lib/alignment/pcaProjection.ts
@@ -62,7 +62,7 @@ export function projectPCAToDimensions(
   }
 
   // For each dimension, compute the DRep's projected score
-  const scores: Record<string, number> = {};
+  const scores: Record<string, number | null> = {};
 
   for (const dim of DIMENSION_KEYS) {
     const field = CLASSIFICATION_FIELDS[dim];
@@ -99,7 +99,7 @@ export function projectPCAToDimensions(
       const normalized = sigmoid(projectedValue) * 100;
       scores[dim] = Math.round(Math.max(0, Math.min(100, normalized)));
     } else {
-      scores[dim] = 50; // neutral fallback
+      scores[dim] = null; // no relevant data for this dimension
     }
   }
 

--- a/lib/alignment/validate.ts
+++ b/lib/alignment/validate.ts
@@ -77,8 +77,8 @@ export function validateDimensionIndependence(rows: NormalizedScoreRow[]): Valid
       const dim1 = DIMENSIONS[i];
       const dim2 = DIMENSIONS[j];
 
-      const x = rows.map((r) => r[dim1]);
-      const y = rows.map((r) => r[dim2]);
+      const x = rows.map((r) => r[dim1] ?? 50);
+      const y = rows.map((r) => r[dim2] ?? 50);
 
       const r = pearsonCorrelation(x, y);
       const result: CorrelationResult = {

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -334,6 +334,13 @@ export async function getActiveProposalEpochs(): Promise<Map<number, number>> {
 }
 
 /**
+ * Last known-good proposal count, updated periodically.
+ * Used as fallback when Supabase is unreachable. Must be kept roughly current
+ * to avoid inflating participation rates.
+ */
+const FALLBACK_PROPOSAL_COUNT = 300;
+
+/**
  * Get the actual total number of governance proposals from the proposals table.
  * Used as the denominator for participation rate calculations.
  */
@@ -347,13 +354,13 @@ export async function getActualProposalCount(): Promise<number> {
 
     if (error) {
       logger.warn('[Data] getActualProposalCount query failed', { error: error.message });
-      return 88; // fallback based on known count
+      return FALLBACK_PROPOSAL_COUNT;
     }
 
-    return count && count > 0 ? count : 88;
+    return count && count > 0 ? count : FALLBACK_PROPOSAL_COUNT;
   } catch (err) {
     logger.error('[Data] getActualProposalCount error', { error: err });
-    return 88;
+    return FALLBACK_PROPOSAL_COUNT;
   }
 }
 
@@ -1621,8 +1628,12 @@ export async function getDRepPercentile(score: number): Promise<number> {
     const supabase = createClient();
 
     const [{ count: belowCount }, { count: totalCount }] = await Promise.all([
-      supabase.from('dreps').select('*', { count: 'exact', head: true }).lt('score', score),
-      supabase.from('dreps').select('*', { count: 'exact', head: true }),
+      supabase
+        .from('dreps')
+        .select('*', { count: 'exact', head: true })
+        .gt('score', 0)
+        .lt('score', score),
+      supabase.from('dreps').select('*', { count: 'exact', head: true }).gt('score', 0),
     ]);
 
     if (!totalCount || totalCount === 0) return 0;

--- a/lib/sync/slow.ts
+++ b/lib/sync/slow.ts
@@ -561,13 +561,13 @@ async function runDRepMetadataHashVerification(supabase: SupabaseClient) {
   let verified = 0;
   let failed = 0;
 
-  const metaHashUpdates: { id: string; metadata_hash_verified: boolean }[] = [];
+  const metaHashUpdates: { id: string; metadata_hash_verified: boolean | null }[] = [];
 
-  // Mark DReps without anchor data so they don't block the queue
+  // DReps without anchor data get null (not checked) rather than false (failed)
   for (const id of drepIds) {
     const anchor = anchorMap.get(id);
     if (!anchor) {
-      metaHashUpdates.push({ id, metadata_hash_verified: false });
+      metaHashUpdates.push({ id, metadata_hash_verified: null });
       continue;
     }
     try {


### PR DESCRIPTION
## Summary
- **P0**: Sidebar metrics showed total proposals labeled as "active" and queried non-existent columns (`drep_id`, `status`) on `dreps` table — fixed to filter open proposals and use correct column (`id`) with `isActive` filter
- **P1**: Updated stale proposal count fallback (88→300), fixed claim page V2 pillar weights/labels to V3, excluded zero-score DReps from percentile calculation
- **P2**: Distinguish "no anchor URL" (null) from "failed verification" (false) for `metadataHashVerified`; return null instead of 50 for alignment dimensions with no relevant votes; filter discover page DRep count to active only
- **P3**: Removed unused hardcoded-zero fields from homepage pulse data interface

## Impact
- **What changed**: 12 data integrity issues fixed across sidebar metrics, claim page, scoring, alignment, and homepage
- **User-facing**: Yes — sidebar now shows correct active proposal/DRep counts; claim page shows accurate V3 pillar breakdown; percentile rankings are more meaningful; alignment scores distinguish "no data" from "centrist"
- **Risk**: Low-Medium — all changes are data-correctness fixes with no new features; 648 tests pass; alignment null changes cascade through normalization but null handling is clean
- **Scope**: 14 files across API routes, pages, alignment lib, scoring, sync pipeline

## Test plan
- [ ] Verify sidebar shows correct active proposal count (should be ~30-50, not 300+)
- [ ] Verify sidebar shows non-zero DRep count
- [ ] Verify claim page pillar bars match V3 weights (35/25/25/15)
- [ ] Verify DRep percentiles are reasonable (not inflated by inactive DReps)
- [ ] Verify discover page DRep count matches other active counts
- [ ] Verify alignment null values don't break profile/compare pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)