### PR TITLE
fix: kill light mode entirely, dark-only with Compass palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,44 +58,44 @@
 :root {
   --radius: 0.625rem;
 
-  /* ── Light Mode: Warm Paper ── */
-  --background: oklch(0.97 0.005 90);
-  --foreground: oklch(0.15 0.02 260);
-  --card: oklch(0.99 0.003 90);
-  --card-foreground: oklch(0.15 0.02 260);
-  --popover: oklch(0.99 0.003 90);
-  --popover-foreground: oklch(0.15 0.02 260);
+  /* ── Light mode fallback (dark forced, but tokens needed for components) ── */
+  --background: oklch(0.98 0.005 260);
+  --foreground: oklch(0.1 0.02 260);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.1 0.02 260);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.1 0.02 260);
 
-  /* Primary: Compass Teal — deep, institutional */
+  /* Primary: Compass Teal */
   --primary: oklch(0.5 0.12 192);
   --primary-foreground: oklch(0.98 0 0);
 
-  /* Secondary: Wayfinder Amber — brass warmth */
+  /* Secondary: Wayfinder Amber */
   --secondary: oklch(0.68 0.14 75);
-  --secondary-foreground: oklch(0.15 0.02 260);
+  --secondary-foreground: oklch(0.98 0 0);
 
-  --muted: oklch(0.94 0.005 90);
+  --muted: oklch(0.94 0.005 260);
   --muted-foreground: oklch(0.45 0.02 260);
 
-  --accent: oklch(0.95 0.01 90);
-  --accent-foreground: oklch(0.15 0.02 260);
+  --accent: oklch(0.95 0.01 260);
+  --accent-foreground: oklch(0.1 0.02 260);
 
-  --destructive: oklch(0.58 0.2 25);
-  --border: oklch(0.9 0.01 90);
-  --input: oklch(0.9 0.01 90);
+  --destructive: oklch(0.55 0.22 25);
+  --border: oklch(0.88 0.005 260);
+  --input: oklch(0.88 0.005 260);
   --ring: oklch(0.5 0.12 192);
 
   /* Identity accent — Compass Teal default */
-  --identity: oklch(0.5 0.12 192);
-  --identity-rgb: 0 128 128;
+  --identity: oklch(0.72 0.12 192);
+  --identity-rgb: 56 190 190;
 
   /* Primary RGB for glow effects */
-  --primary-rgb: 0 128 128;
+  --primary-rgb: 56 190 190;
 
   /* Compass Palette — named governance colors */
-  --compass-teal: oklch(0.5 0.12 192);
-  --wayfinder-amber: oklch(0.68 0.14 75);
-  --meridian-violet: oklch(0.55 0.15 295);
+  --compass-teal: oklch(0.72 0.12 192);
+  --wayfinder-amber: oklch(0.78 0.12 75);
+  --meridian-violet: oklch(0.7 0.14 295);
 
   /* Vote colors — morally neutral */
   --vote-affirm: oklch(0.62 0.12 245);
@@ -103,19 +103,19 @@
   --vote-reserve: oklch(0.55 0.02 260);
 
   /* Chart palette */
-  --chart-1: oklch(0.5 0.12 192);
-  --chart-2: oklch(0.68 0.14 75);
-  --chart-3: oklch(0.55 0.15 295);
-  --chart-4: oklch(0.68 0.16 162);
-  --chart-5: oklch(0.58 0.2 25);
+  --chart-1: oklch(0.72 0.12 192);
+  --chart-2: oklch(0.78 0.12 75);
+  --chart-3: oklch(0.7 0.14 295);
+  --chart-4: oklch(0.72 0.16 162);
+  --chart-5: oklch(0.65 0.2 25);
 
-  --sidebar: oklch(0.97 0.005 90);
-  --sidebar-foreground: oklch(0.15 0.02 260);
+  --sidebar: oklch(0.97 0.005 260);
+  --sidebar-foreground: oklch(0.1 0.02 260);
   --sidebar-primary: oklch(0.5 0.12 192);
   --sidebar-primary-foreground: oklch(0.98 0 0);
-  --sidebar-accent: oklch(0.94 0.005 90);
-  --sidebar-accent-foreground: oklch(0.15 0.02 260);
-  --sidebar-border: oklch(0.9 0.01 90);
+  --sidebar-accent: oklch(0.94 0.005 260);
+  --sidebar-accent-foreground: oklch(0.1 0.02 260);
+  --sidebar-border: oklch(0.88 0.005 260);
   --sidebar-ring: oklch(0.5 0.12 192);
 
   /* ── Mode spacing defaults (Browse) ── */
@@ -241,42 +241,6 @@
 }
 
 /* ============================================================
-   Browse mode forces light theme on dark-mode pages
-   ============================================================ */
-
-[data-mode='browse'] {
-  --background: oklch(0.97 0.005 90);
-  --foreground: oklch(0.15 0.02 260);
-  --card: oklch(0.99 0.003 90);
-  --card-foreground: oklch(0.15 0.02 260);
-  --popover: oklch(0.99 0.003 90);
-  --popover-foreground: oklch(0.15 0.02 260);
-  --primary: oklch(0.5 0.12 192);
-  --primary-foreground: oklch(0.98 0 0);
-  --secondary: oklch(0.68 0.14 75);
-  --secondary-foreground: oklch(0.15 0.02 260);
-  --muted: oklch(0.94 0.005 90);
-  --muted-foreground: oklch(0.45 0.02 260);
-  --accent: oklch(0.95 0.01 90);
-  --accent-foreground: oklch(0.15 0.02 260);
-  --border: oklch(0.9 0.01 90);
-  --input: oklch(0.9 0.01 90);
-  --ring: oklch(0.5 0.12 192);
-  --identity: oklch(0.5 0.12 192);
-  --identity-rgb: 0 128 128;
-  --primary-rgb: 0 128 128;
-  --sidebar: oklch(0.97 0.005 90);
-  --sidebar-foreground: oklch(0.15 0.02 260);
-  --sidebar-primary: oklch(0.5 0.12 192);
-  --sidebar-primary-foreground: oklch(0.98 0 0);
-  --sidebar-accent: oklch(0.94 0.005 90);
-  --sidebar-accent-foreground: oklch(0.15 0.02 260);
-  --sidebar-border: oklch(0.9 0.01 90);
-  --sidebar-ring: oklch(0.5 0.12 192);
-  color-scheme: light;
-}
-
-/* ============================================================
    Force-Dark — wraps elements that must stay dark regardless of mode
    Used for: constellation canvas overlays, branded loader, WebGL scenes.
    ============================================================ */
@@ -399,9 +363,8 @@
   }
 }
 
-/* Subtle noise texture overlay — adds organic depth to dark surfaces.
-   Hidden in Browse mode (light theme). */
-.dark body:not([data-mode='browse'])::before {
+/* Subtle noise texture overlay — adds organic depth to dark surfaces */
+.dark body::before {
   content: '';
   position: fixed;
   inset: 0;

--- a/components/hub/cards/HubCard.tsx
+++ b/components/hub/cards/HubCard.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 export type CardUrgency = 'default' | 'success' | 'warning' | 'critical';
 
 const URGENCY_STYLES: Record<CardUrgency, string> = {
-  default: 'border-border/20 bg-card/80 backdrop-blur-md',
+  default: 'border-white/[0.08] bg-card/15 backdrop-blur-md',
   success: 'border-emerald-500/30 bg-emerald-500/8 backdrop-blur-md',
   warning: 'border-amber-500/30 bg-amber-500/8 backdrop-blur-md',
   critical: 'border-red-500/30 bg-red-500/8 backdrop-blur-md',
@@ -54,7 +54,7 @@ export function HubCard({ href, urgency = 'default', className, children, label 
 /** Skeleton placeholder for a loading Hub card */
 export function HubCardSkeleton() {
   return (
-    <div className="min-h-[6.5rem] rounded-2xl border border-border/20 bg-card/80 backdrop-blur-md p-4 sm:p-5 animate-pulse">
+    <div className="min-h-[6.5rem] rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5 animate-pulse">
       <div className="space-y-3">
         <div className="h-4 w-24 rounded bg-muted" />
         <div className="h-6 w-48 rounded bg-muted" />
@@ -67,7 +67,7 @@ export function HubCardSkeleton() {
 /** Error state for a Hub card — shows a brief message with retry affordance */
 export function HubCardError({ message, onRetry }: { message?: string; onRetry?: () => void }) {
   return (
-    <div className="rounded-2xl border border-border/20 bg-card/80 backdrop-blur-md p-4 sm:p-5">
+    <div className="rounded-2xl border border-white/[0.08] bg-card/15 backdrop-blur-md p-4 sm:p-5">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">{message ?? 'Unable to load'}</p>
         {onRetry && (

--- a/components/providers/ModeProvider.tsx
+++ b/components/providers/ModeProvider.tsx
@@ -84,16 +84,6 @@ export function ModeProvider({ children }: { children: ReactNode }) {
     }
   }, [autoMode, userOverride]);
 
-  // Sync mode to body for CSS selectors that target body-level elements
-  // (e.g., noise texture on body::before, scrollbar styles)
-  useEffect(() => {
-    const resolvedMode = mounted ? mode : autoMode;
-    document.body.setAttribute('data-mode', resolvedMode);
-    return () => {
-      document.body.removeAttribute('data-mode');
-    };
-  }, [mode, autoMode, mounted]);
-
   return (
     <ModeContext.Provider value={{ mode, setMode, cycleMode, isAutoSelected }}>
       <div data-mode={mounted ? mode : autoMode} className="contents">


### PR DESCRIPTION
## Summary
- Remove Browse-mode light theme override from globals.css
- Governada is dark-only — constellation globe defines the brand
- Modes now control density only (Browse=spacious, Work=compact), not theme
- Revert HubCard glassmorphism to dark-optimized styling
- Remove body data-mode sync from ModeProvider (no longer needed)

## Impact
- **What changed**: Removed light mode that was shipped in #415. All pages stay dark.
- **User-facing**: Yes — pages that briefly showed light theme are back to dark
- **Risk**: Low — reverting to the dark theme the app has always used
- **Scope**: globals.css, ModeProvider.tsx, HubCard.tsx

## Test plan
- [ ] All pages render dark theme
- [ ] Constellation globe visible and correct
- [ ] Hub cards have glassmorphic borders (white/8%)
- [ ] Compass Teal palette still applied (not old cyan)
- [ ] Fraunces + Space Grotesk fonts still active

🤖 Generated with [Claude Code](https://claude.com/claude-code)