### PR TITLE
fix: remove duplicate delegation CTA on DRep profile

### DIFF
--- a/components/DRepProfileHero.tsx
+++ b/components/DRepProfileHero.tsx
@@ -159,8 +159,10 @@ export function DRepProfileHero({
               </span>
             </div>
 
-            {/* Actions slot (delegation CTA, compare, etc.) */}
-            {children && <div className="pt-2 flex flex-wrap gap-2">{children}</div>}
+            {/* Actions slot (delegation CTA, compare, etc.) — skip for citizens since it renders in the right column */}
+            {children && (isGovernanceParticipant || !trustSignals || !tier) && (
+              <div className="pt-2 flex flex-wrap gap-2">{children}</div>
+            )}
           </motion.div>
 
           {/* Right: Signature visuals — radar for governance participants, trust signals already shown for citizens */}


### PR DESCRIPTION
## Summary
- The `children` slot (InlineDelegationCTA, CompareButton, etc.) was rendered in **both** the left column and the right-column citizen tier display in `DRepProfileHero`, causing the "Connect wallet to delegate" button to appear twice for citizen viewers
- Now the left-column actions slot is conditionally skipped when the right-column citizen tier view is active

## Impact
- **What changed**: Citizen viewers see the delegation CTA once (in the right column next to the tier badge) instead of duplicated in both columns
- **User-facing**: Yes — removes visual duplication on DRep profile pages for non-governance-participant viewers
- **Risk**: Low — conditional rendering change only, no data/logic changes. Governance participants (DRep/SPO/CC) are unaffected
- **Scope**: `components/DRepProfileHero.tsx` only

## Test plan
- [ ] View a DRep profile as anonymous/citizen — CTA appears once (right column)
- [ ] View a DRep profile as DRep/SPO/CC — CTA appears once (left column), radar on right
- [ ] Delegation flow still works from the single CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)