### PR TITLE
fix: epoch-gap detection in freshness guard + contextual alert counts

### DIFF
--- a/app/api/admin/integrity/alert/route.ts
+++ b/app/api/admin/integrity/alert/route.ts
@@ -174,8 +174,9 @@ export const GET = withRouteHandler(async (request) => {
     }
 
     if (row.last_success === false) {
-      const failureCount = row.failure_count ?? '?';
-      const totalCount = (row.success_count ?? 0) + (row.failure_count ?? 0);
+      const failureCount = row.failure_count ?? 0;
+      const successCount = row.success_count ?? 0;
+      const totalCount = successCount + (failureCount as number);
       const errorDetail = row.last_error
         ? row.last_error.length > 200
           ? row.last_error.slice(0, 200) + '…'
@@ -197,10 +198,18 @@ export const GET = withRouteHandler(async (request) => {
         action = `Check Railway/Inngest logs for ${config.label}. Retrigger via Inngest Cloud (event: ${config.event}).`;
       }
 
+      // Show success rate to give context — a single transient failure among hundreds
+      // of successes is very different from a pattern of repeated failures.
+      const successRate = totalCount > 0 ? Math.round((successCount / totalCount) * 100) : 0;
+      const failureContext =
+        successRate >= 95
+          ? `${failureCount} failures out of ${totalCount} runs (${successRate}% success rate)`
+          : `${failureCount}/${totalCount} runs failed`;
+
       alerts.push({
         level: 'critical',
         metric: `${config.label} — Last Run Failed`,
-        value: `${errorDetail}\n${failureCount}/${totalCount} runs failed · ${runAge}`,
+        value: `${errorDetail}\n${failureContext} · ${runAge}`,
         threshold: 'must succeed',
         action,
       });

--- a/inngest/functions/sync-freshness-guard.ts
+++ b/inngest/functions/sync-freshness-guard.ts
@@ -160,7 +160,72 @@ export const syncFreshnessGuard = inngest.createFunction(
       return stale;
     });
 
-    if (staleTypes.length === 0) {
+    // ── Epoch-gap detection for snapshot tables ──
+    // Catches cases where the daily GHI/treasury sync ran before an epoch boundary,
+    // leaving the new epoch without a snapshot until the next scheduled run.
+    const epochGaps = await step.run('check-epoch-gaps', async () => {
+      const supabase = getSupabaseAdmin();
+      const { data: stats } = await supabase
+        .from('governance_stats')
+        .select('current_epoch')
+        .eq('id', 1)
+        .single();
+      const currentEpoch = stats?.current_epoch ?? 0;
+      if (currentEpoch === 0) return [];
+
+      const gaps: { syncType: string; event: string; epoch: number }[] = [];
+
+      const snapshotChecks: { table: string; epochCol: string; syncType: string; event: string }[] =
+        [
+          {
+            table: 'ghi_snapshots',
+            epochCol: 'epoch_no',
+            syncType: 'ghi',
+            event: 'drepscore/sync.ghi',
+          },
+          {
+            table: 'treasury_snapshots',
+            epochCol: 'epoch_no',
+            syncType: 'treasury',
+            event: 'drepscore/sync.treasury',
+          },
+        ];
+
+      for (const check of snapshotChecks) {
+        const { count } = await supabase
+          .from(check.table)
+          .select('*', { count: 'exact', head: true })
+          .eq(check.epochCol, currentEpoch);
+
+        if ((count ?? 0) === 0) {
+          gaps.push({ syncType: check.syncType, event: check.event, epoch: currentEpoch });
+        }
+      }
+
+      return gaps;
+    });
+
+    for (const gap of epochGaps) {
+      await step.run(`recover-epoch-gap-${gap.syncType}`, async () => {
+        logger.info('[FreshnessGuard] Epoch gap detected — triggering sync', {
+          syncType: gap.syncType,
+          missingEpoch: gap.epoch,
+        });
+        await inngest.send({ name: gap.event });
+
+        emitPostHog(true, gap.syncType as SyncType, 0, {
+          event_override: 'sync_epoch_gap_healed',
+          missing_epoch: gap.epoch,
+        });
+        await alertDiscord(
+          `Epoch Gap Healed: ${gap.syncType}`,
+          `No epoch ${gap.epoch} snapshot found. Triggered sync via freshness guard.`,
+        );
+        recoveries.push(`${gap.syncType}: epoch ${gap.epoch} gap`);
+      });
+    }
+
+    if (staleTypes.length === 0 && epochGaps.length === 0) {
       return { recovered: 0, message: 'All syncs fresh' };
     }
 


### PR DESCRIPTION
## Summary
- Freshness guard now detects missing epoch snapshots (GHI, treasury) and triggers syncs within 30 min of an epoch transition
- Integrity alerts show success rate context when sync is generally healthy (e.g., "29 failures out of 630 runs (95% success rate)")

## Impact
- **What changed**: Epoch-gap auto-healing in freshness guard + less alarming alert formatting for transient failures
- **User-facing**: No — backend sync resilience only
- **Risk**: Low — additive logic in existing freshness guard, cosmetic change in alert text
- **Scope**: `inngest/functions/sync-freshness-guard.ts`, `app/api/admin/integrity/alert/route.ts`

## Test plan
- [x] Preflight passes (648/648 tests, 0 errors)
- [ ] CI green
- [ ] Next epoch transition: verify GHI snapshot created within 30 min
- [ ] Next transient sync failure: verify alert shows success rate context

🤖 Generated with [Claude Code](https://claude.com/claude-code)