### PR TITLE
refactor: discovery/action split — bridge components

### DIFF
--- a/app/drep/[drepId]/page.tsx
+++ b/app/drep/[drepId]/page.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/utils/scoring';
 import { VoteRecord } from '@/types/drep';
 import { InlineDelegationCTA } from '@/components/InlineDelegationCTA';
+import { DelegationBridgeButton } from '@/components/governada/profiles/DelegationBridgeButton';
 const ScoreHistoryChart = nextDynamic(
   () => import('@/components/ScoreHistoryChart').then((m) => m.ScoreHistoryChart),
   { loading: () => <div className="h-32 animate-pulse bg-muted rounded-lg" /> },
@@ -61,6 +62,7 @@ import { DRepTreasuryStance } from '@/components/DRepTreasuryStance';
 import { DRepProfileHero } from '@/components/DRepProfileHero';
 import { DRepDetailedAnalysis } from '@/components/drep/DRepDetailedAnalysis';
 import { FeatureGate } from '@/components/FeatureGate';
+import { getFeatureFlag } from '@/lib/featureFlags';
 import { DelegationImpactPreview } from '@/components/drep/DelegationImpactPreview';
 import { TrustCard } from '@/components/governada/profiles/TrustCard';
 const CitizenEndorsements = nextDynamic(
@@ -419,6 +421,8 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
     withTimeout(getDRepTreasuryTrackRecord(drep.drepId), null, 'treasuryRecord'),
   ]);
 
+  const discoveryActionSplit = await getFeatureFlag('discovery_action_split', false);
+
   const pendingProposalCount = openProposals.length;
 
   // Treasury stewardship signals — summary-level only
@@ -590,7 +594,11 @@ export default async function DRepDetailPage({ params, searchParams }: DRepDetai
         narrativeAccentColor={getIdentityColor(getDominantDimension(alignments)).hex}
       >
         <SegmentGate hide={['drep']}>
-          <InlineDelegationCTA drepId={drep.drepId} drepName={drepName} />
+          {discoveryActionSplit ? (
+            <DelegationBridgeButton drepId={drep.drepId} drepName={drepName} />
+          ) : (
+            <InlineDelegationCTA drepId={drep.drepId} drepName={drepName} />
+          )}
         </SegmentGate>
         <CompareButton currentDrepId={drep.drepId} currentDrepName={drepName} />
         <WatchEntityButton entityType="drep" entityId={drep.drepId} />

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -30,6 +30,7 @@ import { EntityPageConnections } from '@/components/shared/EntityPageConnections
 import { IntelligenceBriefing } from '@/components/governada/proposals/IntelligenceBriefing';
 import { DebateSection } from '@/components/governada/proposals/DebateSection';
 import { ProposalActionZone } from '@/components/governada/proposals/ProposalActionZone';
+import { ProposalBridge } from '@/components/governada/proposals/ProposalBridge';
 import { ProposalDepthGate } from '@/components/governada/proposals/ProposalDepthGate';
 import { ProposalDepthSection } from '@/components/governada/proposals/ProposalDepthSection';
 import { getFeatureFlag } from '@/lib/featureFlags';
@@ -94,6 +95,7 @@ export default async function ProposalDetailPage({ params }: PageProps) {
 
   // Living Brief feature flag
   const livingBriefEnabled = await getFeatureFlag('living_brief', false);
+  const discoveryActionSplit = await getFeatureFlag('discovery_action_split', false);
 
   // Fetch brief data + historical context if enabled (non-blocking, defaults to null)
   const brief = livingBriefEnabled
@@ -371,6 +373,17 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         treasuryBalanceAda={treasury?.balanceAda ?? null}
       />
 
+      {/* Action bridge — routes to review workspace or citizen sentiment */}
+      {discoveryActionSplit && (
+        <ProposalBridge
+          txHash={txHash}
+          proposalIndex={proposalIndex}
+          title={title}
+          isOpen={isOpen}
+          proposalType={proposal.proposalType}
+        />
+      )}
+
       {/* Zone 2: Living Brief */}
       <ProposalDepthSection section="intelligenceBriefing">
         <LivingBrief
@@ -519,15 +532,25 @@ export default async function ProposalDetailPage({ params }: PageProps) {
 
       {/* Zone 2: Primary Action — persona-branching (DRep/SPO vote flow vs citizen engagement) */}
       <ProposalDepthSection section="actionZone">
-        <ProposalActionZone
-          txHash={txHash}
-          proposalIndex={proposalIndex}
-          title={title}
-          isOpen={isOpen}
-          proposalAbstract={proposal.abstract}
-          proposalType={proposal.proposalType}
-          aiSummary={proposal.aiSummary}
-        />
+        {discoveryActionSplit ? (
+          <ProposalBridge
+            txHash={txHash}
+            proposalIndex={proposalIndex}
+            title={title}
+            isOpen={isOpen}
+            proposalType={proposal.proposalType}
+          />
+        ) : (
+          <ProposalActionZone
+            txHash={txHash}
+            proposalIndex={proposalIndex}
+            title={title}
+            isOpen={isOpen}
+            proposalAbstract={proposal.abstract}
+            proposalType={proposal.proposalType}
+            aiSummary={proposal.aiSummary}
+          />
+        )}
       </ProposalDepthSection>
 
       {/* Zone 3: Intelligence Briefing — AI summary + constitutional + params */}

--- a/app/workspace/review/page.tsx
+++ b/app/workspace/review/page.tsx
@@ -10,12 +10,17 @@ export const metadata: Metadata = {
   description: 'Review active governance proposals, vote, and write rationales.',
 };
 
-export default function ReviewPage() {
+interface ReviewPageProps {
+  searchParams: Promise<{ proposal?: string }>;
+}
+
+export default async function ReviewPage({ searchParams }: ReviewPageProps) {
+  const params = await searchParams;
   return (
     <>
       <PageViewTracker event="review_workspace_viewed" />
       <FeatureGate flag="proposal_workspace">
-        <ReviewWorkspace />
+        <ReviewWorkspace initialProposalKey={params.proposal} />
       </FeatureGate>
     </>
   );

--- a/components/governada/profiles/DelegationBridgeButton.tsx
+++ b/components/governada/profiles/DelegationBridgeButton.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Vote, Loader2, CheckCircle, ExternalLink, AlertTriangle, Shield } from 'lucide-react';
+import { useDelegation, type DelegationPhase } from '@/hooks/useDelegation';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { type AlignmentScores } from '@/lib/drepIdentity';
+
+const DelegationCeremony = dynamic(
+  () => import('@/components/DelegationCeremony').then((m) => m.DelegationCeremony),
+  { ssr: false },
+);
+
+interface DelegationBridgeButtonProps {
+  drepId: string;
+  drepName: string;
+}
+
+const PHASE_LABELS: Record<string, string> = {
+  preflight: 'Checking eligibility...',
+  building: 'Preparing transaction...',
+  signing: 'Please sign in your wallet...',
+  submitting: 'Submitting to the network...',
+};
+
+/**
+ * Compact delegation button that opens a Sheet for the full delegation flow.
+ * Replaces InlineDelegationCTA in the discovery/action split layout.
+ */
+export function DelegationBridgeButton({ drepId, drepName }: DelegationBridgeButtonProps) {
+  const {
+    phase,
+    startDelegation,
+    confirmDelegation,
+    reset,
+    isProcessing,
+    delegatedDrepId,
+    canDelegate,
+  } = useDelegation();
+
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [showCeremony, setShowCeremony] = useState(false);
+  const [ceremonyScore, setCeremonyScore] = useState(0);
+  const [ceremonyAlignments, setCeremonyAlignments] = useState<AlignmentScores | undefined>(
+    undefined,
+  );
+
+  const isAlreadyDelegated = !!delegatedDrepId && delegatedDrepId === drepId;
+
+  const handleClick = () => {
+    if (!canDelegate) {
+      window.dispatchEvent(new Event('openWalletConnect'));
+      return;
+    }
+    if (isAlreadyDelegated) return;
+    setSheetOpen(true);
+    startDelegation(drepId);
+  };
+
+  const handleConfirm = async () => {
+    const result = await confirmDelegation(drepId);
+    if (result) {
+      fetch(`/api/dreps/${encodeURIComponent(drepId)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (data?.drepScore) setCeremonyScore(data.drepScore);
+          if (data?.alignmentTreasuryConservative != null) {
+            setCeremonyAlignments({
+              treasuryConservative: data.alignmentTreasuryConservative ?? 50,
+              treasuryGrowth: data.alignmentTreasuryGrowth ?? 50,
+              decentralization: data.alignmentDecentralization ?? 50,
+              security: data.alignmentSecurity ?? 50,
+              innovation: data.alignmentInnovation ?? 50,
+              transparency: data.alignmentTransparency ?? 50,
+            });
+          }
+        })
+        .catch(() => {});
+      setShowCeremony(true);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isProcessing) {
+      setSheetOpen(false);
+      if (phase.status !== 'success') reset();
+    }
+  };
+
+  const handleCeremonyDone = () => {
+    setShowCeremony(false);
+    setSheetOpen(false);
+  };
+
+  // Already delegated — show static badge
+  if (isAlreadyDelegated && phase.status !== 'success') {
+    return (
+      <Button variant="outline" size="sm" className="gap-1.5 pointer-events-none" disabled>
+        <CheckCircle className="h-3.5 w-3.5 text-emerald-500" />
+        Delegating
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant={delegatedDrepId ? 'outline' : 'default'}
+        className="gap-1.5"
+        onClick={handleClick}
+        disabled={isProcessing}
+      >
+        {isProcessing ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Vote className="h-3.5 w-3.5" />
+        )}
+        {delegatedDrepId ? 'Switch DRep' : 'Delegate'}
+      </Button>
+
+      <Sheet open={sheetOpen} onOpenChange={handleClose}>
+        <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Delegate to {drepName}</SheetTitle>
+            <SheetDescription>
+              Your voting power will be assigned to this representative.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="px-4 pb-6 pt-2">
+            <SheetBody
+              phase={phase}
+              drepId={drepId}
+              drepName={drepName}
+              onConfirm={handleConfirm}
+              onReset={reset}
+              isProcessing={isProcessing}
+              showCeremony={showCeremony}
+              ceremonyScore={ceremonyScore}
+              ceremonyAlignments={ceremonyAlignments}
+              onCeremonyDone={handleCeremonyDone}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+/** Inner content of the delegation Sheet, branching on phase. */
+function SheetBody({
+  phase,
+  drepId,
+  drepName,
+  onConfirm,
+  onReset,
+  isProcessing,
+  showCeremony,
+  ceremonyScore,
+  ceremonyAlignments,
+  onCeremonyDone,
+}: {
+  phase: DelegationPhase;
+  drepId: string;
+  drepName: string;
+  onConfirm: () => void;
+  onReset: () => void;
+  isProcessing: boolean;
+  showCeremony: boolean;
+  ceremonyScore: number;
+  ceremonyAlignments?: AlignmentScores;
+  onCeremonyDone: () => void;
+}) {
+  // Success with ceremony
+  if (phase.status === 'success' && showCeremony) {
+    return (
+      <DelegationCeremony
+        drepId={drepId}
+        drepName={drepName}
+        score={ceremonyScore || 0}
+        alignments={ceremonyAlignments}
+        onContinue={onCeremonyDone}
+      />
+    );
+  }
+
+  // Success without ceremony
+  if (phase.status === 'success') {
+    return (
+      <div className="space-y-3 text-center py-6">
+        <CheckCircle className="h-8 w-8 text-emerald-500 mx-auto" />
+        <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+          {phase.confirmed ? 'Delegation confirmed on-chain!' : 'Delegation submitted!'}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {phase.confirmed
+            ? 'Your voting power will be active with this DRep next epoch.'
+            : 'Waiting for on-chain confirmation...'}
+        </p>
+        <a
+          href={`https://cardanoscan.io/transaction/${phase.txHash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+        >
+          View transaction <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    );
+  }
+
+  // Error
+  if (phase.status === 'error') {
+    return (
+      <div className="space-y-3 text-center py-6">
+        <AlertTriangle className="h-8 w-8 text-destructive mx-auto" />
+        <p className="text-sm text-destructive">{phase.hint}</p>
+        {phase.code !== 'user_rejected' && (
+          <p className="text-xs text-muted-foreground">{phase.message}</p>
+        )}
+        <Button variant="outline" size="sm" onClick={onReset}>
+          Try Again
+        </Button>
+      </div>
+    );
+  }
+
+  // Confirming
+  if (phase.status === 'confirming') {
+    const { preflight } = phase;
+    return (
+      <div className="space-y-4 py-4">
+        <div className="text-sm text-muted-foreground space-y-2">
+          <p>Your voting power will be assigned to this DRep. You can change anytime.</p>
+          <p>
+            Transaction fee:{' '}
+            <span className="font-medium text-foreground">{preflight.estimatedFee}</span>
+          </p>
+          {preflight.needsDeposit && (
+            <p className="flex items-start gap-1 text-amber-600 dark:text-amber-400">
+              <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
+              Includes a 2 ADA refundable deposit for stake registration.
+            </p>
+          )}
+          <p className="flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+            <Shield className="h-3 w-3 shrink-0" />
+            Your ADA stays in your wallet at all times.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" className="flex-1" onClick={onReset}>
+            Cancel
+          </Button>
+          <Button size="sm" className="flex-1 gap-1" onClick={onConfirm}>
+            <Vote className="h-3.5 w-3.5" />
+            Confirm &amp; Sign
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Processing (preflight/building/signing/submitting)
+  if (isProcessing) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <p className="text-sm text-muted-foreground">
+          {PHASE_LABELS[phase.status] || 'Processing...'}
+        </p>
+      </div>
+    );
+  }
+
+  // Idle fallback (brief flash while preflight starts)
+  return (
+    <div className="flex flex-col items-center gap-3 py-8">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <p className="text-sm text-muted-foreground">Starting...</p>
+    </div>
+  );
+}

--- a/components/governada/proposals/CitizenSentimentReaction.tsx
+++ b/components/governada/proposals/CitizenSentimentReaction.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useSentimentResults, type SentimentResults } from '@/hooks/useEngagement';
+import { useWallet } from '@/utils/wallet';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface CitizenSentimentReactionProps {
+  txHash: string;
+  proposalIndex: number;
+  isOpen: boolean;
+  readOnly?: boolean;
+}
+
+const CHOICES = [
+  { key: 'support', label: 'Support', color: 'bg-emerald-500' },
+  { key: 'oppose', label: 'Oppose', color: 'bg-red-500' },
+  { key: 'unsure', label: 'Unsure', color: 'bg-amber-500' },
+] as const;
+
+type SentimentChoice = (typeof CHOICES)[number]['key'];
+
+/**
+ * Compact one-tap sentiment micro-interaction for citizens.
+ * Shows 3 pill buttons + inline results bar + social proof count.
+ */
+export function CitizenSentimentReaction({
+  txHash,
+  proposalIndex,
+  isOpen,
+  readOnly,
+}: CitizenSentimentReactionProps) {
+  const { connected } = useWallet();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useSentimentResults(txHash, proposalIndex);
+
+  const community = data?.community ?? { support: 0, oppose: 0, unsure: 0, total: 0 };
+  const userSentiment = data?.userSentiment ?? null;
+  const total = community.total;
+
+  const castVote = useCallback(
+    async (choice: SentimentChoice) => {
+      if (readOnly || !isOpen || !connected) return;
+
+      // Optimistic update
+      const queryKey = ['citizen-sentiment', txHash, proposalIndex, null];
+      const previous = queryClient.getQueryData<SentimentResults>(queryKey);
+      queryClient.setQueryData<SentimentResults>(queryKey, (old) => {
+        if (!old) return old;
+        const c = { ...old.community };
+        // Remove previous vote if switching
+        if (old.userSentiment && old.userSentiment !== choice) {
+          c[old.userSentiment] = Math.max(0, c[old.userSentiment] - 1);
+        }
+        // Add new vote if not already this choice
+        if (old.userSentiment !== choice) {
+          c[choice] = c[choice] + 1;
+          c.total = c.support + c.oppose + c.unsure;
+        }
+        return { ...old, community: c, userSentiment: choice, hasVoted: true };
+      });
+
+      try {
+        const headers: HeadersInit = { 'Content-Type': 'application/json' };
+        const token = getStoredSession();
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+        await fetch('/api/engagement/sentiment/vote', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ proposalTxHash: txHash, proposalIndex, sentiment: choice }),
+        });
+      } catch {
+        // Rollback on failure
+        queryClient.setQueryData(queryKey, previous);
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['citizen-sentiment', txHash, proposalIndex] });
+    },
+    [txHash, proposalIndex, readOnly, isOpen, connected, queryClient],
+  );
+
+  if (isLoading) {
+    return <Skeleton className="h-10 w-full rounded-lg" />;
+  }
+
+  const showResults = readOnly || userSentiment || !isOpen;
+
+  return (
+    <div className="space-y-2">
+      {/* Pill buttons */}
+      {!readOnly && isOpen && (
+        <div className="flex gap-2">
+          {CHOICES.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() =>
+                connected ? castVote(key) : window.dispatchEvent(new Event('openWalletConnect'))
+              }
+              className={cn(
+                'flex-1 rounded-full px-3 py-1.5 text-xs font-medium transition-all',
+                'border hover:opacity-90',
+                userSentiment === key
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-card text-muted-foreground border-border hover:border-primary/40',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Results bar */}
+      {showResults && total > 0 && (
+        <div className="space-y-1">
+          <div className="flex h-2 rounded-full overflow-hidden bg-muted">
+            {CHOICES.map(({ key, color }) => {
+              const pct = total > 0 ? (community[key] / total) * 100 : 0;
+              if (pct === 0) return null;
+              return (
+                <div
+                  key={key}
+                  className={cn(color, 'transition-all duration-300')}
+                  style={{ width: `${pct}%` }}
+                />
+              );
+            })}
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            {total} citizen{total !== 1 ? 's' : ''} weighed in
+          </p>
+        </div>
+      )}
+
+      {/* Not connected hint */}
+      {!connected && !readOnly && isOpen && (
+        <p className="text-[11px] text-muted-foreground">
+          <button
+            className="text-primary hover:underline"
+            onClick={() => window.dispatchEvent(new Event('openWalletConnect'))}
+          >
+            Connect
+          </button>{' '}
+          to share your view
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/governada/proposals/ProposalBridge.tsx
+++ b/components/governada/proposals/ProposalBridge.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import Link from 'next/link';
+import { Vote, CheckCircle2, Wallet } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { canBodyVote } from '@/lib/governance/votingBodies';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { CitizenSentimentReaction } from './CitizenSentimentReaction';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface ProposalBridgeProps {
+  txHash: string;
+  proposalIndex: number;
+  title: string;
+  isOpen: boolean;
+  proposalType?: string | null;
+  existingVote?: string | null;
+}
+
+/**
+ * Bridge component that routes users from discovery (proposal detail)
+ * to the appropriate action layer:
+ * - DRep/SPO/CC: "Review & Vote" link to workspace
+ * - Citizen: inline sentiment reaction
+ * - Anonymous: wallet-connect CTA + read-only results
+ */
+export function ProposalBridge({
+  txHash,
+  proposalIndex,
+  title: _title,
+  isOpen,
+  proposalType,
+  existingVote,
+}: ProposalBridgeProps) {
+  const { segment, isLoading } = useSegment();
+
+  if (isLoading) {
+    return <Skeleton className="h-14 w-full rounded-xl" />;
+  }
+
+  const isGovernanceActor = segment === 'drep' || segment === 'spo' || segment === 'cc';
+  const effectiveType = proposalType ?? 'InfoAction';
+  const voterBody = segment === 'spo' ? 'spo' : segment === 'cc' ? 'cc' : 'drep';
+  const canVote = isGovernanceActor && canBodyVote(voterBody, effectiveType);
+
+  // Governance actors: show review & vote button
+  if (isGovernanceActor) {
+    const workspaceUrl = `/workspace/review?proposal=${encodeURIComponent(txHash)}:${proposalIndex}`;
+
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-3 rounded-xl border px-4 py-3',
+          'bg-card/50 backdrop-blur-sm',
+        )}
+      >
+        {existingVote ? (
+          <>
+            <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium">
+                You voted{' '}
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'text-xs ml-1',
+                    existingVote === 'Yes' && 'border-emerald-500/40 text-emerald-500',
+                    existingVote === 'No' && 'border-red-500/40 text-red-500',
+                    existingVote === 'Abstain' && 'border-amber-500/40 text-amber-500',
+                  )}
+                >
+                  {existingVote}
+                </Badge>
+              </p>
+            </div>
+            <Button variant="ghost" size="sm" asChild>
+              <Link href={workspaceUrl}>Change vote</Link>
+            </Button>
+          </>
+        ) : canVote && isOpen ? (
+          <>
+            <Vote className="h-4 w-4 text-primary shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium">Ready to decide?</p>
+              <p className="text-xs text-muted-foreground truncate">
+                Review and cast your vote in the workspace
+              </p>
+            </div>
+            <Button size="sm" asChild>
+              <Link href={workspaceUrl}>Review &amp; Vote</Link>
+            </Button>
+          </>
+        ) : (
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-muted-foreground">
+              {!isOpen
+                ? 'This proposal is no longer open for voting.'
+                : 'Your governance body cannot vote on this proposal type.'}
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Citizen: inline sentiment
+  if (segment === 'citizen') {
+    return (
+      <div className="rounded-xl border bg-card/50 backdrop-blur-sm px-4 py-3 space-y-2">
+        <p className="text-xs font-medium text-muted-foreground">How do you feel about this?</p>
+        <CitizenSentimentReaction txHash={txHash} proposalIndex={proposalIndex} isOpen={isOpen} />
+      </div>
+    );
+  }
+
+  // Anonymous: CTA + read-only results
+  return (
+    <div className="rounded-xl border bg-card/50 backdrop-blur-sm px-4 py-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <Wallet className="h-4 w-4 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          <button
+            className="text-primary font-medium hover:underline"
+            onClick={() => window.dispatchEvent(new Event('openWalletConnect'))}
+          >
+            Connect your wallet
+          </button>{' '}
+          to share your view
+        </p>
+      </div>
+      <CitizenSentimentReaction
+        txHash={txHash}
+        proposalIndex={proposalIndex}
+        isOpen={isOpen}
+        readOnly
+      />
+    </div>
+  );
+}

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -24,12 +24,19 @@ import {
 import type { VoteChoice } from '@/lib/voting';
 import { posthog } from '@/lib/posthog';
 
+interface ReviewWorkspaceProps {
+  initialProposalKey?: string;
+}
+
 /**
  * ReviewWorkspace — the top-level client component for /workspace/review.
  * Three-column layout on desktop (queue rail + main content + notes sidebar),
  * stacked on mobile with a floating button for the notes sheet.
+ *
+ * Accepts an optional `initialProposalKey` (format: "txHash:index") to
+ * auto-select a proposal on load (used by deep-links from discovery pages).
  */
-export function ReviewWorkspace() {
+export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {}) {
   const { segment, drepId, poolId } = useSegment();
   const { ownDRepId } = useWallet();
 
@@ -52,6 +59,21 @@ export function ReviewWorkspace() {
   useEffect(() => {
     posthog.capture('review_workspace_viewed', { voter_role: voterRole });
   }, [voterRole]);
+
+  // Auto-select proposal from deep-link (initialProposalKey = "txHash:index")
+  useEffect(() => {
+    if (!initialProposalKey || items.length === 0) return;
+    const [targetTxHash, targetIndexStr] = initialProposalKey.split(':');
+    if (!targetTxHash || !targetIndexStr) return;
+    const targetIndex = parseInt(targetIndexStr, 10);
+    if (isNaN(targetIndex)) return;
+    const matchIdx = items.findIndex(
+      (item) => item.txHash === targetTxHash && item.proposalIndex === targetIndex,
+    );
+    if (matchIdx >= 0) {
+      setSelectedIndex(matchIdx);
+    }
+  }, [initialProposalKey, items]);
 
   // Progress computation
   const progress = useMemo(() => {


### PR DESCRIPTION
## Summary
- **ProposalBridge** replaces `ProposalActionZone` on proposal pages — DReps get "Review & Vote" link to workspace, citizens get one-tap sentiment, anonymous get connect CTA
- **CitizenSentimentReaction** — slim 3-button micro-interaction (~120 lines vs 570) that stays on proposal page as discovery infrastructure
- **DelegationBridgeButton** — opens delegation ceremony in a Sheet instead of inline on DRep profiles
- **ReviewWorkspace deep-link** — accepts `?proposal=txHash:index` to auto-select a specific proposal

## Impact
- **What changed**: New bridge components + feature-flagged wiring on proposal detail and DRep profile pages
- **User-facing**: No — all behind `discovery_action_split` flag (default: off). Enable to test.
- **Risk**: Low — flag-gated, existing behavior completely preserved when off
- **Scope**: 3 new components, 4 modified files

## Test plan
- [ ] Enable `discovery_action_split` flag in admin
- [ ] Visit proposal page → see ProposalBridge instead of ProposalActionZone
- [ ] Click "Review & Vote" as DRep → land in ReviewWorkspace with proposal selected
- [ ] Vote as citizen → one-tap sentiment reaction works, results show immediately
- [ ] Visit DRep profile → "Delegate" button opens Sheet with ceremony flow
- [ ] Disable flag → everything reverts to current behavior
- [ ] Preflight passes: format, lint, types, 648 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)