### PR TITLE
fix: entity connections map key mismatch

### DIFF
--- a/lib/entityConnections.ts
+++ b/lib/entityConnections.ts
@@ -142,7 +142,7 @@ async function getDRepConnections(
     const proposalMap = await getProposalsByIds(proposalIds);
 
     for (const vote of recentVotes) {
-      const proposal = proposalMap.get(vote.proposal_tx_hash);
+      const proposal = proposalMap.get(`${vote.proposal_tx_hash}-${vote.proposal_index}`);
       connections.push({
         label: `Voted ${vote.vote}`,
         sublabel:
@@ -327,7 +327,7 @@ async function getPoolConnections(poolId: string): Promise<EntityConnection[]> {
     const proposalMap = await getProposalsByIds(proposalIds);
 
     for (const vote of poolVotes.slice(0, 3)) {
-      const proposal = proposalMap.get(vote.proposal_tx_hash);
+      const proposal = proposalMap.get(`${vote.proposal_tx_hash}-${vote.proposal_index}`);
       connections.push({
         label: `Voted ${vote.vote}`,
         sublabel:


### PR DESCRIPTION
## Summary
Fix Map key format mismatch in `lib/entityConnections.ts` — `getProposalsByIds` returns Map keyed by `${txHash}-${index}` but lookups used `txHash` alone, always returning undefined.

## Impact
- **What changed**: Proposal titles now display correctly in DRep and Pool connection panels
- **Risk**: Low — single line fix in two places, same file
- **Scope**: 1 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)