### PR TITLE
fix: workspace fullscreen layout — editor takes over viewport

### DIFF
--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -151,6 +151,7 @@ function WorkspaceEditorPage() {
         userRole={userRole}
         readOnly={!isOwner}
         onContentChange={handleContentChange}
+        backLabel="Back to drafts"
         toolbarActions={
           isOwner ? (
             <button

--- a/components/workspace/agent/AgentChatPanel.tsx
+++ b/components/workspace/agent/AgentChatPanel.tsx
@@ -308,7 +308,7 @@ export function AgentChatPanel({
   );
 
   return (
-    <div className={cn('flex flex-col h-full', className)}>
+    <div className={cn('flex flex-col h-full min-h-0', className)}>
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border shrink-0">
         <Bot className="h-4 w-4 text-primary" />
@@ -316,8 +316,8 @@ export function AgentChatPanel({
         {isStreaming && <Loader2 className="h-3 w-3 animate-spin text-primary ml-auto" />}
       </div>
 
-      {/* Messages area */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-4">
+      {/* Messages area — scrolls independently, never pushes input off-screen */}
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
         {/* Conversation resumed indicator */}
         {isResumed && messages.length > 2 && (
           <div className="flex items-center justify-center gap-1.5 py-2">
@@ -380,13 +380,13 @@ export function AgentChatPanel({
 
       {/* Error banner */}
       {error && (
-        <div className="mx-4 mb-2 flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive">
+        <div className="mx-4 mb-2 flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive shrink-0">
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1 min-w-0">{error}</span>
         </div>
       )}
 
-      {/* Input area */}
+      {/* Input area — always pinned at bottom */}
       <div className="shrink-0 border-t border-border p-3">
         <div className="relative">
           <textarea

--- a/components/workspace/editor/WorkspaceEmbed.tsx
+++ b/components/workspace/editor/WorkspaceEmbed.tsx
@@ -67,6 +67,12 @@ export interface WorkspaceEmbedProps {
   backUrl?: string;
   /** Override root layout class (e.g. "h-full" when embedded in another layout) */
   layoutClassName?: string;
+  /** Optional queue rail content (review workspace only) */
+  queueRail?: ReactNode;
+  /** Callback for back button (overrides backUrl Link with a button click) */
+  onBack?: () => void;
+  /** Label for the back button (e.g. "Back to queue") */
+  backLabel?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +192,9 @@ export function WorkspaceEmbed({
   showModeSwitch = true,
   backUrl: _backUrl,
   layoutClassName,
+  queueRail,
+  onBack,
+  backLabel,
 }: WorkspaceEmbedProps) {
   const [mode, setModeRaw] = useState<EditorMode>(readOnly ? 'review' : 'edit');
   const setMode = useCallback(
@@ -380,6 +389,9 @@ export function WorkspaceEmbed({
             proposalType={typeLabel}
             mode={mode}
             onModeChange={showModeSwitch ? setMode : () => {}}
+            onBack={onBack}
+            backLabel={backLabel}
+            backUrl={_backUrl}
           />
           {toolbarActions}
         </div>
@@ -387,6 +399,7 @@ export function WorkspaceEmbed({
       editor={renderEditor()}
       chat={renderChatPanel()}
       statusBar={statusBarOverride ?? defaultStatusBar}
+      queueRail={queueRail}
     />
   );
 }

--- a/components/workspace/layout/WorkspaceLayout.tsx
+++ b/components/workspace/layout/WorkspaceLayout.tsx
@@ -3,36 +3,62 @@
 /**
  * WorkspaceLayout — resizable two-panel layout for the governance workspace.
  *
- * Left panel: editor. Right panel: agent chat (collapsible).
+ * Full viewport takeover (fixed inset-0) by default — the site sidebar
+ * disappears and the editor gets maximum width. Pass `className="h-full"`
+ * to embed inside another layout instead.
+ *
+ * Left panel: optional queue rail (collapsible). Center: editor. Right: agent chat (collapsible).
  * Bottom: status bar.
  */
 
-import { useState, useCallback, useRef, type ReactNode } from 'react';
+import { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
 
 interface WorkspaceLayoutProps {
   toolbar: ReactNode;
   editor: ReactNode;
   chat: ReactNode;
   statusBar: ReactNode;
-  /** Override the root container class (default: "h-screen"). Use "h-full" when embedded. */
+  /** Optional queue rail (review workspace only) */
+  queueRail?: ReactNode;
+  /** Override the root container class. Default renders as fullscreen overlay (fixed inset-0).
+   *  Pass "h-full" to embed inside another layout without viewport takeover. */
   className?: string;
 }
 
 const MIN_EDITOR_WIDTH = 400;
 const MIN_CHAT_WIDTH = 280;
 const DEFAULT_CHAT_WIDTH = 380;
+const QUEUE_COLLAPSED_WIDTH = 48;
+const QUEUE_EXPANDED_WIDTH = 288; // md:w-72
 
 export function WorkspaceLayout({
   toolbar,
   editor,
   chat,
   statusBar,
+  queueRail,
   className,
 }: WorkspaceLayoutProps) {
   const [chatWidth, setChatWidth] = useState(DEFAULT_CHAT_WIDTH);
   const [chatCollapsed, setChatCollapsed] = useState(false);
+  const [queueExpanded, setQueueExpanded] = useState(false);
   const isDragging = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const isEmbedded = className?.includes('h-full');
+  const isFullscreen = !isEmbedded;
+
+  // Keyboard shortcut: Cmd+Shift+C to toggle chat
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'C') {
+        e.preventDefault();
+        setChatCollapsed((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -64,13 +90,83 @@ export function WorkspaceLayout({
     setChatCollapsed((prev) => !prev);
   }, []);
 
+  const toggleQueue = useCallback(() => {
+    setQueueExpanded((prev) => !prev);
+  }, []);
+
   return (
-    <div className={`flex flex-col bg-background ${className ?? 'h-screen'}`}>
+    <div
+      className={`flex flex-col bg-background ${
+        isFullscreen ? 'fixed inset-0 z-50 h-screen' : (className ?? 'h-full')
+      }`}
+    >
       {/* Toolbar */}
       <div className="shrink-0 border-b border-border">{toolbar}</div>
 
-      {/* Main content: editor + chat */}
+      {/* Main content: queue rail + editor + chat */}
       <div ref={containerRef} className="flex flex-1 min-h-0 overflow-hidden">
+        {/* Queue rail (review workspace only) */}
+        {queueRail && (
+          <>
+            <div
+              className="shrink-0 border-r border-border overflow-hidden transition-[width] duration-200 ease-in-out"
+              style={{ width: queueExpanded ? QUEUE_EXPANDED_WIDTH : QUEUE_COLLAPSED_WIDTH }}
+            >
+              {queueExpanded ? (
+                <div className="h-full flex flex-col" style={{ width: QUEUE_EXPANDED_WIDTH }}>
+                  <div className="shrink-0 flex items-center justify-between px-2 py-1.5 border-b border-border">
+                    <span className="text-xs font-medium text-muted-foreground px-1">Queue</span>
+                    <button
+                      onClick={toggleQueue}
+                      className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                      title="Collapse queue"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="m11 17-5-5 5-5" />
+                        <path d="m18 17-5-5 5-5" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="flex-1 min-h-0 overflow-y-auto">{queueRail}</div>
+                </div>
+              ) : (
+                <div className="h-full flex flex-col items-center py-2 gap-2">
+                  <button
+                    onClick={toggleQueue}
+                    className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                    title="Expand queue"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <rect width="18" height="18" x="3" y="3" rx="2" />
+                      <path d="M9 3v18" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
         {/* Editor panel */}
         <div className="flex-1 min-w-0 overflow-y-auto">{editor}</div>
 
@@ -86,10 +182,7 @@ export function WorkspaceLayout({
 
         {/* Chat panel */}
         {!chatCollapsed && (
-          <div
-            className="shrink-0 overflow-y-auto border-l border-border"
-            style={{ width: chatWidth }}
-          >
+          <div className="shrink-0 border-l border-border" style={{ width: chatWidth }}>
             {chat}
           </div>
         )}

--- a/components/workspace/layout/WorkspaceToolbar.tsx
+++ b/components/workspace/layout/WorkspaceToolbar.tsx
@@ -2,6 +2,10 @@
 
 /**
  * WorkspaceToolbar — top bar with mode switcher, version selector, and nav.
+ *
+ * Supports two back-nav modes:
+ * - `backUrl` (default: "/workspace/author") — renders a Next.js Link
+ * - `onBack` callback — renders a button (used by review workspace overlay)
  */
 
 import { ArrowLeft } from 'lucide-react';
@@ -18,6 +22,12 @@ interface WorkspaceToolbarProps {
   onVersionChange?: (version: number) => void;
   compareVersion?: number;
   onCompareVersionChange?: (version: number) => void;
+  /** If provided, renders a button that calls this instead of a Link. */
+  onBack?: () => void;
+  /** Label shown next to the back arrow (e.g. "Back to queue"). */
+  backLabel?: string;
+  /** URL for the back link (ignored when onBack is provided). Default: /workspace/author */
+  backUrl?: string;
 }
 
 const MODE_LABELS: Record<EditorMode, string> = {
@@ -36,15 +46,29 @@ export function WorkspaceToolbar({
   onVersionChange,
   compareVersion,
   onCompareVersionChange,
+  onBack,
+  backLabel,
+  backUrl = '/workspace/author',
 }: WorkspaceToolbarProps) {
   return (
     <div className="flex items-center gap-3 px-4 py-2">
       {/* Back */}
-      <Link href="/workspace/author" className="shrink-0">
-        <button className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors">
+      {onBack ? (
+        <button
+          onClick={onBack}
+          className="shrink-0 flex items-center gap-1.5 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+        >
           <ArrowLeft className="h-4 w-4" />
+          {backLabel && <span className="text-xs font-medium">{backLabel}</span>}
         </button>
-      </Link>
+      ) : (
+        <Link href={backUrl} className="shrink-0">
+          <button className="flex items-center gap-1.5 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors">
+            <ArrowLeft className="h-4 w-4" />
+            {backLabel && <span className="text-xs font-medium">{backLabel}</span>}
+          </button>
+        </Link>
+      )}
 
       {/* Title + type */}
       <div className="flex items-center gap-2 min-w-0 flex-1">

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -185,6 +185,18 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   // Derive the agent userRole from segment
   const agentUserRole = segment === 'cc' ? ('cc_member' as const) : ('reviewer' as const);
 
+  // The current active item depends on which tab is active
+  const currentItem = activeTab === 'drafts' ? selectedDraft : selectedItem;
+
+  // Deselect to return to queue-only view
+  const handleBackToQueue = useCallback(() => {
+    if (activeTab === 'drafts') {
+      setDraftSelectedIndex(-1);
+    } else {
+      setSelectedIndex(-1);
+    }
+  }, [activeTab]);
+
   // Loading state
   if (isLoading) {
     return (
@@ -255,59 +267,82 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
     );
   }
 
-  // The current active item depends on which tab is active
-  const currentItem = activeTab === 'drafts' ? selectedDraft : selectedItem;
-
-  return (
-    <div className="flex flex-col md:flex-row h-full min-h-0">
-      {/* Queue rail */}
-      <div className="md:w-72 md:shrink-0 md:border-r border-b md:border-b-0 border-border">
-        {/* Revision notifications badge */}
-        {unreadCount > 0 && (
-          <div className="relative px-3 pt-2">
-            <button
-              onClick={() => setShowNotifications((prev) => !prev)}
-              className="flex w-full items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-foreground hover:bg-amber-500/10 transition-colors"
-            >
-              <Bell className="h-3.5 w-3.5 text-amber-500" />
-              <span>
-                {unreadCount} revised proposal{unreadCount !== 1 ? 's' : ''}
-              </span>
-              <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-amber-500 text-[10px] font-bold text-white">
-                {unreadCount}
-              </span>
-            </button>
-            {showNotifications && notifications.length > 0 && (
-              <div className="mt-1 rounded-md border border-border bg-background shadow-lg divide-y divide-border max-h-48 overflow-y-auto">
-                {notifications.map((n) => (
-                  <button
-                    key={n.id}
-                    onClick={() => {
-                      markRead.mutate(n.id);
-                      const matchIdx = items.findIndex((item) => item.txHash === n.proposalId);
-                      if (matchIdx >= 0) {
-                        setSelectedIndex(matchIdx);
-                      }
-                      setShowNotifications(false);
-                    }}
-                    className="flex w-full flex-col gap-0.5 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                  >
-                    <span className="text-xs font-medium truncate">
-                      Proposal v{n.versionNumber}
-                    </span>
-                    <span className="text-[10px] text-muted-foreground">
-                      {n.sectionsChanged.length} section{n.sectionsChanged.length !== 1 ? 's' : ''}{' '}
-                      revised &mdash; tap to review
-                    </span>
-                  </button>
-                ))}
-              </div>
-            )}
+  // Queue rail content — used inside the fullscreen WorkspaceLayout
+  const queueRailContent = (
+    <>
+      {/* Revision notifications badge */}
+      {unreadCount > 0 && (
+        <div className="relative px-3 pt-2">
+          <button
+            onClick={() => setShowNotifications((prev) => !prev)}
+            className="flex w-full items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-foreground hover:bg-amber-500/10 transition-colors"
+          >
+            <Bell className="h-3.5 w-3.5 text-amber-500" />
+            <span>
+              {unreadCount} revised proposal{unreadCount !== 1 ? 's' : ''}
+            </span>
+            <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-amber-500 text-[10px] font-bold text-white">
+              {unreadCount}
+            </span>
+          </button>
+          {showNotifications && notifications.length > 0 && (
+            <div className="mt-1 rounded-md border border-border bg-background shadow-lg divide-y divide-border max-h-48 overflow-y-auto">
+              {notifications.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => {
+                    markRead.mutate(n.id);
+                    const matchIdx = items.findIndex((item) => item.txHash === n.proposalId);
+                    if (matchIdx >= 0) {
+                      setSelectedIndex(matchIdx);
+                    }
+                    setShowNotifications(false);
+                  }}
+                  className="flex w-full flex-col gap-0.5 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                >
+                  <span className="text-xs font-medium truncate">Proposal v{n.versionNumber}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {n.sectionsChanged.length} section{n.sectionsChanged.length !== 1 ? 's' : ''}{' '}
+                    revised &mdash; tap to review
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      <FeatureGate
+        flag="review_unified_tabs"
+        fallback={
+          <ReviewQueue
+            items={items}
+            selectedIndex={selectedIndex}
+            onSelect={handleSelect}
+            getStatus={getStatus}
+            progress={progress}
+          />
+        }
+      >
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+          <div className="px-2 pt-2 shrink-0">
+            <TabsList className="w-full">
+              <TabsTrigger value="active" className="flex-1 text-xs">
+                Active Proposals
+                {items.length > 0 && (
+                  <span className="ml-1 text-[10px] text-muted-foreground">({items.length})</span>
+                )}
+              </TabsTrigger>
+              <TabsTrigger value="drafts" className="flex-1 text-xs">
+                Pre-submission
+                {draftItems.length > 0 && (
+                  <span className="ml-1 text-[10px] text-muted-foreground">
+                    ({draftItems.length})
+                  </span>
+                )}
+              </TabsTrigger>
+            </TabsList>
           </div>
-        )}
-        <FeatureGate
-          flag="review_unified_tabs"
-          fallback={
+          <TabsContent value="active" className="flex-1 min-h-0 mt-0">
             <ReviewQueue
               items={items}
               selectedIndex={selectedIndex}
@@ -315,117 +350,85 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
               getStatus={getStatus}
               progress={progress}
             />
-          }
-        >
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-            <div className="px-2 pt-2 shrink-0">
-              <TabsList className="w-full">
-                <TabsTrigger value="active" className="flex-1 text-xs">
-                  Active Proposals
-                  {items.length > 0 && (
-                    <span className="ml-1 text-[10px] text-muted-foreground">({items.length})</span>
-                  )}
-                </TabsTrigger>
-                <TabsTrigger value="drafts" className="flex-1 text-xs">
-                  Pre-submission
-                  {draftItems.length > 0 && (
-                    <span className="ml-1 text-[10px] text-muted-foreground">
-                      ({draftItems.length})
-                    </span>
-                  )}
-                </TabsTrigger>
-              </TabsList>
-            </div>
-            <TabsContent value="active" className="flex-1 min-h-0 mt-0">
-              <ReviewQueue
-                items={items}
-                selectedIndex={selectedIndex}
-                onSelect={handleSelect}
-                getStatus={getStatus}
-                progress={progress}
-              />
-            </TabsContent>
-            <TabsContent value="drafts" className="flex-1 min-h-0 mt-0">
-              {draftItems.length === 0 ? (
-                <div className="px-3 py-8 text-center">
-                  <p className="text-xs text-muted-foreground">
-                    No pre-submission drafts awaiting review.
-                  </p>
-                </div>
-              ) : (
-                <ReviewQueue
-                  items={draftItems}
-                  selectedIndex={draftSelectedIndex}
-                  onSelect={handleDraftSelect}
-                  getStatus={() => 'unreviewed'}
-                  progress={{ reviewed: 0, total: draftItems.length }}
-                />
-              )}
-            </TabsContent>
-          </Tabs>
-        </FeatureGate>
-      </div>
-
-      {/* Main content: Tiptap workspace replaces old ReviewBrief + sidebar */}
-      <div className="flex-1 min-h-0 min-w-0">
-        {activeTab === 'active' && selectedItem && (
-          <WorkspaceEmbed
-            key={`${selectedItem.txHash}:${selectedItem.proposalIndex}`}
-            proposalId={selectedItem.txHash}
-            content={{
-              title: selectedItem.title || '',
-              abstract: selectedItem.abstract || '',
-              motivation: selectedItem.motivation || '',
-              rationale: selectedItem.rationale || '',
-            }}
-            proposalType={selectedItem.proposalType}
-            userRole={agentUserRole}
-            readOnly={true}
-            layoutClassName="h-full"
-            belowEditor={
-              <div className="max-w-3xl mx-auto px-6 pb-6">
-                <ReviewActionZone
-                  item={selectedItem}
-                  drepId={voterId}
-                  onVote={(_txHash, _index, vote) => handleVoteSuccess(vote as VoteChoice)}
-                  onNextProposal={goNext}
-                  totalProposals={progress.total}
-                  votedCount={progress.reviewed}
-                />
+          </TabsContent>
+          <TabsContent value="drafts" className="flex-1 min-h-0 mt-0">
+            {draftItems.length === 0 ? (
+              <div className="px-3 py-8 text-center">
+                <p className="text-xs text-muted-foreground">
+                  No pre-submission drafts awaiting review.
+                </p>
               </div>
-            }
-            statusBar={
-              <StatusBar
-                completeness={{ done: progress.reviewed, total: progress.total }}
-                userStatus={`Reviewing ${progress.reviewed}/${progress.total}`}
+            ) : (
+              <ReviewQueue
+                items={draftItems}
+                selectedIndex={draftSelectedIndex}
+                onSelect={handleDraftSelect}
+                getStatus={() => 'unreviewed'}
+                progress={{ reviewed: 0, total: draftItems.length }}
               />
-            }
-            showModeSwitch={false}
-          />
-        )}
-        {activeTab === 'drafts' && selectedDraft && (
-          <WorkspaceEmbed
-            key={`draft:${selectedDraft.txHash}`}
-            proposalId={selectedDraft.txHash}
-            content={{
-              title: selectedDraft.title || '',
-              abstract: selectedDraft.abstract || '',
-              motivation: selectedDraft.motivation || '',
-              rationale: selectedDraft.rationale || '',
-            }}
-            proposalType={selectedDraft.proposalType}
-            userRole={agentUserRole}
-            readOnly={true}
-            layoutClassName="h-full"
-            statusBar={<StatusBar userStatus="Pre-submission review" />}
-            showModeSwitch={false}
-          />
-        )}
-        {!currentItem && (
-          <div className="flex items-center justify-center h-full">
-            <p className="text-sm text-muted-foreground">Select a proposal from the queue</p>
-          </div>
-        )}
+            )}
+          </TabsContent>
+        </Tabs>
+      </FeatureGate>
+    </>
+  );
+
+  // When a proposal is selected, render the fullscreen workspace overlay
+  if (currentItem) {
+    const isActiveDraft = activeTab === 'drafts';
+    const item = isActiveDraft ? selectedDraft! : selectedItem!;
+    const key = isActiveDraft ? `draft:${item.txHash}` : `${item.txHash}:${item.proposalIndex}`;
+
+    return (
+      <WorkspaceEmbed
+        key={key}
+        proposalId={item.txHash}
+        content={{
+          title: item.title || '',
+          abstract: item.abstract || '',
+          motivation: item.motivation || '',
+          rationale: item.rationale || '',
+        }}
+        proposalType={item.proposalType}
+        userRole={agentUserRole}
+        readOnly={true}
+        onBack={handleBackToQueue}
+        backLabel="Back to queue"
+        queueRail={queueRailContent}
+        belowEditor={
+          !isActiveDraft ? (
+            <div className="max-w-3xl mx-auto px-6 pb-6">
+              <ReviewActionZone
+                item={selectedItem!}
+                drepId={voterId}
+                onVote={(_txHash, _index, vote) => handleVoteSuccess(vote as VoteChoice)}
+                onNextProposal={goNext}
+                totalProposals={progress.total}
+                votedCount={progress.reviewed}
+              />
+            </div>
+          ) : undefined
+        }
+        statusBar={
+          isActiveDraft ? (
+            <StatusBar userStatus="Pre-submission review" />
+          ) : (
+            <StatusBar
+              completeness={{ done: progress.reviewed, total: progress.total }}
+              userStatus={`Reviewing ${progress.reviewed}/${progress.total}`}
+            />
+          )
+        }
+        showModeSwitch={false}
+      />
+    );
+  }
+
+  // No proposal selected — show the queue as a standalone list view
+  return (
+    <div className="flex flex-col h-full">
+      <div className="max-w-2xl mx-auto w-full flex-1 min-h-0 overflow-y-auto">
+        {queueRailContent}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
The workspace was crammed into 400px between 4 columns. Now it takes over the full viewport like Cursor/VS Code.

- **Fullscreen overlay**: workspace renders as `fixed inset-0 z-50`, covering the site sidebar
- **Collapsible queue rail**: 48px collapsed (icon), 288px expanded — only on review page
- **Sticky chat input**: messages scroll independently, input stays pinned at bottom
- **Back navigation**: "Back to queue" / "Back to drafts" returns to previous context
- **Keyboard shortcut**: `Cmd+Shift+C` toggles chat panel

## Impact
- **User-facing**: Yes — the workspace now fills the entire screen
- **Risk**: Low — only affects workspace pages, no changes to other routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)