### PR TITLE
feat: AI quality measurement for workspace

### DIFF
--- a/__tests__/workspace/aiQuality.test.ts
+++ b/__tests__/workspace/aiQuality.test.ts
@@ -1,0 +1,232 @@
+import { describe, test, expect } from 'vitest';
+import {
+  computeAiInfluence,
+  computeOriginality,
+  computeReviewRelevance,
+  computeReviewOriginality,
+  computeReviewDiversity,
+  detectHomogenization,
+} from '@/lib/workspace/aiQuality';
+
+describe('computeAiInfluence', () => {
+  test('identical vectors (no change) return 0', () => {
+    const v = [1, 0, 0];
+    expect(computeAiInfluence(v, v)).toBeCloseTo(0, 5);
+  });
+
+  test('orthogonal vectors (complete rewrite) return 100', () => {
+    const pre = [1, 0, 0];
+    const post = [0, 1, 0];
+    expect(computeAiInfluence(pre, post)).toBeCloseTo(100, 5);
+  });
+
+  test('partially similar vectors return middle range', () => {
+    const pre = [1, 0, 0];
+    const post = [1, 1, 0]; // cos_sim = 1/sqrt(2) ~= 0.707
+    const influence = computeAiInfluence(pre, post);
+    expect(influence).toBeGreaterThan(20);
+    expect(influence).toBeLessThan(50);
+  });
+
+  test('nearly identical vectors return low influence', () => {
+    const pre = [1, 0, 0];
+    const post = [0.99, 0.01, 0]; // very similar
+    const influence = computeAiInfluence(pre, post);
+    expect(influence).toBeGreaterThanOrEqual(0);
+    expect(influence).toBeLessThan(5);
+  });
+});
+
+describe('computeOriginality', () => {
+  test('unique draft vs no corpus returns 100', () => {
+    const draft = [1, 0, 0];
+    expect(computeOriginality(draft, [])).toBe(100);
+  });
+
+  test('identical copy of existing returns ~0', () => {
+    const draft = [1, 0, 0];
+    const existing = [[1, 0, 0]];
+    expect(computeOriginality(draft, existing)).toBeCloseTo(0, 5);
+  });
+
+  test('orthogonal to all existing returns 100', () => {
+    const draft = [0, 0, 1];
+    const existing = [
+      [1, 0, 0],
+      [0, 1, 0],
+    ];
+    expect(computeOriginality(draft, existing)).toBeCloseTo(100, 5);
+  });
+
+  test('partially similar returns intermediate score', () => {
+    const draft = [1, 1, 0];
+    const existing = [[1, 0, 0]]; // cos_sim = 1/sqrt(2) ~= 0.707
+    const originality = computeOriginality(draft, existing);
+    expect(originality).toBeGreaterThan(20);
+    expect(originality).toBeLessThan(50);
+  });
+
+  test('most similar match determines score (not average)', () => {
+    const draft = [1, 0, 0];
+    const existing = [
+      [0, 1, 0], // orthogonal
+      [0.99, 0.01, 0], // very similar
+    ];
+    const originality = computeOriginality(draft, existing);
+    // Should be low because the second existing is very similar
+    expect(originality).toBeLessThan(5);
+  });
+});
+
+describe('computeReviewRelevance', () => {
+  test('on-topic annotation returns high score', () => {
+    const annotation = [1, 0, 0];
+    const section = [1, 0, 0];
+    expect(computeReviewRelevance(annotation, section)).toBeCloseTo(100, 5);
+  });
+
+  test('off-topic annotation returns ~0', () => {
+    const annotation = [0, 1, 0];
+    const section = [1, 0, 0];
+    expect(computeReviewRelevance(annotation, section)).toBeCloseTo(0, 5);
+  });
+
+  test('partially relevant returns intermediate score', () => {
+    const annotation = [1, 1, 0];
+    const section = [1, 0, 0];
+    const relevance = computeReviewRelevance(annotation, section);
+    expect(relevance).toBeGreaterThan(50);
+    expect(relevance).toBeLessThan(100);
+  });
+});
+
+describe('computeReviewOriginality', () => {
+  test('paraphrase of section returns ~0', () => {
+    const annotation = [1, 0, 0];
+    const section = [1, 0, 0];
+    expect(computeReviewOriginality(annotation, section)).toBeCloseTo(0, 5);
+  });
+
+  test('novel concern returns high score', () => {
+    const annotation = [0, 1, 0];
+    const section = [1, 0, 0];
+    expect(computeReviewOriginality(annotation, section)).toBeCloseTo(100, 5);
+  });
+
+  test('partially novel returns intermediate score', () => {
+    const annotation = [1, 1, 0];
+    const section = [1, 0, 0];
+    const originality = computeReviewOriginality(annotation, section);
+    expect(originality).toBeGreaterThan(20);
+    expect(originality).toBeLessThan(50);
+  });
+});
+
+describe('computeReviewDiversity', () => {
+  test('single annotation returns diversity 0 and cluster count 1', () => {
+    const result = computeReviewDiversity([[1, 0, 0]]);
+    expect(result.diversityScore).toBe(0);
+    expect(result.clusterCount).toBe(1);
+  });
+
+  test('empty input returns diversity 0 and cluster count 0', () => {
+    const result = computeReviewDiversity([]);
+    expect(result.diversityScore).toBe(0);
+    expect(result.clusterCount).toBe(0);
+  });
+
+  test('identical annotations return diversity 0 and cluster count 1', () => {
+    const result = computeReviewDiversity([
+      [1, 0, 0],
+      [1, 0, 0],
+      [1, 0, 0],
+    ]);
+    expect(result.diversityScore).toBe(0);
+    expect(result.clusterCount).toBe(1);
+  });
+
+  test('orthogonal annotations return high diversity and multiple clusters', () => {
+    const result = computeReviewDiversity([
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ]);
+    expect(result.diversityScore).toBeCloseTo(1, 5);
+    expect(result.clusterCount).toBe(3);
+  });
+
+  test('mixed annotations return intermediate diversity', () => {
+    const result = computeReviewDiversity([
+      [1, 0, 0],
+      [1, 0, 0], // duplicate of first
+      [0, 1, 0], // different
+    ]);
+    expect(result.diversityScore).toBeGreaterThan(0);
+    expect(result.diversityScore).toBeLessThan(1);
+    expect(result.clusterCount).toBe(2);
+  });
+});
+
+describe('detectHomogenization', () => {
+  test('tighter AI cluster triggers homogenization risk', () => {
+    // AI proposals all very similar (tight cluster)
+    const aiEmbeddings = [
+      [1, 0.01, 0],
+      [1, 0.02, 0],
+      [1, -0.01, 0],
+    ];
+    // Non-AI proposals are diverse
+    const nonAiEmbeddings = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    const result = detectHomogenization(aiEmbeddings, nonAiEmbeddings);
+    expect(result.homogenizationRisk).toBe(true);
+    expect(result.aiClusterTightness).toBeGreaterThan(result.nonAiClusterTightness);
+  });
+
+  test('diverse AI cluster does not trigger risk', () => {
+    // AI proposals are diverse
+    const aiEmbeddings = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    // Non-AI proposals are tight
+    const nonAiEmbeddings = [
+      [1, 0.01, 0],
+      [1, 0.02, 0],
+      [1, -0.01, 0],
+    ];
+    const result = detectHomogenization(aiEmbeddings, nonAiEmbeddings);
+    expect(result.homogenizationRisk).toBe(false);
+  });
+
+  test('insufficient data does not flag risk', () => {
+    const aiEmbeddings = [[1, 0, 0]]; // only 1
+    const nonAiEmbeddings = [
+      [1, 0, 0],
+      [0, 1, 0],
+    ];
+    const result = detectHomogenization(aiEmbeddings, nonAiEmbeddings);
+    expect(result.homogenizationRisk).toBe(false);
+  });
+
+  test('both groups insufficient returns no risk', () => {
+    const result = detectHomogenization([[1, 0, 0]], [[0, 1, 0]]);
+    expect(result.homogenizationRisk).toBe(false);
+    expect(result.aiClusterTightness).toBe(1); // 1 - 0 diversity
+    expect(result.nonAiClusterTightness).toBe(1);
+  });
+
+  test('equal tightness does not flag risk', () => {
+    const embeddings = [
+      [1, 0, 0],
+      [0, 1, 0],
+    ];
+    const result = detectHomogenization(embeddings, embeddings);
+    expect(result.homogenizationRisk).toBe(false);
+    expect(result.aiClusterTightness).toBeCloseTo(result.nonAiClusterTightness, 5);
+  });
+});

--- a/app/api/ai/skill/route.ts
+++ b/app/api/ai/skill/route.ts
@@ -6,6 +6,9 @@
  *
  * Validates input against the skill's schema, injects personal context,
  * executes via the AI provider, logs provenance, and returns structured output.
+ *
+ * When `embedding_ai_quality` flag is ON and a draftId is provided,
+ * embeds the draft before and after skill execution to compute AI influence.
  */
 
 import { NextResponse } from 'next/server';
@@ -15,6 +18,7 @@ import { createAIProvider } from '@/lib/ai/provider';
 import { assemblePersonalContext, formatPersonalContext } from '@/lib/ai/context';
 import { getSkill, loadBuiltinSkills } from '@/lib/ai/skills/registry';
 import { getFeatureFlag } from '@/lib/featureFlags';
+import { logger } from '@/lib/logger';
 import type { SkillContext } from '@/lib/ai/skills/types';
 
 export const dynamic = 'force-dynamic';
@@ -27,6 +31,122 @@ const SkillRequestSchema = z.object({
   proposalIndex: z.number().optional(),
   draftId: z.string().optional(),
 });
+
+/**
+ * Embed the current draft content and return the embedding vector.
+ * Returns null if the draft is not found or embedding fails.
+ */
+async function embedDraft(draftId: string): Promise<number[] | null> {
+  try {
+    const { getSupabaseAdmin } = await import('@/lib/supabase');
+    const { composeProposalDraft } = await import('@/lib/embeddings/compose');
+    const { generateEmbedding } = await import('@/lib/embeddings/provider');
+
+    const supabase = getSupabaseAdmin();
+    const { data: draft } = await supabase
+      .from('proposal_drafts')
+      .select('id, title, abstract, motivation, rationale')
+      .eq('id', draftId)
+      .single();
+
+    if (!draft) return null;
+
+    const composed = composeProposalDraft({
+      draft_id: draft.id,
+      title: draft.title,
+      abstract: draft.abstract,
+      motivation: draft.motivation,
+      rationale: draft.rationale,
+    });
+
+    if (composed.text.length < 20) return null;
+
+    return await generateEmbedding(composed.text);
+  } catch (err) {
+    logger.warn('[ai-quality] Failed to embed draft', { draftId, error: err });
+    return null;
+  }
+}
+
+/**
+ * Post-skill: compute AI influence, store the post-embedding, and update the draft score.
+ * Runs asynchronously — errors are logged but do not block the response.
+ */
+async function computeAndStoreAiInfluence(draftId: string, preEmbedding: number[]): Promise<void> {
+  try {
+    const postEmbedding = await embedDraft(draftId);
+    if (!postEmbedding) return;
+
+    const { computeAiInfluence } = await import('@/lib/workspace/aiQuality');
+    const influence = computeAiInfluence(preEmbedding, postEmbedding);
+
+    // Store post-embedding in the embeddings table
+    const { getSupabaseAdmin } = await import('@/lib/supabase');
+    const supabase = getSupabaseAdmin();
+
+    // Upsert the embedding (delete + insert pattern from generate.ts)
+    await supabase
+      .from('embeddings')
+      .delete()
+      .eq('entity_type', 'proposal_draft')
+      .eq('entity_id', draftId)
+      .is('secondary_id', null);
+
+    const { createHash } = await import('crypto');
+    const { composeProposalDraft } = await import('@/lib/embeddings/compose');
+    const { data: draft } = await supabase
+      .from('proposal_drafts')
+      .select('id, title, abstract, motivation, rationale')
+      .eq('id', draftId)
+      .single();
+
+    if (draft) {
+      const composed = composeProposalDraft({
+        draft_id: draft.id,
+        title: draft.title,
+        abstract: draft.abstract,
+        motivation: draft.motivation,
+        rationale: draft.rationale,
+      });
+
+      await supabase.from('embeddings').insert({
+        entity_type: 'proposal_draft',
+        entity_id: draftId,
+        secondary_id: null,
+        embedding: JSON.stringify(postEmbedding),
+        content_hash: createHash('sha256').update(composed.text).digest('hex'),
+        model: 'text-embedding-3-large',
+        dimensions: 3072,
+        metadata: { source: 'ai_skill_lifecycle' },
+        updated_at: new Date().toISOString(),
+      });
+    }
+
+    // High-water mark: only update if new score > existing
+    const { data: existingDraft } = await supabase
+      .from('proposal_drafts')
+      .select('ai_influence_score')
+      .eq('id', draftId)
+      .single();
+
+    if (
+      existingDraft &&
+      (existingDraft.ai_influence_score === null || influence > existingDraft.ai_influence_score)
+    ) {
+      await supabase
+        .from('proposal_drafts')
+        .update({ ai_influence_score: influence })
+        .eq('id', draftId);
+    }
+
+    logger.info('[ai-quality] AI influence computed', {
+      draftId,
+      influence: Math.round(influence * 10) / 10,
+    });
+  } catch (err) {
+    logger.warn('[ai-quality] Failed to compute AI influence', { draftId, error: err });
+  }
+}
 
 export const POST = withRouteHandler(
   async (request, ctx) => {
@@ -51,6 +171,16 @@ export const POST = withRouteHandler(
 
     // Validate input against skill's schema
     const validatedInput = skill.inputSchema.parse(parsed.input);
+
+    // --- AI Quality: pre-skill embedding (non-blocking) ---
+    let preEmbedding: number[] | null = null;
+    const aiQualityEnabled = parsed.draftId
+      ? await getFeatureFlag('embedding_ai_quality', false)
+      : false;
+
+    if (aiQualityEnabled && parsed.draftId) {
+      preEmbedding = await embedDraft(parsed.draftId);
+    }
 
     // Assemble personal context
     const stakeAddress = ctx.wallet ?? '';
@@ -102,6 +232,12 @@ export const POST = withRouteHandler(
       draftId: parsed.draftId,
       inputSummary: JSON.stringify(validatedInput).slice(0, 200),
     });
+
+    // --- AI Quality: post-skill embedding + influence score (fire-and-forget) ---
+    if (aiQualityEnabled && parsed.draftId && preEmbedding) {
+      // Fire and forget — do not await, do not block the response
+      void computeAndStoreAiInfluence(parsed.draftId, preEmbedding);
+    }
 
     return NextResponse.json({
       output,

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -50,6 +50,7 @@ import { clusterPerspectives } from '@/inngest/functions/cluster-perspectives';
 import { consolidateFeedbackFn } from '@/inngest/functions/consolidate-feedback';
 import { generateEmbeddings as generateEmbeddingsFn } from '@/inngest/functions/generate-embeddings';
 import { generateUserEmbedding } from '@/inngest/functions/generate-user-embedding';
+import { computeAiQuality } from '@/inngest/functions/compute-ai-quality';
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [
@@ -101,5 +102,6 @@ export const { GET, POST, PUT } = serve({
     consolidateFeedbackFn,
     generateEmbeddingsFn,
     generateUserEmbedding,
+    computeAiQuality,
   ],
 });

--- a/inngest/functions/compute-ai-quality.ts
+++ b/inngest/functions/compute-ai-quality.ts
@@ -1,0 +1,166 @@
+/**
+ * Compute AI Quality — Inngest cron function.
+ *
+ * Runs every 12 hours. Computes cross-proposal quality metrics:
+ * 1. Originality scores for all proposal drafts (compare each vs published proposals)
+ * 2. Homogenization detection (compare AI-assisted vs non-AI clustering)
+ *
+ * Gated behind `embedding_ai_quality` feature flag.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { logger } from '@/lib/logger';
+import { computeOriginality, detectHomogenization } from '@/lib/workspace/aiQuality';
+
+export const computeAiQuality = inngest.createFunction(
+  {
+    id: 'compute-ai-quality',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"ai-quality"' },
+  },
+  { cron: '0 */12 * * *' },
+  async ({ step }) => {
+    // Step 1: Check feature flag
+    const enabled = await step.run('check-flag', async () => {
+      return getFeatureFlag('embedding_ai_quality', false);
+    });
+
+    if (!enabled) return { skipped: true, reason: 'feature flag disabled' };
+
+    // Step 2: Compute originality scores for all proposal drafts
+    const originalityResult = await step.run('compute-originality', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get all published proposal embeddings (the corpus)
+      const { data: publishedEmbeddings } = await supabase
+        .from('embeddings')
+        .select('entity_id, embedding')
+        .eq('entity_type', 'proposal')
+        .limit(500);
+
+      if (!publishedEmbeddings?.length) {
+        return { updated: 0, reason: 'no published proposal embeddings' };
+      }
+
+      const corpus = publishedEmbeddings.map(
+        (e) =>
+          (typeof e.embedding === 'string' ? JSON.parse(e.embedding) : e.embedding) as number[],
+      );
+
+      // Get all draft embeddings
+      const { data: draftEmbeddings } = await supabase
+        .from('embeddings')
+        .select('entity_id, embedding')
+        .eq('entity_type', 'proposal_draft')
+        .limit(500);
+
+      if (!draftEmbeddings?.length) {
+        return { updated: 0, reason: 'no draft embeddings' };
+      }
+
+      let updated = 0;
+
+      for (const draft of draftEmbeddings) {
+        const embedding = (
+          typeof draft.embedding === 'string' ? JSON.parse(draft.embedding) : draft.embedding
+        ) as number[];
+
+        const originality = computeOriginality(embedding, corpus);
+
+        const { error } = await supabase
+          .from('proposal_drafts')
+          .update({ ai_originality_score: originality })
+          .eq('id', draft.entity_id);
+
+        if (!error) updated++;
+      }
+
+      return { updated, totalDrafts: draftEmbeddings.length };
+    });
+
+    // Step 3: Compute homogenization metrics
+    const homogenizationResult = await step.run('compute-homogenization', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get draft IDs that have been AI-assisted (ai_influence_score > 0)
+      const { data: aiDrafts } = await supabase
+        .from('proposal_drafts')
+        .select('id')
+        .gt('ai_influence_score', 0)
+        .limit(500);
+
+      const { data: nonAiDrafts } = await supabase
+        .from('proposal_drafts')
+        .select('id')
+        .or('ai_influence_score.is.null,ai_influence_score.eq.0')
+        .limit(500);
+
+      const aiDraftIds = new Set((aiDrafts ?? []).map((d) => d.id));
+      const nonAiDraftIds = new Set((nonAiDrafts ?? []).map((d) => d.id));
+
+      // Get embeddings for both groups
+      const { data: allDraftEmbeddings } = await supabase
+        .from('embeddings')
+        .select('entity_id, embedding')
+        .eq('entity_type', 'proposal_draft')
+        .limit(1000);
+
+      if (!allDraftEmbeddings?.length) {
+        return { computed: false, reason: 'no draft embeddings' };
+      }
+
+      const aiEmbeddings: number[][] = [];
+      const nonAiEmbeddings: number[][] = [];
+
+      for (const row of allDraftEmbeddings) {
+        const embedding = (
+          typeof row.embedding === 'string' ? JSON.parse(row.embedding) : row.embedding
+        ) as number[];
+
+        if (aiDraftIds.has(row.entity_id)) {
+          aiEmbeddings.push(embedding);
+        } else if (nonAiDraftIds.has(row.entity_id)) {
+          nonAiEmbeddings.push(embedding);
+        }
+      }
+
+      if (aiEmbeddings.length < 2 || nonAiEmbeddings.length < 2) {
+        return {
+          computed: false,
+          reason: 'insufficient data for comparison',
+          aiCount: aiEmbeddings.length,
+          nonAiCount: nonAiEmbeddings.length,
+        };
+      }
+
+      const metrics = detectHomogenization(aiEmbeddings, nonAiEmbeddings);
+
+      logger.info('[compute-ai-quality] Homogenization analysis', {
+        aiClusterTightness: metrics.aiClusterTightness,
+        nonAiClusterTightness: metrics.nonAiClusterTightness,
+        homogenizationRisk: metrics.homogenizationRisk,
+        aiCount: aiEmbeddings.length,
+        nonAiCount: nonAiEmbeddings.length,
+      });
+
+      return {
+        computed: true,
+        ...metrics,
+        aiCount: aiEmbeddings.length,
+        nonAiCount: nonAiEmbeddings.length,
+      };
+    });
+
+    logger.info('[compute-ai-quality] Batch complete', {
+      originality: originalityResult,
+      homogenization: homogenizationResult,
+    });
+
+    return {
+      originality: originalityResult,
+      homogenization: homogenizationResult,
+    };
+  },
+);

--- a/lib/workspace/aiQuality.ts
+++ b/lib/workspace/aiQuality.ts
@@ -1,0 +1,170 @@
+/**
+ * AI Quality Measurement Module
+ *
+ * Measures AI influence on proposal drafting and review quality using
+ * semantic embeddings. All functions operate on pre-computed embedding
+ * vectors — no API calls or database access here.
+ *
+ * Gated behind the `embedding_ai_quality` feature flag.
+ */
+
+import { cosineSimilarity } from '@/lib/embeddings/query';
+import { computePairwiseDiversity, computeCentroid } from '@/lib/embeddings/quality';
+
+/**
+ * AI Influence Score (0-100).
+ *
+ * Compares draft embedding before and after AI skill invocation.
+ * Higher = more AI influence on the content.
+ *
+ * Ranges:
+ *  0-20: Light touch-ups (formatting, grammar)
+ * 20-50: Structural improvements (reorganization, argument strengthening)
+ * 50-100: Substantial rewrite (new content direction)
+ */
+export function computeAiInfluence(preEmbedding: number[], postEmbedding: number[]): number {
+  const similarity = cosineSimilarity(preEmbedding, postEmbedding);
+  return (1 - similarity) * 100;
+}
+
+/**
+ * Originality vs Corpus (0-100).
+ *
+ * Compares a proposal draft embedding against all existing published
+ * proposal embeddings. Higher = more original/unique content.
+ *
+ * Returns 100 if there are no existing embeddings to compare against.
+ */
+export function computeOriginality(
+  draftEmbedding: number[],
+  existingEmbeddings: number[][],
+): number {
+  if (existingEmbeddings.length === 0) return 100;
+
+  let maxSimilarity = -Infinity;
+  for (const existing of existingEmbeddings) {
+    const sim = cosineSimilarity(draftEmbedding, existing);
+    if (sim > maxSimilarity) maxSimilarity = sim;
+  }
+
+  return (1 - maxSimilarity) * 100;
+}
+
+/**
+ * Review Relevance (0-100).
+ *
+ * How on-topic is a review annotation relative to the proposal section
+ * it's annotating. Higher = more relevant/on-topic.
+ */
+export function computeReviewRelevance(
+  annotationEmbedding: number[],
+  sectionEmbedding: number[],
+): number {
+  return cosineSimilarity(annotationEmbedding, sectionEmbedding) * 100;
+}
+
+/**
+ * Review Originality (0-100).
+ *
+ * Does the review add novel concerns vs just paraphrasing the proposal
+ * section? Higher = more original insight beyond what the section says.
+ */
+export function computeReviewOriginality(
+  annotationEmbedding: number[],
+  sectionEmbedding: number[],
+): number {
+  return (1 - cosineSimilarity(annotationEmbedding, sectionEmbedding)) * 100;
+}
+
+/**
+ * Review Diversity (per-proposal).
+ *
+ * For proposals with 3+ reviews, measures the spread of annotation
+ * embeddings. Higher diversity = more distinct perspectives being raised.
+ *
+ * Uses pairwise diversity and estimates distinct perspective clusters
+ * by counting groups of annotations with mutual similarity > 0.8.
+ */
+export function computeReviewDiversity(annotationEmbeddings: number[][]): {
+  diversityScore: number;
+  clusterCount: number;
+} {
+  if (annotationEmbeddings.length < 2) {
+    return { diversityScore: 0, clusterCount: annotationEmbeddings.length };
+  }
+
+  const diversityScore = computePairwiseDiversity(annotationEmbeddings);
+
+  // Estimate cluster count via greedy clustering:
+  // Assign each embedding to the first cluster whose centroid is > 0.8 similar,
+  // or create a new cluster.
+  const CLUSTER_THRESHOLD = 0.8;
+  const clusterCentroids: number[][] = [];
+
+  for (const embedding of annotationEmbeddings) {
+    let assigned = false;
+    for (const centroid of clusterCentroids) {
+      if (cosineSimilarity(embedding, centroid) > CLUSTER_THRESHOLD) {
+        assigned = true;
+        break;
+      }
+    }
+    if (!assigned) {
+      clusterCentroids.push(embedding);
+    }
+  }
+
+  return {
+    diversityScore,
+    clusterCount: clusterCentroids.length,
+  };
+}
+
+/**
+ * Homogenization Detection.
+ *
+ * Compares how tightly AI-assisted proposals cluster vs non-AI proposals.
+ * If AI-assisted proposals are more tightly clustered, that indicates
+ * the AI is reducing diversity of ideas across the ecosystem.
+ *
+ * Tightness = 1 - average pairwise distance (lower distance = tighter cluster).
+ * homogenizationRisk = true when AI proposals cluster more tightly than non-AI.
+ */
+export function detectHomogenization(
+  aiAssistedEmbeddings: number[][],
+  nonAiEmbeddings: number[][],
+): {
+  aiClusterTightness: number;
+  nonAiClusterTightness: number;
+  homogenizationRisk: boolean;
+} {
+  // Need at least 2 embeddings in each group to compare
+  const aiDiversity =
+    aiAssistedEmbeddings.length >= 2 ? computePairwiseDiversity(aiAssistedEmbeddings) : 0;
+  const nonAiDiversity =
+    nonAiEmbeddings.length >= 2 ? computePairwiseDiversity(nonAiEmbeddings) : 0;
+
+  // Tightness is inverse of diversity: lower diversity = tighter cluster
+  const aiTightness = 1 - aiDiversity;
+  const nonAiTightness = 1 - nonAiDiversity;
+
+  // Compute centroid spread as secondary signal
+  const aiCentroid =
+    aiAssistedEmbeddings.length >= 2 ? computeCentroid(aiAssistedEmbeddings) : null;
+  const nonAiCentroid = nonAiEmbeddings.length >= 2 ? computeCentroid(nonAiEmbeddings) : null;
+
+  // homogenizationRisk: AI proposals cluster tighter (higher tightness) than non-AI
+  // Only flag when both groups have enough data to compare meaningfully
+  const canCompare = aiAssistedEmbeddings.length >= 2 && nonAiEmbeddings.length >= 2;
+  const homogenizationRisk = canCompare && aiTightness > nonAiTightness;
+
+  // Suppress unused variable warnings — centroids reserved for future metrics
+  void aiCentroid;
+  void nonAiCentroid;
+
+  return {
+    aiClusterTightness: aiTightness,
+    nonAiClusterTightness: nonAiTightness,
+    homogenizationRisk,
+  };
+}


### PR DESCRIPTION
## Summary
- New `lib/workspace/aiQuality.ts` -- AI influence scoring, originality measurement, review diversity, homogenization detection
- AI skill lifecycle hooks: embed draft before/after skill execution, compute influence delta (fire-and-forget, non-blocking)
- Inngest batch job (`compute-ai-quality`, every 12h) for cross-proposal originality and homogenization metrics
- 25 unit tests covering all quality metric functions
- Gated behind `embedding_ai_quality` flag (default OFF)

## Impact
- **What changed**: AI quality measurement infrastructure for proposal authoring and review -- measures how much AI rewrites drafts, how original proposals are vs the corpus, how diverse review annotations are, and whether AI is homogenizing proposals
- **User-facing**: No -- behind feature flag, disabled by default
- **Risk**: Low -- additive only, all embedding work is non-blocking (failures logged but never block skill execution), new Inngest function registered
- **Scope**: New `lib/workspace/aiQuality.ts`, modified `app/api/ai/skill/route.ts`, new `inngest/functions/compute-ai-quality.ts`, modified `app/api/inngest/route.ts`, new `__tests__/workspace/aiQuality.test.ts`

## Test plan
- [x] `npm run preflight` passes (710/710 tests, lint, types, format all green)
- [x] 25 unit tests for all quality metrics (influence, originality, relevance, diversity, homogenization)
- [x] Existing tests unchanged and passing
- [x] Skill route works normally when flag OFF (no embedding logic runs)
- [x] Embedding failures don't block skill execution (fire-and-forget pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)