### PR TITLE
feat: Governada Design Language — Compass palette, Governance Rings, three-mode system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-governada-body);
   --font-mono: var(--font-geist-mono);
   --font-display: var(--font-governada-display);
   --font-body: var(--font-governada-body);
@@ -50,118 +50,259 @@
 }
 
 /* ============================================================
-   GOVERNANCE OBSERVATORY — Design System Tokens
-   The constellation hero's aesthetic extended to every surface.
-   Deep space. Glowing data. Living governance.
+   THE COMPASS — Governada Design Language
+   A precision instrument for navigating governance.
+   Warm in your hand, precise in its reading.
    ============================================================ */
 
 :root {
   --radius: 0.625rem;
 
-  /* Light mode — functional, clean */
-  --background: oklch(0.98 0.005 260);
-  --foreground: oklch(0.1 0.02 260);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.1 0.02 260);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.1 0.02 260);
+  /* ── Light Mode: Warm Paper ── */
+  --background: oklch(0.97 0.005 90);
+  --foreground: oklch(0.15 0.02 260);
+  --card: oklch(0.99 0.003 90);
+  --card-foreground: oklch(0.15 0.02 260);
+  --popover: oklch(0.99 0.003 90);
+  --popover-foreground: oklch(0.15 0.02 260);
 
-  --primary: oklch(0.5 0.18 200);
+  /* Primary: Compass Teal — deep, institutional */
+  --primary: oklch(0.5 0.12 192);
   --primary-foreground: oklch(0.98 0 0);
 
-  --secondary: oklch(0.55 0.15 290);
-  --secondary-foreground: oklch(0.98 0 0);
+  /* Secondary: Wayfinder Amber — brass warmth */
+  --secondary: oklch(0.68 0.14 75);
+  --secondary-foreground: oklch(0.15 0.02 260);
 
-  --muted: oklch(0.94 0.005 260);
+  --muted: oklch(0.94 0.005 90);
   --muted-foreground: oklch(0.45 0.02 260);
 
-  --accent: oklch(0.95 0.01 260);
-  --accent-foreground: oklch(0.1 0.02 260);
+  --accent: oklch(0.95 0.01 90);
+  --accent-foreground: oklch(0.15 0.02 260);
 
-  --destructive: oklch(0.55 0.22 25);
-  --border: oklch(0.88 0.005 260);
-  --input: oklch(0.88 0.005 260);
-  --ring: oklch(0.5 0.18 200);
+  --destructive: oklch(0.58 0.2 25);
+  --border: oklch(0.9 0.01 90);
+  --input: oklch(0.9 0.01 90);
+  --ring: oklch(0.5 0.12 192);
 
-  /* Identity accent system — overridden by AccentProvider per page/section */
-  --identity: oklch(0.72 0.14 200);
-  --identity-rgb: 6 182 212;
+  /* Identity accent — Compass Teal default */
+  --identity: oklch(0.5 0.12 192);
+  --identity-rgb: 0 128 128;
 
   /* Primary RGB for glow effects */
-  --primary-rgb: 6 182 212;
+  --primary-rgb: 0 128 128;
+
+  /* Compass Palette — named governance colors */
+  --compass-teal: oklch(0.5 0.12 192);
+  --wayfinder-amber: oklch(0.68 0.14 75);
+  --meridian-violet: oklch(0.55 0.15 295);
+
+  /* Vote colors — morally neutral */
+  --vote-affirm: oklch(0.62 0.12 245);
+  --vote-oppose: oklch(0.62 0.1 50);
+  --vote-reserve: oklch(0.55 0.02 260);
 
   /* Chart palette */
-  --chart-1: oklch(0.5 0.18 200);
-  --chart-2: oklch(0.5 0.16 160);
-  --chart-3: oklch(0.5 0.15 290);
-  --chart-4: oklch(0.55 0.16 80);
-  --chart-5: oklch(0.5 0.2 25);
+  --chart-1: oklch(0.5 0.12 192);
+  --chart-2: oklch(0.68 0.14 75);
+  --chart-3: oklch(0.55 0.15 295);
+  --chart-4: oklch(0.68 0.16 162);
+  --chart-5: oklch(0.58 0.2 25);
 
-  --sidebar: oklch(0.97 0.005 260);
-  --sidebar-foreground: oklch(0.1 0.02 260);
-  --sidebar-primary: oklch(0.5 0.18 200);
+  --sidebar: oklch(0.97 0.005 90);
+  --sidebar-foreground: oklch(0.15 0.02 260);
+  --sidebar-primary: oklch(0.5 0.12 192);
   --sidebar-primary-foreground: oklch(0.98 0 0);
-  --sidebar-accent: oklch(0.94 0.005 260);
-  --sidebar-accent-foreground: oklch(0.1 0.02 260);
-  --sidebar-border: oklch(0.88 0.005 260);
-  --sidebar-ring: oklch(0.5 0.18 200);
+  --sidebar-accent: oklch(0.94 0.005 90);
+  --sidebar-accent-foreground: oklch(0.15 0.02 260);
+  --sidebar-border: oklch(0.9 0.01 90);
+  --sidebar-ring: oklch(0.5 0.12 192);
+
+  /* ── Mode spacing defaults (Browse) ── */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+  --space-section: 64px;
+  --space-card-padding: 1.5rem;
+  --space-card-gap: 1rem;
+  --radius-card: 0.75rem;
+  --text-body-size: 1rem;
+  --text-body-leading: 1.6;
+  --min-tap-target: 44px;
 }
 
 .dark {
-  /* ── Governance Observatory Dark Mode ──
-     Background matches the constellation hero (#0a0b14).
-     Surfaces are subtle elevations, not white cards.
-     Borders glow rather than divide. */
+  /* ── Dark Mode: Deep Space ──
+     Compass Teal glows brighter against dark.
+     Surfaces are subtle elevations. */
 
-  --background: oklch(0.07 0.015 260);
-  --foreground: oklch(0.96 0.005 260);
+  --background: oklch(0.12 0.015 260);
+  --foreground: oklch(0.95 0.005 260);
 
-  --card: oklch(0.1 0.015 260);
-  --card-foreground: oklch(0.96 0.005 260);
+  --card: oklch(0.16 0.012 260);
+  --card-foreground: oklch(0.95 0.005 260);
 
-  --popover: oklch(0.11 0.015 260);
-  --popover-foreground: oklch(0.96 0.005 260);
+  --popover: oklch(0.16 0.012 260);
+  --popover-foreground: oklch(0.95 0.005 260);
 
-  /* Primary: Electric Cyan — the Governada brand accent */
-  --primary: oklch(0.72 0.14 200);
-  --primary-foreground: oklch(0.07 0.015 260);
+  /* Primary: Compass Teal — brighter for dark */
+  --primary: oklch(0.72 0.12 192);
+  --primary-foreground: oklch(0.12 0.015 260);
 
-  /* Secondary: Vivid Purple */
-  --secondary: oklch(0.55 0.18 290);
-  --secondary-foreground: oklch(0.96 0.005 260);
+  /* Secondary: Wayfinder Amber — softer glow */
+  --secondary: oklch(0.78 0.12 75);
+  --secondary-foreground: oklch(0.95 0.005 260);
 
-  --muted: oklch(0.15 0.015 260);
-  --muted-foreground: oklch(0.65 0.025 260);
+  --muted: oklch(0.18 0.015 260);
+  --muted-foreground: oklch(0.6 0.01 260);
 
-  --accent: oklch(0.13 0.02 260);
-  --accent-foreground: oklch(0.96 0.005 260);
+  --accent: oklch(0.2 0.012 260);
+  --accent-foreground: oklch(0.95 0.005 260);
 
-  --destructive: oklch(0.55 0.2 25);
+  --destructive: oklch(0.58 0.2 25);
 
-  --border: oklch(0.17 0.015 260);
-  --input: oklch(0.13 0.015 260);
-  --ring: oklch(0.72 0.14 200);
+  --border: oklch(0.25 0.01 260);
+  --input: oklch(0.2 0.012 260);
+  --ring: oklch(0.72 0.12 192);
 
-  /* Identity accent — contextual per DRep/page, default: Electric Cyan */
-  --identity: oklch(0.72 0.14 200);
-  --identity-rgb: 6 182 212;
-  --primary-rgb: 6 182 212;
+  /* Identity accent — Compass Teal bright */
+  --identity: oklch(0.72 0.12 192);
+  --identity-rgb: 56 190 190;
+  --primary-rgb: 56 190 190;
+
+  /* Compass Palette — dark variants */
+  --compass-teal: oklch(0.72 0.12 192);
+  --wayfinder-amber: oklch(0.78 0.12 75);
+  --meridian-violet: oklch(0.7 0.14 295);
+
+  /* Vote colors stay consistent */
+  --vote-affirm: oklch(0.65 0.12 245);
+  --vote-oppose: oklch(0.65 0.1 50);
+  --vote-reserve: oklch(0.55 0.02 260);
 
   /* Chart palette — vivid against deep dark */
-  --chart-1: oklch(0.72 0.14 200);
-  --chart-2: oklch(0.68 0.16 160);
-  --chart-3: oklch(0.6 0.18 290);
-  --chart-4: oklch(0.75 0.14 80);
-  --chart-5: oklch(0.6 0.2 25);
+  --chart-1: oklch(0.72 0.12 192);
+  --chart-2: oklch(0.78 0.12 75);
+  --chart-3: oklch(0.7 0.14 295);
+  --chart-4: oklch(0.72 0.16 162);
+  --chart-5: oklch(0.65 0.2 25);
 
-  --sidebar: oklch(0.08 0.015 260);
-  --sidebar-foreground: oklch(0.96 0.005 260);
-  --sidebar-primary: oklch(0.72 0.14 200);
-  --sidebar-primary-foreground: oklch(0.07 0.015 260);
-  --sidebar-accent: oklch(0.13 0.02 260);
-  --sidebar-accent-foreground: oklch(0.96 0.005 260);
-  --sidebar-border: oklch(0.17 0.015 260);
-  --sidebar-ring: oklch(0.72 0.14 200);
+  --sidebar: oklch(0.12 0.015 260);
+  --sidebar-foreground: oklch(0.95 0.005 260);
+  --sidebar-primary: oklch(0.72 0.12 192);
+  --sidebar-primary-foreground: oklch(0.12 0.015 260);
+  --sidebar-accent: oklch(0.2 0.012 260);
+  --sidebar-accent-foreground: oklch(0.95 0.005 260);
+  --sidebar-border: oklch(0.25 0.01 260);
+  --sidebar-ring: oklch(0.72 0.12 192);
+}
+
+/* ============================================================
+   Mode: Work — compact density for professional workflows
+   ============================================================ */
+
+[data-mode='work'] {
+  --space-xs: 2px;
+  --space-sm: 4px;
+  --space-md: 8px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+  --space-section: 40px;
+  --space-card-padding: 0.75rem;
+  --space-card-gap: 0.5rem;
+  --radius-card: 0.5rem;
+  --text-body-size: 0.875rem;
+  --text-body-leading: 1.5;
+  --min-tap-target: 32px;
+}
+
+/* ============================================================
+   Mode: Analyze — maximum density for data exploration
+   ============================================================ */
+
+[data-mode='analyze'] {
+  --space-xs: 2px;
+  --space-sm: 3px;
+  --space-md: 6px;
+  --space-lg: 12px;
+  --space-xl: 16px;
+  --space-2xl: 24px;
+  --space-section: 32px;
+  --space-card-padding: 0.5rem;
+  --space-card-gap: 0.375rem;
+  --radius-card: 0.25rem;
+  --text-body-size: 0.8125rem;
+  --text-body-leading: 1.4;
+  --min-tap-target: 28px;
+}
+
+/* ============================================================
+   Browse mode forces light theme on dark-mode pages
+   ============================================================ */
+
+[data-mode='browse'] {
+  --background: oklch(0.97 0.005 90);
+  --foreground: oklch(0.15 0.02 260);
+  --card: oklch(0.99 0.003 90);
+  --card-foreground: oklch(0.15 0.02 260);
+  --popover: oklch(0.99 0.003 90);
+  --popover-foreground: oklch(0.15 0.02 260);
+  --primary: oklch(0.5 0.12 192);
+  --primary-foreground: oklch(0.98 0 0);
+  --secondary: oklch(0.68 0.14 75);
+  --secondary-foreground: oklch(0.15 0.02 260);
+  --muted: oklch(0.94 0.005 90);
+  --muted-foreground: oklch(0.45 0.02 260);
+  --accent: oklch(0.95 0.01 90);
+  --accent-foreground: oklch(0.15 0.02 260);
+  --border: oklch(0.9 0.01 90);
+  --input: oklch(0.9 0.01 90);
+  --ring: oklch(0.5 0.12 192);
+  --identity: oklch(0.5 0.12 192);
+  --identity-rgb: 0 128 128;
+  --primary-rgb: 0 128 128;
+  --sidebar: oklch(0.97 0.005 90);
+  --sidebar-foreground: oklch(0.15 0.02 260);
+  --sidebar-primary: oklch(0.5 0.12 192);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.94 0.005 90);
+  --sidebar-accent-foreground: oklch(0.15 0.02 260);
+  --sidebar-border: oklch(0.9 0.01 90);
+  --sidebar-ring: oklch(0.5 0.12 192);
+  color-scheme: light;
+}
+
+/* ============================================================
+   Force-Dark — wraps elements that must stay dark regardless of mode
+   Used for: constellation canvas overlays, branded loader, WebGL scenes.
+   ============================================================ */
+
+.force-dark {
+  --background: oklch(0.12 0.015 260);
+  --foreground: oklch(0.95 0.005 260);
+  --card: oklch(0.16 0.012 260);
+  --card-foreground: oklch(0.95 0.005 260);
+  --popover: oklch(0.16 0.012 260);
+  --popover-foreground: oklch(0.95 0.005 260);
+  --primary: oklch(0.72 0.12 192);
+  --primary-foreground: oklch(0.12 0.015 260);
+  --secondary: oklch(0.78 0.12 75);
+  --secondary-foreground: oklch(0.95 0.005 260);
+  --muted: oklch(0.18 0.015 260);
+  --muted-foreground: oklch(0.6 0.01 260);
+  --accent: oklch(0.2 0.012 260);
+  --accent-foreground: oklch(0.95 0.005 260);
+  --border: oklch(0.25 0.01 260);
+  --input: oklch(0.2 0.012 260);
+  --ring: oklch(0.72 0.12 192);
+  --identity: oklch(0.72 0.12 192);
+  --identity-rgb: 56 190 190;
+  --primary-rgb: 56 190 190;
+  color-scheme: dark;
 }
 
 /* ============================================================
@@ -239,14 +380,10 @@
    ============================================================ */
 
 :root {
-  --font-governada-display: var(--font-geist-sans);
-  --font-governada-body: var(--font-geist-sans);
-}
-
-/* Governance font — feature-flagged via data-font attribute on body.
-   Toggle via /admin/flags → governance_font or FF_GOVERNANCE_FONT env var. */
-body[data-font='governance'] {
-  --font-governada-display: var(--font-space-grotesk), var(--font-geist-sans);
+  /* Display: Fraunces serif for scores, titles, hero numbers */
+  --font-governada-display: var(--font-fraunces), var(--font-geist-sans);
+  /* Body: Space Grotesk geometric for readability */
+  --font-governada-body: var(--font-space-grotesk), var(--font-geist-sans);
 }
 
 /* ============================================================
@@ -262,8 +399,9 @@ body[data-font='governance'] {
   }
 }
 
-/* Subtle noise texture overlay — adds organic depth to dark surfaces */
-.dark body::before {
+/* Subtle noise texture overlay — adds organic depth to dark surfaces.
+   Hidden in Browse mode (light theme). */
+.dark body:not([data-mode='browse'])::before {
   content: '';
   position: fixed;
   inset: 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Geist, Geist_Mono, Space_Grotesk } from 'next/font/google';
+import { Geist, Geist_Mono, Space_Grotesk, Fraunces } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Providers } from '@/components/Providers';
@@ -13,6 +13,7 @@ import { OfflineBanner } from '@/components/OfflineBanner';
 import { GovernadaShell } from '@/components/governada/GovernadaShell';
 import { GovernanceFontProvider } from '@/components/GovernanceFontProvider';
 import { LocaleProvider } from '@/components/providers/LocaleProvider';
+import { ModeProvider } from '@/components/providers/ModeProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -28,6 +29,12 @@ const spaceGrotesk = Space_Grotesk({
   variable: '--font-space-grotesk',
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
+});
+
+const fraunces = Fraunces({
+  variable: '--font-fraunces',
+  subsets: ['latin'],
+  axes: ['SOFT', 'WONK', 'opsz'],
 });
 
 export const metadata: Metadata = {
@@ -76,7 +83,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${spaceGrotesk.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${spaceGrotesk.variable} ${fraunces.variable} antialiased`}
         suppressHydrationWarning
       >
         <ThemeProvider
@@ -96,7 +103,9 @@ export default function RootLayout({
                   Skip to main content
                 </a>
                 <GovernanceFontProvider />
-                <GovernadaShell>{children}</GovernadaShell>
+                <ModeProvider>
+                  <GovernadaShell>{children}</GovernadaShell>
+                </ModeProvider>
                 <CommandPalette />
                 <KeyboardShortcuts />
                 <ShortcutsHelpOverlay />

--- a/components/BrandedLoader.tsx
+++ b/components/BrandedLoader.tsx
@@ -33,7 +33,7 @@ export function BrandedLoader() {
 
   return (
     <div
-      className={`fixed inset-0 z-[10000] flex flex-col items-center justify-center bg-[#0a0b14] transition-opacity duration-500 ${
+      className={`force-dark fixed inset-0 z-[10000] flex flex-col items-center justify-center bg-[#0a0b14] transition-opacity duration-500 ${
         fading ? 'opacity-0 pointer-events-none' : 'opacity-100'
       }`}
       aria-hidden

--- a/components/ConstellationHero.tsx
+++ b/components/ConstellationHero.tsx
@@ -247,7 +247,7 @@ export function ConstellationHero({
 
   return (
     <div
-      className={`relative w-full transition-all duration-700 -mt-16 ${contracted ? 'min-h-[calc(35vh+4rem)]' : 'min-h-[calc(65vh+4rem)]'}`}
+      className={`force-dark relative w-full transition-all duration-700 -mt-16 ${contracted ? 'min-h-[calc(35vh+4rem)]' : 'min-h-[calc(65vh+4rem)]'}`}
       onMouseEnter={handleConstellationHover}
     >
       <ConstellationScene

--- a/components/DelegationGraph.tsx
+++ b/components/DelegationGraph.tsx
@@ -268,7 +268,7 @@ export function DelegationGraph() {
                 cy={pos.y}
                 r={r}
                 fill={color}
-                stroke={isHovered ? identityColor.hex : 'rgba(255,255,255,0.15)'}
+                stroke={isHovered ? identityColor.hex : 'hsl(var(--border))'}
                 strokeWidth={isHovered ? 2 : 1}
                 opacity={isHovered ? 1 : 0.9}
                 cursor="pointer"

--- a/components/GovernanceRadar.tsx
+++ b/components/GovernanceRadar.tsx
@@ -357,7 +357,7 @@ export function GovernanceRadar({
               y={cy - 4}
               textAnchor="middle"
               dominantBaseline="auto"
-              fill="white"
+              fill="currentColor"
               fontSize={28}
               fontWeight={800}
               fontFamily="var(--font-geist-mono)"
@@ -370,7 +370,7 @@ export function GovernanceRadar({
               y={cy + 12}
               textAnchor="middle"
               dominantBaseline="hanging"
-              fill="white"
+              fill="currentColor"
               fontSize={9}
               fontWeight={500}
               fontFamily="var(--font-geist-sans)"
@@ -422,7 +422,7 @@ export function GovernanceRadar({
                   y={ly + 7}
                   textAnchor={textAnchor}
                   dominantBaseline="hanging"
-                  fill="white"
+                  fill="currentColor"
                   fontSize={12}
                   fontWeight={700}
                   fontFamily="var(--font-geist-mono)"

--- a/components/HexScore.tsx
+++ b/components/HexScore.tsx
@@ -167,7 +167,7 @@ export function HexScore({
           <polygon
             points={polygonPoints}
             fill="none"
-            stroke="white"
+            stroke="currentColor"
             strokeWidth={1.5}
             strokeLinejoin="round"
             strokeDasharray={`${Math.round(perimeterLength * 0.06)} ${Math.round(perimeterLength * 0.94)}`}
@@ -188,7 +188,7 @@ export function HexScore({
               y={size === 'card' ? svgSize / 2 : svgSize / 2 - 2}
               textAnchor="middle"
               dominantBaseline="central"
-              fill="white"
+              fill="currentColor"
               fontSize={fontSize}
               fontWeight={700}
               letterSpacing="0.04em"
@@ -205,7 +205,7 @@ export function HexScore({
                 y={svgSize / 2 + fontSize * 0.55}
                 textAnchor="middle"
                 dominantBaseline="hanging"
-                fill="white"
+                fill="currentColor"
                 fontSize={11}
                 fontFamily="var(--font-geist-mono)"
                 opacity={0.35}

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -94,7 +94,7 @@ function BackgroundGlobe({
   return (
     <div
       className={cn(
-        'fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
+        'force-dark fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
         sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
       )}
       aria-hidden="true"

--- a/components/governada/proposals/ForceBeam.tsx
+++ b/components/governada/proposals/ForceBeam.tsx
@@ -93,7 +93,7 @@ export function ForceBeam({ yesPct, noPct, compact = false, className }: ForceBe
 
       {/* Clash point */}
       {progress > 0.8 && (
-        <circle cx={clashX} cy={beamY + beamHeight / 2} r={3} fill="white" opacity={0.5} />
+        <circle cx={clashX} cy={beamY + beamHeight / 2} r={3} fill="currentColor" opacity={0.5} />
       )}
     </svg>
   );

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -45,7 +45,7 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
   return (
     <div className="relative flex flex-col min-h-[calc(100vh-4rem)]">
       {/* Constellation hero */}
-      <section className="relative flex-1 min-h-[50vh] sm:-mt-14 overflow-hidden flex items-center justify-center">
+      <section className="force-dark relative flex-1 min-h-[50vh] sm:-mt-14 overflow-hidden flex items-center justify-center">
         <div className="absolute inset-0">
           <ConstellationScene className="w-full h-full" interactive={false} />
         </div>

--- a/components/hub/HubHero.tsx
+++ b/components/hub/HubHero.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { GovernanceRings, type GovernanceRingsData } from '@/components/ui/GovernanceRings';
+import { useSegment } from '@/components/providers/SegmentProvider';
+
+interface HubHeroProps {
+  pulseData: {
+    activeProposals: number;
+    activeDReps: number;
+    totalDReps: number;
+    totalDelegators: number;
+  };
+}
+
+/**
+ * HubHero — Governance Rings hero for the Hub page.
+ * Shows rings + verdict + contextual subtitle.
+ * Rings data is placeholder until engagement tracking is built.
+ */
+export function HubHero({ pulseData }: HubHeroProps) {
+  const { segment } = useSegment();
+
+  // Placeholder ring data until engagement metrics are computed
+  // TODO: Wire to real participation/deliberation/impact scores
+  const ringsData: GovernanceRingsData = {
+    participation: segment === 'anonymous' ? 0 : 42,
+    deliberation: segment === 'anonymous' ? 0 : 28,
+    impact: segment === 'anonymous' ? 0 : 15,
+  };
+
+  const isAuthenticated = segment !== 'anonymous';
+
+  return (
+    <section className="flex flex-col items-center text-center py-[var(--space-2xl)] px-[var(--space-md)]">
+      <GovernanceRings data={ringsData} size="hero" showLabels animate />
+
+      <h1
+        className="mt-6 font-display text-[2rem] font-semibold leading-tight tracking-tight text-foreground"
+        style={{ fontFamily: 'var(--font-governada-display)' }}
+      >
+        {isAuthenticated ? 'Your governance at a glance.' : 'Cardano has a government.'}
+      </h1>
+
+      <p className="mt-2 max-w-md text-[var(--text-body-size)] leading-relaxed text-muted-foreground">
+        {isAuthenticated ? (
+          <>
+            {pulseData.activeProposals > 0 && (
+              <span>
+                {pulseData.activeProposals} active proposal
+                {pulseData.activeProposals !== 1 ? 's' : ''}.{' '}
+              </span>
+            )}
+            <span>Close your governance rings by participating this epoch.</span>
+          </>
+        ) : (
+          <>
+            <span className="font-medium" style={{ fontFamily: 'var(--font-governada-display)' }}>
+              {pulseData.activeDReps.toLocaleString()}
+            </span>{' '}
+            DReps represent{' '}
+            <span className="font-medium" style={{ fontFamily: 'var(--font-governada-display)' }}>
+              {pulseData.totalDelegators.toLocaleString()}
+            </span>{' '}
+            delegators. Know who represents your ADA.
+          </>
+        )}
+      </p>
+    </section>
+  );
+}

--- a/components/hub/HubHomePage.tsx
+++ b/components/hub/HubHomePage.tsx
@@ -5,6 +5,7 @@ import { DepthGate } from '@/components/providers/DepthGate';
 import { HubCardRenderer } from './HubCardRenderer';
 import { AnonymousLanding } from './AnonymousLanding';
 import { CitizenHub } from './CitizenHub';
+import { HubHero } from './HubHero';
 import { HubCardSkeleton } from './cards/HubCard';
 import { OnboardingChecklist } from '@/components/funnel/OnboardingChecklist';
 import { DRepCockpit } from '@/components/workspace/DRepCockpit';
@@ -27,9 +28,11 @@ interface HubHomePageProps {
 /**
  * HubHomePage — The home page dispatcher.
  *
- * Anonymous: Clean conversion landing page with social proof.
- * Citizen: Onboarding checklist + consequence story Hub.
- * Other personas: Hub cards over constellation globe.
+ * All authenticated personas get the Governance Rings hero.
+ * Anonymous: Clean conversion landing page with hero + social proof.
+ * Citizen: Hero + onboarding checklist + consequence story Hub.
+ * DRep/SPO: Hero + cockpit dashboards.
+ * CC: Hero + hub cards.
  */
 export function HubHomePage({ pulseData }: HubHomePageProps) {
   const { segment, isLoading, drepId, poolId } = useSegment();
@@ -37,7 +40,7 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
   // While detecting segment, show skeleton cards to prevent CLS flash
   if (isLoading) {
     return (
-      <div className="mx-auto w-full max-w-2xl space-y-3 px-4 py-6">
+      <div className="mx-auto w-full max-w-2xl space-y-3 px-[var(--space-md)] py-[var(--space-lg)]">
         <HubCardSkeleton />
         <HubCardSkeleton />
         <HubCardSkeleton />
@@ -50,11 +53,12 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
     return <AnonymousLanding pulseData={pulseData} />;
   }
 
-  // Citizens get the onboarding checklist + consequence story Hub
+  // Citizens get the full Browse mode experience
   if (segment === 'citizen') {
     return (
       <>
-        <div className="mx-auto w-full max-w-2xl px-4 pt-6">
+        <HubHero pulseData={pulseData} />
+        <div className="mx-auto w-full max-w-2xl px-[var(--space-md)] space-y-[var(--space-card-gap)]">
           <ActionQueueCard />
         </div>
         <OnboardingChecklist />
@@ -66,41 +70,67 @@ export function HubHomePage({ pulseData }: HubHomePageProps) {
   // DReps get the Governance Cockpit as their homepage
   if (segment === 'drep') {
     return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
-        <ActionQueueCard />
-        <h1 className="text-xl font-bold text-foreground">Governance Cockpit</h1>
-        <DRepCockpit />
-        {/* Competitive context — engaged only (competitive intelligence) */}
-        <DepthGate minDepth="engaged">
-          <CompetitiveContext />
-        </DepthGate>
-        {/* Profile sharing — engaged+ (workspace integration) */}
-        <DepthGate minDepth="engaged">
-          {drepId && (
-            <ProfileShareToolkit entityType="drep" entityId={drepId} entityName="My DRep Profile" />
-          )}
-        </DepthGate>
-      </div>
+      <>
+        <HubHero pulseData={pulseData} />
+        <div className="mx-auto w-full max-w-2xl px-[var(--space-md)] py-[var(--space-lg)] space-y-[var(--space-lg)]">
+          <ActionQueueCard />
+          <h2
+            className="text-xl font-semibold text-foreground"
+            style={{ fontFamily: 'var(--font-governada-display)' }}
+          >
+            Governance Cockpit
+          </h2>
+          <DRepCockpit />
+          <DepthGate minDepth="engaged">
+            <CompetitiveContext />
+          </DepthGate>
+          <DepthGate minDepth="engaged">
+            {drepId && (
+              <ProfileShareToolkit
+                entityType="drep"
+                entityId={drepId}
+                entityName="My DRep Profile"
+              />
+            )}
+          </DepthGate>
+        </div>
+      </>
     );
   }
 
   // SPOs get their Governance Overview cockpit as homepage
   if (segment === 'spo') {
     return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-6 space-y-6">
-        <ActionQueueCard />
-        <h1 className="text-xl font-bold text-foreground">Governance Overview</h1>
-        <SPOCockpit />
-        {/* Profile sharing — engaged+ (workspace integration) */}
-        <DepthGate minDepth="engaged">
-          {poolId && (
-            <ProfileShareToolkit entityType="spo" entityId={poolId} entityName="My Pool Profile" />
-          )}
-        </DepthGate>
-      </div>
+      <>
+        <HubHero pulseData={pulseData} />
+        <div className="mx-auto w-full max-w-2xl px-[var(--space-md)] py-[var(--space-lg)] space-y-[var(--space-lg)]">
+          <ActionQueueCard />
+          <h2
+            className="text-xl font-semibold text-foreground"
+            style={{ fontFamily: 'var(--font-governada-display)' }}
+          >
+            Governance Overview
+          </h2>
+          <SPOCockpit />
+          <DepthGate minDepth="engaged">
+            {poolId && (
+              <ProfileShareToolkit
+                entityType="spo"
+                entityId={poolId}
+                entityName="My Pool Profile"
+              />
+            )}
+          </DepthGate>
+        </div>
+      </>
     );
   }
 
-  // CC and other authenticated personas — hub cards
-  return <HubCardRenderer persona={segment} />;
+  // CC and other authenticated personas — hero + hub cards
+  return (
+    <>
+      <HubHero pulseData={pulseData} />
+      <HubCardRenderer persona={segment} />
+    </>
+  );
 }

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 export type CardUrgency = 'default' | 'success' | 'warning' | 'critical';
 
 const URGENCY_STYLES: Record<CardUrgency, string> = {
-  default: 'border-white/[0.08] bg-card/15 backdrop-blur-md',
+  default: 'border-border/20 bg-card/80 backdrop-blur-md',
   success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-md',
   warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-md',
   critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-md',
@@ -54,7 +54,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="min-h-[6.5rem] rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-border/20 bg-card/80 backdrop-blur-md p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />
@@ -67,7 +67,7 @@ export function HubCardSkeleton() {
 /** Error state for a Hub card — shows a brief message with retry affordance */
 export function HubCardError({ message, onRetry }: { message?: string; onRetry?: () => void }) {
   return (
-    <div className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5">
+    <div className="rounded-2xl border border-border/20 bg-card/80 backdrop-blur-md p-4 sm:p-5">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">{message ?? 'Unable to load'}</p>
         {onRetry && (

--- a/components/providers/ModeProvider.tsx
+++ b/components/providers/ModeProvider.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+
+export type GovernadaMode = 'browse' | 'work' | 'analyze';
+
+interface ModeContextValue {
+  mode: GovernadaMode;
+  setMode: (mode: GovernadaMode) => void;
+  cycleMode: () => void;
+  isAutoSelected: boolean;
+}
+
+const ModeContext = createContext<ModeContextValue>({
+  mode: 'browse',
+  setMode: () => {},
+  cycleMode: () => {},
+  isAutoSelected: true,
+});
+
+export function useMode() {
+  return useContext(ModeContext);
+}
+
+const STORAGE_KEY = 'governada-mode-override';
+const MODE_ORDER: GovernadaMode[] = ['browse', 'work', 'analyze'];
+
+function getModeForPath(pathname: string): GovernadaMode {
+  if (pathname.startsWith('/workspace')) return 'work';
+  if (pathname.startsWith('/admin')) return 'work';
+  // Everything else defaults to browse
+  return 'browse';
+}
+
+export function ModeProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const autoMode = getModeForPath(pathname);
+
+  const [userOverride, setUserOverride] = useState<GovernadaMode | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  // Read persisted override on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && MODE_ORDER.includes(stored as GovernadaMode)) {
+        setUserOverride(stored as GovernadaMode);
+      }
+    } catch {
+      // localStorage unavailable
+    }
+    setMounted(true);
+  }, []);
+
+  const mode = userOverride ?? autoMode;
+  const isAutoSelected = userOverride === null;
+
+  const setMode = useCallback((newMode: GovernadaMode) => {
+    setUserOverride(newMode);
+    try {
+      localStorage.setItem(STORAGE_KEY, newMode);
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const cycleMode = useCallback(() => {
+    const currentIndex = MODE_ORDER.indexOf(mode);
+    const nextMode = MODE_ORDER[(currentIndex + 1) % MODE_ORDER.length];
+    setMode(nextMode);
+  }, [mode, setMode]);
+
+  // Clear override when user navigates to a route with a different auto-mode
+  // This prevents Work mode from sticking when navigating to Browse routes
+  useEffect(() => {
+    if (userOverride && userOverride === autoMode) {
+      setUserOverride(null);
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // localStorage unavailable
+      }
+    }
+  }, [autoMode, userOverride]);
+
+  // Sync mode to body for CSS selectors that target body-level elements
+  // (e.g., noise texture on body::before, scrollbar styles)
+  useEffect(() => {
+    const resolvedMode = mounted ? mode : autoMode;
+    document.body.setAttribute('data-mode', resolvedMode);
+    return () => {
+      document.body.removeAttribute('data-mode');
+    };
+  }, [mode, autoMode, mounted]);
+
+  return (
+    <ModeContext.Provider value={{ mode, setMode, cycleMode, isAutoSelected }}>
+      <div data-mode={mounted ? mode : autoMode} className="contents">
+        {children}
+      </div>
+    </ModeContext.Provider>
+  );
+}

--- a/components/ui/GlowBar.tsx
+++ b/components/ui/GlowBar.tsx
@@ -57,7 +57,7 @@ export function GlowBar({
         }}
       >
         {/* Glass highlight */}
-        <div className="absolute inset-x-0 top-0 h-[40%] rounded-t-full bg-white/[0.12]" />
+        <div className="absolute inset-x-0 top-0 h-[40%] rounded-t-full bg-foreground/[0.12]" />
       </div>
     </div>
   );

--- a/components/ui/GovernanceRings.tsx
+++ b/components/ui/GovernanceRings.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+
+export interface GovernanceRingsData {
+  /** Participation: 0-100 (votes cast, proposals reviewed, sessions) */
+  participation: number;
+  /** Deliberation: 0-100 (time on proposals, annotations, rationales) */
+  deliberation: number;
+  /** Impact: 0-100 (delegation count, vote influence, alignment accuracy) */
+  impact: number;
+}
+
+interface GovernanceRingsProps {
+  data: GovernanceRingsData;
+  size?: 'hero' | 'card' | 'badge' | 'inline';
+  animate?: boolean;
+  className?: string;
+  showLabels?: boolean;
+}
+
+const SIZE_CONFIG = {
+  hero: { diameter: 200, strokeWidth: 12, gap: 4, labelSize: 'text-xs' },
+  card: { diameter: 80, strokeWidth: 8, gap: 3, labelSize: 'text-[10px]' },
+  badge: { diameter: 32, strokeWidth: 4, gap: 2, labelSize: '' },
+  inline: { diameter: 20, strokeWidth: 3, gap: 1, labelSize: '' },
+} as const;
+
+// Ring colors from the Compass Palette
+const RING_COLORS = {
+  participation: {
+    stroke: 'oklch(0.50 0.12 192)',
+    strokeDark: 'oklch(0.72 0.12 192)',
+    track: 'oklch(0.50 0.12 192 / 0.08)',
+    trackDark: 'oklch(0.72 0.12 192 / 0.08)',
+    label: 'Participation',
+  },
+  deliberation: {
+    stroke: 'oklch(0.68 0.14 75)',
+    strokeDark: 'oklch(0.78 0.12 75)',
+    track: 'oklch(0.68 0.14 75 / 0.08)',
+    trackDark: 'oklch(0.78 0.12 75 / 0.08)',
+    label: 'Deliberation',
+  },
+  impact: {
+    stroke: 'oklch(0.55 0.15 295)',
+    strokeDark: 'oklch(0.70 0.14 295)',
+    track: 'oklch(0.55 0.15 295 / 0.08)',
+    trackDark: 'oklch(0.70 0.14 295 / 0.08)',
+    label: 'Impact',
+  },
+} as const;
+
+function Ring({
+  cx,
+  cy,
+  radius,
+  strokeWidth,
+  value,
+  color,
+  animate,
+  delay,
+}: {
+  cx: number;
+  cy: number;
+  radius: number;
+  strokeWidth: number;
+  value: number;
+  color: { stroke: string; strokeDark: string; track: string; trackDark: string };
+  animate: boolean;
+  delay: number;
+}) {
+  const circumference = 2 * Math.PI * radius;
+  const fillLength = (Math.min(value, 100) / 100) * circumference;
+  const [currentFill, setCurrentFill] = useState(animate ? 0 : fillLength);
+  const animFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!animate) {
+      setCurrentFill(fillLength);
+      return;
+    }
+
+    const startTime = performance.now() + delay;
+    const duration = 800; // ms
+
+    function tick(now: number) {
+      const elapsed = now - startTime;
+      if (elapsed < 0) {
+        animFrameRef.current = requestAnimationFrame(tick);
+        return;
+      }
+      // Spring-like ease-out
+      const t = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setCurrentFill(eased * fillLength);
+      if (t < 1) {
+        animFrameRef.current = requestAnimationFrame(tick);
+      }
+    }
+
+    animFrameRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
+    };
+  }, [animate, fillLength, delay]);
+
+  return (
+    <g>
+      {/* Background track */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={radius}
+        fill="none"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        className="[stroke:--ring-track]"
+        style={
+          {
+            '--ring-track': color.track,
+          } as React.CSSProperties
+        }
+      />
+      {/* Foreground fill */}
+      {currentFill > 0 && (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={`${currentFill} ${circumference - currentFill}`}
+          strokeDashoffset={circumference * 0.25} // Start from top
+          className="[stroke:--ring-fill]"
+          style={
+            {
+              '--ring-fill': color.stroke,
+              transition: animate ? 'none' : 'stroke-dasharray 0.5s ease-out',
+            } as React.CSSProperties
+          }
+        />
+      )}
+    </g>
+  );
+}
+
+export function GovernanceRings({
+  data,
+  size = 'hero',
+  animate = true,
+  className = '',
+  showLabels = false,
+}: GovernanceRingsProps) {
+  const config = SIZE_CONFIG[size];
+  const { diameter, strokeWidth, gap } = config;
+  const center = diameter / 2;
+
+  // Calculate radii for each ring (outer to inner)
+  const outerRadius = center - strokeWidth / 2;
+  const middleRadius = outerRadius - strokeWidth - gap;
+  const innerRadius = middleRadius - strokeWidth - gap;
+
+  const rings = [
+    {
+      key: 'participation',
+      value: data.participation,
+      radius: outerRadius,
+      color: RING_COLORS.participation,
+      delay: 0,
+    },
+    {
+      key: 'deliberation',
+      value: data.deliberation,
+      radius: middleRadius,
+      color: RING_COLORS.deliberation,
+      delay: 100,
+    },
+    {
+      key: 'impact',
+      value: data.impact,
+      radius: innerRadius,
+      color: RING_COLORS.impact,
+      delay: 200,
+    },
+  ] as const;
+
+  const showLabelText = showLabels && (size === 'hero' || size === 'card');
+
+  return (
+    <div className={`inline-flex flex-col items-center ${className}`}>
+      <svg
+        width={diameter}
+        height={diameter}
+        viewBox={`0 0 ${diameter} ${diameter}`}
+        aria-label={`Governance rings: Participation ${data.participation}%, Deliberation ${data.deliberation}%, Impact ${data.impact}%`}
+        role="img"
+      >
+        {rings.map((ring) => (
+          <Ring
+            key={ring.key}
+            cx={center}
+            cy={center}
+            radius={ring.radius}
+            strokeWidth={strokeWidth}
+            value={ring.value}
+            color={ring.color}
+            animate={animate}
+            delay={ring.delay}
+          />
+        ))}
+      </svg>
+      {showLabelText && (
+        <div className={`flex items-center gap-3 mt-3 ${config.labelSize}`}>
+          {rings.map((ring) => (
+            <div key={ring.key} className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-2 h-2 rounded-full"
+                style={{ backgroundColor: ring.color.stroke }}
+              />
+              <span className="text-muted-foreground font-medium">{ring.color.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/strategy/design-language.md
+++ b/docs/strategy/design-language.md
@@ -1,0 +1,592 @@
+# The Governada Design Language
+
+> **Status:** Specification — ready for Hub proof of concept
+> **Created:** 2026-03-17
+> **Metaphor:** The Compass
+> **Signature:** Governance Rings
+
+---
+
+## 1. Identity: The Compass
+
+Governada is a compass for navigating governance. Not a dashboard. Not a voting booth. A precision instrument that helps you find your direction in a complex landscape.
+
+This metaphor shapes every design decision:
+
+- **Colors** evoke cartographic maps and brass instruments
+- **Typography** carries institutional authority (serif display) with modern readability (geometric body)
+- **Interactions** feel like orienting a compass — deliberate, precise, revealing
+- **Data visualizations** show position and direction, not just magnitude
+- **Empty states** are invitations to explore, not dead ends
+
+The compass is warm in your hand but precise in its reading. That duality — warm accessibility, cool precision — defines the three modes.
+
+---
+
+## 2. Color System: The Compass Palette
+
+### Philosophy
+
+Color in Governada serves three purposes: **brand identity**, **governance semantics**, and **emotional temperature**. No color is arbitrary — each earns its place.
+
+OKLCH throughout for perceptual consistency across light and dark modes.
+
+### Primary: Compass Teal
+
+Deep, warm teal. The color of a compass rose on a cartographic chart. Authoritative but not cold. Replaces the placeholder cyan.
+
+```
+Light: oklch(0.50 0.12 192)   — deep, institutional
+Dark:  oklch(0.72 0.12 192)   — brighter for dark backgrounds
+```
+
+Used for: primary buttons, active states, links, focus rings, navigation accents, Participation governance ring.
+
+### Secondary: Wayfinder Amber
+
+The brass of a compass instrument. Warmth, illumination, guidance.
+
+```
+Light: oklch(0.68 0.14 75)    — warm, golden
+Dark:  oklch(0.78 0.12 75)    — softer glow on dark
+```
+
+Used for: secondary accents, highlights, hover warmth, Deliberation governance ring, callout borders.
+
+### Tertiary: Meridian Violet
+
+The third point of the compass triangle. Significance, depth, influence.
+
+```
+Light: oklch(0.55 0.15 295)   — deep, purposeful
+Dark:  oklch(0.70 0.14 295)   — vibrant on dark
+```
+
+Used for: Impact governance ring, premium/notable indicators, alignment dimension accents.
+
+### Vote Colors (Morally Neutral)
+
+Governance decisions are not right or wrong. The colors must feel **deliberate and considered**, not **correct or incorrect**.
+
+| Action                | Color Name | OKLCH                  | Emotional Register                                |
+| --------------------- | ---------- | ---------------------- | ------------------------------------------------- |
+| **Affirm** (Yes)      | Cerulean   | `oklch(0.62 0.12 245)` | Calm conviction. "I've considered and I proceed." |
+| **Oppose** (No)       | Copper     | `oklch(0.62 0.10 50)`  | Firm resolve. "I've considered and I decline."    |
+| **Reserve** (Abstain) | Slate      | `oklch(0.55 0.02 260)` | Deliberate pause. "I choose to observe."          |
+
+Design rule: Vote buttons at rest are ALL the same neutral style (outline). Color activates only on selection. This prevents visual bias toward any direction.
+
+### Semantic Colors
+
+| Purpose | OKLCH                       | Usage                                  |
+| ------- | --------------------------- | -------------------------------------- |
+| Success | `oklch(0.68 0.16 162)`      | Transactions confirmed, syncs complete |
+| Warning | `oklch(0.72 0.14 80)`       | Approaching deadlines, data staleness  |
+| Error   | `oklch(0.58 0.20 25)`       | Failed operations, critical alerts     |
+| Info    | Primary teal at 60% opacity | Informational banners, tips            |
+
+### Tier Colors
+
+The existing 6-tier identity system is retained. Tiers appear on entity-level surfaces (cards, borders, badges) and don't conflict with vote or semantic colors because they occupy different visual contexts.
+
+```
+Emerging:   oklch(0.55 0.03 260)   — subtle, neutral
+Bronze:     oklch(0.60 0.12 55)    — warm earth
+Silver:     oklch(0.72 0.02 260)   — cool metal
+Gold:       oklch(0.76 0.15 85)    — rich warmth
+Diamond:    oklch(0.76 0.12 200)   — clear, bright
+Legendary:  oklch(0.62 0.20 310)   — vivid, rare
+```
+
+### Surface Colors
+
+| Surface    | Light Mode                          | Dark Mode                            |
+| ---------- | ----------------------------------- | ------------------------------------ |
+| Background | `oklch(0.97 0.005 90)` — warm paper | `oklch(0.12 0.015 260)` — deep space |
+| Card       | `oklch(0.99 0.003 90)` — clean      | `oklch(0.16 0.012 260)` — elevated   |
+| Elevated   | `oklch(1.0 0 0)` — white            | `oklch(0.20 0.010 260)` — raised     |
+| Border     | `oklch(0.90 0.01 90)` — subtle      | `oklch(0.25 0.01 260)` — subtle      |
+| Muted text | `oklch(0.55 0.01 260)`              | `oklch(0.60 0.01 260)`               |
+| Foreground | `oklch(0.15 0.02 260)` — near black | `oklch(0.95 0.005 260)` — near white |
+
+Note the warm hue shift in light mode backgrounds (hue 90 = warm paper) vs. cool in dark mode (hue 260 = deep blue-space). This creates the context-adaptive temperature: Browse/light feels warm, Work/dark feels cool.
+
+---
+
+## 3. Typography: Authority + Readability
+
+### Three-Font Architecture
+
+| Role        | Font          | Weights            | Purpose                                                                          |
+| ----------- | ------------- | ------------------ | -------------------------------------------------------------------------------- |
+| **Display** | Fraunces      | 400, 600, 800      | Scores, page titles, hero numbers, share cards. The "verdict" font.              |
+| **Body**    | Space Grotesk | 400, 500, 600, 700 | Everything else. Proposals, descriptions, UI labels, navigation. Already loaded. |
+| **Data**    | Geist Mono    | 400, 500           | On-chain hashes, ADA amounts, epoch numbers, addresses. Already loaded.          |
+
+### Why Fraunces for Display
+
+Fraunces is a variable "soft serif" inspired by early 20th century typefaces. It has:
+
+- **Optical sizing** — automatically adjusts stroke contrast for different sizes
+- **Soft axis** — can range from sharp to rounded, letting us tune warmth
+- **Excellent numerals** — the number "72" in Fraunces feels like a _verdict_, not a statistic
+- **Distinctive** — not overused (unlike Playfair Display). No other governance tool uses it.
+- **Warm authority** — it signals "institution" without being cold or stuffy
+
+When a DRep sees their score in Fraunces at 48px, it should feel like receiving a judgment from a body that matters — not reading a dashboard metric.
+
+### Type Scale
+
+Base size adapts per mode. Scale ratio: 1.25 (Major Third).
+
+| Token            | Browse (16px base)  | Work (14px base)    | Analyze (13px base) |
+| ---------------- | ------------------- | ------------------- | ------------------- |
+| `--text-hero`    | 48px / Fraunces 800 | 36px / Fraunces 800 | 32px / Fraunces 800 |
+| `--text-h1`      | 32px / Fraunces 600 | 24px / Fraunces 600 | 22px / Fraunces 600 |
+| `--text-h2`      | 24px / Space 600    | 20px / Space 600    | 18px / Space 600    |
+| `--text-h3`      | 20px / Space 600    | 16px / Space 600    | 15px / Space 600    |
+| `--text-body`    | 16px / Space 400    | 14px / Space 400    | 13px / Space 400    |
+| `--text-small`   | 14px / Space 400    | 12px / Space 400    | 12px / Space 400    |
+| `--text-caption` | 12px / Space 400    | 11px / Space 400    | 11px / Space 400    |
+| `--text-data`    | 14px / Mono 400     | 13px / Mono 400     | 12px / Mono 400     |
+
+### Line Heights
+
+| Context             | Value           | Rationale                                                 |
+| ------------------- | --------------- | --------------------------------------------------------- |
+| Display / headings  | 1.1–1.2         | Tight — scores and titles should feel dense and impactful |
+| Body text           | 1.5–1.6         | Comfortable — proposals and descriptions need readability |
+| Data / mono         | 1.4             | Functional — enough to read, no wasted vertical space     |
+| Compact (Work mode) | -0.1 from above | Slightly tighter across the board                         |
+
+### Font Pairing Rationale
+
+Fraunces and Space Grotesk share geometric DNA — Fraunces' letterforms have underlying geometric structure softened by serif terminals. This creates visual harmony despite the serif/sans contrast. They work together because they agree on proportions but disagree on details.
+
+### Number Rendering
+
+| Context                    | Font             | Feature                             |
+| -------------------------- | ---------------- | ----------------------------------- |
+| Governance scores (72, 85) | Fraunces Display | Proportional, high-contrast         |
+| ADA amounts (₳1,234,567)   | Geist Mono       | Tabular figures, fixed-width digits |
+| Epoch numbers (Epoch 142)  | Geist Mono       | Tabular, clear differentiation      |
+| Percentages in body text   | Space Grotesk    | Matches surrounding text            |
+| Table data                 | Geist Mono       | Tabular for column alignment        |
+
+---
+
+## 4. Spacing & Density: Three Modes
+
+### Mode Definitions
+
+Each mode has a distinct emotional register, density level, and interaction model.
+
+#### Browse Mode
+
+> "Show me what's happening." Warm, inviting, narrative-first.
+
+- **Default for**: Citizens, discovery pages, proposal detail, profile pages, mobile
+- **Theme**: Light (warm paper backgrounds)
+- **Emotional register**: Warm-professional
+- **Base unit**: 16px
+- **Card padding**: 1.5rem (24px)
+- **Card gap**: 1rem (16px)
+- **Card radius**: 0.75rem (12px)
+- **Max content width**: 42rem (672px) — single column focus
+- **Information philosophy**: Conclusions first, data on demand
+- **Interaction model**: Touch-friendly, spacious tap targets (44px minimum)
+- **Typography emphasis**: Narrative (body text prominent, scores contextual)
+- **Animations**: Fluid spring entrances, celebration moments
+
+#### Work Mode
+
+> "Let me get this done." Cool, focused, action-first.
+
+- **Default for**: Workspace pages, DRep/SPO tools, admin
+- **Theme**: Dark (deep space backgrounds)
+- **Emotional register**: Cool-professional
+- **Base unit**: 14px
+- **Card padding**: 0.75rem (12px)
+- **Card gap**: 0.5rem (8px)
+- **Card radius**: 0.5rem (8px)
+- **Max content width**: Full viewport with multi-panel layout
+- **Information philosophy**: Actions first, context available
+- **Interaction model**: Keyboard-first, shortcut hints visible, compact click targets (32px)
+- **Typography emphasis**: Labels and data (body text secondary)
+- **Animations**: Snappy transitions (150ms ease-out), minimal decoration
+
+#### Analyze Mode
+
+> "Let me understand everything." Neutral, dense, data-first.
+
+- **Default for**: Opt-in only — governance health deep dive, score analysis, comparative views
+- **Theme**: User preference (inherits current)
+- **Emotional register**: Neutral-clinical
+- **Base unit**: 13px
+- **Card padding**: 0.5rem (8px)
+- **Card gap**: 0.375rem (6px)
+- **Card radius**: 0.25rem (4px)
+- **Max content width**: Full viewport, side-by-side panels
+- **Information philosophy**: All data visible, comparisons prominent
+- **Interaction model**: Keyboard + mouse, export affordances visible
+- **Typography emphasis**: Data (mono numbers prominent, minimal prose)
+- **Animations**: Minimal — instant state changes, no decorative motion
+
+### Spacing Scale (per mode)
+
+| Token             | Browse | Work | Analyze |
+| ----------------- | ------ | ---- | ------- |
+| `--space-xs`      | 4px    | 2px  | 2px     |
+| `--space-sm`      | 8px    | 4px  | 3px     |
+| `--space-md`      | 16px   | 8px  | 6px     |
+| `--space-lg`      | 24px   | 16px | 12px    |
+| `--space-xl`      | 32px   | 24px | 16px    |
+| `--space-2xl`     | 48px   | 32px | 24px    |
+| `--space-section` | 64px   | 40px | 32px    |
+
+### Mode Selection Logic
+
+```
+Route-based defaults:
+  /hub, /discover/*, /proposal/*, /match/*  → Browse
+  /workspace/*                               → Work
+  /governance/health (deep analysis view)    → Analyze
+
+Overrides:
+  User preference (persisted in localStorage)
+  Manual toggle: Cmd+Shift+M cycles modes
+  Header pill: [Browse] [Work] [Analyze]
+
+Mobile:
+  Always Browse mode (Work/Analyze not available on mobile)
+```
+
+### Context-Adaptive Theme
+
+| Mode    | Default Theme    | Rationale                                                         |
+| ------- | ---------------- | ----------------------------------------------------------------- |
+| Browse  | Light (warm)     | Citizens browsing should feel invited, not intimidated by dark UI |
+| Work    | Dark (cool)      | DReps working long sessions benefit from reduced eye strain       |
+| Analyze | Inherits current | User preference — some prefer dark data views, others light       |
+
+Users can override any mode's default theme. The recommendation is opinionated but not mandatory.
+
+---
+
+## 5. Motion Language: Fluid Precision
+
+### Philosophy
+
+Every animation serves a purpose and belongs to one of four categories. No orphaned keyframes.
+
+### Motion Categories
+
+| Category        | Duration  | Easing                            | When Used                                                            |
+| --------------- | --------- | --------------------------------- | -------------------------------------------------------------------- |
+| **Enter**       | 300–400ms | `spring(1, 80, 10)` — underdamped | Element appears: page load, panel open, card reveal                  |
+| **Feedback**    | 100–150ms | `ease-out`                        | User action confirmed: button press, checkbox toggle, selection      |
+| **Transition**  | 200–250ms | `ease-in-out`                     | State changes: mode switch, tab change, panel resize                 |
+| **Celebration** | 500–700ms | `spring(1, 60, 8)` — bouncy       | Milestone moments: vote published, ring closed, delegation confirmed |
+
+### Spring Presets
+
+```ts
+export const springs = {
+  enter: { type: 'spring', stiffness: 80, damping: 10 }, // Fluid arrival
+  feedback: { type: 'spring', stiffness: 300, damping: 25 }, // Snappy response
+  transition: { type: 'spring', stiffness: 120, damping: 15 }, // Smooth shift
+  celebrate: { type: 'spring', stiffness: 60, damping: 8 }, // Joyful bounce
+} as const;
+```
+
+### Mode-Specific Motion
+
+| Category    | Browse                    | Work                    | Analyze                |
+| ----------- | ------------------------- | ----------------------- | ---------------------- |
+| Enter       | Full spring (300ms)       | Fast fade (150ms)       | Instant (0ms)          |
+| Feedback    | Spring scale + glow       | Opacity flash           | Background color pulse |
+| Transition  | Slide + fade              | Cut (instant)           | Cut                    |
+| Celebration | Full animation + confetti | Subtle glow + checkmark | Score update highlight |
+
+### Governance-Specific Animations
+
+| Animation            | Category    | Description                                                            |
+| -------------------- | ----------- | ---------------------------------------------------------------------- |
+| Ring fill            | Enter       | Governance ring segment fills clockwise with spring physics            |
+| Score reveal         | Enter       | Number counts up from 0 to value over 400ms in Fraunces display        |
+| Vote cast            | Celebration | Selected vote color pulses outward, button scales to 1.05 then settles |
+| Rationale published  | Celebration | Brief aurora glow on card border, checkmark pop                        |
+| Delegation confirmed | Celebration | Connection line draws between citizen and DRep nodes                   |
+| Ring closed          | Celebration | Ring completes 360 degrees, brief golden pulse on full circle          |
+| Proposal queued      | Feedback    | Card slides right into "reviewed" stack                                |
+| Mode switch          | Transition  | Cross-fade between density levels, 200ms                               |
+
+### Reduced Motion
+
+When `prefers-reduced-motion: reduce`:
+
+- All Enter animations → instant (opacity: 0 → 1, no spring)
+- All Feedback → opacity change only (no scale, no spring)
+- All Transition → instant cut
+- All Celebration → static final state (no animation, still show the visual result)
+
+---
+
+## 6. Signature Elements
+
+### Governance Rings
+
+The primary signature element. Inspired by Apple Health activity rings but purpose-built for civic participation.
+
+**Three rings, three dimensions of governance health:**
+
+| Ring       | Dimension     | Color           | What It Measures                                                                             |
+| ---------- | ------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| **Outer**  | Participation | Compass Teal    | Are you showing up? Votes cast, proposals reviewed, sessions active                          |
+| **Middle** | Deliberation  | Wayfinder Amber | Are you thinking deeply? Time spent on proposals, annotations made, rationales published     |
+| **Inner**  | Impact        | Meridian Violet | Is your governance making a difference? Delegation count, vote influence, alignment accuracy |
+
+**Visual Design:**
+
+- Three concentric circular arcs, each filling 0–360 degrees
+- Gap between rings: 4px (Browse), 3px (Work), 2px (Analyze)
+- Ring stroke width: 12px (hero), 8px (card), 4px (badge)
+- Background track: 8% opacity of ring color (shows unfilled portion)
+- Fill animation: clockwise spring, staggered start (outer → middle → inner, 100ms delay)
+- Completion: when a ring reaches 100%, brief golden pulse on the filled arc
+
+**Size Variants:**
+
+| Variant  | Diameter | Use Case                               |
+| -------- | -------- | -------------------------------------- |
+| `hero`   | 200px    | Hub page hero, profile hero            |
+| `card`   | 80px     | Dashboard cards, sidebar               |
+| `badge`  | 32px     | Navigation indicator, inline reference |
+| `inline` | 20px     | Next to text, table cells              |
+
+**Interaction:**
+
+- Hover on a ring → tooltip shows dimension name + current value + what would improve it
+- Click → navigates to the relevant section (Participation → vote history, Deliberation → review activity, Impact → delegation stats)
+
+**Epoch Reset:**
+
+Rings reset each epoch (5 days). Previous epoch rings are shown as faded ghosts behind current epoch rings, creating a "progress trail" visual history.
+
+**The Share Moment:**
+
+"Close your governance rings" — when all three rings hit 100% in an epoch, trigger a celebration animation and offer a share card: "I closed my governance rings for Epoch 142."
+
+### HexScore (Retained, Refined)
+
+HexScore remains as the entity-level score visualization. Refinements for the new design language:
+
+- Score number rendered in **Fraunces Display** (serif) instead of Geist Mono
+- Breathing glow tinted with the entity's tier color (unchanged)
+- Edge shimmer slightly warmer in Browse mode, cooler in Work mode
+- Size variants maintained: hero-lg (172px), hero (120px), card (48px), badge (24px)
+
+### Alignment Compass (Future)
+
+A 6-axis radar visualization showing a user's governance identity across the alignment dimensions. Not for the initial proof of concept, but designed into the system for later:
+
+- Each axis: treasury-conservative, treasury-growth, decentralization, security, innovation, transparency
+- Rendered as a filled polygon on a hexagonal grid
+- Color: gradient from primary to secondary based on dominant dimension
+- Planned for: profile pages, match comparison, "your governance fingerprint"
+
+---
+
+## 7. Component Philosophy
+
+### Layer Architecture
+
+```
+Layer 4: Page Compositions      (Hub, ReviewWorkspace, DRepProfile)
+Layer 3: Governance Primitives  (VoteAction, ScoreDisplay, ProposalQueue, GovernanceRings)
+Layer 2: Foundation Primitives  (Button, Card, Input, Dialog — built on Radix)
+Layer 1: Providers              (ModeProvider, ShortcutProvider, ProposalContext, TierThemeProvider)
+Layer 0: Design Tokens          (CSS variables — colors, typography, spacing, motion)
+```
+
+### Foundation Primitives (Layer 2) — Built on Radix
+
+Replace shadcn with governance-native Radix implementations. Same components, Governada identity baked in.
+
+Every foundation primitive:
+
+- Uses `data-slot` for global CSS targeting (retain existing pattern)
+- Responds to mode CSS variables (spacing, radius, typography adapt automatically)
+- Has accessible labels, focus management, keyboard nav via Radix
+- Supports `asChild` for composition
+
+### Governance Primitives (Layer 3) — Domain-Specific
+
+Each governance primitive:
+
+1. **Declares its data contract** — typed props matching `lib/` data shapes
+2. **Self-registers keyboard shortcuts** — via ShortcutProvider context
+3. **Auto-fires analytics** — PostHog events on meaningful interactions
+4. **Has built-in states** — documented state machine (idle → active → loading → success → error)
+5. **Adapts to mode** — Browse/Work/Analyze variants designed in, not bolted on
+6. **Composes via context** — primitives inside `<ProposalContext>` share state automatically
+
+### The Composition Protocol
+
+```tsx
+// ProposalContext provides shared state to all governance primitives within it
+<ProposalContext proposal={currentProposal}>
+  {/* All children share proposal state — select in queue, everything updates */}
+  <ProposalQueue items={proposals} />
+  <ProposalBrief />
+  <VoteAction />
+  <ScoreDisplay />
+  <IntelligenceStrip />
+</ProposalContext>
+```
+
+Changing the selected proposal in `ProposalQueue` cascades to all siblings. Bloomberg's "security groups" pattern, applied to governance.
+
+---
+
+## 8. Keyboard & Command System
+
+### Command Palette (Cmd+K)
+
+Universal search + actions + navigation. Every keyboard chord, page, and action accessible through one interface.
+
+- **Search**: proposals by title, DReps by name, governance actions
+- **Navigate**: type a page name to go there
+- **Act**: "Vote Yes on..." "Delegate to..." "Create draft..."
+- **Recent**: last 5 actions for quick replay
+
+### Chord Navigation
+
+| Chord | Action             | Context |
+| ----- | ------------------ | ------- |
+| `G W` | Go to Workspace    | Global  |
+| `G H` | Go to Hub          | Global  |
+| `G P` | Go to Proposals    | Global  |
+| `G M` | Go to Match        | Global  |
+| `G S` | Go to Settings     | Global  |
+| `?`   | Show shortcut help | Global  |
+
+### Direct Actions (Work Mode)
+
+| Key         | Action                   | Context        |
+| ----------- | ------------------------ | -------------- |
+| `Y`         | Vote Yes / Affirm        | Review panel   |
+| `N`         | Vote No / Oppose         | Review panel   |
+| `A`         | Vote Abstain / Reserve   | Review panel   |
+| `J` / `K`   | Next / Previous in queue | Queue panel    |
+| `Enter`     | Open selected item       | Queue panel    |
+| `S`         | Snooze proposal          | Review panel   |
+| `R`         | Start rationale          | Review panel   |
+| `Escape`    | Back / Close / Deselect  | Global         |
+| `Cmd+Enter` | Submit / Confirm         | Forms, dialogs |
+
+### Context Awareness
+
+- Letter shortcuts (Y/N/A/J/K/S/R) are **disabled** when focus is in a text input or textarea
+- Chord shortcuts (G+W) work everywhere except when a modal is open
+- Cmd+K works everywhere, always
+- ShortcutProvider manages all registration, context, and conflict resolution
+
+---
+
+## 9. Implementation: Hub Proof of Concept
+
+The Hub page is the proof of concept for the design language. It proves Browse mode, Governance Rings, the new typography, and context-adaptive theming.
+
+### What Changes
+
+| Element       | Current                 | New                                   |
+| ------------- | ----------------------- | ------------------------------------- |
+| Theme         | Dark (constellation bg) | Light (warm paper) in Browse mode     |
+| Typography    | Geist Sans              | Space Grotesk body + Fraunces display |
+| Hero element  | Card grid               | Governance Rings (hero size, 200px)   |
+| Color accent  | Electric cyan           | Compass Teal                          |
+| Card spacing  | Dense (space-y-3)       | Generous (space-y-4, larger padding)  |
+| Score numbers | Geist Mono              | Fraunces Display                      |
+| Info style    | Cards with links        | Narrative summary + cards             |
+
+### Hub Layout (Browse Mode)
+
+```
+┌─────────────────────────────────────────┐
+│  [Logo]  Governada  [Mode] [Settings]   │  ← Header
+├─────────────────────────────────────────┤
+│                                         │
+│         [Governance Rings: hero]        │  ← Hero: 200px rings
+│      Participation · Deliberation       │     with ring labels
+│              · Impact                   │
+│                                         │
+│   "Your governance is healthy."         │  ← One-line verdict (Fraunces)
+│   "3 proposals need your attention      │     Contextual subtitle (Space)
+│    before Epoch 143 ends."              │
+│                                         │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌─ Action Card ─────────────────┐     │  ← Priority actions (if any)
+│   │  3 proposals awaiting vote     │     │     Compass teal accent
+│   │  [Review Now →]               │     │
+│   └───────────────────────────────┘     │
+│                                         │
+│   ┌─ Governance Pulse ───────────┐     │  ← Health summary
+│   │  GHI: 74 (Strong)            │     │     Score in Fraunces
+│   │  Treasury: ₳1.2B             │     │     Amount in Geist Mono
+│   │  Active DReps: 847           │     │
+│   └───────────────────────────────┘     │
+│                                         │
+│   ┌─ Your Delegation ────────────┐     │  ← Persona-specific
+│   │  Delegated to: DRepName      │     │
+│   │  Score: 72  Alignment: 85%   │     │
+│   └───────────────────────────────┘     │
+│                                         │
+│   ┌─ Discovery ──────────────────┐     │  ← Engagement
+│   │  Find your governance team   │     │
+│   │  [Explore →]                 │     │
+│   └───────────────────────────────┘     │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### What Stays
+
+- Persona-adaptive card selection (HubCardConfig.ts)
+- SSR governance pulse data
+- TanStack Query for client-side personalization
+- SegmentProvider persona routing
+- Feature flag architecture
+- Constellation background (moved to Work mode only, or as a subtle element)
+
+### Implementation Steps
+
+1. **Add Fraunces font** to `app/layout.tsx` via `next/font/google`
+2. **Create ModeProvider** in `components/providers/ModeProvider.tsx`
+3. **Update globals.css** — new color tokens, mode-scoped spacing/typography variables
+4. **Build GovernanceRings** component with hero/card/badge/inline variants
+5. **Rebuild Hub page** with Browse mode layout, Governance Rings hero, new typography
+6. **Wire mode auto-selection** — Hub → Browse mode
+7. **Feature-flag the new design** — `design_language_v2` flag, existing Hub as fallback
+
+### What NOT to Do Yet
+
+- Don't rebuild workspace pages (Work mode proof comes after Hub validation)
+- Don't build command palette or keyboard system (that's Work mode)
+- Don't replace shadcn components globally (do that after Hub validates the language)
+- Don't build Alignment Compass (future signature element)
+- Don't build Analyze mode (lowest priority, prove Browse and Work first)
+
+---
+
+## 10. Validation Criteria
+
+The Hub proof of concept succeeds if:
+
+1. **First impression test**: A new visitor can identify Governada's purpose in <5 seconds without reading text (rings + typography + color = "governance health")
+2. **Screenshot test**: The Governance Rings hero is immediately recognizable — someone seeing a screenshot says "what app is that?"
+3. **Typography test**: Score numbers in Fraunces feel like verdicts, not statistics. Body text in Space Grotesk reads comfortably at proposal length.
+4. **Temperature test**: Browse mode feels warm and inviting. Not cold, not sterile, not startup-generic.
+5. **Mode contrast test**: Switching to Work mode (when built) feels like a genuine context shift — not just smaller text.
+6. **Founder test**: You look at the Hub and think "this was designed for governance" — not "this is a nice React app."

--- a/docs/strategy/explorations/design-system.md
+++ b/docs/strategy/explorations/design-system.md
@@ -568,7 +568,33 @@ Layer 0: Design Tokens (OKLCH colors, motion, tiers, density)
 
 ## Phase 6: Recommendation
 
-### The Hybrid: Modes + Primitives (Phased)
+### Decision: Full Design Language Rebuild
+
+After founder review, the decision is to invest in a complete design language rebuild rather than incremental phasing. Effort is not the constraint — identity is. The goal is a design system that is irreplaceable, not improvable.
+
+**See:** `docs/strategy/design-language.md` for the full specification.
+
+**Key decisions:**
+
+- **Metaphor**: The Compass (navigation, alignment, finding direction)
+- **Signature**: Governance Rings (three-ring participation/deliberation/impact display, Apple Health-inspired)
+- **Typography**: Fraunces (serif display for verdicts) + Space Grotesk (geometric body) + Geist Mono (data)
+- **Color**: Compass Teal (primary), Wayfinder Amber (secondary), Meridian Violet (tertiary). Morally neutral vote colors.
+- **Modes**: Browse (warm/light) / Work (cool/dark) / Analyze (neutral/user-choice) — designed into every component from day one
+- **Motion**: Fluid precision — spring-based with four categories (Enter/Feedback/Transition/Celebration)
+- **Foundation**: Built on Radix directly, not shadcn. Governance-native primitives.
+- **Theme**: Context-adaptive (Browse=light, Work=dark)
+- **Proof of concept**: Hub page in Browse mode
+
+### Previous Recommendation (Superseded)
+
+The original recommendation was a phased hybrid (Modes first, then Primitives, then Workbench). This has been superseded by the full rebuild decision, but the phasing insight remains valid for execution order: prove Browse mode on Hub → prove Work mode on Workspace → build remaining primitives → add Analyze mode.
+
+---
+
+### Original Phased Approach (for reference)
+
+#### The Hybrid: Modes + Primitives (Phased)
 
 **Why this wins:** The concepts aren't competing — they're layers.
 


### PR DESCRIPTION
## Summary
- Complete design language replacing placeholder cyan with the Compass palette (Teal/Amber/Violet)
- Three-mode system: Browse (warm/light), Work (cool/dark), Analyze (neutral/dense) with route-based auto-selection
- Governance Rings signature element (Participation/Deliberation/Impact) as Hub hero
- Fraunces serif for display typography, Space Grotesk for body, morally neutral vote colors
- 14 component fixes for light-mode compatibility (SVG currentColor, glassmorphism, force-dark constellation wrappers)

## Impact
- **What changed**: Full visual identity overhaul — colors, typography, density modes, signature visualization
- **User-facing**: Yes — every page gets new fonts and Compass palette. Hub gets Governance Rings hero and warm light theme. Workspace stays dark/compact.
- **Risk**: Medium — visual changes across the entire app, but no functional/data changes. All 648 tests pass.
- **Scope**: globals.css (tokens), layout.tsx (fonts), 12 components, 2 new components (ModeProvider, GovernanceRings), design language spec

## Test plan
- [ ] Visual check: Hub page shows Governance Rings + warm light theme
- [ ] Visual check: `/governance` pages show Compass Teal accents, Fraunces scores
- [ ] Visual check: `/drep/[id]` HexScore renders with currentColor (visible on light bg)
- [ ] Visual check: `/workspace` stays dark with compact density (Work mode)
- [ ] Visual check: Constellation hero sections maintain dark canvas with light text
- [ ] Visual check: HubCards have visible borders on light backgrounds
- [ ] Verify mode toggle works (keyboard or manual)
- [ ] `npm run preflight` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)