### PR TITLE
feat: Governance Studio — purpose-built workspace shell

### DIFF
--- a/app/workspace/WorkspacePillBar.tsx
+++ b/app/workspace/WorkspacePillBar.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { SectionPillBar } from '@/components/governada/SectionPillBar';
+
+export function WorkspacePillBar() {
+  const pathname = usePathname();
+  const isStudioMode =
+    pathname === '/workspace/review' || /^\/workspace\/(author|editor)\/[^/]+/.test(pathname);
+  if (isStudioMode) return null;
+  return <SectionPillBar section="home" />;
+}

--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -3,22 +3,90 @@
 export const dynamic = 'force-dynamic';
 
 /**
- * Workspace Editor — Tiptap-based proposal workspace.
+ * Workspace Editor — Tiptap-based proposal workspace using Studio shell.
  *
- * Uses the reusable WorkspaceEmbed component with page-specific overlays:
+ * Uses StudioProvider + StudioHeader/StudioPanel/StudioActionBar for the
+ * author experience. Replaces the old WorkspaceEmbed fullscreen overlay.
+ *
+ * Page-specific overlays:
  * - RevisionJustificationFlow (proposer saves a new version)
- * - EndorsementPrompt (when reviewer comment overlaps feedback theme)
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useDraft, useUpdateDraft } from '@/hooks/useDrafts';
 import { useSegment } from '@/components/providers/SegmentProvider';
+import { useAgent } from '@/hooks/useAgent';
 import { useFeedbackThemes } from '@/hooks/useFeedbackThemes';
+import { posthog } from '@/lib/posthog';
+import { StudioProvider, useStudio } from '@/components/studio/StudioProvider';
+import { StudioHeader } from '@/components/studio/StudioHeader';
+import { StudioActionBar } from '@/components/studio/StudioActionBar';
+import { StudioPanel } from '@/components/studio/StudioPanel';
+import {
+  SLASH_COMMAND_PROMPTS,
+  buildEditorContext,
+  injectInlineComment,
+} from '@/components/studio/studioEditorHelpers';
+import { ProposalEditor, injectProposedEdit } from '@/components/workspace/editor/ProposalEditor';
+import { AgentChatPanel } from '@/components/workspace/agent/AgentChatPanel';
 import { StatusBar } from '@/components/workspace/layout/StatusBar';
-import { WorkspaceEmbed } from '@/components/workspace/editor/WorkspaceEmbed';
 import { RevisionJustificationFlow } from '@/components/workspace/editor/RevisionJustificationFlow';
-import type { ProposalField } from '@/lib/workspace/editor/types';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import type { ProposalType } from '@/lib/workspace/types';
+import type {
+  EditorMode,
+  ProposalField,
+  ProposedEdit,
+  ProposedComment,
+  SlashCommandType,
+} from '@/lib/workspace/editor/types';
+import type { Editor } from '@tiptap/core';
+
+// ---------------------------------------------------------------------------
+// AuthorPanelWrapper — thin wrapper that connects StudioPanel to StudioProvider
+// ---------------------------------------------------------------------------
+
+function AuthorPanelWrapper({ agentContent }: { agentContent: ReactNode }) {
+  const { panelOpen, activePanel, panelWidth, closePanel, togglePanel, setPanelWidth } =
+    useStudio();
+
+  return (
+    <StudioPanel
+      isOpen={panelOpen}
+      onClose={closePanel}
+      activeTab={activePanel}
+      onTabChange={(tab) => togglePanel(tab)}
+      width={panelWidth}
+      onWidthChange={setPanelWidth}
+      agentContent={agentContent}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AuthorActionBarWrapper — connects action bar to studio context
+// ---------------------------------------------------------------------------
+
+function AuthorActionBarWrapper({
+  statusInfo,
+  contextActions,
+}: {
+  statusInfo: ReactNode;
+  contextActions?: ReactNode;
+}) {
+  const { panelOpen, activePanel, togglePanel } = useStudio();
+
+  return (
+    <StudioActionBar
+      activePanel={panelOpen ? activePanel : null}
+      onPanelToggle={togglePanel}
+      statusInfo={statusInfo}
+      contextActions={contextActions}
+    />
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Main workspace page
@@ -31,10 +99,21 @@ function WorkspaceEditorPage() {
   const { data, isLoading, error } = useDraft(draftId);
 
   const [showJustificationFlow, setShowJustificationFlow] = useState(false);
+  const [mode, setModeRaw] = useState<EditorMode>('edit');
+  const editorRef = useRef<Editor | null>(null);
 
   const { stakeAddress, segment } = useSegment();
 
   const updateDraft = useUpdateDraft(draftId ?? '');
+
+  // --- Mode change with analytics ---
+  const setMode = useCallback(
+    (next: EditorMode) => {
+      posthog.capture('workspace_mode_changed', { proposal_id: draftId, mode: next });
+      setModeRaw(next);
+    },
+    [draftId],
+  );
 
   // --- Derive user role from ownership + segment ---
   const draft = data?.draft ?? null;
@@ -44,6 +123,27 @@ function WorkspaceEditorPage() {
     : segment === 'cc'
       ? ('cc_member' as const)
       : ('reviewer' as const);
+  const readOnly = !isOwner;
+
+  // Set initial mode based on readOnly
+  useEffect(() => {
+    if (readOnly) {
+      setModeRaw('review');
+    }
+  }, [readOnly]);
+
+  // --- Agent hook (lifted to page level so slash commands + Cmd+K can call it) ---
+  const {
+    sendMessage: agentSendMessage,
+    messages: agentMessages,
+    isStreaming: agentIsStreaming,
+    lastEdit: agentLastEdit,
+    lastComment: agentLastComment,
+    clearLastEdit: agentClearLastEdit,
+    clearLastComment: agentClearLastComment,
+    activeToolCall: agentActiveToolCall,
+    error: agentError,
+  } = useAgent({ proposalId: draftId ?? '', userRole });
 
   // --- Derived version data ---
   const versions = data?.versions ?? null;
@@ -52,30 +152,112 @@ function WorkspaceEditorPage() {
   // --- Feedback themes (for justification flow) ---
   const { themes: feedbackThemes } = useFeedbackThemes(submittedTxHash, submittedTxHash ? 0 : null);
 
+  // --- Content ---
+  const content = useMemo(
+    () => ({
+      title: draft?.title ?? '',
+      abstract: draft?.abstract ?? '',
+      motivation: draft?.motivation ?? '',
+      rationale: draft?.rationale ?? '',
+    }),
+    [draft?.title, draft?.abstract, draft?.motivation, draft?.rationale],
+  );
+
   // --- Content change handler (auto-save) ---
   const handleContentChange = useCallback(
-    (field: ProposalField, content: string) => {
-      updateDraft.mutate({ [field]: content });
+    (field: ProposalField, value: string) => {
+      updateDraft.mutate({ [field]: value });
     },
     [updateDraft],
   );
 
+  // --- Capture editor instance ---
+  const handleEditorReady = useCallback((editor: Editor) => {
+    editorRef.current = editor;
+  }, []);
+
+  // --- Agent lastEdit -> inject into editor ---
+  useEffect(() => {
+    if (!agentLastEdit || !editorRef.current) return;
+    injectProposedEdit(editorRef.current, agentLastEdit);
+    agentClearLastEdit();
+  }, [agentLastEdit, agentClearLastEdit]);
+
+  // --- Agent lastComment -> apply inline comment ---
+  useEffect(() => {
+    if (!agentLastComment || !editorRef.current) return;
+    injectInlineComment(editorRef.current, agentLastComment);
+    agentClearLastComment();
+  }, [agentLastComment, agentClearLastComment]);
+
+  // --- Slash command -> agent ---
+  const handleSlashCommand = useCallback(
+    (command: SlashCommandType, sectionContext: string) => {
+      const prompt = SLASH_COMMAND_PROMPTS[command]?.(sectionContext);
+      if (!prompt) return;
+      const ctx = buildEditorContext(editorRef.current, content, mode);
+      agentSendMessage(prompt, ctx);
+    },
+    [agentSendMessage, content, mode],
+  );
+
+  // --- Cmd+K -> agent ---
+  const handleCommand = useCallback(
+    (instruction: string, selectedText: string, section: string) => {
+      let prompt = instruction;
+      if (selectedText) {
+        prompt = `Regarding the selected text in the ${section} section: "${selectedText}"\n\nInstruction: ${instruction}`;
+      }
+      const ctx = buildEditorContext(editorRef.current, content, mode);
+      agentSendMessage(prompt, ctx);
+    },
+    [agentSendMessage, content, mode],
+  );
+
+  // --- Chat panel: send message with editor context ---
+  const handleChatSendMessage = useCallback(
+    async (message: string) => {
+      const ctx = buildEditorContext(editorRef.current, content, mode);
+      posthog.capture('workspace_agent_message_sent', {
+        proposal_id: draftId,
+        mode,
+        user_role: userRole,
+        has_selection: !!ctx.selectedText,
+      });
+      await agentSendMessage(message, ctx);
+    },
+    [agentSendMessage, content, mode, draftId, userRole],
+  );
+
+  // --- Apply proposed edit from chat panel ---
+  const handleApplyEdit = useCallback((edit: ProposedEdit) => {
+    if (!editorRef.current) return;
+    injectProposedEdit(editorRef.current, edit);
+  }, []);
+
+  // --- Apply proposed comment from chat panel ---
+  const handleApplyComment = useCallback((comment: ProposedComment) => {
+    if (!editorRef.current) return;
+    injectInlineComment(editorRef.current, comment);
+  }, []);
+
+  // --- Type label ---
+  const typeLabel = draft
+    ? (PROPOSAL_TYPE_LABELS[draft.proposalType as ProposalType] ?? draft.proposalType)
+    : '';
+
   // --- Status bar data ---
-  const draftStatus = draft?.status;
-  const draftTitle = draft?.title ?? '';
-  const draftAbstract = draft?.abstract ?? '';
-  const draftMotivation = draft?.motivation ?? '';
-  const draftRationale = draft?.rationale ?? '';
   const feedbackThemeCount = feedbackThemes.length;
+  const draftStatus = draft?.status;
 
   const statusBarNode = useMemo(() => {
     const completenessChecks = [
-      !!draftTitle,
-      !!draftAbstract,
-      !!draftMotivation,
-      !!draftRationale,
-      draftTitle.length > 10,
-      draftAbstract.length > 50,
+      !!content.title,
+      !!content.abstract,
+      !!content.motivation,
+      !!content.rationale,
+      content.title.length > 10,
+      content.abstract.length > 50,
     ];
     const done = completenessChecks.filter(Boolean).length;
 
@@ -91,13 +273,49 @@ function WorkspaceEditorPage() {
         }
       />
     );
-  }, [draftTitle, draftAbstract, draftMotivation, draftRationale, draftStatus, feedbackThemeCount]);
+  }, [content, draftStatus, feedbackThemeCount]);
+
+  // --- Save Version button ---
+  const saveVersionButton = isOwner ? (
+    <button
+      onClick={() => setShowJustificationFlow(true)}
+      className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer"
+    >
+      Save Version
+    </button>
+  ) : undefined;
+
+  // --- Agent chat panel (rendered once, passed to panel wrapper) ---
+  const agentChatNode = (
+    <AgentChatPanel
+      sendMessage={handleChatSendMessage}
+      messages={agentMessages}
+      isStreaming={agentIsStreaming}
+      activeToolCall={agentActiveToolCall}
+      error={agentError}
+      onApplyEdit={readOnly ? undefined : handleApplyEdit}
+      onApplyComment={handleApplyComment}
+    />
+  );
 
   // --- Loading state ---
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="h-8 w-8 rounded-full border-2 border-primary/30 border-t-primary animate-spin" />
+      <div className="flex flex-col h-screen">
+        <div className="h-12 border-t-2 border-teal-500 border-b border-b-border bg-background px-4 flex items-center shrink-0">
+          <Skeleton className="h-5 w-24" />
+          <div className="flex-1" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+        <div className="flex-1 flex items-start justify-center pt-12">
+          <div className="max-w-3xl w-full px-6 space-y-4">
+            <Skeleton className="h-8 w-2/3" />
+            <Skeleton className="h-32 w-full rounded-xl" />
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-36 w-full rounded-xl" />
+          </div>
+        </div>
+        <div className="h-12 border-t border-border bg-background shrink-0" />
       </div>
     );
   }
@@ -110,7 +328,7 @@ function WorkspaceEditorPage() {
           <h1 className="text-lg font-semibold">Draft not found</h1>
           <button
             onClick={() => router.push('/workspace/author')}
-            className="text-sm text-primary hover:underline"
+            className="text-sm text-primary hover:underline cursor-pointer"
           >
             Back to Author
           </button>
@@ -139,31 +357,58 @@ function WorkspaceEditorPage() {
         />
       )}
 
-      <WorkspaceEmbed
-        proposalId={draftId ?? ''}
-        content={{
-          title: draft.title,
-          abstract: draft.abstract,
-          motivation: draft.motivation,
-          rationale: draft.rationale,
-        }}
-        proposalType={draft.proposalType}
-        userRole={userRole}
-        readOnly={!isOwner}
-        onContentChange={handleContentChange}
-        backLabel="Back to drafts"
-        toolbarActions={
-          isOwner ? (
-            <button
-              onClick={() => setShowJustificationFlow(true)}
-              className="mr-4 shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Save Version
-            </button>
-          ) : undefined
-        }
-        statusBar={statusBarNode}
-      />
+      <StudioProvider>
+        <div className="flex flex-col h-screen">
+          {/* Studio Header */}
+          <StudioHeader
+            backLabel="Back to drafts"
+            backHref="/workspace/author"
+            title={draft.title || 'Untitled'}
+            proposalType={typeLabel}
+            showModeSwitch={isOwner}
+            mode={mode}
+            onModeChange={isOwner ? setMode : undefined}
+            actions={saveVersionButton}
+          />
+
+          {/* Main content area */}
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            {/* Editor area (scrollable) */}
+            <div className="flex-1 min-w-0 overflow-y-auto">
+              <div className="max-w-3xl mx-auto px-6 py-6">
+                <ProposalEditor
+                  content={content}
+                  mode={mode}
+                  readOnly={readOnly || mode === 'review'}
+                  onContentChange={readOnly ? undefined : handleContentChange}
+                  onSlashCommand={handleSlashCommand}
+                  onCommand={handleCommand}
+                  onDiffAccept={(editId) => {
+                    posthog.capture('workspace_inline_edit_accepted', {
+                      proposal_id: draftId,
+                      edit_id: editId,
+                    });
+                  }}
+                  onDiffReject={(editId) => {
+                    posthog.capture('workspace_inline_edit_rejected', {
+                      proposal_id: draftId,
+                      edit_id: editId,
+                    });
+                  }}
+                  currentUserId={stakeAddress ?? 'anonymous'}
+                  onEditorReady={handleEditorReady}
+                />
+              </div>
+            </div>
+
+            {/* Studio Panel (on-demand right panel) */}
+            <AuthorPanelWrapper agentContent={agentChatNode} />
+          </div>
+
+          {/* Studio Action Bar */}
+          <AuthorActionBarWrapper statusInfo={statusBarNode} />
+        </div>
+      </StudioProvider>
     </>
   );
 }

--- a/app/workspace/layout.tsx
+++ b/app/workspace/layout.tsx
@@ -1,10 +1,10 @@
-import { SectionPillBar } from '@/components/governada/SectionPillBar';
+import { WorkspacePillBar } from './WorkspacePillBar';
 import { SectionSpotlightTrigger } from '@/components/discovery/SectionSpotlightTrigger';
 
 export default function WorkspaceLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <SectionPillBar section="home" />
+      <WorkspacePillBar />
       <SectionSpotlightTrigger section="workspace" />
       {children}
     </>

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -116,6 +116,8 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { t } = useTranslation();
   const isHomepage = pathname === '/';
+  const isStudioMode =
+    pathname === '/workspace/review' || /^\/workspace\/(author|editor)\/[^/]+/.test(pathname);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   useEffect(() => {
@@ -138,36 +140,43 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
           <DeepLinkHandler />
         </Suspense>
         <SyncFreshnessBanner />
-        <GovernadaHeader />
-        <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
-        <EpochContextBar sidebarCollapsed={sidebarCollapsed} />
+        {!isStudioMode && <GovernadaHeader />}
+        {!isStudioMode && (
+          <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+        )}
+        {!isStudioMode && <EpochContextBar sidebarCollapsed={sidebarCollapsed} />}
 
         {/* Global constellation globe — subtle glassmorphic background */}
-        <BackgroundGlobe isHomepage={isHomepage} sidebarCollapsed={sidebarCollapsed} />
+        {!isStudioMode && (
+          <BackgroundGlobe isHomepage={isHomepage} sidebarCollapsed={sidebarCollapsed} />
+        )}
 
         <main
           id="main-content"
           className={cn(
-            'relative z-0 min-h-screen pb-16 lg:pb-0 transition-[padding-left] duration-200',
-            sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+            'relative z-0 min-h-screen transition-[padding-left] duration-200',
+            isStudioMode ? '' : 'pb-16 lg:pb-0',
+            isStudioMode ? '' : sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
           )}
           tabIndex={-1}
         >
           {children}
         </main>
-        <footer
-          className={cn(
-            'relative z-0 border-t border-border/40 py-4 px-4 text-center transition-[padding-left] duration-200',
-            sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
-          )}
-        >
-          <p className="text-xs text-muted-foreground/70">
-            {t(
-              'Governada is an independent community project and is not affiliated with, endorsed by, or associated with the Cardano Foundation, IOG, or EMURGO.',
+        {!isStudioMode && (
+          <footer
+            className={cn(
+              'relative z-0 border-t border-border/40 py-4 px-4 text-center transition-[padding-left] duration-200',
+              sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
             )}
-          </p>
-        </footer>
-        <GovernadaBottomNav />
+          >
+            <p className="text-xs text-muted-foreground/70">
+              {t(
+                'Governada is an independent community project and is not affiliated with, endorsed by, or associated with the Cardano Foundation, IOG, or EMURGO.',
+              )}
+            </p>
+          </footer>
+        )}
+        {!isStudioMode && <GovernadaBottomNav />}
 
         {/* Discovery Layer — lazy-loaded, zero impact on initial render */}
         <SpotlightProvider>

--- a/components/studio/StudioActionBar.tsx
+++ b/components/studio/StudioActionBar.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, type ReactNode } from 'react';
+import { MessageSquare, BarChart3, StickyNote } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type PanelId = 'agent' | 'intel' | 'notes';
+
+interface StudioActionBarProps {
+  activePanel: PanelId | null;
+  onPanelToggle: (panel: PanelId) => void;
+  contextActions?: ReactNode;
+  statusInfo?: ReactNode;
+}
+
+const PANEL_BUTTONS: Array<{
+  id: PanelId;
+  label: string;
+  Icon: typeof MessageSquare;
+  shortcutKey: string;
+  shortcutLabel: string;
+}> = [
+  {
+    id: 'agent',
+    label: 'Agent',
+    Icon: MessageSquare,
+    shortcutKey: 'c',
+    shortcutLabel: 'Ctrl+Shift+C',
+  },
+  { id: 'intel', label: 'Intel', Icon: BarChart3, shortcutKey: 'i', shortcutLabel: 'Ctrl+Shift+I' },
+  {
+    id: 'notes',
+    label: 'Notes',
+    Icon: StickyNote,
+    shortcutKey: 'n',
+    shortcutLabel: 'Ctrl+Shift+N',
+  },
+];
+
+export function StudioActionBar({
+  activePanel,
+  onPanelToggle,
+  contextActions,
+  statusInfo,
+}: StudioActionBarProps) {
+  // Ctrl+Shift+C/I/N keyboard shortcuts for panel toggles
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!e.ctrlKey || !e.shiftKey) return;
+      const key = e.key.toLowerCase();
+      const match = PANEL_BUTTONS.find((b) => b.shortcutKey === key);
+      if (match) {
+        e.preventDefault();
+        onPanelToggle(match.id);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onPanelToggle]);
+
+  return (
+    <div className="sticky bottom-0 z-40 min-h-12 border-t border-border bg-background/95 backdrop-blur-sm px-4 pb-[env(safe-area-inset-bottom)] flex items-center shrink-0">
+      {/* Left: panel toggle buttons */}
+      <div className="flex items-center gap-1">
+        {PANEL_BUTTONS.map(({ id, label, Icon, shortcutLabel }) => {
+          const isActive = activePanel === id;
+          return (
+            <button
+              key={id}
+              onClick={() => onPanelToggle(id)}
+              className={cn(
+                'flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs transition-colors cursor-pointer',
+                isActive
+                  ? 'bg-primary/10 text-primary border border-primary/30'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50 border border-transparent',
+              )}
+              title={`Toggle ${label} panel (${shortcutLabel})`}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" />
+              <span className="hidden lg:inline">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Center: status info */}
+      {statusInfo && (
+        <div className="flex-1 flex items-center justify-center min-w-0 px-3">{statusInfo}</div>
+      )}
+
+      {/* Spacer when no status */}
+      {!statusInfo && <div className="flex-1" />}
+
+      {/* Right: context actions */}
+      {contextActions && <div className="flex items-center gap-2 shrink-0">{contextActions}</div>}
+    </div>
+  );
+}

--- a/components/studio/StudioHeader.tsx
+++ b/components/studio/StudioHeader.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Bell, Command } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { StudioQueueProgress } from './StudioQueueProgress';
+
+interface StudioHeaderProps {
+  backHref?: string;
+  onBack?: () => void;
+  backLabel?: string;
+  title?: string;
+  proposalType?: string;
+  queueProgress?: { current: number; total: number };
+  onQueueJump?: (index: number) => void;
+  showModeSwitch?: boolean;
+  mode?: 'edit' | 'review' | 'diff';
+  onModeChange?: (mode: 'edit' | 'review' | 'diff') => void;
+  actions?: ReactNode;
+  /** Notification count for the bell icon */
+  notificationCount?: number;
+  /** Callback for Cmd+K button */
+  onCommandPalette?: () => void;
+  /** User segment badge label */
+  segmentBadge?: { label: string; color: string };
+}
+
+const MODE_LABELS: Record<string, string> = {
+  edit: 'Edit',
+  review: 'Review',
+  diff: 'Diff',
+};
+
+export function StudioHeader({
+  backHref = '/workspace',
+  onBack,
+  backLabel = 'governada',
+  title,
+  proposalType,
+  queueProgress,
+  onQueueJump,
+  showModeSwitch,
+  mode = 'edit',
+  onModeChange,
+  actions,
+  notificationCount = 0,
+  onCommandPalette,
+  segmentBadge,
+}: StudioHeaderProps) {
+  const backContent = (
+    <span className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors">
+      <ArrowLeft className="h-4 w-4 shrink-0" />
+      <span className="text-sm font-semibold">{backLabel}</span>
+    </span>
+  );
+
+  return (
+    <header className="h-12 border-t-2 border-teal-500 border-b border-b-border bg-background px-4 flex items-center gap-3 shrink-0">
+      {/* Back button */}
+      {onBack ? (
+        <button
+          onClick={onBack}
+          className="shrink-0 flex items-center p-1 rounded-md cursor-pointer"
+        >
+          {backContent}
+        </button>
+      ) : (
+        <Link href={backHref} className="shrink-0 flex items-center p-1 rounded-md">
+          {backContent}
+        </Link>
+      )}
+
+      {/* Separator */}
+      <div className="w-px h-5 bg-border shrink-0 hidden lg:block" />
+
+      {/* Title + type badge */}
+      {title && (
+        <div className="hidden lg:flex items-center gap-2 min-w-0 flex-1">
+          <h1 className="text-sm font-semibold truncate min-w-0">{title}</h1>
+          {proposalType && (
+            <span className="text-[10px] font-medium text-muted-foreground bg-muted/50 rounded px-1.5 py-0.5 shrink-0">
+              {proposalType}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Spacer when title is hidden on mobile */}
+      {!title && <div className="flex-1" />}
+      {title && <div className="flex-1 lg:hidden" />}
+
+      {/* Queue progress */}
+      {queueProgress && (
+        <div className="hidden lg:flex">
+          <StudioQueueProgress
+            current={queueProgress.current}
+            total={queueProgress.total}
+            onDotClick={onQueueJump}
+          />
+        </div>
+      )}
+      {/* Mobile: dots only, no text */}
+      {queueProgress && (
+        <div className="flex lg:hidden items-center gap-1">
+          {Array.from({ length: Math.min(queueProgress.total, 6) }, (_, i) => (
+            <div
+              key={i}
+              className={cn(
+                'w-1.5 h-1.5 rounded-full shrink-0',
+                i + 1 < queueProgress.current && 'bg-primary',
+                i + 1 === queueProgress.current && 'bg-primary ring-2 ring-primary/30',
+                i + 1 > queueProgress.current && 'bg-muted-foreground/30',
+              )}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Mode switcher */}
+      {showModeSwitch && onModeChange && (
+        <div className="flex items-center rounded-md border border-border bg-muted/30 p-0.5">
+          {(['edit', 'review', 'diff'] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => onModeChange(m)}
+              className={cn(
+                'px-3 py-1 text-[11px] font-medium rounded-sm transition-colors cursor-pointer',
+                mode === m
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {MODE_LABELS[m]}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Extra toolbar actions */}
+      {actions}
+
+      {/* Right side controls */}
+      <div className="flex items-center gap-1 shrink-0">
+        {/* Cmd+K */}
+        <button
+          onClick={() => {
+            if (onCommandPalette) {
+              onCommandPalette();
+            } else {
+              // Trigger the global CommandPalette via its keyboard listener
+              document.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                  key: 'k',
+                  ctrlKey: true,
+                  bubbles: true,
+                }),
+              );
+            }
+          }}
+          className="flex items-center gap-1 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground rounded-md border border-border hover:bg-muted/50 transition-colors cursor-pointer"
+          title="Command palette (Ctrl+K)"
+        >
+          <Command className="h-3 w-3" />
+          <span className="hidden sm:inline">K</span>
+        </button>
+
+        {/* Notification bell */}
+        <button
+          className="relative p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          title="Notifications"
+        >
+          <Bell className="h-4 w-4" />
+          {notificationCount > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-destructive text-destructive-foreground text-[9px] font-bold flex items-center justify-center">
+              {notificationCount > 9 ? '9+' : notificationCount}
+            </span>
+          )}
+        </button>
+
+        {/* Segment badge */}
+        {segmentBadge && (
+          <span
+            className="text-[10px] font-medium px-1.5 py-0.5 rounded-full shrink-0"
+            style={{ backgroundColor: `${segmentBadge.color}20`, color: segmentBadge.color }}
+          >
+            {segmentBadge.label}
+          </span>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/components/studio/StudioPanel.tsx
+++ b/components/studio/StudioPanel.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
+import { X, MessageSquare, BarChart3, StickyNote } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type TabId = 'agent' | 'intel' | 'notes';
+
+interface StudioPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activeTab: TabId;
+  onTabChange: (tab: TabId) => void;
+  width: number;
+  onWidthChange: (width: number) => void;
+  agentContent: ReactNode;
+  intelContent?: ReactNode;
+  notesContent?: ReactNode;
+}
+
+const TABS: Array<{ id: TabId; label: string; Icon: typeof MessageSquare }> = [
+  { id: 'agent', label: 'Agent', Icon: MessageSquare },
+  { id: 'intel', label: 'Intel', Icon: BarChart3 },
+  { id: 'notes', label: 'Notes', Icon: StickyNote },
+];
+
+const MIN_PANEL_WIDTH = 280;
+
+export function StudioPanel({
+  isOpen,
+  onClose,
+  activeTab,
+  onTabChange,
+  width,
+  onWidthChange,
+  agentContent,
+  intelContent,
+  notesContent,
+}: StudioPanelProps) {
+  const isDragging = useRef(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const mobileSheetRef = useRef<HTMLDivElement>(null);
+
+  // Escape key closes panel — only when focus is within the panel itself
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        const target = e.target as Node;
+        const desktopPanel = panelRef.current;
+        const mobilePanel = mobileSheetRef.current;
+        if (
+          (desktopPanel && desktopPanel.contains(target)) ||
+          (mobilePanel && mobilePanel.contains(target))
+        ) {
+          e.preventDefault();
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  // Max width: 50% of viewport
+  const clampedWidth = Math.min(
+    width,
+    typeof window !== 'undefined' ? window.innerWidth * 0.5 : 600,
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isDragging.current = true;
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        if (!isDragging.current) return;
+        const newWidth = window.innerWidth - ev.clientX;
+        if (newWidth >= MIN_PANEL_WIDTH && newWidth <= window.innerWidth * 0.5) {
+          onWidthChange(newWidth);
+        }
+      };
+
+      const handleMouseUp = () => {
+        isDragging.current = false;
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [onWidthChange],
+  );
+
+  const tabContent: Record<TabId, ReactNode> = {
+    agent: agentContent,
+    intel: intelContent ?? (
+      <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">
+        Intel panel coming soon
+      </div>
+    ),
+    notes: notesContent ?? (
+      <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">
+        Notes panel coming soon
+      </div>
+    ),
+  };
+
+  // ---- Desktop panel (lg+) ----
+  const desktopPanel = (
+    <div
+      ref={panelRef}
+      className={cn(
+        'hidden lg:flex flex-col relative border-l border-border bg-background shrink-0 overflow-hidden',
+        'transition-[width,opacity] duration-200 ease-out',
+      )}
+      style={{ width: isOpen ? clampedWidth : 0 }}
+    >
+      {isOpen && (
+        <>
+          {/* Resize handle */}
+          <div
+            onMouseDown={handleMouseDown}
+            className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize bg-transparent hover:bg-primary/30 transition-colors z-10"
+            role="separator"
+            aria-label="Resize panel"
+          />
+
+          {/* Tab bar */}
+          <div className="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0">
+            <div className="flex items-center gap-0.5">
+              {TABS.map(({ id, label, Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => onTabChange(id)}
+                  className={cn(
+                    'flex items-center gap-1 px-2 py-1 text-xs rounded-sm transition-colors cursor-pointer',
+                    activeTab === id
+                      ? 'bg-muted text-foreground font-medium'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <Icon className="h-3 w-3" />
+                  {label}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={onClose}
+              className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+              title="Close panel (Esc)"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto min-h-0">{tabContent[activeTab]}</div>
+        </>
+      )}
+    </div>
+  );
+
+  // ---- Mobile bottom sheet (<lg) ----
+  const mobileSheet = isOpen && (
+    <>
+      {/* Backdrop */}
+      <div
+        className="lg:hidden fixed inset-0 z-50 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={mobileSheetRef}
+        className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-background rounded-t-xl max-h-[80vh] flex flex-col border-t border-border pb-[env(safe-area-inset-bottom)]"
+      >
+        {/* Drag handle */}
+        <div className="flex justify-center py-2 shrink-0">
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+        </div>
+
+        {/* Tab bar */}
+        <div className="flex items-center justify-between px-3 pb-1.5 border-b border-border shrink-0">
+          <div className="flex items-center gap-0.5">
+            {TABS.map(({ id, label, Icon }) => (
+              <button
+                key={id}
+                onClick={() => onTabChange(id)}
+                className={cn(
+                  'flex items-center gap-1 px-2 py-1 text-xs rounded-sm transition-colors cursor-pointer',
+                  activeTab === id
+                    ? 'bg-muted text-foreground font-medium'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <Icon className="h-3 w-3" />
+                {label}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+            title="Close panel"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto min-h-0 p-3">{tabContent[activeTab]}</div>
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      {desktopPanel}
+      {mobileSheet}
+    </>
+  );
+}

--- a/components/studio/StudioProvider.tsx
+++ b/components/studio/StudioProvider.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+interface StudioState {
+  panelOpen: boolean;
+  activePanel: 'agent' | 'intel' | 'notes';
+  panelWidth: number;
+  focusLevel: 0 | 1 | 2; // 0=normal, 1=panel hidden, 2=zen
+}
+
+interface StudioContextValue extends StudioState {
+  togglePanel: (panel: 'agent' | 'intel' | 'notes') => void;
+  closePanel: () => void;
+  setPanelWidth: (width: number) => void;
+  setFocusLevel: (level: 0 | 1 | 2) => void;
+}
+
+const StudioContext = createContext<StudioContextValue | null>(null);
+
+export function useStudio() {
+  const ctx = useContext(StudioContext);
+  if (!ctx) throw new Error('useStudio must be used within StudioProvider');
+  return ctx;
+}
+
+/** Safe version that returns null outside studio mode — no throw. */
+export function useStudioSafe() {
+  return useContext(StudioContext);
+}
+
+export function StudioProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<StudioState>({
+    panelOpen: false,
+    activePanel: 'agent',
+    panelWidth: 380,
+    focusLevel: 0,
+  });
+
+  const togglePanel = useCallback((panel: 'agent' | 'intel' | 'notes') => {
+    setState((prev) => {
+      if (prev.panelOpen && prev.activePanel === panel) {
+        return { ...prev, panelOpen: false };
+      }
+      return { ...prev, panelOpen: true, activePanel: panel };
+    });
+  }, []);
+
+  const closePanel = useCallback(() => {
+    setState((prev) => ({ ...prev, panelOpen: false }));
+  }, []);
+
+  const setPanelWidth = useCallback((width: number) => {
+    setState((prev) => ({ ...prev, panelWidth: Math.max(280, Math.min(width, 600)) }));
+  }, []);
+
+  const setFocusLevel = useCallback((level: 0 | 1 | 2) => {
+    setState((prev) => ({
+      ...prev,
+      focusLevel: level,
+      panelOpen: level === 0 ? prev.panelOpen : false,
+    }));
+  }, []);
+
+  return (
+    <StudioContext.Provider
+      value={{ ...state, togglePanel, closePanel, setPanelWidth, setFocusLevel }}
+    >
+      {children}
+    </StudioContext.Provider>
+  );
+}

--- a/components/studio/StudioQueueProgress.tsx
+++ b/components/studio/StudioQueueProgress.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface StudioQueueProgressProps {
+  current: number; // 1-indexed position
+  total: number;
+  onDotClick?: (index: number) => void;
+  className?: string;
+}
+
+export function StudioQueueProgress({
+  current,
+  total,
+  onDotClick,
+  className,
+}: StudioQueueProgressProps) {
+  const interactive = !!onDotClick;
+
+  // When total > 10, show abbreviated dots
+  const renderAbbreviated = total > 10;
+
+  function renderDot(index: number) {
+    const isCurrent = index + 1 === current;
+    const isCompleted = index + 1 < current;
+
+    return (
+      <button
+        key={index}
+        type="button"
+        onClick={interactive ? () => onDotClick(index) : undefined}
+        disabled={!interactive}
+        className={cn(
+          'w-1.5 h-1.5 rounded-full shrink-0 transition-colors',
+          interactive && 'cursor-pointer hover:opacity-80',
+          !interactive && 'cursor-default',
+          isCurrent && 'bg-primary ring-2 ring-primary/30',
+          isCompleted && !isCurrent && 'bg-primary',
+          !isCompleted && !isCurrent && 'bg-muted-foreground/30',
+        )}
+        aria-label={`Item ${index + 1} of ${total}${isCurrent ? ' (current)' : ''}`}
+      />
+    );
+  }
+
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      {renderAbbreviated ? (
+        <>
+          {/* First 3 dots */}
+          {Array.from({ length: Math.min(3, total) }, (_, i) => renderDot(i))}
+          <span className="text-[10px] text-muted-foreground px-0.5">...</span>
+          {/* Last 3 dots */}
+          {Array.from({ length: Math.min(3, total) }, (_, i) => renderDot(total - 3 + i))}
+        </>
+      ) : (
+        Array.from({ length: total }, (_, i) => renderDot(i))
+      )}
+      <span className="text-[10px] text-muted-foreground ml-1.5 tabular-nums">
+        {current}/{total}
+      </span>
+    </div>
+  );
+}

--- a/components/studio/studioEditorHelpers.ts
+++ b/components/studio/studioEditorHelpers.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared helpers for Studio editor integration (author + review flows).
+ *
+ * Centralises slash-command prompts, editor-context building, and inline
+ * comment injection so both the author editor page and ReviewWorkspace can
+ * import from a single location.
+ */
+
+import type { Editor } from '@tiptap/core';
+import type {
+  EditorMode,
+  EditorContext,
+  ProposalField,
+  ProposedComment,
+  SlashCommandType,
+} from '@/lib/workspace/editor/types';
+
+// ---------------------------------------------------------------------------
+// Slash command -> agent prompt mapping
+// ---------------------------------------------------------------------------
+
+export const SLASH_COMMAND_PROMPTS: Record<SlashCommandType, (section: string) => string> = {
+  improve: (section) =>
+    `Please suggest improvements to the ${section} section of my proposal. Focus on clarity, persuasiveness, and completeness.`,
+  'check-constitution': (section) =>
+    `Check the ${section} section for constitutional alignment. Flag any potential issues with the Cardano Constitution.`,
+  'similar-proposals': (_section) =>
+    `Search for similar governance proposals that have been submitted before. Show me precedents and their outcomes.`,
+  complete: (section) =>
+    `Continue writing the ${section} section from where I left off. Match the existing tone and style.`,
+  draft: (section) =>
+    `Draft content for the ${section} section based on the other sections and the proposal type.`,
+};
+
+// ---------------------------------------------------------------------------
+// EditorContext builder
+// ---------------------------------------------------------------------------
+
+export function buildEditorContext(
+  editor: Editor | null,
+  draftContent: { title: string; abstract: string; motivation: string; rationale: string },
+  mode: EditorMode,
+): EditorContext {
+  let selectedText: string | undefined;
+  let cursorSection: ProposalField | undefined;
+
+  if (editor) {
+    const { from, to, empty } = editor.state.selection;
+    if (!empty) {
+      selectedText = editor.state.doc.textBetween(from, to, '\n');
+    }
+
+    const resolvedPos = editor.state.doc.resolve(from);
+    for (let depth = resolvedPos.depth; depth >= 0; depth--) {
+      const node = resolvedPos.node(depth);
+      if (node.type.name === 'sectionBlock' && node.attrs.field) {
+        cursorSection = node.attrs.field as ProposalField;
+        break;
+      }
+    }
+  }
+
+  return {
+    selectedText,
+    cursorSection,
+    currentContent: {
+      title: draftContent.title,
+      abstract: draftContent.abstract,
+      motivation: draftContent.motivation,
+      rationale: draftContent.rationale,
+    },
+    mode,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Comment injection helper
+// ---------------------------------------------------------------------------
+
+export function injectInlineComment(editor: Editor, comment: ProposedComment): void {
+  const { doc } = editor.state;
+  let sectionStart = 0;
+  let found = false;
+
+  doc.descendants((node, pos) => {
+    if (found) return false;
+    if (node.type.name === 'sectionBlock' && node.attrs.field === comment.field) {
+      sectionStart = pos + 1;
+      found = true;
+      return false;
+    }
+  });
+
+  if (found) {
+    const from = sectionStart + comment.anchorStart;
+    const to = sectionStart + comment.anchorEnd;
+
+    if (from >= 0 && to <= doc.content.size && from < to) {
+      const commentId = `comment-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      editor
+        .chain()
+        .focus()
+        .setMark('inlineComment', {
+          id: commentId,
+          author: 'Agent',
+          authorId: 'agent',
+          timestamp: new Date().toISOString(),
+          category: comment.category,
+          text: comment.commentText,
+        })
+        .setTextSelection({ from, to })
+        .run();
+    }
+  }
+}

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -1,26 +1,29 @@
 'use client';
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { Bell, CheckCircle2, Vote } from 'lucide-react';
+import { CheckCircle2, Vote } from 'lucide-react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useWallet } from '@/utils/wallet';
 import { useReviewQueue, useQueueState } from '@/hooks/useReviewQueue';
 import { useReviewableDrafts } from '@/hooks/useReviewableDrafts';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
-import {
-  useRevisionNotifications,
-  useMarkNotificationRead,
-} from '@/hooks/useRevisionNotifications';
+import { useRevisionNotifications } from '@/hooks/useRevisionNotifications';
+import { useAgent } from '@/hooks/useAgent';
 import { trackProposalView } from '@/lib/workspace/engagement';
-import { ReviewQueue } from './ReviewQueue';
 import { ReviewActionZone } from './ReviewActionZone';
-import { WorkspaceEmbed } from '@/components/workspace/editor/WorkspaceEmbed';
-import { StatusBar } from '@/components/workspace/layout/StatusBar';
+import { StudioProvider, useStudio } from '@/components/studio/StudioProvider';
+import { StudioHeader } from '@/components/studio/StudioHeader';
+import { StudioActionBar } from '@/components/studio/StudioActionBar';
+import { StudioPanel } from '@/components/studio/StudioPanel';
+import { buildEditorContext, injectInlineComment } from '@/components/studio/studioEditorHelpers';
+import { ProposalEditor, injectProposedEdit } from '@/components/workspace/editor/ProposalEditor';
+import { AgentChatPanel } from '@/components/workspace/agent/AgentChatPanel';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { FeatureGate } from '@/components/FeatureGate';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import type { ProposalType, ReviewQueueItem } from '@/lib/workspace/types';
 import type { VoteChoice } from '@/lib/voting';
-import type { ReviewQueueItem } from '@/lib/workspace/types';
+import type { ProposedEdit, ProposedComment } from '@/lib/workspace/editor/types';
+import type { Editor } from '@tiptap/core';
 import { posthog } from '@/lib/posthog';
 
 interface ReviewWorkspaceProps {
@@ -57,16 +60,174 @@ function draftToQueueItem(draft: import('@/lib/workspace/types').ProposalDraft):
   };
 }
 
+// ---------------------------------------------------------------------------
+// StudioPanelWrapper — manages agent + panel rendering
+// ---------------------------------------------------------------------------
+
+interface StudioPanelWrapperProps {
+  proposalId: string;
+  proposalType: string;
+  userRole: 'proposer' | 'reviewer' | 'cc_member';
+  content: {
+    title: string;
+    abstract: string;
+    motivation: string;
+    rationale: string;
+  };
+  editorRef: React.RefObject<Editor | null>;
+  readOnly: boolean;
+}
+
+function StudioPanelWrapper({
+  proposalId,
+  userRole,
+  content,
+  editorRef,
+  readOnly,
+}: StudioPanelWrapperProps) {
+  const { panelOpen, activePanel, panelWidth, closePanel, togglePanel, setPanelWidth } =
+    useStudio();
+
+  const {
+    sendMessage: agentSendMessage,
+    messages: agentMessages,
+    isStreaming: agentIsStreaming,
+    lastEdit: agentLastEdit,
+    lastComment: agentLastComment,
+    clearLastEdit: agentClearLastEdit,
+    clearLastComment: agentClearLastComment,
+    activeToolCall: agentActiveToolCall,
+    error: agentError,
+  } = useAgent({ proposalId, userRole });
+
+  // --- Agent lastEdit -> inject into editor ---
+  useEffect(() => {
+    if (!agentLastEdit || !editorRef.current) return;
+    injectProposedEdit(editorRef.current, agentLastEdit);
+    agentClearLastEdit();
+  }, [agentLastEdit, agentClearLastEdit, editorRef]);
+
+  // --- Agent lastComment -> apply inline comment ---
+  useEffect(() => {
+    if (!agentLastComment || !editorRef.current) return;
+    injectInlineComment(editorRef.current, agentLastComment);
+    agentClearLastComment();
+  }, [agentLastComment, agentClearLastComment, editorRef]);
+
+  // --- Chat send message with editor context ---
+  const handleChatSendMessage = useCallback(
+    async (message: string) => {
+      const ctx = buildEditorContext(editorRef.current, content, 'review');
+      posthog.capture('workspace_agent_message_sent', {
+        proposal_id: proposalId,
+        mode: 'review',
+        user_role: userRole,
+        has_selection: !!ctx.selectedText,
+      });
+      await agentSendMessage(message, ctx);
+    },
+    [agentSendMessage, content, proposalId, userRole, editorRef],
+  );
+
+  // --- Apply proposed edit from chat panel ---
+  const handleApplyEdit = useCallback(
+    (edit: ProposedEdit) => {
+      if (!editorRef.current) return;
+      injectProposedEdit(editorRef.current, edit);
+    },
+    [editorRef],
+  );
+
+  // --- Apply proposed comment from chat panel ---
+  const handleApplyComment = useCallback(
+    (comment: ProposedComment) => {
+      if (!editorRef.current) return;
+      injectInlineComment(editorRef.current, comment);
+    },
+    [editorRef],
+  );
+
+  return (
+    <StudioPanel
+      isOpen={panelOpen}
+      onClose={closePanel}
+      activeTab={activePanel}
+      onTabChange={(tab) => togglePanel(tab)}
+      width={panelWidth}
+      onWidthChange={setPanelWidth}
+      agentContent={
+        <AgentChatPanel
+          sendMessage={handleChatSendMessage}
+          messages={agentMessages}
+          isStreaming={agentIsStreaming}
+          activeToolCall={agentActiveToolCall}
+          error={agentError}
+          onApplyEdit={readOnly ? undefined : handleApplyEdit}
+          onApplyComment={handleApplyComment}
+        />
+      }
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StudioActionBarWrapper — connects action bar to studio context
+// ---------------------------------------------------------------------------
+
+interface StudioActionBarWrapperProps {
+  progress: { reviewed: number; total: number };
+  currentVoted?: boolean;
+  currentUrgent?: boolean;
+}
+
+function StudioActionBarWrapper({
+  progress,
+  currentVoted,
+  currentUrgent,
+}: StudioActionBarWrapperProps) {
+  const { panelOpen, activePanel, togglePanel } = useStudio();
+
+  return (
+    <StudioActionBar
+      activePanel={panelOpen ? activePanel : null}
+      onPanelToggle={togglePanel}
+      statusInfo={
+        <span className="flex items-center gap-2 text-xs text-muted-foreground tabular-nums">
+          <span>
+            {progress.reviewed} of {progress.total} reviewed
+          </span>
+          {currentVoted && (
+            <span className="inline-flex items-center gap-1 text-emerald-400">
+              <CheckCircle2 className="h-3 w-3" />
+              <span className="hidden sm:inline">Voted</span>
+            </span>
+          )}
+          {currentUrgent && !currentVoted && (
+            <span className="inline-flex items-center gap-1 text-amber-400">
+              <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+              <span className="hidden sm:inline">Urgent</span>
+            </span>
+          )}
+        </span>
+      }
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReviewWorkspace — main component
+// ---------------------------------------------------------------------------
+
 /**
  * ReviewWorkspace — the top-level client component for /workspace/review.
- * Two-column layout: queue rail (left) + Tiptap workspace (right) with
- * agent chat panel replacing the old Notes/Annotations/Journal sidebar.
+ * Uses the Studio shell (StudioHeader, StudioPanel, StudioActionBar) for a
+ * clean, focused review experience. No sidebar, no fullscreen overlay.
  *
- * Accepts an optional `initialProposalKey` (format: "txHash:index") to
- * auto-select a proposal on load (used by deep-links from discovery pages).
+ * Auto-selects the first unreviewed proposal on mount. The editor is centered
+ * at max-w-3xl, with the agent panel available on-demand from the action bar.
  */
 export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {}) {
-  const { segment, drepId, poolId } = useSegment();
+  const { segment, drepId, poolId, stakeAddress } = useSegment();
   const { ownDRepId } = useWallet();
 
   // Determine voter identity
@@ -77,32 +238,59 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   const { data: draftsData } = useReviewableDrafts();
   const { getStatus, setStatus, reviewedCount } = useQueueState(voterId);
 
-  const [activeTab, setActiveTab] = useState('active');
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [draftSelectedIndex, setDraftSelectedIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(-1); // -1 = not yet auto-selected
+  const [voteToast, setVoteToast] = useState<{ vote: string; visible: boolean } | null>(null);
   const lastTrackedRef = useRef<string | null>(null);
+  const editorRef = useRef<Editor | null>(null);
 
   const items = useMemo(() => data?.items ?? [], [data?.items]);
-  const selectedItem = items[selectedIndex] ?? null;
 
-  // Convert drafts to queue-compatible items
+  // Convert drafts to queue-compatible items (kept for future use)
   const draftItems = useMemo(() => {
     const drafts = draftsData?.drafts ?? [];
     return drafts.map(draftToQueueItem);
   }, [draftsData?.drafts]);
-  const selectedDraft = draftItems[draftSelectedIndex] ?? null;
 
   // Revision notifications
   const { data: notificationsData } = useRevisionNotifications(!!voterId);
-  const markRead = useMarkNotificationRead();
   const unreadCount = notificationsData?.unreadCount ?? 0;
-  const notifications = notificationsData?.notifications ?? [];
-  const [showNotifications, setShowNotifications] = useState(false);
 
   // Track page view
   useEffect(() => {
     posthog.capture('review_workspace_viewed', { voter_role: voterRole });
   }, [voterRole]);
+
+  // Auto-select first unreviewed item on mount (or from deep-link)
+  useEffect(() => {
+    if (items.length === 0) return;
+
+    // If deep-link, use that
+    if (initialProposalKey) {
+      const [targetTxHash, targetIndexStr] = initialProposalKey.split(':');
+      if (targetTxHash && targetIndexStr) {
+        const targetIndex = parseInt(targetIndexStr, 10);
+        if (!isNaN(targetIndex)) {
+          const matchIdx = items.findIndex(
+            (item) => item.txHash === targetTxHash && item.proposalIndex === targetIndex,
+          );
+          if (matchIdx >= 0) {
+            setSelectedIndex(matchIdx);
+            return;
+          }
+        }
+      }
+    }
+
+    // Auto-select first unreviewed item
+    if (selectedIndex === -1) {
+      const firstUnreviewed = items.findIndex(
+        (item) => getStatus(item.txHash, item.proposalIndex) !== 'voted' && !item.existingVote,
+      );
+      setSelectedIndex(firstUnreviewed >= 0 ? firstUnreviewed : 0);
+    }
+  }, [items, initialProposalKey, selectedIndex, getStatus]);
+
+  const selectedItem = items[selectedIndex] ?? null;
 
   // Track proposal view when selection changes
   useEffect(() => {
@@ -118,21 +306,6 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
     );
   }, [selectedItem, voterId, segment]);
 
-  // Auto-select proposal from deep-link (initialProposalKey = "txHash:index")
-  useEffect(() => {
-    if (!initialProposalKey || items.length === 0) return;
-    const [targetTxHash, targetIndexStr] = initialProposalKey.split(':');
-    if (!targetTxHash || !targetIndexStr) return;
-    const targetIndex = parseInt(targetIndexStr, 10);
-    if (isNaN(targetIndex)) return;
-    const matchIdx = items.findIndex(
-      (item) => item.txHash === targetTxHash && item.proposalIndex === targetIndex,
-    );
-    if (matchIdx >= 0) {
-      setSelectedIndex(matchIdx);
-    }
-  }, [initialProposalKey, items]);
-
   // Progress computation
   const progress = useMemo(() => {
     const reviewed = reviewedCount(items);
@@ -144,77 +317,127 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
 
   // Navigation callbacks
   const goNext = useCallback(() => {
-    if (activeTab === 'drafts') {
-      setDraftSelectedIndex((prev) => Math.min(prev + 1, draftItems.length - 1));
-    } else {
-      setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1));
-    }
-  }, [activeTab, items.length, draftItems.length]);
+    setSelectedIndex((prev) => Math.min(prev + 1, items.length - 1));
+  }, [items.length]);
 
   const goPrev = useCallback(() => {
-    if (activeTab === 'drafts') {
-      setDraftSelectedIndex((prev) => Math.max(prev - 1, 0));
-    } else {
-      setSelectedIndex((prev) => Math.max(prev - 1, 0));
-    }
-  }, [activeTab]);
-
-  const handleSelect = useCallback((index: number) => {
-    setSelectedIndex(index);
+    setSelectedIndex((prev) => Math.max(prev - 1, 0));
   }, []);
 
-  const handleDraftSelect = useCallback((index: number) => {
-    setDraftSelectedIndex(index);
-  }, []);
-
-  // Vote success handler — called by ReviewActionZone after on-chain vote succeeds
+  // Vote success handler — auto-advances to next unreviewed proposal after 1.5s
   const handleVoteSuccess = useCallback(
     (vote: VoteChoice) => {
       if (!selectedItem) return;
       setStatus(selectedItem.txHash, selectedItem.proposalIndex, 'voted', vote);
+
+      // Show toast
+      setVoteToast({ vote, visible: true });
+      setTimeout(() => setVoteToast(null), 2500);
+
+      // Auto-advance after delay
+      setTimeout(() => {
+        setSelectedIndex((prev) => {
+          // Find next unreviewed item
+          const nextUnreviewed = items.findIndex(
+            (item, idx) =>
+              idx > prev &&
+              getStatus(item.txHash, item.proposalIndex) !== 'voted' &&
+              !item.existingVote,
+          );
+          if (nextUnreviewed >= 0) return nextUnreviewed;
+          // If no more unreviewed, go to next item
+          if (prev < items.length - 1) return prev + 1;
+          return prev;
+        });
+      }, 1500);
     },
-    [selectedItem, setStatus],
+    [selectedItem, setStatus, items, getStatus],
   );
 
-  // Keyboard shortcuts
+  // Keyboard shortcuts (arrow keys)
   useKeyboardShortcuts({
     onNext: goNext,
     onPrev: goPrev,
   });
 
+  // J/K keyboard navigation (disabled in text inputs)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Don't intercept when user is typing
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (e.key === 'j' || e.key === 'J') {
+        e.preventDefault();
+        goNext();
+      } else if (e.key === 'k' || e.key === 'K') {
+        e.preventDefault();
+        goPrev();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [goNext, goPrev]);
+
   // Derive the agent userRole from segment
   const agentUserRole = segment === 'cc' ? ('cc_member' as const) : ('reviewer' as const);
 
-  // The current active item depends on which tab is active
-  const currentItem = activeTab === 'drafts' ? selectedDraft : selectedItem;
+  // Capture editor instance
+  const handleEditorReady = useCallback((editor: Editor) => {
+    editorRef.current = editor;
+  }, []);
 
-  // Deselect to return to queue-only view
-  const handleBackToQueue = useCallback(() => {
-    if (activeTab === 'drafts') {
-      setDraftSelectedIndex(-1);
-    } else {
-      setSelectedIndex(-1);
-    }
-  }, [activeTab]);
+  // Type label
+  const typeLabel = selectedItem
+    ? (PROPOSAL_TYPE_LABELS[selectedItem.proposalType as ProposalType] ?? selectedItem.proposalType)
+    : '';
+
+  // Segment badge
+  const segmentBadge = useMemo(() => {
+    const badges: Record<string, { label: string; color: string }> = {
+      drep: { label: 'DRep', color: '#6366f1' },
+      spo: { label: 'SPO', color: '#f59e0b' },
+      cc: { label: 'CC', color: '#ef4444' },
+    };
+    return badges[segment] ?? undefined;
+  }, [segment]);
+
+  // Queue jump handler for dots
+  const handleQueueJump = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < items.length) {
+        setSelectedIndex(index);
+      }
+    },
+    [items.length],
+  );
 
   // Loading state
   if (isLoading) {
     return (
-      <div className="flex h-full">
-        <div className="hidden md:block w-72 border-r border-border shrink-0">
-          <div className="p-3 space-y-3">
-            <Skeleton className="h-5 w-full" />
-            {[1, 2, 3, 4].map((i) => (
-              <Skeleton key={i} className="h-14 w-full rounded-lg" />
-            ))}
+      <div className="flex flex-col h-screen">
+        <div className="h-12 border-t-2 border-teal-500 border-b border-b-border bg-background px-4 flex items-center shrink-0">
+          <Skeleton className="h-5 w-24" />
+          <div className="flex-1" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+        <div className="flex-1 flex items-start justify-center pt-12">
+          <div className="max-w-3xl w-full px-6 space-y-4">
+            <Skeleton className="h-8 w-2/3" />
+            <Skeleton className="h-32 w-full rounded-xl" />
+            <Skeleton className="h-24 w-full rounded-xl" />
+            <Skeleton className="h-36 w-full rounded-xl" />
           </div>
         </div>
-        <div className="flex-1 p-6 space-y-4">
-          <Skeleton className="h-8 w-2/3" />
-          <Skeleton className="h-32 w-full rounded-xl" />
-          <Skeleton className="h-24 w-full rounded-xl" />
-          <Skeleton className="h-36 w-full rounded-xl" />
-        </div>
+        <div className="h-12 border-t border-border bg-background shrink-0" />
       </div>
     );
   }
@@ -222,7 +445,7 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   // Error state
   if (error) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex items-center justify-center h-screen">
         <div className="text-center space-y-2">
           <p className="text-sm text-muted-foreground">Failed to load review queue</p>
           <p className="text-xs text-muted-foreground/60">{String(error)}</p>
@@ -234,7 +457,7 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   // No voter ID (not a DRep/SPO)
   if (!voterId) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex items-center justify-center h-screen">
         <div className="text-center space-y-3">
           <Vote className="mx-auto h-8 w-8 text-muted-foreground" />
           <div>
@@ -251,7 +474,7 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   // Empty state
   if (items.length === 0 && draftItems.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex items-center justify-center h-screen">
         <div className="text-center space-y-3">
           <div className="mx-auto w-12 h-12 rounded-full bg-emerald-500/10 flex items-center justify-center">
             <CheckCircle2 className="h-6 w-6 text-emerald-500" />
@@ -267,169 +490,135 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
     );
   }
 
-  // Queue rail content — used inside the fullscreen WorkspaceLayout
-  const queueRailContent = (
-    <>
-      {/* Revision notifications badge */}
-      {unreadCount > 0 && (
-        <div className="relative px-3 pt-2">
-          <button
-            onClick={() => setShowNotifications((prev) => !prev)}
-            className="flex w-full items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-foreground hover:bg-amber-500/10 transition-colors"
-          >
-            <Bell className="h-3.5 w-3.5 text-amber-500" />
-            <span>
-              {unreadCount} revised proposal{unreadCount !== 1 ? 's' : ''}
-            </span>
-            <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-amber-500 text-[10px] font-bold text-white">
-              {unreadCount}
-            </span>
-          </button>
-          {showNotifications && notifications.length > 0 && (
-            <div className="mt-1 rounded-md border border-border bg-background shadow-lg divide-y divide-border max-h-48 overflow-y-auto">
-              {notifications.map((n) => (
-                <button
-                  key={n.id}
-                  onClick={() => {
-                    markRead.mutate(n.id);
-                    const matchIdx = items.findIndex((item) => item.txHash === n.proposalId);
-                    if (matchIdx >= 0) {
-                      setSelectedIndex(matchIdx);
-                    }
-                    setShowNotifications(false);
-                  }}
-                  className="flex w-full flex-col gap-0.5 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-xs font-medium truncate">Proposal v{n.versionNumber}</span>
-                  <span className="text-[10px] text-muted-foreground">
-                    {n.sectionsChanged.length} section{n.sectionsChanged.length !== 1 ? 's' : ''}{' '}
-                    revised &mdash; tap to review
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-      <FeatureGate
-        flag="review_unified_tabs"
-        fallback={
-          <ReviewQueue
-            items={items}
-            selectedIndex={selectedIndex}
-            onSelect={handleSelect}
-            getStatus={getStatus}
-            progress={progress}
-          />
-        }
-      >
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-          <div className="px-2 pt-2 shrink-0">
-            <TabsList className="w-full">
-              <TabsTrigger value="active" className="flex-1 text-xs">
-                Active Proposals
-                {items.length > 0 && (
-                  <span className="ml-1 text-[10px] text-muted-foreground">({items.length})</span>
-                )}
-              </TabsTrigger>
-              <TabsTrigger value="drafts" className="flex-1 text-xs">
-                Pre-submission
-                {draftItems.length > 0 && (
-                  <span className="ml-1 text-[10px] text-muted-foreground">
-                    ({draftItems.length})
-                  </span>
-                )}
-              </TabsTrigger>
-            </TabsList>
-          </div>
-          <TabsContent value="active" className="flex-1 min-h-0 mt-0">
-            <ReviewQueue
-              items={items}
-              selectedIndex={selectedIndex}
-              onSelect={handleSelect}
-              getStatus={getStatus}
-              progress={progress}
-            />
-          </TabsContent>
-          <TabsContent value="drafts" className="flex-1 min-h-0 mt-0">
-            {draftItems.length === 0 ? (
-              <div className="px-3 py-8 text-center">
-                <p className="text-xs text-muted-foreground">
-                  No pre-submission drafts awaiting review.
-                </p>
-              </div>
-            ) : (
-              <ReviewQueue
-                items={draftItems}
-                selectedIndex={draftSelectedIndex}
-                onSelect={handleDraftSelect}
-                getStatus={() => 'unreviewed'}
-                progress={{ reviewed: 0, total: draftItems.length }}
-              />
-            )}
-          </TabsContent>
-        </Tabs>
-      </FeatureGate>
-    </>
-  );
-
-  // When a proposal is selected, render the fullscreen workspace overlay
-  if (currentItem) {
-    const isActiveDraft = activeTab === 'drafts';
-    const item = isActiveDraft ? selectedDraft! : selectedItem!;
-    const key = isActiveDraft ? `draft:${item.txHash}` : `${item.txHash}:${item.proposalIndex}`;
-
+  // No selected item yet (shouldn't happen after auto-select, but guard)
+  if (!selectedItem) {
     return (
-      <WorkspaceEmbed
-        key={key}
-        proposalId={item.txHash}
-        content={{
-          title: item.title || '',
-          abstract: item.abstract || '',
-          motivation: item.motivation || '',
-          rationale: item.rationale || '',
-        }}
-        proposalType={item.proposalType}
-        userRole={agentUserRole}
-        readOnly={true}
-        onBack={handleBackToQueue}
-        backLabel="Back to queue"
-        queueRail={queueRailContent}
-        belowEditor={
-          !isActiveDraft ? (
-            <div className="max-w-3xl mx-auto px-6 pb-6">
-              <ReviewActionZone
-                item={selectedItem!}
-                drepId={voterId}
-                onVote={(_txHash, _index, vote) => handleVoteSuccess(vote as VoteChoice)}
-                onNextProposal={goNext}
-                totalProposals={progress.total}
-                votedCount={progress.reviewed}
-              />
-            </div>
-          ) : undefined
-        }
-        statusBar={
-          isActiveDraft ? (
-            <StatusBar userStatus="Pre-submission review" />
-          ) : (
-            <StatusBar
-              completeness={{ done: progress.reviewed, total: progress.total }}
-              userStatus={`Reviewing ${progress.reviewed}/${progress.total}`}
-            />
-          )
-        }
-        showModeSwitch={false}
-      />
+      <div className="flex items-center justify-center h-screen">
+        <Skeleton className="h-8 w-48" />
+      </div>
     );
   }
 
-  // No proposal selected — show the queue as a standalone list view
+  // Queue complete celebration
+  if (progress.reviewed >= progress.total && progress.total > 0) {
+    return (
+      <StudioProvider>
+        <div className="flex flex-col h-screen">
+          <StudioHeader
+            backLabel="governada"
+            backHref="/workspace"
+            queueProgress={{ current: progress.total, total: progress.total }}
+            segmentBadge={segmentBadge}
+          />
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-center space-y-4">
+              <div className="mx-auto w-16 h-16 rounded-full bg-emerald-500/10 flex items-center justify-center">
+                <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+              </div>
+              <div>
+                <p className="text-lg font-semibold text-foreground">All caught up!</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  You&apos;ve reviewed all {progress.total} proposal
+                  {progress.total !== 1 ? 's' : ''} in the queue.
+                </p>
+              </div>
+              <a
+                href="/workspace"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+              >
+                Back to workspace
+              </a>
+            </div>
+          </div>
+          <StudioActionBarWrapper progress={progress} />
+        </div>
+      </StudioProvider>
+    );
+  }
+
+  // --- Main studio layout ---
+  const itemContent = {
+    title: selectedItem.title || '',
+    abstract: selectedItem.abstract || '',
+    motivation: selectedItem.motivation || '',
+    rationale: selectedItem.rationale || '',
+  };
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="max-w-2xl mx-auto w-full flex-1 min-h-0 overflow-y-auto">
-        {queueRailContent}
+    <StudioProvider>
+      <div className="flex flex-col h-screen">
+        {/* Studio Header */}
+        <StudioHeader
+          backLabel="governada"
+          backHref="/workspace"
+          title={selectedItem.title || 'Untitled'}
+          proposalType={typeLabel}
+          queueProgress={{ current: selectedIndex + 1, total: items.length }}
+          onQueueJump={handleQueueJump}
+          segmentBadge={segmentBadge}
+          notificationCount={unreadCount}
+        />
+
+        {/* Main content area */}
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          {/* Editor area (scrollable) */}
+          <div className="flex-1 min-w-0 overflow-y-auto">
+            <div className="max-w-3xl mx-auto px-6 py-6">
+              <div
+                key={`proposal-${selectedItem.txHash}-${selectedItem.proposalIndex}`}
+                className="animate-in fade-in duration-150"
+              >
+                <ProposalEditor
+                  content={itemContent}
+                  mode="review"
+                  readOnly={true}
+                  currentUserId={stakeAddress ?? 'anonymous'}
+                  onEditorReady={handleEditorReady}
+                />
+                {/* ReviewActionZone below editor */}
+                <div className="mt-6">
+                  <ReviewActionZone
+                    item={selectedItem}
+                    drepId={voterId}
+                    onVote={(_txHash, _index, vote) => handleVoteSuccess(vote as VoteChoice)}
+                    onNextProposal={goNext}
+                    totalProposals={progress.total}
+                    votedCount={progress.reviewed}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Studio Panel (on-demand right panel) */}
+          <StudioPanelWrapper
+            proposalId={selectedItem.txHash}
+            proposalType={selectedItem.proposalType}
+            userRole={agentUserRole}
+            content={itemContent}
+            editorRef={editorRef}
+            readOnly={true}
+          />
+        </div>
+
+        {/* Studio Action Bar */}
+        <StudioActionBarWrapper
+          progress={progress}
+          currentVoted={
+            !!selectedItem.existingVote ||
+            getStatus(selectedItem.txHash, selectedItem.proposalIndex) === 'voted'
+          }
+          currentUrgent={selectedItem.isUrgent}
+        />
+
+        {/* Vote success toast */}
+        {voteToast?.visible && (
+          <div className="fixed bottom-16 left-1/2 -translate-x-1/2 z-50 flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500/90 text-white text-sm font-medium shadow-lg animate-in slide-in-from-bottom-2 fade-in">
+            <CheckCircle2 className="h-4 w-4" />
+            Vote recorded — {voteToast.vote}
+          </div>
+        )}
       </div>
-    </div>
+    </StudioProvider>
   );
 }

--- a/docs/strategy/specs/governance-studio-spec.md
+++ b/docs/strategy/specs/governance-studio-spec.md
@@ -1,0 +1,383 @@
+# Governance Studio — Work Plan & Spec
+
+> **Status**: Active build
+> **Branch**: `fix/workspace-layout-ux`
+> **Goal**: Replace the current workspace shell (sidebar + fullscreen overlay) with a purpose-built Studio mode — minimal chrome, content-first, keyboard-driven, world-class UX.
+
+---
+
+## Architecture Overview
+
+### Two Shells, One Design Language
+
+```
+Browse Mode (citizens, exploration)     Studio Mode (DReps, proposers, reviewers)
+┌─────────────────────────────┐         ┌──────────────────────────────────────┐
+│ Header                      │         │ StudioHeader (minimal)               │
+├──────┬──────────────────────┤         ├──────────────────────────────────────┤
+│Side  │                      │         │                                      │
+│bar   │  Page Content        │         │    Full-width centered content        │
+│      │                      │         │    (max-w-3xl, proposal editor)       │
+│      │                      │         │                    ┌────────────────┐ │
+│      │                      │         │                    │ Panel (on      │ │
+│      │                      │         │                    │ demand, slides │ │
+│      │                      │         │                    │ from right)    │ │
+├──────┴──────────────────────┤         ├────────────────────┴────────────────┤ │
+│ BottomNav (mobile)          │         │ StudioActionBar (sticky bottom)      │
+└─────────────────────────────┘         └──────────────────────────────────────┘
+```
+
+### Studio Mode Detection
+
+`GovernadaShell` detects studio routes via pathname:
+
+- `/workspace/review` → Studio mode (review)
+- `/workspace/author/<id>` → Studio mode (author)
+- `/workspace/editor/<id>` → Studio mode (author)
+- Everything else → Browse mode
+
+When studio mode is active:
+
+- `GovernadaSidebar` is NOT rendered
+- `GovernadaHeader` is NOT rendered (replaced by `StudioHeader`)
+- `GovernadaBottomNav` is NOT rendered (replaced by `StudioActionBar`)
+- `EpochContextBar` is NOT rendered
+- Background constellation globe is NOT rendered
+- Main content has NO left padding (full-width)
+- Footer is NOT rendered
+
+### Component Inventory
+
+**New components** (`components/studio/`):
+
+| Component                 | Purpose                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| `StudioHeader.tsx`        | Minimal top bar: ← back, title, queue progress dots, Cmd+K, notifications, user badge            |
+| `StudioActionBar.tsx`     | Sticky bottom bar: panel launchers (Agent, Intel, Notes) + context actions (Vote or Save/Submit) |
+| `StudioPanel.tsx`         | On-demand right panel with tabs. Slides in from right. Resizable.                                |
+| `StudioQueueProgress.tsx` | Dot-based progress indicator (●●●○○○) for the header                                             |
+| `StudioProvider.tsx`      | React context providing studio state (panel open/closed, active tab, focus level)                |
+
+**Modified components**:
+
+| Component                       | Change                                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `GovernadaShell.tsx`            | Detect studio routes, conditionally hide sidebar/header/footer/bottom-nav                |
+| `ReviewWorkspace.tsx`           | Complete rewrite — content-first layout, no queue list first, auto-select first proposal |
+| `WorkspaceEmbed.tsx`            | Remove `WorkspaceLayout` wrapper, render editor directly, accept new layout props        |
+| `app/workspace/layout.tsx`      | Suppress `SectionPillBar` in studio mode                                                 |
+| `app/workspace/review/page.tsx` | Pass studio mode context                                                                 |
+
+**Preserved (no changes)**:
+
+- `ProposalEditor.tsx` (Tiptap) — unchanged
+- `AgentChatPanel.tsx` — unchanged, wrapped inside `StudioPanel`
+- `ReviewActionZone.tsx` — reused inside `StudioActionBar`
+- `StatusBar.tsx` — reused inside `StudioHeader` or `StudioActionBar`
+- All hooks (`useReviewQueue`, `useAgent`, `useDraft`, etc.) — unchanged
+- All API routes — unchanged
+
+---
+
+## Component Specifications
+
+### StudioHeader
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ ← governada    [Title · Type]    ●●●○○○    ⌘K   🔔  [DRep]│
+└────────────────────────────────────────────────────────────┘
+```
+
+**Props:**
+
+```ts
+interface StudioHeaderProps {
+  backHref?: string; // Default: "/workspace/review" or "/workspace/author"
+  onBack?: () => void; // Override back behavior
+  backLabel?: string; // e.g. "governada" or "Back to drafts"
+  title?: string; // Proposal title (truncated)
+  proposalType?: string; // Badge: "Treasury Withdrawal"
+  queueProgress?: { current: number; total: number };
+  showModeSwitch?: boolean; // Edit/Review/Diff tabs
+  mode?: EditorMode;
+  onModeChange?: (mode: EditorMode) => void;
+}
+```
+
+**Behavior:**
+
+- Height: 48px (py-2 px-4)
+- Left: Back button (← + label). Clicking navigates to browse mode.
+- Center: Proposal title (truncated, text-sm font-semibold) + type badge (text-[10px])
+- Center-right: Queue progress dots (`StudioQueueProgress`)
+- Right: ⌘K button, notification bell (from GovernadaHeader), user segment badge
+- Border-bottom: `border-border` (standard)
+- Visual signal: thin 2px top border in `var(--color-teal-500)` to indicate studio mode
+- Mobile: Title hidden below sm, queue dots compact
+
+### StudioActionBar
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  [💬 Agent]  [📊 Intel]  [📋 Notes]    [Yes] [No] [Abstain]│
+└────────────────────────────────────────────────────────────┘
+```
+
+**Props:**
+
+```ts
+interface StudioActionBarProps {
+  // Panel controls
+  activePanel: 'agent' | 'intel' | 'notes' | null;
+  onPanelToggle: (panel: 'agent' | 'intel' | 'notes') => void;
+  // Context actions (review mode)
+  reviewActions?: ReactNode; // ReviewActionZone buttons
+  // Context actions (author mode)
+  authorActions?: ReactNode; // Save/Submit buttons
+  // Status info
+  statusInfo?: ReactNode; // StatusBar content (completeness, etc.)
+}
+```
+
+**Behavior:**
+
+- Position: `sticky bottom-0` with `bg-background/95 backdrop-blur-sm border-t`
+- Height: 48px (py-2 px-4)
+- Left: Panel toggle buttons (icon + label). Active panel button is highlighted.
+- Right: Context-specific action buttons
+- Keyboard: Panel toggles respond to Cmd+Shift+C (agent), Cmd+Shift+I (intel), Cmd+Shift+N (notes)
+- Mobile: Icon-only panel buttons, full-width action buttons below
+
+### StudioPanel
+
+**Props:**
+
+```ts
+interface StudioPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activeTab: 'agent' | 'intel' | 'notes';
+  onTabChange: (tab: 'agent' | 'intel' | 'notes') => void;
+  width: number;
+  onWidthChange: (width: number) => void;
+  // Content
+  agentContent: ReactNode; // AgentChatPanel
+  intelContent?: ReactNode; // Intelligence cards
+  notesContent?: ReactNode; // Decision journal
+}
+```
+
+**Behavior:**
+
+- Slides in from right edge with transition (transform + opacity, 200ms ease)
+- Resizable left edge (drag handle, min 280px, max 50% viewport)
+- Tab bar at top: Agent | Intel | Notes
+- Close button (X) in top-right
+- Escape key closes the panel
+- Content area scrolls independently
+- When open, main content area is pushed left (not overlaid)
+- Mobile: renders as a bottom sheet (slides up from bottom, 80% height)
+
+### StudioQueueProgress
+
+```
+●●●○○○  3/6
+```
+
+**Props:**
+
+```ts
+interface StudioQueueProgressProps {
+  current: number;
+  total: number;
+  onClick?: () => void; // Opens queue picker
+}
+```
+
+**Behavior:**
+
+- Filled dots for completed + current, hollow for remaining
+- Current dot is slightly larger or pulsing
+- Clicking opens a dropdown/popover showing the full queue for quick-jump
+- Compact text (3/6) shown next to dots
+- Max 10 dots visible; beyond that, show `●●● 3/15`
+
+### StudioProvider
+
+```ts
+interface StudioState {
+  // Panel
+  panelOpen: boolean;
+  activePanel: 'agent' | 'intel' | 'notes';
+  panelWidth: number;
+  // Focus
+  focusLevel: 0 | 1 | 2; // 0=normal, 1=panel hidden, 2=zen (header hidden too)
+  // Queue
+  queuePosition: number;
+  queueTotal: number;
+}
+```
+
+---
+
+## Execution Chunks
+
+### Chunk 1: Studio Shell + GovernadaShell Integration
+
+**Files to create:**
+
+- `components/studio/StudioProvider.tsx`
+- `components/studio/StudioHeader.tsx`
+- `components/studio/StudioActionBar.tsx`
+- `components/studio/StudioPanel.tsx`
+- `components/studio/StudioQueueProgress.tsx`
+
+**Files to modify:**
+
+- `components/governada/GovernadaShell.tsx` — add studio route detection + conditional rendering
+- `app/workspace/layout.tsx` — suppress SectionPillBar in studio mode
+
+**Acceptance criteria:**
+
+- Studio routes show minimal header, no sidebar, no bottom nav
+- Non-studio routes are completely unaffected
+- Panel slides in/out smoothly
+- Action bar is sticky at bottom
+- All components follow Compass design language (dark theme, Space Grotesk, proper spacing)
+
+### Chunk 2: Review Flow Rewrite
+
+**Files to modify:**
+
+- `components/workspace/review/ReviewWorkspace.tsx` — complete rewrite for studio layout
+- `components/workspace/editor/WorkspaceEmbed.tsx` — remove WorkspaceLayout wrapper, render editor directly
+
+**Key changes:**
+
+1. Remove the "queue list first, then open editor" pattern
+2. Auto-select first unreviewed proposal on mount
+3. Render proposal content full-width centered (max-w-3xl mx-auto)
+4. Move `ReviewActionZone` buttons into `StudioActionBar`
+5. Wrap `AgentChatPanel` inside `StudioPanel` as the "Agent" tab
+6. Remove `WorkspaceLayout` usage — editor renders directly in the page content area
+7. Remove the separate `queueRailContent` — queue is navigated via J/K and progress dots
+
+**Layout in review mode:**
+
+```
+StudioHeader (← governada | "Amaru TWO 2026" · Treasury | ●●●○○○ | ⌘K 🔔 DRep)
+─────────────────────────────────────────────────────────────────────────────────
+                                                              ┌─ StudioPanel ─┐
+   [Proposal content, full-width centered max-w-3xl]          │ Agent | Intel  │
+   [ProposalEditor in read-only mode]                         │                │
+   [Below editor: optional inline intelligence cards]         │ (content)      │
+                                                              │                │
+                                                              └────────────────┘
+─────────────────────────────────────────────────────────────────────────────────
+StudioActionBar ([Agent] [Intel] [Notes]  ···  [Yes] [No] [Abstain])
+```
+
+### Chunk 3: Author Flow Adaptation
+
+**Files to modify:**
+
+- `app/workspace/editor/[draftId]/page.tsx` — adapt for studio layout
+- `app/workspace/author/[draftId]/page.tsx` — same (delegates to editor route)
+
+**Key changes:**
+
+1. Remove `WorkspaceLayout` wrapper (same as review)
+2. Editor renders full-width centered
+3. Action bar shows: [Agent] [Feedback] [Preview] ··· [Save Draft] [Submit]
+4. Panel tabs: Agent (chat) | Feedback (themes) | Preview (rendered view)
+5. Back button: "← Back to drafts" → navigates to `/workspace/author`
+
+### Chunk 4: Queue Processing UX
+
+**Files to modify:**
+
+- `components/workspace/review/ReviewWorkspace.tsx` — add queue processing logic
+- `components/studio/StudioQueueProgress.tsx` — add queue picker popover
+
+**Key features:**
+
+1. **J/K navigation**: Press J to go to next proposal, K for previous. Content swaps in-place.
+2. **Y/N/A voting**: Press Y/N/A to start the vote flow (same as clicking the button)
+3. **S to snooze**: Move current proposal to end of queue
+4. **R for rationale**: Open rationale step
+5. **Auto-advance**: After successful vote, auto-advance to next proposal (with 1.5s delay for toast)
+6. **Queue completion**: When all proposals reviewed, show celebration state
+7. **Toast notifications**: "Vote recorded ✓" toast on successful vote
+
+**Keyboard shortcut registration:**
+
+- Must be disabled when user is typing in textarea/input (rationale, agent chat)
+- Must be disabled when panel is focused
+- Use existing `useKeyboardShortcuts` pattern
+
+### Chunk 5: Polish + Transitions
+
+**Specific polish items:**
+
+1. **Studio entry transition**: When navigating from browse to studio, the sidebar slides out and header morphs. Framer Motion `AnimatePresence` on sidebar. CSS transition on header.
+2. **Content crossfade**: When J/K navigating between proposals, content fades out/in (opacity 150ms).
+3. **Panel slide**: StudioPanel slides in from right edge (transform translateX, 200ms spring).
+4. **Visual mode signal**: StudioHeader has a 2px top border in teal (`border-t-2 border-teal-500`).
+5. **Queue dot animation**: Current dot has a subtle pulse animation.
+6. **Vote toast**: Success toast slides up from bottom, fades after 2s.
+7. **Queue completion celebration**: "All caught up 🎉" with Governance Rings animation.
+
+---
+
+## Quality Bar
+
+### What "World-Class" Means Here
+
+| Dimension               | Target                                         | Specific Criteria                                                                        |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **Chrome reduction**    | No element that doesn't serve the current task | Header: 1 bar, 48px. No sidebar. No footer. Action bar: 1 bar, 48px. Total chrome: 96px. |
+| **Content focus**       | Proposal text is the dominant visual element   | Max-w-3xl centered. Generous padding. Space Grotesk body. Clear section headers.         |
+| **Keyboard efficiency** | Power users never touch the mouse              | J/K/Y/N/A/S/R/Escape + Cmd+K all functional. Flow state possible.                        |
+| **Panel flexibility**   | Panels serve the user, not the layout          | Agent/Intel/Notes on-demand. Not permanent. Not overlapping content.                     |
+| **Visual identity**     | Unmistakably Governada                         | Dark mode, teal accent, Fraunces for scores, constellation reference in header logo      |
+| **Transitions**         | Every state change has smooth motion           | No layout jumps. No flash of unstyled content. Spring physics on panels.                 |
+| **Mobile**              | Functional, not just responsive                | Action bar adapts. Panels become bottom sheets. Full-width content natural.              |
+
+### Linear-Quality Checklist
+
+- [ ] Every interactive element has hover + active states
+- [ ] Keyboard shortcuts have visible hints (tooltips or Cmd+K menu)
+- [ ] Focus rings are visible and consistent
+- [ ] Loading states for content swap (skeleton or crossfade, never blank)
+- [ ] Error states are graceful (toast, not page-level error)
+- [ ] Empty states guide action ("No proposals to review" + suggestion)
+- [ ] Typography hierarchy is clear (title → section → body → metadata)
+- [ ] Spacing is consistent (using Compass Work mode: 14px base, 12px padding)
+
+---
+
+## Migration Notes
+
+### What Gets Removed (after all chunks ship)
+
+- `WorkspaceLayout.tsx` fullscreen overlay pattern — replaced by studio shell
+- `WorkspaceToolbar.tsx` as standalone component — replaced by StudioHeader
+- Queue rail in `ReviewWorkspace` — replaced by J/K + progress dots
+- Double header (app header + workspace toolbar) — single StudioHeader
+
+### What's Preserved
+
+- `ProposalEditor` (Tiptap) — the editor itself is excellent, don't touch it
+- `AgentChatPanel` — wraps inside StudioPanel's Agent tab
+- `ReviewActionZone` — the vote flow logic stays, buttons move to action bar
+- All hooks and data layer — zero backend changes
+- Feature flags — `proposal_workspace` still gates the feature
+
+### Rollback
+
+If studio mode has issues:
+
+- The old `WorkspaceLayout.tsx` fullscreen overlay still exists
+- Studio mode is route-detected — removing the detection restores old behavior
+- No database migrations, no API changes, no flag changes needed


### PR DESCRIPTION
## Summary
- **New Studio mode** activates on `/workspace/review` and `/workspace/author/*` routes — hides the sidebar, header, footer, and bottom nav, replacing them with a minimal `StudioHeader` (teal accent border, queue progress dots, Cmd+K) and a sticky `StudioActionBar`
- **Review flow rewritten**: content-first centered layout (max-w-3xl), auto-selects first unreviewed proposal, J/K keyboard navigation between proposals with crossfade transitions, auto-advance to next proposal after voting with toast notification
- **Author flow adapted**: same Studio shell with mode switcher (Edit/Review/Diff), Save Version button, agent chat via on-demand panel
- **On-demand panel system**: Agent/Intel/Notes tabbed right panel, resizable, Escape-to-close (scoped to panel focus), mobile bottom sheet with safe area support
- **Queue processing UX**: J/K navigation, auto-advance after vote, queue completion celebration state, progress dots with quick-jump

## Impact
- **What changed**: Complete workspace navigation overhaul — the proposer/reviewer experience now uses a purpose-built Studio shell instead of competing with the app's browse-mode sidebar
- **User-facing**: Yes — DReps reviewing proposals and proposers authoring drafts see a dramatically cleaner, more focused interface with keyboard-first workflow
- **Risk**: Medium — the review and author flows have been substantially rewritten, but the data layer, editor (Tiptap), agent (AI chat), and vote flow (ReviewActionZone) are completely unchanged. The old WorkspaceLayout.tsx remains as fallback.
- **Scope**: 12 files (7 new Studio components, 4 modified, 1 spec). No migrations, no API changes, no feature flag changes.

## Test plan
- [ ] Navigate to `/workspace/review` as a DRep — verify sidebar/header/footer hidden, Studio layout visible
- [ ] Verify proposal loads immediately (no queue list first)
- [ ] Press J/K to navigate between proposals — verify crossfade transition
- [ ] Cast a vote — verify toast appears and auto-advance works
- [ ] Click Agent/Intel/Notes buttons in action bar — verify panel slides in from right
- [ ] Resize panel — verify drag handle works
- [ ] Press Escape with panel focused — verify it closes
- [ ] Navigate to `/workspace/author/{draftId}` — verify Studio layout with mode switcher
- [ ] Use slash commands and Cmd+K in author mode — verify agent integration
- [ ] Test on mobile viewport — verify bottom sheet panel, safe area padding
- [ ] Navigate to non-workspace routes — verify normal sidebar/header still shows
- [ ] Run preflight: all 648 tests pass, types clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)