### PR TITLE
fix: UX polish batch + Quick Match improvements

### DIFF
--- a/app/api/governance/pools/[poolId]/summary/route.ts
+++ b/app/api/governance/pools/[poolId]/summary/route.ts
@@ -19,7 +19,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const { data: pool } = await supabase
     .from('pools')
     .select(
-      'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, delegator_count, live_stake_lovelace, claimed_by, score_momentum, current_tier, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
+      'pool_id, ticker, pool_name, governance_score, vote_count, participation_pct, consistency_pct, reliability_pct, deliberation_pct, governance_identity_pct, confidence, delegator_count, live_stake_lovelace, claimed_by, score_momentum, current_tier, pool_status, alignment_treasury_conservative, alignment_treasury_growth, alignment_decentralization, alignment_security, alignment_innovation, alignment_transparency',
     )
     .eq('pool_id', poolId)
     .single();
@@ -68,6 +68,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
         : 0,
       scoreDelta,
       momentum: pool.score_momentum ?? null,
+      poolStatus: pool.pool_status ?? 'registered',
       alignment: {
         treasuryConservative: pool.alignment_treasury_conservative,
         treasuryGrowth: pool.alignment_treasury_growth,

--- a/app/governance/committee/[ccHotId]/page.tsx
+++ b/app/governance/committee/[ccHotId]/page.tsx
@@ -73,7 +73,9 @@ export default async function CCMemberProfilePage({ params }: PageProps) {
   ]);
 
   const safeVotes = votes ?? [];
-  if (safeVotes.length === 0) notFound();
+
+  // Allow pages for CC members with no votes yet (newly seated members)
+  if (safeVotes.length === 0 && !member) notFound();
 
   // Build lookups
   const proposalMap = new Map<string, { title: string | null; type: string }>();

--- a/app/learn/LearnClient.tsx
+++ b/app/learn/LearnClient.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import {
   BookOpen,
@@ -9,15 +8,10 @@ import {
   Vote,
   Shield,
   Scale,
-  Search,
-  X,
   Rocket,
   ArrowRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Input } from '@/components/ui/input';
-import { GOV_TERMS, type GovTermDef } from '@/lib/microcopy';
-import { useSegment } from '@/components/providers/SegmentProvider';
 
 const GETTING_STARTED = [
   {
@@ -58,27 +52,7 @@ const GETTING_STARTED = [
   },
 ];
 
-function getWhyItMatters(term: GovTermDef, segment: string): string {
-  if (segment in term.whyItMatters) {
-    return (term.whyItMatters as Record<string, string>)[segment];
-  }
-  return term.whyItMatters.default;
-}
-
 export function LearnClient() {
-  const [search, setSearch] = useState('');
-  const { segment } = useSegment();
-
-  const termEntries = Object.entries(GOV_TERMS);
-  const filteredTerms = search.trim()
-    ? termEntries.filter(
-        ([key, term]) =>
-          term.label.toLowerCase().includes(search.toLowerCase()) ||
-          term.definition.toLowerCase().includes(search.toLowerCase()) ||
-          key.toLowerCase().includes(search.toLowerCase()),
-      )
-    : termEntries;
-
   return (
     <div className="space-y-8">
       {/* Header */}
@@ -145,47 +119,24 @@ export function LearnClient() {
         </div>
       </section>
 
-      {/* Governance Glossary */}
+      {/* Governance Glossary — link to dedicated page */}
       <section data-discovery="help-methodology">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold">Governance Glossary</h2>
-          <span className="text-xs text-muted-foreground">{filteredTerms.length} terms</span>
-        </div>
-
-        <div className="relative mb-4">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-          <Input
-            placeholder="Search terms…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-9 h-9"
-          />
-          {search && (
-            <button
-              onClick={() => setSearch('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
-          )}
-        </div>
-
-        <div className="rounded-xl border border-border divide-y divide-border/50 overflow-hidden">
-          {filteredTerms.map(([key, term]) => (
-            <div key={key} className="px-5 py-4 space-y-1">
-              <h3 className="text-sm font-semibold text-foreground">{term.label}</h3>
-              <p className="text-xs text-muted-foreground leading-relaxed">{term.definition}</p>
-              <p className="text-xs text-primary/80 leading-relaxed">
-                {getWhyItMatters(term, segment)}
-              </p>
-            </div>
-          ))}
-          {filteredTerms.length === 0 && (
-            <div className="px-5 py-8 text-center text-sm text-muted-foreground">
-              No terms match your search.
-            </div>
-          )}
-        </div>
+        <h2 className="text-lg font-semibold mb-4">Governance Glossary</h2>
+        <Link
+          href="/help/glossary"
+          className="group flex items-center gap-4 rounded-xl border border-border/50 bg-card/70 backdrop-blur-md hover:bg-accent/50 transition-colors p-5"
+        >
+          <div className="w-10 h-10 rounded-full bg-primary/15 flex items-center justify-center shrink-0">
+            <BookOpen className="h-5 w-5 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold">Browse the full glossary</p>
+            <p className="text-xs text-muted-foreground">
+              100+ governance terms explained in plain language, organized by category.
+            </p>
+          </div>
+          <ArrowRight className="h-4 w-4 text-primary shrink-0 group-hover:translate-x-0.5 transition-transform" />
+        </Link>
       </section>
     </div>
   );

--- a/components/DRepCard.tsx
+++ b/components/DRepCard.tsx
@@ -36,9 +36,21 @@ export function DRepCard({
   const score = drep.drepScore ?? 0;
 
   const pillarBars = [
-    { label: 'Participation', value: drep.effectiveParticipation },
-    { label: 'Rationale', value: drep.rationaleRate },
-    { label: 'Reliability', value: drep.reliabilityScore },
+    {
+      label: 'Participation',
+      value: drep.effectiveParticipation,
+      tooltip: 'How often this DRep votes on available proposals',
+    },
+    {
+      label: 'Rationale',
+      value: drep.rationaleRate,
+      tooltip: 'How consistently this DRep explains their votes',
+    },
+    {
+      label: 'Reliability',
+      value: drep.reliabilityScore,
+      tooltip: 'Can delegators count on this DRep to keep showing up?',
+    },
   ];
 
   return (
@@ -135,7 +147,7 @@ export function DRepCard({
       {/* Pillar mini-bars */}
       <div className="grid grid-cols-3 gap-2">
         {pillarBars.map((pillar) => (
-          <div key={pillar.label} className="space-y-0.5">
+          <div key={pillar.label} className="space-y-0.5" title={pillar.tooltip}>
             <div className="flex justify-between text-[10px] text-muted-foreground">
               <span>{pillar.label}</span>
               <span className="tabular-nums">{Math.round(pillar.value)}%</span>

--- a/components/cc/CCBriefingCard.tsx
+++ b/components/cc/CCBriefingCard.tsx
@@ -35,20 +35,38 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
   return (
     <motion.div
       variants={fadeInUp}
-      className="rounded-xl border border-border/60 bg-card/30 p-5 sm:p-6 space-y-3"
+      className="rounded-xl border border-border/60 bg-card/30 p-5 sm:p-6 space-y-4"
     >
+      {/* Header with AI badge */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-violet-500/10 shrink-0">
+            <Sparkles className="h-3.5 w-3.5 text-violet-400" />
+          </div>
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+            Committee Intelligence Brief
+          </span>
+        </div>
+      </div>
+
       {/* Headline */}
       <p className="text-base font-semibold leading-snug">{briefing.headline}</p>
 
       {/* What changed */}
       {briefing.whatChanged && (
-        <div className="text-sm text-muted-foreground leading-relaxed">
+        <div className="rounded-lg bg-muted/20 px-4 py-3 space-y-1.5">
+          <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+            Recent changes
+          </p>
           {briefing.whatChanged
             .split('\n')
             .filter(Boolean)
             .map((line, idx) => (
-              <p key={idx} className="flex items-start gap-2">
-                <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-muted-foreground/50" />
+              <p
+                key={idx}
+                className="flex items-start gap-2 text-sm text-muted-foreground leading-relaxed"
+              >
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/40" />
                 <span>{line.replace(/^[-*]\s*/, '')}</span>
               </p>
             ))}
@@ -67,18 +85,18 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
             ) : (
               <ChevronDown className="h-3.5 w-3.5" />
             )}
-            {showFindings ? 'Hide findings' : `Show findings (${briefing.keyFindings.length})`}
+            {showFindings ? 'Hide findings' : `Key findings (${briefing.keyFindings.length})`}
           </button>
 
           {showFindings && (
-            <div className="mt-2 space-y-2">
+            <div className="mt-2 space-y-2 pl-1">
               {briefing.keyFindings.map((f, idx) => {
                 const severityStyle = SEVERITY_STYLES[f.severity] || SEVERITY_STYLES.info;
                 return (
                   <div key={idx} className="flex items-start gap-2.5 text-sm">
                     <span
                       className={cn(
-                        'mt-0.5 shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-medium leading-none',
+                        'mt-0.5 shrink-0 rounded-md border px-1.5 py-0.5 text-[10px] font-medium leading-none capitalize',
                         severityStyle,
                       )}
                     >
@@ -109,7 +127,7 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
           </button>
 
           {showSummary && (
-            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+            <p className="mt-2 text-sm text-muted-foreground leading-relaxed pl-1">
               {briefing.executiveSummary}
             </p>
           )}
@@ -117,9 +135,11 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
       )}
 
       {/* AI attribution */}
-      <div className="flex items-center gap-1.5 pt-1">
-        <Sparkles className="h-3 w-3 text-muted-foreground/50" />
-        <span className="text-[10px] text-muted-foreground/50">AI-generated briefing</span>
+      <div className="flex items-center gap-1.5 pt-1 border-t border-border/30">
+        <Sparkles className="h-3 w-3 text-muted-foreground/40" />
+        <span className="text-[10px] text-muted-foreground/40">
+          AI-generated analysis — updated periodically
+        </span>
       </div>
     </motion.div>
   );

--- a/components/community/GovernanceTemperature.tsx
+++ b/components/community/GovernanceTemperature.tsx
@@ -65,7 +65,7 @@ export function GovernanceTemperature() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Thermometer className="h-4 w-4 text-primary" />
-          <h3 className="text-sm font-bold">Governance Temperature</h3>
+          <h3 className="text-sm font-bold">Governance Pulse</h3>
         </div>
         <span className="text-xs text-muted-foreground">Epoch {data.epoch}</span>
       </div>

--- a/components/drep/DRepDetailedAnalysis.tsx
+++ b/components/drep/DRepDetailedAnalysis.tsx
@@ -69,7 +69,12 @@ export function DRepDetailedAnalysis({ children }: DRepDetailedAnalysisProps) {
     return <>{children}</>;
   }
 
-  // Citizens, anonymous, and loading state: show collapsed gate (stable layout)
+  // Anonymous users: hide detailed analysis entirely
+  if (!isLoading && segment === 'anonymous') {
+    return null;
+  }
+
+  // Citizens and loading state: show collapsed gate (stable layout)
   return (
     <div className="space-y-4" ref={gateRef}>
       {!expanded && (

--- a/components/get-started/StageConnect.tsx
+++ b/components/get-started/StageConnect.tsx
@@ -162,12 +162,18 @@ export function StageConnect({ passport, onComplete, onGoBack }: StageConnectPro
       {/* Trust messaging */}
       <motion.div
         variants={fadeInUp}
-        className="flex items-start gap-2 rounded-lg border border-blue-500/20 bg-blue-950/20 px-4 py-3 max-w-md"
+        className="rounded-lg border border-blue-500/20 bg-blue-950/20 px-4 py-3 max-w-md space-y-2"
       >
-        <Shield className="h-4 w-4 mt-0.5 shrink-0 text-blue-400" />
-        <p className="text-xs text-blue-300">
-          Read-only connection. We never request transactions or access to your funds.
-        </p>
+        <div className="flex items-start gap-2">
+          <Shield className="h-4 w-4 mt-0.5 shrink-0 text-blue-400" />
+          <p className="text-xs text-blue-300 font-medium">Your funds are completely safe</p>
+        </div>
+        <ul className="text-xs text-blue-300/80 space-y-1 pl-6">
+          <li>Read-only connection — we never request transactions</li>
+          <li>Your ADA stays in your wallet at all times</li>
+          <li>Delegation doesn&apos;t move or lock your funds</li>
+          <li>You can disconnect or change delegation anytime</li>
+        </ul>
       </motion.div>
 
       {/* Wallet list */}

--- a/components/get-started/StagePrepare.tsx
+++ b/components/get-started/StagePrepare.tsx
@@ -78,10 +78,14 @@ function WalletRecommendations({ onDone }: { onDone: () => void }) {
       variants={staggerContainer}
       className="space-y-4"
     >
-      <motion.div variants={fadeInUp} className="space-y-1">
+      <motion.div variants={fadeInUp} className="space-y-2">
         <h3 className="text-lg font-semibold">Recommended Wallets</h3>
         <p className="text-sm text-muted-foreground">
           You need a Cardano wallet to participate in governance. Here are our top picks.
+        </p>
+        <p className="text-xs text-blue-300/80">
+          A wallet is like a digital keychain — it lets you prove ownership of your ADA without ever
+          giving anyone access to it. Your funds remain fully in your control.
         </p>
       </motion.div>
 
@@ -418,6 +422,10 @@ export function StagePrepare({ passport, onComplete }: StagePrepareProps) {
             <h1 className="text-2xl font-bold tracking-tight">Get the tools you need</h1>
             <p className="text-muted-foreground">
               To participate in governance, you need a Cardano wallet. Which best describes you?
+            </p>
+            <p className="text-xs text-muted-foreground/70">
+              Don&apos;t worry — your ADA never leaves your wallet. Delegation and staking are safe,
+              reversible, and fee-free.
             </p>
           </motion.div>
 

--- a/components/governada/GovernadaBottomNav.tsx
+++ b/components/governada/GovernadaBottomNav.tsx
@@ -25,7 +25,7 @@ export function GovernadaBottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 inset-x-0 z-40 lg:hidden bg-background/80 backdrop-blur-xl border-t border-border/50 pb-[env(safe-area-inset-bottom)]"
+      className="fixed bottom-0 inset-x-0 z-40 lg:hidden bg-background/60 backdrop-blur-xl border-t border-border/30 pb-[env(safe-area-inset-bottom)]"
       aria-label="Mobile navigation"
     >
       <div className="flex items-center justify-around h-14">

--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -216,7 +216,7 @@ export function GovernadaHeader() {
         'sticky top-0 z-50 hidden md:block transition-[background-color,border-color,backdrop-filter] duration-300',
         headerTransparent
           ? 'bg-transparent'
-          : 'border-b border-border/30 bg-background/80 backdrop-blur-xl',
+          : 'border-b border-border/20 bg-background/60 backdrop-blur-xl',
       )}
     >
       <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">

--- a/components/governada/GovernadaSidebar.tsx
+++ b/components/governada/GovernadaSidebar.tsx
@@ -133,7 +133,7 @@ export function GovernadaSidebar({ collapsed, onToggle }: GovernadaSidebarProps)
   return (
     <aside
       className={cn(
-        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/30 bg-background/80 backdrop-blur-xl transition-[width] duration-200',
+        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/20 bg-background/60 backdrop-blur-xl transition-[width] duration-200',
         collapsed ? 'w-16' : 'w-60',
       )}
     >

--- a/components/governada/cards/GovernadaSPOCard.tsx
+++ b/components/governada/cards/GovernadaSPOCard.tsx
@@ -187,20 +187,34 @@ export function GovernadaSPOCard({ pool, rank }: GovernadaSPOCardProps) {
 
         {/* Key metrics row */}
         <div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-2 flex-wrap">
-          <span className="tabular-nums font-medium">
+          <span
+            className="tabular-nums font-medium"
+            title="Total governance votes cast by this pool"
+          >
             {pool.voteCount} vote{pool.voteCount !== 1 ? 's' : ''}
           </span>
           {pool.participationPct != null && (
-            <span className="tabular-nums">{Math.round(pool.participationPct)}% participation</span>
+            <span
+              className="tabular-nums"
+              title="Percentage of eligible proposals this pool voted on"
+            >
+              {Math.round(pool.participationPct)}% participation
+            </span>
           )}
           {pool.delegatorCount > 0 && (
-            <span className="flex items-center gap-0.5 tabular-nums">
+            <span
+              className="flex items-center gap-0.5 tabular-nums"
+              title="Number of wallets delegating to this pool"
+            >
               <Users className="h-3 w-3" />
               {pool.delegatorCount.toLocaleString()}
             </span>
           )}
           {pool.liveStakeAda > 0 && (
-            <span className="flex items-center gap-0.5 tabular-nums">
+            <span
+              className="flex items-center gap-0.5 tabular-nums"
+              title="Total ADA delegated to this pool (voting power)"
+            >
               <Coins className="h-3 w-3" />₳{formatAda(pool.liveStakeAda)}
             </span>
           )}
@@ -209,13 +223,22 @@ export function GovernadaSPOCard({ pool, rank }: GovernadaSPOCardProps) {
         {/* Footer: momentum + CTA */}
         <div className="mt-auto flex items-center justify-between pt-2 border-t border-border/30">
           <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-            <span className="flex items-center gap-0.5">
+            <span className="flex items-center gap-0.5" title="Score trend over recent epochs">
               {momentum !== null && momentum > 0.5 ? (
-                <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
+                <>
+                  <TrendingUp className="h-3 w-3 text-emerald-400" aria-hidden="true" />
+                  <span className="text-emerald-400">Rising</span>
+                </>
               ) : momentum !== null && momentum < -0.5 ? (
-                <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
+                <>
+                  <TrendingDown className="h-3 w-3 text-rose-400" aria-hidden="true" />
+                  <span className="text-rose-400">Falling</span>
+                </>
               ) : (
-                <Minus className="h-3 w-3 text-muted-foreground/40" aria-hidden="true" />
+                <>
+                  <Minus className="h-3 w-3 text-muted-foreground/40" aria-hidden="true" />
+                  <span>Stable</span>
+                </>
               )}
             </span>
             {isProvisional && <span className="text-amber-500/80">Provisional</span>}

--- a/components/governada/match/QuickMatchFlow.tsx
+++ b/components/governada/match/QuickMatchFlow.tsx
@@ -296,7 +296,7 @@ export function QuickMatchFlow() {
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Progress bar */}
       {typeof step === 'number' && (
-        <div className="sticky top-14 z-10 bg-background/80 backdrop-blur-sm border-b border-border/30">
+        <div className="sticky top-14 z-10 bg-background border-b border-border/50">
           <div className="mx-auto max-w-2xl px-4 py-3">
             <div className="flex items-center gap-3">
               <button
@@ -736,53 +736,58 @@ function ResultsScreen({
         <ShareButton results={drepResults} />
       </div>
 
-      {/* Tab toggle */}
-      <div className="flex justify-center">
-        <div
-          className="inline-flex rounded-lg border border-border p-0.5 bg-muted/30"
-          role="tablist"
-          aria-label="Match results"
-        >
-          <button
-            onClick={() => setActiveTab('drep')}
-            role="tab"
-            aria-selected={activeTab === 'drep'}
-            className={cn(
-              'px-4 py-1.5 rounded-md text-sm font-medium transition-all',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-              activeTab === 'drep'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
+      {/* Team explanation + tab toggle */}
+      <div className="space-y-3">
+        <div className="text-center max-w-md mx-auto">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Your governance team has two roles: <strong className="text-foreground">a DRep</strong>{' '}
+            who votes on proposals for you, and <strong className="text-foreground">an SPO</strong>{' '}
+            who secures the network. Pick one of each.
+          </p>
+        </div>
+        <div className="flex justify-center">
+          <div
+            className="inline-flex rounded-lg border border-border p-0.5 bg-muted/30"
+            role="tablist"
+            aria-label="Match results"
           >
-            <Users className="h-3.5 w-3.5 inline mr-1.5" aria-hidden="true" />
-            DReps
-            {drepResults.matches.length > 0 && (
-              <span className="ml-1.5 text-xs text-muted-foreground">
-                ({drepResults.matches.length})
+            <button
+              onClick={() => setActiveTab('drep')}
+              role="tab"
+              aria-selected={activeTab === 'drep'}
+              className={cn(
+                'px-5 py-2 rounded-md text-sm font-medium transition-all',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                activeTab === 'drep'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Users className="h-4 w-4 inline mr-1.5" aria-hidden="true" />
+              DReps
+              <span className="ml-1 text-[10px] text-muted-foreground/80 block">
+                Votes on proposals
               </span>
-            )}
-          </button>
-          <button
-            onClick={() => setActiveTab('spo')}
-            role="tab"
-            aria-selected={activeTab === 'spo'}
-            className={cn(
-              'px-4 py-1.5 rounded-md text-sm font-medium transition-all',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-              activeTab === 'spo'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <Server className="h-3.5 w-3.5 inline mr-1.5" aria-hidden="true" />
-            SPOs
-            {spoResults.matches.length > 0 && (
-              <span className="ml-1.5 text-xs text-muted-foreground">
-                ({spoResults.matches.length})
+            </button>
+            <button
+              onClick={() => setActiveTab('spo')}
+              role="tab"
+              aria-selected={activeTab === 'spo'}
+              className={cn(
+                'px-5 py-2 rounded-md text-sm font-medium transition-all',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                activeTab === 'spo'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Server className="h-4 w-4 inline mr-1.5" aria-hidden="true" />
+              SPOs
+              <span className="ml-1 text-[10px] text-muted-foreground/80 block">
+                Secures the network
               </span>
-            )}
-          </button>
+            </button>
+          </div>
         </div>
       </div>
 
@@ -825,6 +830,7 @@ function ResultsScreen({
                           userAlignments={drepResults.userAlignments}
                           drepAlignments={heroMatch.alignments}
                           size={180}
+                          animate
                         />
                       </div>
                       <div className="text-center space-y-2">

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -26,6 +26,7 @@ import {
   Sparkles,
   Share2,
   X,
+  AlertTriangle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { briefingContainer, briefingItem, spring } from '@/lib/animations';
@@ -507,6 +508,8 @@ function PoolAndCoverage({
   const poolName = (pool?.poolName as string) || (pool?.ticker as string) || null;
   const ticker = (pool?.ticker as string) ?? '';
   const govScore = Math.round((pool?.governanceScore as number) ?? 0);
+  const poolStatus = (pool?.poolStatus as string) ?? 'registered';
+  const isPoolRetiring = poolStatus === 'retiring';
   const poolParticipation = Math.round((pool?.participationRate as number) ?? 0);
   const poolVoteCount = (pool?.voteCount as number) ?? 0;
   const poolIsGovActive = poolVoteCount > 0;
@@ -563,6 +566,21 @@ function PoolAndCoverage({
           style={{ width: `${coveragePct}%` }}
         />
       </div>
+
+      {/* Pool retiring alert */}
+      {isPoolRetiring && delegatedPool && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2.5">
+          <AlertTriangle className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0" />
+          <div className="space-y-0.5">
+            <p className="text-xs font-medium text-amber-400">
+              Your stake pool is scheduled to retire
+            </p>
+            <p className="text-[10px] text-muted-foreground">
+              You may want to choose a new pool to maintain your governance coverage.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Pool info */}
       {delegatedPool && poolName && (

--- a/components/matching/RadarOverlay.tsx
+++ b/components/matching/RadarOverlay.tsx
@@ -16,6 +16,8 @@ interface RadarOverlayProps {
   drepAlignments: AlignmentScores | null | undefined;
   size?: number;
   className?: string;
+  /** Animate the two shapes merging together */
+  animate?: boolean;
 }
 
 const PADDING = 20;
@@ -44,6 +46,7 @@ export function RadarOverlay({
   drepAlignments,
   size = 160,
   className,
+  animate = false,
 }: RadarOverlayProps) {
   const cx = size / 2;
   const cy = size / 2;
@@ -98,6 +101,10 @@ export function RadarOverlay({
 
   const rings = [0.25, 0.5, 0.75, 1];
   const showLabels = size >= 140;
+
+  // Animation offset — shapes start displaced and merge together
+  const offset = size * 0.15;
+  const animDuration = '1.2s';
 
   return (
     <svg
@@ -163,65 +170,120 @@ export function RadarOverlay({
       })}
 
       {/* Entity shape (background) — with gradient fill and glow */}
-      <polygon
-        points={drepPoints}
-        fill={`url(#${uid}-entity)`}
-        stroke={entityColor.hex}
-        strokeWidth={1.5}
-        strokeOpacity={0.6}
-        strokeLinejoin="round"
-        filter={`url(#${uid}-glow)`}
-      />
-      <polygon
-        points={drepPoints}
-        fill={`url(#${uid}-entity)`}
-        stroke={entityColor.hex}
-        strokeWidth={1.5}
-        strokeOpacity={0.7}
-        strokeLinejoin="round"
-      />
+      <g>
+        {animate && (
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            from={`${offset} 0`}
+            to="0 0"
+            dur={animDuration}
+            fill="freeze"
+            calcMode="spline"
+            keySplines="0.16 1 0.3 1"
+          />
+        )}
+        <polygon
+          points={drepPoints}
+          fill={`url(#${uid}-entity)`}
+          stroke={entityColor.hex}
+          strokeWidth={1.5}
+          strokeOpacity={0.6}
+          strokeLinejoin="round"
+          filter={`url(#${uid}-glow)`}
+        />
+        <polygon
+          points={drepPoints}
+          fill={`url(#${uid}-entity)`}
+          stroke={entityColor.hex}
+          strokeWidth={1.5}
+          strokeOpacity={0.7}
+          strokeLinejoin="round"
+        />
+        {/* Vertex dots for entity */}
+        {drepScores.map((score, i) => {
+          const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+          const r = maxR * (score / 100);
+          return (
+            <circle
+              key={`e-${i}`}
+              cx={cx + r * Math.cos(angle)}
+              cy={cy + r * Math.sin(angle)}
+              r={1.5}
+              fill={entityColor.hex}
+              opacity={0.7}
+            />
+          );
+        })}
+      </g>
 
       {/* User shape (foreground) — with gradient fill */}
-      <polygon
-        points={userPoints}
-        fill={`url(#${uid}-user)`}
-        stroke={userColor.hex}
-        strokeWidth={1.5}
-        strokeOpacity={0.8}
-        strokeLinejoin="round"
-      />
-
-      {/* Vertex dots for entity */}
-      {drepScores.map((score, i) => {
-        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
-        const r = maxR * (score / 100);
-        return (
-          <circle
-            key={`e-${i}`}
-            cx={cx + r * Math.cos(angle)}
-            cy={cy + r * Math.sin(angle)}
-            r={1.5}
-            fill={entityColor.hex}
-            opacity={0.7}
+      <g>
+        {animate && (
+          <animateTransform
+            attributeName="transform"
+            type="translate"
+            from={`${-offset} 0`}
+            to="0 0"
+            dur={animDuration}
+            fill="freeze"
+            calcMode="spline"
+            keySplines="0.16 1 0.3 1"
           />
-        );
-      })}
+        )}
+        <polygon
+          points={userPoints}
+          fill={`url(#${uid}-user)`}
+          stroke={userColor.hex}
+          strokeWidth={1.5}
+          strokeOpacity={0.8}
+          strokeLinejoin="round"
+        />
+        {/* Vertex dots for user */}
+        {userScores.map((score, i) => {
+          const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
+          const r = maxR * (score / 100);
+          return (
+            <circle
+              key={`u-${i}`}
+              cx={cx + r * Math.cos(angle)}
+              cy={cy + r * Math.sin(angle)}
+              r={1.5}
+              fill={userColor.hex}
+              opacity={0.8}
+            />
+          );
+        })}
+      </g>
 
-      {/* Vertex dots for user */}
-      {userScores.map((score, i) => {
-        const angle = (Math.PI * 2 * i) / 6 - Math.PI / 2;
-        const r = maxR * (score / 100);
-        return (
-          <circle
-            key={`u-${i}`}
-            cx={cx + r * Math.cos(angle)}
-            cy={cy + r * Math.sin(angle)}
-            r={1.5}
+      {/* Legend — which shape is you vs your match */}
+      {animate && showLabels && (
+        <g opacity={0}>
+          <animate attributeName="opacity" from="0" to="1" begin="0.8s" dur="0.5s" fill="freeze" />
+          <circle cx={PADDING} cy={size - 10} r={3} fill={userColor.hex} opacity={0.8} />
+          <text
+            x={PADDING + 7}
+            y={size - 10}
+            dominantBaseline="central"
+            fontSize={7}
             fill={userColor.hex}
             opacity={0.8}
-          />
-        );
-      })}
+          >
+            You
+          </text>
+          <circle cx={PADDING + 34} cy={size - 10} r={3} fill={entityColor.hex} opacity={0.7} />
+          <text
+            x={PADDING + 41}
+            y={size - 10}
+            dominantBaseline="central"
+            fontSize={7}
+            fill={entityColor.hex}
+            opacity={0.7}
+          >
+            Match
+          </text>
+        </g>
+      )}
 
       {/* Dimension labels — only on larger sizes */}
       {showLabels &&

--- a/components/shared/PinButton.tsx
+++ b/components/shared/PinButton.tsx
@@ -2,6 +2,7 @@
 
 import { Pin, PinOff } from 'lucide-react';
 import { usePinnedItems, type PinnedEntityType } from '@/hooks/usePinnedItems';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
@@ -17,7 +18,11 @@ interface PinButtonProps {
  */
 export function PinButton({ type, id, label }: PinButtonProps) {
   const { isPinned, pin, unpin } = usePinnedItems();
+  const { segment } = useSegment();
   const pinned = isPinned(type, id);
+
+  // Anonymous users cannot pin — requires wallet connection
+  if (segment === 'anonymous') return null;
 
   return (
     <TooltipProvider>

--- a/components/workspace/SPOCockpit.tsx
+++ b/components/workspace/SPOCockpit.tsx
@@ -218,7 +218,7 @@ export function SPOCockpit() {
             </div>
             <div className="rounded-xl bg-muted/50 p-3 text-center">
               <p className="text-xl font-bold tabular-nums text-foreground">
-                {liveStakeAda > 0 ? `₳${formatAdaCompact(liveStakeAda)}` : '—'}
+                {liveStakeAda > 0 ? `₳${formatAdaCompact(liveStakeAda)}` : 'Syncing...'}
               </p>
               <p className="text-xs text-muted-foreground mt-0.5">Voting Power</p>
             </div>


### PR DESCRIPTION
## Summary
- **Quick Match**: Fixed progress bar obscuring question text (fully opaque now), added DRep+SPO team explanation ("Pick one of each"), radar shapes animate merging together with "You"/"Match" legend
- **DRep cards**: Hover tooltips on pillar bars and SPO metrics, momentum labels
- **Anonymous gating**: Hide PinButton and detailed analysis for anonymous users
- **Misc polish**: CC briefing card, Get Started safety copy, glossary consolidation, nav opacity, SPO cockpit voting power fix, citizen retire alert

## Impact
- **What changed**: Quick Match UX clarity + broad polish batch across profiles, cards, nav
- **User-facing**: Yes — clearer Quick Match flow, better DRep/SPO card data, polished anonymous experience
- **Risk**: Low — UI/display changes, one API route addition (poolStatus field)
- **Scope**: 18 files, no migrations

## Test plan
- [ ] Quick Match: progress bar is opaque (no text hidden behind it)
- [ ] Quick Match results: "Pick one of each" explanation above tabs
- [ ] Quick Match results: tab sub-labels "Votes on proposals" / "Secures the network"
- [ ] Quick Match results: radar shapes animate merging from left/right
- [ ] Quick Match results: "You" / "Match" legend appears on radar
- [ ] DRep cards: hover tooltips on stat bars
- [ ] SPO cards: momentum shows "Stable"/"Rising"/"Falling" not bare dash
- [ ] Anonymous users: no PinButton or detailed analysis visible
- [ ] CC member pages: render without error for 0-vote members

🤖 Generated with [Claude Code](https://claude.com/claude-code)