### PR TITLE
fix: citizen intelligence gaps — DRep name + delegation sublabel

### DIFF
--- a/app/api/sidebar-metrics/route.ts
+++ b/app/api/sidebar-metrics/route.ts
@@ -11,10 +11,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
-import { getOpenProposalsForDRep, getDRepById } from '@/lib/data';
+import { getOpenProposalsForDRep, getDRepById, getVotedThisEpoch } from '@/lib/data';
 import { getTreasuryBalance } from '@/lib/treasury';
 import { computeTier } from '@/lib/scoring/tiers';
 import { blockTimeToEpoch } from '@/lib/koios';
+import { getDRepPrimaryName } from '@/utils/display';
 
 export const dynamic = 'force-dynamic';
 
@@ -55,6 +56,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const drepId = request.nextUrl.searchParams.get('drepId');
   const poolId = request.nextUrl.searchParams.get('poolId');
   const stakeAddress = request.nextUrl.searchParams.get('stakeAddress');
+  const delegatedDrepId = request.nextUrl.searchParams.get('delegatedDrepId');
 
   // ── Governance metrics (everyone) ─────────────────────────────────────
 
@@ -161,6 +163,31 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       if (pool.active_stake) {
         metrics['home.delegatedAda'] = formatAda(Number(pool.active_stake));
       }
+    }
+  }
+
+  // ── Citizen delegation metrics ─────────────────────────────────────────
+
+  if (delegatedDrepId && !drepId) {
+    // Citizen with delegation — show their DRep's activity
+    const [delegatedDrep, votedThisEpoch] = await Promise.all([
+      getDRepById(delegatedDrepId),
+      getVotedThisEpoch(delegatedDrepId, epoch),
+    ]);
+
+    if (delegatedDrep) {
+      const drepName = getDRepPrimaryName(delegatedDrep);
+      const score = Math.round(delegatedDrep.drepScore ?? 0);
+      const momentum = delegatedDrep.scoreMomentum ?? 0;
+      const arrow = momentum > 1 ? ' ↑' : momentum < -1 ? ' ↓' : '';
+
+      // Delegation sublabel: DRep name + score
+      metrics['you.coverage'] = `${drepName} · ${score}${arrow}`;
+
+      // Citizen epoch context: DRep name + epoch votes
+      metrics['citizen.drepName'] = drepName;
+      metrics['citizen.drepEpochVotes'] = String(votedThisEpoch);
+      metrics['citizen.drepScore'] = `${score}${arrow}`;
     }
   }
 

--- a/components/governada/EpochContextBar.tsx
+++ b/components/governada/EpochContextBar.tsx
@@ -64,8 +64,17 @@ export function EpochContextBar({ sidebarCollapsed }: { sidebarCollapsed: boolea
         if (proposals) parts.push(proposals);
         return parts.join(' · ') || proposals;
       }
-      case 'citizen':
+      case 'citizen': {
+        const drepName = metrics['citizen.drepName'];
+        const epochVotes = metrics['citizen.drepEpochVotes'];
+        if (drepName && epochVotes) {
+          return `${drepName}: ${epochVotes} ${t('votes this epoch')}`;
+        }
+        if (drepName) {
+          return `${t('Your DRep')}: ${drepName}`;
+        }
         return proposals;
+      }
       case 'cc':
         return proposals;
       case 'anonymous':

--- a/hooks/useSidebarMetrics.ts
+++ b/hooks/useSidebarMetrics.ts
@@ -10,18 +10,19 @@ import { useSegment } from '@/components/providers/SegmentProvider';
  * Polls every 30 seconds. Returns empty map while loading/error.
  */
 export function useSidebarMetrics(): Record<string, string> {
-  const { segment, drepId, poolId, stakeAddress } = useSegment();
+  const { segment, drepId, poolId, stakeAddress, delegatedDrep } = useSegment();
 
   const params = new URLSearchParams();
   if (drepId) params.set('drepId', drepId);
   if (poolId) params.set('poolId', poolId);
   if (stakeAddress) params.set('stakeAddress', stakeAddress);
+  if (delegatedDrep) params.set('delegatedDrepId', delegatedDrep);
 
   const queryString = params.toString();
   const url = queryString ? `/api/sidebar-metrics?${queryString}` : '/api/sidebar-metrics';
 
   const { data } = useQuery<Record<string, string>>({
-    queryKey: ['sidebar-metrics', segment, drepId, poolId, stakeAddress],
+    queryKey: ['sidebar-metrics', segment, drepId, poolId, stakeAddress, delegatedDrep],
     queryFn: async () => {
       const res = await fetch(url);
       if (!res.ok) return {};


### PR DESCRIPTION
## Summary
- Citizen Epoch Bar shows DRep name + epoch vote count instead of generic proposal count
- Delegation sidebar sublabel shows DRep name + score with trend arrow
- Sidebar metrics hook passes delegatedDrepId for citizen-specific data

## Impact
- **What changed**: Citizens (largest persona) now see their DRep's name and activity in epoch bar + sidebar
- **User-facing**: Yes — "AdaHolder DRep: 2 votes this epoch" in epoch bar, "AdaHolder · 82 ↑" under Delegation
- **Risk**: Low — additive data fetch, same pattern as existing DRep metrics
- **Scope**: 3 files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)