### PR TITLE
docs: update strategy, vision, navigation for shipped proposal workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Build failures or production bugs if violated:
 - **Supabase MCP for migrations**, never the CLI.
 - **`.env.local` is PRODUCTION.** No sync/backfill/write ops without user approval.
 - **Feature-flag risky features** via `getFeatureFlag()` / `<FeatureGate>`.
+- **Feature flags for proposal workspace.** All proposal features gated behind `proposal_workspace` and sub-flags (`review_inline_annotations`, `review_treasury_impact`, etc.). See `lib/featureFlags.ts`.
 
 ## Tech Stack
 
@@ -46,19 +47,23 @@ Build failures or production bugs if violated:
 
 ## Key Files
 
-| Purpose                   | Location                                            |
-| ------------------------- | --------------------------------------------------- |
-| Product strategy & vision | `docs/strategy/ultimate-vision.md`                  |
-| Data reads                | `lib/data.ts`                                       |
-| Supabase client           | `lib/supabase.ts`                                   |
-| Koios helpers (sync only) | `utils/koios.ts`                                    |
-| Scoring V3                | `lib/scoring/`                                      |
-| Sync logic                | `lib/sync/`                                         |
-| Alignment (PCA)           | `lib/alignment/`                                    |
-| Matching engine           | `lib/matching/`                                     |
-| GHI v2                    | `lib/ghi/`                                          |
-| Feature flags             | `lib/featureFlags.ts`, `components/FeatureGate.tsx` |
-| Base URL                  | `lib/constants.ts` (`BASE_URL`)                     |
+| Purpose                   | Location                                                  |
+| ------------------------- | --------------------------------------------------------- |
+| Product strategy & vision | `docs/strategy/ultimate-vision.md`                        |
+| Data reads                | `lib/data.ts`                                             |
+| Supabase client           | `lib/supabase.ts`                                         |
+| Koios helpers (sync only) | `utils/koios.ts`                                          |
+| Scoring V3                | `lib/scoring/`                                            |
+| Sync logic                | `lib/sync/`                                               |
+| Alignment (PCA)           | `lib/alignment/`                                          |
+| Matching engine           | `lib/matching/`                                           |
+| GHI v2                    | `lib/ghi/`                                                |
+| Feature flags             | `lib/featureFlags.ts`, `components/FeatureGate.tsx`       |
+| Base URL                  | `lib/constants.ts` (`BASE_URL`)                           |
+| Proposal authoring        | `components/workspace/author/`, `lib/workspace/`          |
+| Proposal review           | `components/workspace/review/`, `hooks/useReviewQueue.ts` |
+| AI skills engine          | `lib/ai/skills/`, `app/api/ai/skill/route.ts`             |
+| Team collaboration        | `app/api/workspace/teams/`, `hooks/useTeam.ts`            |
 
 ## Worktrees
 

--- a/docs/strategy/context/build-manifest.md
+++ b/docs/strategy/context/build-manifest.md
@@ -161,6 +161,37 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 - [x] AnonymousNudge conversion CTAs on proposals, representatives, and health pages — dismissible, localStorage-persisted
 - [x] Shareable match results — `/match/result?profile=<base64>` page, OG image generation with radar chart, share button with `navigator.share()` + clipboard fallback
 
+### Phase 1b: Proposal Workspace ✅ SHIPPED (2026-03-16)
+
+#### Review Workspace (`/workspace/review`)
+
+- [x] Proposal queue with urgency sorting + unvoted-first ordering
+- [x] Full CIP-108 metadata display with markdown rendering
+- [x] On-chain voting with useVote hook + CIP-100 rationale
+- [x] Intelligence blocks: constitutional check, similar proposals, treasury impact, health score, proposer track record
+- [x] Sealed assessment period (5-day independent review)
+- [x] Decision journal with position tracking + confidence calibration
+- [x] Inline text annotations (highlight, note, concern, citation)
+- [x] Review framework templates per proposal type
+- [x] Governance calendar + smart notifications
+- [x] Post-vote share cards
+
+#### Authoring Pipeline (`/workspace/author`)
+
+- [x] Draft creation with CIP-108 templates
+- [x] Lifecycle stages: Draft → Community Review → Response → FCP → Submitted
+- [x] Structured review rubrics + point-by-point response system
+- [x] Team collaboration (Lead/Editor/Viewer, wallet-based invites)
+- [x] Constitutional AI pre-check + CIP-108 preview
+- [x] Version diff engine + on-chain submission flow (feature-flagged)
+
+#### Supporting Infrastructure
+
+- [x] AI provider abstraction with BYOK support
+- [x] Skills engine (constitutional-check, research-precedent)
+- [x] Diversity mechanisms (steelman, uniqueness scoring, perspective clustering)
+- [x] Engagement tracking + provenance logging
+
 ### Remaining
 
 - [ ] `/you/inbox` notifications — page exists but notification pipeline not wired to real events

--- a/docs/strategy/context/navigation-architecture.md
+++ b/docs/strategy/context/navigation-architecture.md
@@ -72,6 +72,17 @@ SPO sub-pages:
 
 DRep+SPO: Both sets of sub-pages appear in the sidebar, grouped by role with clear headers ("DRep" / "Pool"). Action Queue remains the default landing.
 
+#### Author (All authenticated users)
+
+| Route | Label |
+| `/workspace/author` | Author — Draft governance proposals |
+| `/workspace/author/[draftId]` | Draft Editor — Edit a specific draft |
+
+#### Review (DRep/SPO/Citizen)
+
+| Route | Label |
+| `/workspace/review` | Review — Review active and pre-submission proposals |
+
 ### Governance
 
 | Attribute        | Value                                                            |

--- a/docs/strategy/context/strategic-state.md
+++ b/docs/strategy/context/strategic-state.md
@@ -21,6 +21,7 @@ Updated by: Strategy session (Phase 2+3 re-evaluation)
 3. **Restraint as craft** — Fewer, better surfaces. Zero-sum information budget. Bet: removing features can improve the product. Evidence: V3 UX philosophy pivot, page-level JTBD constraints.
 4. **DReps/SPOs as distribution channel** — Representatives share profiles to attract delegation, pulling their followers into the platform. Bet: supply-side activation markets the product for free. Phase 2d builds this.
 5. **"Governance team" framing** — DRep + Pool = governance team. Coverage as differentiated concept. Bet: novel framing creates conversation and conversion. Runs through match, delegation, and Hub briefing — not a standalone card.
+6. **Proposers as third distribution channel.** DReps review, SPOs validate, proposers CREATE. The authoring pipeline makes Governada the place where governance proposals are born. Teams who draft on Governada get structured feedback, constitutional pre-checks, and arrive in DRep workspaces with rich lifecycle context. Teams who don't arrive cold.
 
 ## Launch Strategy
 

--- a/docs/strategy/context/ux-constraints.md
+++ b/docs/strategy/context/ux-constraints.md
@@ -198,6 +198,28 @@ World-class products (Linear, Stripe, Robinhood, Apple Health) share one trait: 
 | **Supporting elements** | Searchable glossary                                                                           |
 | **NOT on this page**    | Exhaustive governance education. Keep it to essentials. Link to external resources for depth. |
 
+### `/workspace/review` — Proposal Review
+
+| Attribute               | Constraint                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Core JTBD**           | Review proposals, decide, vote, share — efficiently                                                                |
+| **5-second answer**     | "You have N proposals to review. Here's the first one."                                                            |
+| **Dominant element**    | The full proposal content (motivation, rationale, references) rendered as markdown                                 |
+| **Supporting elements** | Intelligence accordion (constitutional check, similar proposals, treasury impact), vote action zone, notes sidebar |
+| **NOT on this page**    | Full voter lists, detailed analytics, citizen engagement mechanisms. Those live on the proposal detail page.       |
+| **Mobile**              | Proposal content scrolls, action zone as sticky footer. Queue as horizontal scroll. Notes via sheet drawer.        |
+
+### `/workspace/author` — Proposal Authoring
+
+| Attribute               | Constraint                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| **Core JTBD**           | Draft a governance action from idea to on-chain submission                         |
+| **5-second answer**     | "Write your proposal, get feedback, submit."                                       |
+| **Dominant element**    | Structured form: title, abstract, motivation, rationale with auto-save             |
+| **Supporting elements** | Lifecycle status bar, version history, constitutional check, team management       |
+| **NOT on this page**    | Proposal browsing, voting, analytics. Those are /workspace/review and /governance. |
+| **Mobile**              | Form fields stack vertically, action sidebar becomes bottom sheet.                 |
+
 ---
 
 ## Complexity Gating by User State

--- a/docs/strategy/personas/drep.md
+++ b/docs/strategy/personas/drep.md
@@ -101,6 +101,8 @@ The DRep's primary work surface. Everything they need to make an informed vote a
 
 **Why this matters:** Today, voting and rationale submission are separate, tedious processes across multiple tools. Making them a single 2-minute flow inside the analysis workspace fundamentally changes DRep behavior. DReps who use Governada will provide more rationales, score higher, and attract more delegation. The tool makes them better at governance.
 
+**Community review integration:** Proposals that arrive through Governada's authoring pipeline come with rich lifecycle context: iteration history, community review scores, team responsiveness metrics, and constitutional pre-check results. The DRep's review workspace surfaces this context alongside the proposal content, making evaluation dramatically more informed than reviewing a cold on-chain governance action.
+
 #### Reputation Dashboard
 
 The DRep's view of their own governance reputation -- how the ecosystem sees them:

--- a/docs/strategy/personas/spo.md
+++ b/docs/strategy/personas/spo.md
@@ -97,6 +97,8 @@ The same analysis environment as DReps, with SPO-relevant context:
 - Constitutional alignment analysis
 - Vote + rationale submission integrated at the bottom
 
+**Community review integration:** Proposals that arrive through Governada's authoring pipeline come with rich lifecycle context, making governance participation more efficient — an SPO can evaluate a proposal in minutes rather than hours when structured community feedback and constitutional analysis are already available.
+
 ### Pool Identity (The Rich Profile)
 
 This is where Governada goes beyond governance into the broader SPO identity. The pool profile on Governada should be the richest SPO presence on the internet -- the page SPOs share everywhere as their home page.

--- a/docs/strategy/ultimate-vision.md
+++ b/docs/strategy/ultimate-vision.md
@@ -68,6 +68,9 @@ Governada serves seven distinct personas. Each sees a product tailored to their 
 | **Treasury Team**        | Builders seeking governance funding.                          | Proposer reputation, pre-proposal validation, milestone tracking, citizen impact reports. Accountability as competitive advantage.           | Verified Project ($10-25/project).               |
 | **Researcher**           | Governance scholars, analysts, data journalists.              | API-first data platform: historical datasets, methodology docs, bulk exports, versioned data.                                                | Research API ($50-200/mo).                       |
 | **Integration Partner**  | Wallets, exchanges, pool tools (B2B).                         | Governance intelligence via API + embeddable widgets. Every integration extends reach.                                                       | API tiers ($50-200/mo).                          |
+| **Proposer**             | Anyone submitting governance actions                          | Authoring workspace: draft, iterate, community review, constitutional check, team collaboration, CIP-108 generation, on-chain submission     | Free core. Proposer Pro ($15-25/mo).             |
+
+**Note:** Proposer is a capability, not a segment — any authenticated user can create a proposal. It's additive to their governance persona (citizen, DRep, SPO, CC).
 
 ### Citizen-Centric Architecture
 
@@ -117,9 +120,9 @@ See `docs/strategy/context/navigation-architecture.md` for the complete spec inc
 
 ---
 
-## Five Flywheels
+## Six Flywheels
 
-The product strategy is organized around five self-reinforcing flywheels. Each creates compounding value over time. The build sequence is designed to activate them in order of lowest activation energy to highest.
+The product strategy is organized around six self-reinforcing flywheels. Each creates compounding value over time. The build sequence is designed to activate them in order of lowest activation energy to highest.
 
 ### Flywheel 1: Accountability
 
@@ -195,6 +198,22 @@ Governada builds governance intelligence
 **Moat:** Network effects of integration. Each wallet showing Governada scores validates the system and drives traffic.
 
 **Activation energy:** HIGH. Needs stable product + API v2 + business development. Premature until flywheels 1-4 are running. Post-launch phase.
+
+### Flywheel 6: Proposal Quality
+
+```
+Proposer drafts on Governada with AI tools
+  -> Community review with structured rubrics
+    -> Point-by-point response + iteration
+      -> Higher quality proposals reach on-chain vote
+        -> DReps make better decisions with richer context
+          -> Treasury outcomes improve
+            -> More proposers use the pipeline (trust signal)
+```
+
+**Moat:** Off-chain proposal lifecycle data — drafts, feedback, amendments, constitutional checks, team composition. No competitor has this because it's created by the process, not scraped from the chain.
+
+**Activation energy:** MEDIUM. Pipeline shipped. Needs proposer adoption. DReps in the review workspace create pull for proposers.
 
 ### How Flywheels Compound
 
@@ -452,7 +471,7 @@ flowchart TB
   Coverage --> Hub & DelegationPage & Alerts
 ```
 
-**Every new data source multiplies the value of every existing surface.** The five flywheels are the strategic lens; the data flywheel is the technical engine that powers all of them.
+**Every new data source multiplies the value of every existing surface.** The six flywheels are the strategic lens; the data flywheel is the technical engine that powers all of them.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all strategy and documentation to reflect the shipped proposal workspace (PRs #407-412).

- Vision: added Flywheel 6 (Proposal Quality), Proposer persona, network effects
- Build manifest: Phase 1b Proposal Workspace SHIPPED checklist
- Strategic state: Proposers as third distribution channel
- Navigation: added /workspace/author and /workspace/review routes
- UX constraints: added page constraints for both workspaces
- DRep + SPO personas: community review integration paragraphs
- CLAUDE.md: key files + feature flag hard constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)