### PR TITLE
fix: wire workspace v2 into navigation + P1 followups

### DIFF
--- a/app/workspace/author/[draftId]/WorkspaceV2Redirect.tsx
+++ b/app/workspace/author/[draftId]/WorkspaceV2Redirect.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+/**
+ * Redirects to the new workspace editor when governance_workspace_v2 flag is on.
+ * Renders nothing if the flag is off — the old DraftEditor shows as usual.
+ */
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useFeatureFlag } from '@/components/FeatureGate';
+
+export function WorkspaceV2Redirect() {
+  const params = useParams();
+  const router = useRouter();
+  const draftId = typeof params.draftId === 'string' ? params.draftId : null;
+  const v2Enabled = useFeatureFlag('governance_workspace_v2');
+
+  useEffect(() => {
+    if (v2Enabled === true && draftId) {
+      router.replace(`/workspace/editor/${draftId}`);
+    }
+  }, [v2Enabled, draftId, router]);
+
+  return null;
+}

--- a/app/workspace/author/[draftId]/page.tsx
+++ b/app/workspace/author/[draftId]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { PageViewTracker } from '@/components/PageViewTracker';
 import { DraftEditor } from '@/components/workspace/author/DraftEditor';
+import { WorkspaceV2Redirect } from './WorkspaceV2Redirect';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +14,7 @@ export default function DraftEditorPage() {
   return (
     <>
       <PageViewTracker event="author_draft_viewed" />
+      <WorkspaceV2Redirect />
       <DraftEditor />
     </>
   );

--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -25,6 +25,7 @@ import { useRevisionState } from '@/hooks/useRevision';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useFeedbackThemes } from '@/hooks/useFeedbackThemes';
 import { FeatureGate } from '@/components/FeatureGate';
+import { posthog } from '@/lib/posthog';
 import { WorkspaceLayout } from '@/components/workspace/layout/WorkspaceLayout';
 import { WorkspaceToolbar } from '@/components/workspace/layout/WorkspaceToolbar';
 import { StatusBar } from '@/components/workspace/layout/StatusBar';
@@ -33,9 +34,11 @@ import { AgentChatPanel } from '@/components/workspace/agent/AgentChatPanel';
 import { RevisionDiffView } from '@/components/workspace/editor/RevisionDiffView';
 import { RevisionJustificationFlow } from '@/components/workspace/editor/RevisionJustificationFlow';
 import { FeedbackStream } from '@/components/workspace/feedback/FeedbackStream';
+import { EndorsementPrompt } from '@/components/workspace/feedback/EndorsementPrompt';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
 import type { DraftContent } from '@/lib/workspace/types';
+import type { FeedbackTheme } from '@/lib/workspace/feedback/types';
 import type {
   EditorMode,
   EditorContext,
@@ -62,6 +65,34 @@ const SLASH_COMMAND_PROMPTS: Record<SlashCommandType, (section: string) => strin
   draft: (section) =>
     `Draft content for the ${section} section based on the other sections and the proposal type.`,
 };
+
+// ---------------------------------------------------------------------------
+// Simple overlap check (client-side, no AI)
+// ---------------------------------------------------------------------------
+
+function findOverlappingTheme(commentText: string, themes: FeedbackTheme[]): FeedbackTheme | null {
+  if (!commentText || themes.length === 0) return null;
+  const words = commentText
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 3);
+  if (words.length === 0) return null;
+
+  let bestTheme: FeedbackTheme | null = null;
+  let bestScore = 0;
+
+  for (const theme of themes) {
+    const summary = theme.summary.toLowerCase();
+    const matches = words.filter((w) => summary.includes(w)).length;
+    const score = matches / words.length;
+    if (score > bestScore && score >= 0.3) {
+      bestScore = score;
+      bestTheme = theme;
+    }
+  }
+
+  return bestTheme;
+}
 
 // ---------------------------------------------------------------------------
 // EditorContext builder
@@ -157,7 +188,16 @@ function WorkspaceEditorPage() {
   const draftId = typeof params.draftId === 'string' ? params.draftId : null;
   const { data, isLoading, error } = useDraft(draftId);
 
-  const [mode, setMode] = useState<EditorMode>('edit');
+  const [mode, setModeRaw] = useState<EditorMode>('edit');
+  const setMode = useCallback(
+    (next: EditorMode) => {
+      if (next === 'diff') {
+        posthog.capture('workspace_revision_diff_opened', { draft_id: draftId });
+      }
+      setModeRaw(next);
+    },
+    [draftId],
+  );
   const editorRef = useRef<Editor | null>(null);
   const [showJustificationFlow, setShowJustificationFlow] = useState(false);
 
@@ -199,8 +239,14 @@ function WorkspaceEditorPage() {
   const versions = data?.versions ?? null;
   const submittedTxHash = draft?.submittedTxHash ?? null;
 
-  // --- Feedback themes (for proposer tab) ---
+  // --- Feedback themes (for proposer tab + endorsement prompt) ---
   const { themes: feedbackThemes } = useFeedbackThemes(submittedTxHash, submittedTxHash ? 0 : null);
+
+  // --- Endorsement prompt state ---
+  const [endorsementPrompt, setEndorsementPrompt] = useState<{
+    theme: FeedbackTheme;
+    annotationText: string;
+  } | null>(null);
 
   // --- Content change handler (auto-save) ---
   const handleContentChange = useCallback(
@@ -250,21 +296,38 @@ function WorkspaceEditorPage() {
     agentClearLastEdit();
   }, [agentLastEdit, agentClearLastEdit]);
 
-  // --- Agent lastComment -> apply inline comment ---
+  // --- Agent lastComment -> apply inline comment + check for endorsement overlap ---
   useEffect(() => {
     if (!agentLastComment || !editorRef.current) return;
     injectInlineComment(editorRef.current, agentLastComment);
+
+    // Check if this comment overlaps an existing feedback theme (reviewer only)
+    if (!isOwner && feedbackThemes.length > 0) {
+      const overlapping = findOverlappingTheme(agentLastComment.commentText, feedbackThemes);
+      if (overlapping) {
+        setEndorsementPrompt({
+          theme: overlapping,
+          annotationText: agentLastComment.commentText,
+        });
+      }
+    }
+
     agentClearLastComment();
-  }, [agentLastComment, agentClearLastComment]);
+  }, [agentLastComment, agentClearLastComment, isOwner, feedbackThemes]);
 
   // --- Chat panel: send message with editor context ---
   const handleChatSendMessage = useCallback(
     async (message: string) => {
       if (!draft) return;
       const ctx = buildEditorContext(editorRef.current, draft, mode);
+      posthog.capture('workspace_agent_message_sent', {
+        draft_id: draftId,
+        mode,
+        has_selection: !!ctx.selectedText,
+      });
       await agentSendMessage(message, ctx);
     },
-    [agentSendMessage, draft, mode],
+    [agentSendMessage, draft, mode, draftId],
   );
 
   // --- Apply proposed edit from chat panel ---
@@ -402,14 +465,18 @@ function WorkspaceEditorPage() {
         onSlashCommand={handleSlashCommand}
         onCommand={handleCommand}
         onDiffAccept={(editId) => {
-          // Edit accepted -- agent can track this for learning
-          void editId;
+          posthog.capture('workspace_inline_edit_accepted', {
+            draft_id: draftId,
+            edit_id: editId,
+          });
         }}
         onDiffReject={(editId) => {
-          // Edit rejected
-          void editId;
+          posthog.capture('workspace_inline_edit_rejected', {
+            draft_id: draftId,
+            edit_id: editId,
+          });
         }}
-        currentUserId="current-user" // TODO: wire to real user ID
+        currentUserId={stakeAddress ?? 'anonymous'}
         onEditorReady={handleEditorReady}
       />
     );
@@ -490,6 +557,21 @@ function WorkspaceEditorPage() {
           onSkip={() => setShowJustificationFlow(false)}
           onCancel={() => setShowJustificationFlow(false)}
         />
+      )}
+
+      {/* Endorsement prompt — shown when a reviewer's comment overlaps an existing theme */}
+      {endorsementPrompt && submittedTxHash && (
+        <div className="fixed inset-x-0 bottom-20 z-50 mx-auto max-w-lg px-4">
+          <EndorsementPrompt
+            theme={endorsementPrompt.theme}
+            annotationText={endorsementPrompt.annotationText}
+            proposalTxHash={submittedTxHash}
+            proposalIndex={0}
+            onEndorse={() => setEndorsementPrompt(null)}
+            onAddNew={() => setEndorsementPrompt(null)}
+            onCancel={() => setEndorsementPrompt(null)}
+          />
+        </div>
       )}
 
       <WorkspaceLayout

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import {
+  Bell,
   CheckCircle2,
   Vote,
   BookOpen,
@@ -16,6 +17,10 @@ import { useReviewQueue, useQueueState } from '@/hooks/useReviewQueue';
 import { useReviewableDrafts } from '@/hooks/useReviewableDrafts';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useAnnotations, useUpdateAnnotation, useDeleteAnnotation } from '@/hooks/useAnnotations';
+import {
+  useRevisionNotifications,
+  useMarkNotificationRead,
+} from '@/hooks/useRevisionNotifications';
 import { trackProposalView } from '@/lib/workspace/engagement';
 import { ReviewQueue } from './ReviewQueue';
 import { ReviewBrief } from './ReviewBrief';
@@ -161,6 +166,13 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   );
   const updateAnnotation = useUpdateAnnotation();
   const deleteAnnotation = useDeleteAnnotation();
+
+  // Revision notifications
+  const { data: notificationsData } = useRevisionNotifications(!!voterId);
+  const markRead = useMarkNotificationRead();
+  const unreadCount = notificationsData?.unreadCount ?? 0;
+  const notifications = notificationsData?.notifications ?? [];
+  const [showNotifications, setShowNotifications] = useState(false);
 
   const handleUpdateAnnotation = useCallback(
     (
@@ -369,6 +381,51 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
     <div className="flex flex-col md:flex-row h-full min-h-0">
       {/* Queue rail */}
       <div className="md:w-72 md:shrink-0 md:border-r border-b md:border-b-0 border-border">
+        {/* Revision notifications badge */}
+        {unreadCount > 0 && (
+          <div className="relative px-3 pt-2">
+            <button
+              onClick={() => setShowNotifications((prev) => !prev)}
+              className="flex w-full items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-foreground hover:bg-amber-500/10 transition-colors"
+            >
+              <Bell className="h-3.5 w-3.5 text-amber-500" />
+              <span>
+                {unreadCount} revised proposal{unreadCount !== 1 ? 's' : ''}
+              </span>
+              <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-amber-500 text-[10px] font-bold text-white">
+                {unreadCount}
+              </span>
+            </button>
+            {showNotifications && notifications.length > 0 && (
+              <div className="mt-1 rounded-md border border-border bg-background shadow-lg divide-y divide-border max-h-48 overflow-y-auto">
+                {notifications.map((n) => (
+                  <button
+                    key={n.id}
+                    onClick={() => {
+                      markRead.mutate(n.id);
+                      // Navigate to the revised proposal in the queue if found
+                      const matchIdx = items.findIndex((item) => item.txHash === n.proposalId);
+                      if (matchIdx >= 0) {
+                        setSelectedIndex(matchIdx);
+                        setSidebarTab('changes');
+                      }
+                      setShowNotifications(false);
+                    }}
+                    className="flex w-full flex-col gap-0.5 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                  >
+                    <span className="text-xs font-medium truncate">
+                      Proposal v{n.versionNumber}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {n.sectionsChanged.length} section{n.sectionsChanged.length !== 1 ? 's' : ''}{' '}
+                      revised &mdash; tap to review
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
         <FeatureGate
           flag="review_unified_tabs"
           fallback={

--- a/hooks/useFeedbackThemes.ts
+++ b/hooks/useFeedbackThemes.ts
@@ -9,6 +9,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { posthog } from '@/lib/posthog';
 import type { FeedbackTheme } from '@/lib/workspace/feedback/types';
 
 // ---------------------------------------------------------------------------
@@ -134,7 +135,12 @@ export function useEndorseTheme(
       }
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
+      posthog.capture('workspace_feedback_endorsed', {
+        theme_id: variables.themeId,
+        has_context: !!variables.additionalContext,
+        proposal_tx_hash: txHash,
+      });
       queryClient.invalidateQueries({ queryKey: feedbackKey(txHash, index) });
     },
   });
@@ -168,7 +174,12 @@ export function useAddressTheme(
       }
       return res.json();
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
+      posthog.capture('workspace_feedback_addressed', {
+        theme_id: variables.themeId,
+        action: variables.action,
+        proposal_tx_hash: txHash,
+      });
       queryClient.invalidateQueries({ queryKey: feedbackKey(txHash, index) });
     },
   });


### PR DESCRIPTION
## Summary
- **Critical**: New workspace v2 was unreachable — `/workspace/author/[draftId]` now redirects to `/workspace/editor/[draftId]` when `governance_workspace_v2` flag is on
- **P1-1**: Revision notification badge in review workspace queue rail (Bell icon with unread count)
- **P1-2**: EndorsementPrompt wired into annotation flow (keyword overlap detection after comment creation)
- **P1-3**: PostHog analytics for 6 new events (agent messages, edit accept/reject, feedback endorse/address, diff opened)
- **P1-4**: Fixed hardcoded `currentUserId` — now uses real `stakeAddress` from segment context

## Impact
- **What changed**: Navigation redirect + 4 P1 fixes from pre-ship review
- **User-facing**: Yes — enabling the flag now actually shows the new workspace
- **Risk**: Low — redirect only fires when flag is on, all other changes are additive
- **Scope**: 5 files changed (page, redirect component, ReviewWorkspace, useFeedbackThemes, editor page)

## Test plan
- [ ] Enable `governance_workspace_v2` flag → go to `/workspace/author/[draftId]` → verify redirect to `/workspace/editor/[draftId]`
- [ ] Disable flag → same URL → verify old DraftEditor loads (no redirect)
- [ ] Review workspace queue rail shows Bell icon with notification count when revisions exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)