### PR TITLE
feat: semantic research precedent and proposal similarity

### DIFF
--- a/lib/ai/skills/research-precedent.ts
+++ b/lib/ai/skills/research-precedent.ts
@@ -3,12 +3,19 @@
  *
  * Finds and analyzes similar past proposals, comparing outcomes and
  * highlighting patterns relevant to the user's governance perspective.
+ *
+ * When the `embedding_research_precedent` feature flag is ON, uses
+ * semantic embedding search for higher-quality precedent matching.
+ * Falls back to exact proposal_type matching when OFF or on error.
  */
 
 import { z } from 'zod';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { registerSkill } from './registry';
 import type { SkillContext } from './types';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { semanticSearch } from '@/lib/embeddings';
+import { logger } from '@/lib/logger';
 
 const inputSchema = z.object({
   proposalTitle: z.string().min(1),
@@ -100,25 +107,58 @@ given their governance priorities. Not generic questions.`,
   },
 });
 
+type SimilarProposalRow = {
+  tx_hash: string;
+  title: string;
+  proposal_type: string;
+  withdrawal_amount: number | null;
+  ratified_epoch: number | null;
+  expired_epoch: number | null;
+  dropped_epoch: number | null;
+};
+
 /**
  * Fetch similar proposals from the database for context injection.
  * Called by the skill API route before generating the prompt.
+ *
+ * When `embedding_research_precedent` flag is ON:
+ *   1. Generates embedding from title + abstract
+ *   2. Runs semantic search against stored proposal embeddings
+ *   3. Enriches results with outcome data
+ *   Falls back to type-based matching on error.
+ *
+ * When flag is OFF: existing behavior (exact match on proposal_type).
  */
 export async function fetchSimilarProposals(
   proposalType: string,
-  _title: string,
+  title: string,
   limit = 5,
-): Promise<
-  Array<{
-    tx_hash: string;
-    title: string;
-    proposal_type: string;
-    withdrawal_amount: number | null;
-    ratified_epoch: number | null;
-    expired_epoch: number | null;
-    dropped_epoch: number | null;
-  }>
-> {
+  proposalAbstract?: string,
+): Promise<SimilarProposalRow[]> {
+  const useEmbeddings = await getFeatureFlag('embedding_research_precedent', false);
+
+  if (useEmbeddings) {
+    try {
+      const results = await fetchSimilarByEmbedding(title, limit, proposalAbstract);
+      if (results.length > 0) return results;
+      // Fall through to type-based if semantic returned nothing
+    } catch (err) {
+      logger.warn('[research-precedent] Semantic search failed, falling back to type match', {
+        error: err,
+      });
+    }
+  }
+
+  return fetchSimilarByType(proposalType, limit);
+}
+
+/**
+ * Original type-based matching: proposals with the same proposal_type.
+ */
+async function fetchSimilarByType(
+  proposalType: string,
+  limit: number,
+): Promise<SimilarProposalRow[]> {
   const supabase = getSupabaseAdmin();
   const { data } = await supabase
     .from('proposals')
@@ -131,4 +171,50 @@ export async function fetchSimilarProposals(
     .limit(limit);
 
   return data ?? [];
+}
+
+/**
+ * Embedding-based semantic search: find proposals with similar meaning
+ * regardless of proposal_type. Enriches semantic results with outcome data.
+ */
+async function fetchSimilarByEmbedding(
+  title: string,
+  limit: number,
+  proposalAbstract?: string,
+): Promise<SimilarProposalRow[]> {
+  const queryText = proposalAbstract ? `${title}\n\n${proposalAbstract}` : title;
+
+  const semanticResults = await semanticSearch(queryText, 'proposal', {
+    threshold: 0.4,
+    limit,
+  });
+
+  if (semanticResults.length === 0) return [];
+
+  // Enrich with proposal details and outcome data
+  const supabase = getSupabaseAdmin();
+  const txHashes = semanticResults.map((r) => r.entity_id);
+
+  const { data: proposals } = await supabase
+    .from('proposals')
+    .select(
+      'tx_hash, title, proposal_type, withdrawal_amount, ratified_epoch, expired_epoch, dropped_epoch',
+    )
+    .in('tx_hash', txHashes)
+    .not('title', 'is', null);
+
+  if (!proposals || proposals.length === 0) return [];
+
+  // Preserve semantic ranking order
+  const proposalMap = new Map(proposals.map((p) => [p.tx_hash, p]));
+  const ordered: SimilarProposalRow[] = [];
+
+  for (const result of semanticResults) {
+    const proposal = proposalMap.get(result.entity_id);
+    if (proposal) {
+      ordered.push(proposal);
+    }
+  }
+
+  return ordered;
 }

--- a/lib/proposalSimilarity.ts
+++ b/lib/proposalSimilarity.ts
@@ -1,10 +1,21 @@
 /**
  * Classification-Based Proposal Similarity
+ *
  * Uses cosine similarity on 6D classification vectors from proposal_classifications.
+ *
+ * When `embedding_proposal_similarity` flag is ON, computes a hybrid score:
+ *   0.4 * classificationSimilarity + 0.6 * embeddingSimilarity
+ * using precomputed embedding similarities from `semantic_similarity_cache`.
+ * Falls back to classification-only when embeddings are unavailable.
  */
 
 import { getSupabaseAdmin, createClient } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import {
+  getEntityEmbedding,
+  cosineSimilarity as embeddingCosineSimilarity,
+} from '@/lib/embeddings';
 
 export interface SimilarProposalResult {
   txHash: string;
@@ -59,6 +70,9 @@ export function computeProposalSimilarity(vecA: number[], vecB: number[]): numbe
 
 /**
  * Find top-N similar proposals to a given proposal by classification vector.
+ *
+ * When `embedding_proposal_similarity` flag is ON, computes hybrid scores
+ * using both classification and embedding similarity.
  */
 export async function findSimilarByClassification(
   txHash: string,
@@ -85,17 +99,49 @@ export async function findSimilarByClassification(
   if (!allClassifications) return [];
 
   const allRows = (allClassifications || []) as unknown as Array<Record<string, number | string>>;
-  const scored = allRows
+
+  // Compute classification similarity for all candidates
+  const classificationScored = allRows
     .filter((c) => !(c.proposal_tx_hash === txHash && c.proposal_index === index))
     .map((c) => {
       const vec = DIMENSIONS.map((d) => Number(c[d]) || 0);
       return {
         txHash: c.proposal_tx_hash as string,
         index: c.proposal_index as number,
-        score: computeProposalSimilarity(sourceVec, vec),
+        classificationScore: computeProposalSimilarity(sourceVec, vec),
       };
     })
-    .filter((s) => s.score > 0.1)
+    .filter((s) => s.classificationScore > 0.1);
+
+  if (classificationScored.length === 0) return [];
+
+  // Check if hybrid scoring is enabled
+  const useHybrid = await getFeatureFlag('embedding_proposal_similarity', false);
+  let embeddingScores: Map<string, number> | null = null;
+
+  if (useHybrid) {
+    embeddingScores = await getEmbeddingSimilarities(txHash, classificationScored);
+  }
+
+  // Compute final scores
+  const scored = classificationScored
+    .map((s) => {
+      const key = `${s.txHash}-${s.index}`;
+      const embScore = embeddingScores?.get(key);
+
+      // Hybrid: 0.4 classification + 0.6 embedding (when available)
+      // Falls back to classification-only if no embedding for this pair
+      const score =
+        embeddingScores && embScore !== undefined
+          ? CLASSIFICATION_WEIGHT * s.classificationScore + EMBEDDING_WEIGHT * embScore
+          : s.classificationScore;
+
+      return {
+        txHash: s.txHash,
+        index: s.index,
+        score,
+      };
+    })
     .sort((a, b) => b.score - a.score)
     .slice(0, limit);
 
@@ -125,9 +171,78 @@ export async function findSimilarByClassification(
   });
 }
 
+/** Hybrid scoring weights */
+const CLASSIFICATION_WEIGHT = 0.4;
+const EMBEDDING_WEIGHT = 0.6;
+
+/**
+ * Fetch embedding similarities for the source proposal vs candidates.
+ * Tries precomputed cache first, falls back to live computation.
+ */
+async function getEmbeddingSimilarities(
+  sourceTxHash: string,
+  candidates: Array<{ txHash: string; index: number }>,
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+
+  try {
+    const supabase = createClient();
+
+    // Try precomputed cache first
+    const { data: cached } = await supabase
+      .from('semantic_similarity_cache')
+      .select('target_entity_id, similarity')
+      .eq('source_entity_type', 'proposal')
+      .eq('source_entity_id', sourceTxHash)
+      .eq('target_entity_type', 'proposal')
+      .in(
+        'target_entity_id',
+        candidates.map((c) => c.txHash),
+      );
+
+    if (cached && cached.length > 0) {
+      for (const row of cached) {
+        // Map using first candidate with this txHash to get the index
+        const candidate = candidates.find((c) => c.txHash === row.target_entity_id);
+        if (candidate) {
+          result.set(`${row.target_entity_id}-${candidate.index}`, row.similarity);
+        }
+      }
+    }
+
+    // For candidates not in cache, try live embedding comparison
+    const uncachedCandidates = candidates.filter((c) => !result.has(`${c.txHash}-${c.index}`));
+
+    if (uncachedCandidates.length > 0) {
+      const sourceEmbedding = await getEntityEmbedding('proposal', sourceTxHash);
+      if (sourceEmbedding) {
+        for (const candidate of uncachedCandidates) {
+          const targetEmbedding = await getEntityEmbedding('proposal', candidate.txHash);
+          if (targetEmbedding) {
+            const similarity = embeddingCosineSimilarity(sourceEmbedding, targetEmbedding);
+            result.set(`${candidate.txHash}-${candidate.index}`, similarity);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn(
+      '[proposalSimilarity] Embedding similarity lookup failed, using classification only',
+      {
+        error: err,
+      },
+    );
+  }
+
+  return result;
+}
+
 /**
  * Precompute top-5 similar proposals for each classified proposal.
  * Stores results in proposal_similarity_cache.
+ *
+ * When `embedding_proposal_similarity` flag is ON, also precomputes
+ * semantic similarity pairs into `semantic_similarity_cache`.
  */
 export async function precomputeSimilarityCache(): Promise<number> {
   const supabase = getSupabaseAdmin();
@@ -195,6 +310,111 @@ export async function precomputeSimilarityCache(): Promise<number> {
     });
     if (!error) upserted += batch.length;
     else logger.error('[proposalSimilarity] Batch upsert error', { error: error.message });
+  }
+
+  // When embedding flag is ON, also precompute semantic similarity pairs
+  const useEmbeddings = await getFeatureFlag('embedding_proposal_similarity', false);
+  if (useEmbeddings) {
+    const embeddingPairs = await precomputeEmbeddingSimilarityCache(vectors, supabase);
+    logger.info('[proposalSimilarity] Embedding similarity cache updated', {
+      pairs: embeddingPairs,
+    });
+  }
+
+  return upserted;
+}
+
+/**
+ * Precompute embedding-based similarity pairs for proposals that have embeddings.
+ * Stores results in `semantic_similarity_cache` for fast lookup at query time.
+ */
+async function precomputeEmbeddingSimilarityCache(
+  vectors: ClassificationVector[],
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+): Promise<number> {
+  // Fetch all proposal embeddings
+  const txHashes = [...new Set(vectors.map((v) => v.txHash))];
+  const embeddingMap = new Map<string, number[]>();
+
+  // Fetch in batches to avoid query size limits
+  const FETCH_BATCH = 50;
+  for (let i = 0; i < txHashes.length; i += FETCH_BATCH) {
+    const batch = txHashes.slice(i, i + FETCH_BATCH);
+    const { data } = await supabase
+      .from('embeddings')
+      .select('entity_id, embedding')
+      .eq('entity_type', 'proposal')
+      .in('entity_id', batch);
+
+    if (data) {
+      for (const row of data) {
+        embeddingMap.set(row.entity_id, row.embedding as unknown as number[]);
+      }
+    }
+  }
+
+  if (embeddingMap.size < 2) return 0;
+
+  const embeddedHashes = [...embeddingMap.keys()];
+  const semanticRows: Array<{
+    source_entity_type: string;
+    source_entity_id: string;
+    target_entity_type: string;
+    target_entity_id: string;
+    similarity: number;
+    computed_at: string;
+  }> = [];
+
+  const now = new Date().toISOString();
+
+  for (let i = 0; i < embeddedHashes.length; i++) {
+    const sourceHash = embeddedHashes[i];
+    const sourceEmb = embeddingMap.get(sourceHash)!;
+
+    const similarities = embeddedHashes
+      .slice(i + 1) // Only compute each pair once (i < j)
+      .map((targetHash) => ({
+        targetHash,
+        score: embeddingCosineSimilarity(sourceEmb, embeddingMap.get(targetHash)!),
+      }))
+      .filter((s) => s.score > 0.3)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 10);
+
+    for (const { targetHash, score } of similarities) {
+      const roundedScore = Math.round(score * 1000) / 1000;
+      // Store both directions for fast lookup
+      semanticRows.push({
+        source_entity_type: 'proposal',
+        source_entity_id: sourceHash,
+        target_entity_type: 'proposal',
+        target_entity_id: targetHash,
+        similarity: roundedScore,
+        computed_at: now,
+      });
+      semanticRows.push({
+        source_entity_type: 'proposal',
+        source_entity_id: targetHash,
+        target_entity_type: 'proposal',
+        target_entity_id: sourceHash,
+        similarity: roundedScore,
+        computed_at: now,
+      });
+    }
+  }
+
+  if (semanticRows.length === 0) return 0;
+
+  let upserted = 0;
+  const BATCH_SIZE = 200;
+
+  for (let i = 0; i < semanticRows.length; i += BATCH_SIZE) {
+    const batch = semanticRows.slice(i, i + BATCH_SIZE);
+    const { error } = await supabase.from('semantic_similarity_cache').upsert(batch, {
+      onConflict: 'source_entity_type,source_entity_id,target_entity_type,target_entity_id',
+    });
+    if (!error) upserted += batch.length;
+    else logger.error('[proposalSimilarity] Semantic cache upsert error', { error: error.message });
   }
 
   return upserted;


### PR DESCRIPTION
## Summary
- Enhanced research-precedent AI skill with embedding-based semantic search (flag: `embedding_research_precedent`)
- Hybrid proposal similarity scoring: 0.4 classification + 0.6 embedding (flag: `embedding_proposal_similarity`)
- Precompute embedding similarity cache alongside existing classification cache
- Graceful fallback to existing behavior when embeddings unavailable or flags OFF

## Impact
- **What changed**: Research precedent skill and proposal similarity now support semantic matching via embeddings
- **User-facing**: No — behind feature flags, disabled by default
- **Risk**: Low — additive only, all existing behavior preserved when flags OFF, graceful error handling with fallback
- **Scope**: 2 files modified (`lib/ai/skills/research-precedent.ts`, `lib/proposalSimilarity.ts`)

## Test plan
- [x] `npm run preflight` passes (685 tests, types, lint, format)
- [x] Existing tests unchanged and passing
- [x] Flag OFF produces identical behavior (default `false` for both flags)
- [x] Flag ON gracefully handles missing embeddings (try/catch with fallback)
- [x] Backward-compatible function signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)