### PR TITLE
fix: Studio v3 — mode switcher, agent suggestions, legal markup tools

### DIFF
--- a/components/workspace/agent/AgentChatPanel.tsx
+++ b/components/workspace/agent/AgentChatPanel.tsx
@@ -338,24 +338,22 @@ export function AgentChatPanel({
             <div className="text-center space-y-1">
               <p className="text-sm text-muted-foreground">Governance Agent</p>
               <p className="text-xs text-muted-foreground/60 max-w-[240px]">
-                Ask me about this proposal, check constitutional alignment, search for similar
-                proposals, or request edit suggestions.
+                Ask about risks, request a rationale draft, or explore arguments for and against
+                this proposal.
               </p>
             </div>
             <div className="flex flex-wrap gap-1.5 justify-center max-w-[280px]">
               {[
-                'Check constitution',
-                'Find similar proposals',
-                'Improve the abstract',
-                'Summarize community feedback',
+                'What are the key risks of this proposal?',
+                'Summarize the main arguments for and against',
+                'Draft a rationale for voting Yes',
+                'What questions should I ask the proposer?',
               ].map((suggestion) => (
                 <button
                   key={suggestion}
-                  onClick={() => {
-                    setInput(suggestion);
-                    inputRef.current?.focus();
-                  }}
-                  className="text-[11px] px-2.5 py-1 rounded-full border border-border/60 text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+                  onClick={() => sendMessage(suggestion)}
+                  disabled={isStreaming}
+                  className="text-[11px] px-2.5 py-1 rounded-full border border-border/60 text-muted-foreground hover:text-foreground hover:border-border transition-colors disabled:opacity-50"
                 >
                   {suggestion}
                 </button>

--- a/components/workspace/editor/SelectionToolbar.tsx
+++ b/components/workspace/editor/SelectionToolbar.tsx
@@ -14,7 +14,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
-import { MessageSquarePlus, Send, X } from 'lucide-react';
+import { MessageSquarePlus, Send, X, Highlighter, Strikethrough, Flag } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
@@ -156,6 +156,60 @@ export function SelectionToolbar({
     onCommentCreated?.();
   }, [editor, commentText, commentCategory, currentUserId, currentUserName, onCommentCreated]);
 
+  // -------------------------------------------------------------------------
+  // Quick mark handlers — one-click highlight / redline / flag
+  // -------------------------------------------------------------------------
+
+  const handleQuickMark = useCallback(
+    (type: 'highlight' | 'redline' | 'flag') => {
+      const { from, to } = editor.state.selection;
+      if (from === to) return;
+
+      const categoryMap: Record<string, CommentCategory> = {
+        highlight: 'note',
+        redline: 'concern',
+        flag: 'concern',
+      };
+      const textMap: Record<string, string> = {
+        highlight: '[Highlighted for review]',
+        redline: '[Suggested for deletion]',
+        flag: '[Flagged as concerning]',
+      };
+
+      const commentId = `comment-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const wasEditable = editor.isEditable;
+      if (!wasEditable) editor.setEditable(true);
+
+      editor
+        .chain()
+        .focus()
+        .command(({ tr }) => {
+          const markType = editor.schema.marks.inlineComment;
+          if (!markType) return false;
+          tr.addMark(
+            from,
+            to,
+            markType.create({
+              id: commentId,
+              author: currentUserName,
+              authorId: currentUserId,
+              timestamp: new Date().toISOString(),
+              category: categoryMap[type],
+              text: textMap[type],
+            }),
+          );
+          return true;
+        })
+        .setTextSelection({ from, to })
+        .run();
+
+      if (!wasEditable) editor.setEditable(false);
+      setVisible(false);
+      onCommentCreated?.();
+    },
+    [editor, currentUserId, currentUserName, onCommentCreated],
+  );
+
   const handleCancel = useCallback(() => {
     setShowCommentInput(false);
     setCommentText('');
@@ -176,14 +230,38 @@ export function SelectionToolbar({
     >
       <div className="flex items-center gap-1 rounded-lg border border-border bg-background shadow-lg p-1">
         {!showCommentInput ? (
-          <button
-            onClick={() => setShowCommentInput(true)}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground rounded-md hover:bg-muted/50 transition-colors cursor-pointer"
-            title="Add comment"
-          >
-            <MessageSquarePlus className="h-3.5 w-3.5" />
-            Comment
-          </button>
+          <>
+            <button
+              onClick={() => setShowCommentInput(true)}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground rounded-md hover:bg-muted/50 transition-colors cursor-pointer"
+              title="Add comment"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" />
+              Comment
+            </button>
+            <div className="w-px h-4 bg-border" />
+            <button
+              onClick={() => handleQuickMark('highlight')}
+              className="p-1.5 text-amber-400/70 hover:text-amber-400 rounded-md hover:bg-amber-500/10 transition-colors cursor-pointer"
+              title="Highlight"
+            >
+              <Highlighter className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => handleQuickMark('redline')}
+              className="p-1.5 text-rose-400/70 hover:text-rose-400 rounded-md hover:bg-rose-500/10 transition-colors cursor-pointer"
+              title="Suggest deletion (redline)"
+            >
+              <Strikethrough className="h-3.5 w-3.5" />
+            </button>
+            <button
+              onClick={() => handleQuickMark('flag')}
+              className="p-1.5 text-red-400/70 hover:text-red-400 rounded-md hover:bg-red-500/10 transition-colors cursor-pointer"
+              title="Flag as concerning"
+            >
+              <Flag className="h-3.5 w-3.5" />
+            </button>
+          </>
         ) : (
           <div className="flex flex-col gap-2 p-2 min-w-[280px]">
             {/* Category selector */}

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -320,8 +320,6 @@ interface StudioReviewInnerProps {
   voteToast: { vote: string; visible: boolean } | null;
   getStatus: (txHash: string, proposalIndex: number) => string | undefined;
   queueLabels: string[];
-  editorMode: 'edit' | 'review' | 'diff';
-  setEditorMode: (mode: 'edit' | 'review' | 'diff') => void;
 }
 
 function StudioReviewInner({
@@ -343,8 +341,6 @@ function StudioReviewInner({
   voteToast,
   getStatus,
   queueLabels,
-  editorMode,
-  setEditorMode,
 }: StudioReviewInnerProps) {
   const { panelOpen, activePanel, togglePanel, isFullWidth, toggleFullWidth } = useStudio();
   const actionZoneRef = useRef<HTMLDivElement>(null);
@@ -398,9 +394,20 @@ function StudioReviewInner({
         queueLabels={queueLabels}
         segmentBadge={segmentBadge}
         notificationCount={unreadCount}
-        showModeSwitch={true}
-        mode={editorMode}
-        onModeChange={setEditorMode}
+        actions={
+          <div className="flex items-center rounded-md border border-border bg-muted/30 p-0.5">
+            <button className="px-3 py-1 text-[11px] font-medium rounded-sm bg-background text-foreground shadow-sm cursor-default">
+              Review
+            </button>
+            <button
+              disabled
+              className="px-3 py-1 text-[11px] font-medium rounded-sm text-muted-foreground/40 cursor-not-allowed"
+              title="No previous revisions available for comparison"
+            >
+              Diff
+            </button>
+          </div>
+        }
         panelOpen={panelOpen}
         activePanel={activePanel}
         onPanelToggle={togglePanel}
@@ -423,25 +430,14 @@ function StudioReviewInner({
               key={`proposal-${selectedItem.txHash}-${selectedItem.proposalIndex}`}
               className="animate-in fade-in duration-150"
             >
-              {editorMode === 'diff' ? (
-                <div className="rounded-lg border border-border bg-muted/10 p-8 text-center">
-                  <p className="text-sm text-muted-foreground">
-                    No previous version available for comparison.
-                  </p>
-                  <p className="text-xs text-muted-foreground/60 mt-1">
-                    Diff view is available when a proposal has multiple versions.
-                  </p>
-                </div>
-              ) : (
-                <ProposalEditor
-                  content={itemContent}
-                  mode="review"
-                  readOnly={true}
-                  currentUserId={stakeAddress ?? 'anonymous'}
-                  onEditorReady={handleEditorReady}
-                  excludeFields={['title']}
-                />
-              )}
+              <ProposalEditor
+                content={itemContent}
+                mode="review"
+                readOnly={true}
+                currentUserId={stakeAddress ?? 'anonymous'}
+                onEditorReady={handleEditorReady}
+                excludeFields={['title']}
+              />
               {/* ReviewActionZone below editor */}
               <div className="mt-6" ref={actionZoneRef}>
                 <ReviewActionZone
@@ -538,7 +534,6 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
 
   const [selectedIndex, setSelectedIndex] = useState(-1); // -1 = not yet auto-selected
   const [voteToast, setVoteToast] = useState<{ vote: string; visible: boolean } | null>(null);
-  const [editorMode, setEditorMode] = useState<'edit' | 'review' | 'diff'>('review');
   const lastTrackedRef = useRef<string | null>(null);
   const editorRef = useRef<Editor | null>(null);
 
@@ -592,9 +587,7 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
   const selectedItem = items[selectedIndex] ?? null;
 
   // Reset editor mode to 'review' when switching proposals
-  useEffect(() => {
-    setEditorMode('review');
-  }, [selectedIndex]);
+  useEffect(() => {}, [selectedIndex]);
 
   // Track proposal view when selection changes
   useEffect(() => {
@@ -867,8 +860,6 @@ export function ReviewWorkspace({ initialProposalKey }: ReviewWorkspaceProps = {
         voteToast={voteToast}
         getStatus={getStatus}
         queueLabels={queueLabels}
-        editorMode={editorMode}
-        setEditorMode={setEditorMode}
       />
     </StudioProvider>
   );


### PR DESCRIPTION
## Summary
- **Mode switcher fixed**: Reviewers now see Review (active) + Diff (disabled with tooltip) — no more Edit option
- **Agent quick suggestions redesigned**: Reviewer-focused prompts (risks, arguments, rationale draft, proposer questions) that auto-submit on click
- **Legal markup toolbar**: Highlight (amber), Redline/Strikethrough (rose), and Flag (red) one-click tools added to the selection toolbar alongside Comment

## Impact
- **What changed**: Mode switcher finally correct for reviewers, agent suggestions are contextual and frictionless, legal-grade annotation tools available
- **User-facing**: Yes — cleaner mode switcher, one-click agent prompts, professional review tools
- **Risk**: Low — 3 files changed, all additive/corrective
- **Scope**: ReviewWorkspace, AgentChatPanel, SelectionToolbar

## Test plan
- [ ] Verify mode switcher shows Review (active) + Diff (disabled with hover tooltip)
- [ ] Click agent quick suggestion — verify it auto-submits (no input population)
- [ ] Select text → verify 4 tools: Comment, Highlight, Redline, Flag
- [ ] Click Highlight — verify amber annotation applied
- [ ] Click Redline — verify rose annotation applied
- [ ] Click Flag — verify red annotation applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)