### PR TITLE
fix: PinButton TooltipProvider crash breaking all entity pages

### DIFF
--- a/components/shared/PinButton.tsx
+++ b/components/shared/PinButton.tsx
@@ -3,7 +3,7 @@
 import { Pin, PinOff } from 'lucide-react';
 import { usePinnedItems, type PinnedEntityType } from '@/hooks/usePinnedItems';
 import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface PinButtonProps {
   type: PinnedEntityType;
@@ -20,21 +20,23 @@ export function PinButton({ type, id, label }: PinButtonProps) {
   const pinned = isPinned(type, id);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 text-muted-foreground hover:text-foreground"
-          onClick={() => (pinned ? unpin(type, id) : pin(type, id, label))}
-          aria-label={pinned ? 'Unpin from sidebar' : 'Pin to sidebar'}
-        >
-          {pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <p>{pinned ? 'Unpin from sidebar' : 'Pin to sidebar'}</p>
-      </TooltipContent>
-    </Tooltip>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
+            onClick={() => (pinned ? unpin(type, id) : pin(type, id, label))}
+            aria-label={pinned ? 'Unpin from sidebar' : 'Pin to sidebar'}
+          >
+            {pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>{pinned ? 'Unpin from sidebar' : 'Pin to sidebar'}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## Summary
PinButton used `<Tooltip>` without a `<TooltipProvider>` ancestor, causing a client-side hydration crash on every entity page (DRep, Pool, Proposal, CC Member). Added self-contained `<TooltipProvider>` wrapper.

## Impact
- **What changed**: All entity pages now load correctly — the PinButton tooltip no longer crashes hydration
- **User-facing**: Yes — **critical fix**, pages were blank/broken for all users
- **Risk**: None — adds missing required provider wrapper
- **Scope**: 1 file (components/shared/PinButton.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)