### PR TITLE
fix: store full CIP-108 meta_json during proposal sync

### DIFF
--- a/lib/sync/proposals.ts
+++ b/lib/sync/proposals.ts
@@ -55,6 +55,15 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
           );
         }
 
+        // Build a map of raw meta_json by proposal key for enrichment
+        const rawMetaMap = new Map<string, unknown>();
+        for (const raw of validProposals) {
+          const r = raw as unknown as ProposalListResponse[number];
+          if (r.meta_json) {
+            rawMetaMap.set(`${r.proposal_tx_hash}-${r.proposal_index}`, r.meta_json);
+          }
+        }
+
         const classified = classifyProposals(validProposals as unknown as ProposalListResponse);
 
         const proposalRows = [
@@ -68,6 +77,7 @@ export async function executeProposalsSync(): Promise<Record<string, unknown>> {
                 proposal_type: p.type,
                 title: p.title,
                 abstract: p.abstract,
+                meta_json: rawMetaMap.get(`${p.txHash}-${p.index}`) ?? null,
                 withdrawal_amount: p.withdrawalAmountAda,
                 treasury_tier: p.treasuryTier,
                 param_changes: p.paramChanges,


### PR DESCRIPTION
## Summary

Root cause fix for empty motivation/rationale in the review workspace. The sync pipeline was discarding `meta_json` from the Koios response, only storing `title` and `abstract`. Now stores the complete CIP-108 metadata so the review-queue API can extract motivation, rationale, and references.

## Impact
- **What changed**: 1 file, 10 lines — proposal sync now includes `meta_json` in upsert
- **User-facing**: Yes — motivation and rationale will populate after next sync cycle
- **Risk**: Very low — additive change, doesn't affect existing fields
- **Note**: Existing proposals need a re-sync to backfill. This happens automatically every sync cycle (Inngest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)