### PR TITLE
feat: semantic scoring signals — GHI, anti-gaming, CC blocs

### DIFF
--- a/__tests__/scoring/gamingDetection.test.ts
+++ b/__tests__/scoring/gamingDetection.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Gaming Detection Tests
+ *
+ * Tests the pure computation functions from gamingDetection.ts.
+ * Since the actual functions make DB calls, we test the underlying logic
+ * by importing the embedding quality/query helpers and verifying the
+ * detection thresholds work correctly with synthetic data.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { computePairwiseDiversity, computeCentroid } from '@/lib/embeddings/quality';
+import { cosineSimilarity } from '@/lib/embeddings/query';
+
+// ---------------------------------------------------------------------------
+// Rationale Farm Detection Logic
+// ---------------------------------------------------------------------------
+
+describe('Rationale Farm Detection', () => {
+  test('high-similarity set (> 0.92) is flagged as suspect', () => {
+    // Simulate near-identical rationale embeddings
+    const baseVector = [1, 0.1, 0.05, 0.02, 0];
+    const vectors = [
+      baseVector,
+      [1, 0.11, 0.04, 0.02, 0.01],
+      [1, 0.09, 0.06, 0.01, 0],
+      [1, 0.1, 0.05, 0.03, 0.01],
+      [1, 0.12, 0.04, 0.02, 0],
+      [1, 0.1, 0.05, 0.02, 0.01],
+      [1, 0.11, 0.05, 0.01, 0],
+      [1, 0.09, 0.06, 0.02, 0.01],
+      [1, 0.1, 0.04, 0.03, 0],
+      [1, 0.11, 0.05, 0.02, 0.01],
+    ];
+
+    const diversity = computePairwiseDiversity(vectors);
+    const meanSimilarity = 1 - diversity;
+
+    // These near-identical vectors should have very high mean similarity
+    expect(meanSimilarity).toBeGreaterThan(0.92);
+    expect(vectors.length).toBeGreaterThanOrEqual(10);
+
+    // This would trigger the suspect flag
+    const isSuspect = meanSimilarity > 0.92;
+    expect(isSuspect).toBe(true);
+  });
+
+  test('diverse rationale set is not flagged as suspect', () => {
+    // Simulate genuinely diverse rationales
+    const vectors = [
+      [1, 0, 0, 0, 0],
+      [0, 1, 0, 0, 0],
+      [0, 0, 1, 0, 0],
+      [0, 0, 0, 1, 0],
+      [0, 0, 0, 0, 1],
+      [1, 1, 0, 0, 0],
+      [0, 1, 1, 0, 0],
+      [0, 0, 1, 1, 0],
+      [0, 0, 0, 1, 1],
+      [1, 0, 0, 0, 1],
+    ];
+
+    const diversity = computePairwiseDiversity(vectors);
+    const meanSimilarity = 1 - diversity;
+
+    // Diverse set should have low mean similarity
+    expect(meanSimilarity).toBeLessThan(0.92);
+
+    const isSuspect = meanSimilarity > 0.92;
+    expect(isSuspect).toBe(false);
+  });
+
+  test('fewer than 10 rationales should not be assessed', () => {
+    const vectors = [
+      [1, 0, 0],
+      [1, 0, 0],
+      [1, 0, 0],
+    ];
+
+    // Even with identical rationales, fewer than 10 should not trigger
+    const rationaleCount = vectors.length;
+    expect(rationaleCount).toBeLessThan(10);
+
+    // The function returns early for < 10 rationales
+    const isSuspect = rationaleCount >= 10 && 1 - computePairwiseDiversity(vectors) > 0.92;
+    expect(isSuspect).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Template Detection Logic
+// ---------------------------------------------------------------------------
+
+describe('Template Detection', () => {
+  test('identical embeddings from different DReps form a cluster', () => {
+    // Simulate 6+ DReps with near-identical rationales
+    const baseVector = [1, 0.5, 0.2];
+
+    const drepEmbeddings = new Map<string, number[]>();
+    for (let i = 0; i < 8; i++) {
+      drepEmbeddings.set(`drep_${i}`, [
+        baseVector[0] + Math.random() * 0.01,
+        baseVector[1] + Math.random() * 0.01,
+        baseVector[2] + Math.random() * 0.01,
+      ]);
+    }
+
+    const entries = Array.from(drepEmbeddings.entries());
+    const clusterMembers: string[] = [entries[0][0]];
+    const clusterVectors: number[][] = [entries[0][1]];
+
+    for (let j = 1; j < entries.length; j++) {
+      const similarities = clusterVectors.map((v) => cosineSimilarity(v, entries[j][1]));
+      const minSim = Math.min(...similarities);
+
+      if (minSim > 0.95) {
+        clusterMembers.push(entries[j][0]);
+        clusterVectors.push(entries[j][1]);
+      }
+    }
+
+    // Near-identical vectors should cluster
+    expect(clusterMembers.length).toBeGreaterThan(5);
+
+    // Centroid distance should be very small
+    const centroid = computeCentroid(clusterVectors);
+    const distances = clusterVectors.map((v) => 1 - cosineSimilarity(v, centroid));
+    const avgDistance = distances.reduce((s, d) => s + d, 0) / distances.length;
+
+    expect(avgDistance).toBeLessThan(0.05);
+  });
+
+  test('diverse rationales from different DReps do not cluster', () => {
+    const drepEmbeddings = new Map<string, number[]>([
+      ['drep_0', [1, 0, 0]],
+      ['drep_1', [0, 1, 0]],
+      ['drep_2', [0, 0, 1]],
+      ['drep_3', [1, 1, 0]],
+      ['drep_4', [0, 1, 1]],
+      ['drep_5', [1, 0, 1]],
+      ['drep_6', [1, 1, 1]],
+      ['drep_7', [-1, 0, 0]],
+    ]);
+
+    const entries = Array.from(drepEmbeddings.entries());
+    const clusterMembers: string[] = [entries[0][0]];
+    const clusterVectors: number[][] = [entries[0][1]];
+
+    for (let j = 1; j < entries.length; j++) {
+      const similarities = clusterVectors.map((v) => cosineSimilarity(v, entries[j][1]));
+      const minSim = Math.min(...similarities);
+
+      if (minSim > 0.95) {
+        clusterMembers.push(entries[j][0]);
+        clusterVectors.push(entries[j][1]);
+      }
+    }
+
+    // Diverse vectors should not form large clusters
+    expect(clusterMembers.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Profile-Vote Hypocrisy Logic
+// ---------------------------------------------------------------------------
+
+describe('Profile-Vote Hypocrisy', () => {
+  test('aligned profile and rationales yield high consistency score', () => {
+    // Profile emphasizes decentralization
+    const profileEmb = [1, 0.8, 0.3, 0, 0];
+
+    // Rationale embeddings also emphasize decentralization
+    const rationaleEmbs = [
+      [0.9, 0.7, 0.4, 0.1, 0],
+      [1, 0.9, 0.2, 0, 0.1],
+      [0.8, 0.8, 0.3, 0.1, 0.1],
+    ];
+
+    const rationaleCentroid = computeCentroid(rationaleEmbs);
+    const similarity = cosineSimilarity(profileEmb, rationaleCentroid);
+    const consistencyScore = Math.round(Math.max(0, similarity) * 100);
+
+    expect(consistencyScore).toBeGreaterThan(20);
+    expect(consistencyScore).toBeGreaterThan(80); // aligned should be very high
+  });
+
+  test('mismatched profile and rationales yield low consistency score', () => {
+    // Profile emphasizes one direction
+    const profileEmb = [1, 0, 0, 0, 0];
+
+    // Rationales go in opposite direction
+    const rationaleEmbs = [
+      [0, 1, 0, 0, 0],
+      [0, 0, 1, 0, 0],
+      [0, 0, 0, 1, 0],
+    ];
+
+    const rationaleCentroid = computeCentroid(rationaleEmbs);
+    const similarity = cosineSimilarity(profileEmb, rationaleCentroid);
+    const consistencyScore = Math.round(Math.max(0, similarity) * 100);
+
+    // Orthogonal vectors = low consistency
+    expect(consistencyScore).toBeLessThan(50);
+  });
+
+  test('opposite profile and rationales flagged as mismatch', () => {
+    // Profile points in one direction
+    const profileEmb = [1, 0, 0];
+
+    // Rationales point in opposite direction
+    const rationaleEmbs = [
+      [-1, 0.1, 0],
+      [-1, -0.1, 0],
+      [-0.9, 0, 0.1],
+    ];
+
+    const rationaleCentroid = computeCentroid(rationaleEmbs);
+    const similarity = cosineSimilarity(profileEmb, rationaleCentroid);
+    const consistencyScore = Math.round(Math.max(0, similarity) * 100);
+
+    const isMismatch = consistencyScore < 20;
+    expect(isMismatch).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enhanced Sybil Detection Logic
+// ---------------------------------------------------------------------------
+
+describe('Enhanced Sybil Detection', () => {
+  test('high vote correlation + high rationale correlation = high confidence', () => {
+    // Simulate two pools with identical rationale centroids
+    const centroidA = [1, 0.5, 0.2];
+    const centroidB = [0.99, 0.51, 0.19]; // nearly identical
+
+    const rationaleCorrelation = cosineSimilarity(centroidA, centroidB);
+    const voteAgreementRate = 0.97; // > 95%
+
+    expect(rationaleCorrelation).toBeGreaterThan(0.9);
+
+    const highConfidence = voteAgreementRate > 0.95 && rationaleCorrelation > 0.9;
+    expect(highConfidence).toBe(true);
+  });
+
+  test('high vote correlation but low rationale correlation = not high confidence', () => {
+    // Different rationale patterns despite same votes
+    const centroidA = [1, 0, 0];
+    const centroidB = [0, 1, 0]; // orthogonal
+
+    const rationaleCorrelation = cosineSimilarity(centroidA, centroidB);
+    const voteAgreementRate = 0.97;
+
+    expect(rationaleCorrelation).toBeLessThan(0.9);
+
+    const highConfidence = voteAgreementRate > 0.95 && rationaleCorrelation > 0.9;
+    expect(highConfidence).toBe(false);
+  });
+
+  test('low vote correlation should not flag even with identical rationales', () => {
+    const centroidA = [1, 0.5, 0.2];
+    const centroidB = [1, 0.5, 0.2]; // identical
+
+    const rationaleCorrelation = cosineSimilarity(centroidA, centroidB);
+    const voteAgreementRate = 0.8; // below 95% threshold
+
+    expect(rationaleCorrelation).toBeCloseTo(1, 5);
+
+    const highConfidence = voteAgreementRate > 0.95 && rationaleCorrelation > 0.9;
+    expect(highConfidence).toBe(false);
+  });
+});

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -51,6 +51,7 @@ import { consolidateFeedbackFn } from '@/inngest/functions/consolidate-feedback'
 import { generateEmbeddings as generateEmbeddingsFn } from '@/inngest/functions/generate-embeddings';
 import { generateUserEmbedding } from '@/inngest/functions/generate-user-embedding';
 import { computeAiQuality } from '@/inngest/functions/compute-ai-quality';
+import { detectGamingSignals } from '@/inngest/functions/detect-gaming-signals';
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [
@@ -103,5 +104,6 @@ export const { GET, POST, PUT } = serve({
     generateEmbeddingsFn,
     generateUserEmbedding,
     computeAiQuality,
+    detectGamingSignals,
   ],
 });

--- a/inngest/functions/detect-gaming-signals.ts
+++ b/inngest/functions/detect-gaming-signals.ts
@@ -1,0 +1,199 @@
+/**
+ * Gaming Signal Detection — Inngest batch job.
+ *
+ * Runs every 12 hours. Detects embedding-based gaming patterns:
+ * 1. Rationale farming (per DRep)
+ * 2. Template usage (per proposal)
+ * 3. Profile-vote hypocrisy (per DRep)
+ * 4. Enhanced sybil detection (embedding-enriched)
+ *
+ * Results stored in scoring metadata via `drep_score_metadata` JSONB field.
+ * Gated behind `embedding_anti_gaming` feature flag.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { logger } from '@/lib/logger';
+import {
+  detectRationaleFarming,
+  detectTemplateUsage,
+  detectProfileVoteHypocrisy,
+} from '@/lib/scoring/gamingDetection';
+import { detectSybilPairs, enhanceSybilWithEmbeddings } from '@/lib/scoring/sybilDetection';
+
+export const detectGamingSignals = inngest.createFunction(
+  {
+    id: 'detect-gaming-signals',
+    retries: 2,
+    concurrency: { limit: 1, scope: 'env', key: '"gaming-detection"' },
+  },
+  { cron: '0 */12 * * *' },
+  async ({ step }) => {
+    // Step 1: Check feature flag
+    const enabled = await step.run('check-flag', async () => {
+      return getFeatureFlag('embedding_anti_gaming', false);
+    });
+
+    if (!enabled) return { skipped: true, reason: 'feature flag disabled' };
+
+    // Step 2: Rationale farm detection across DReps with sufficient rationales
+    const farmingResult = await step.run('detect-rationale-farming', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get DReps with 10+ rationale embeddings
+      const { data: drepCounts } = await supabase
+        .from('embeddings')
+        .select('secondary_id')
+        .eq('entity_type', 'rationale')
+        .not('secondary_id', 'is', null);
+
+      if (!drepCounts?.length) return { checked: 0, suspects: 0, details: [] };
+
+      // Count per DRep
+      const countMap = new Map<string, number>();
+      for (const row of drepCounts) {
+        if (row.secondary_id) {
+          countMap.set(row.secondary_id, (countMap.get(row.secondary_id) ?? 0) + 1);
+        }
+      }
+
+      const eligibleDreps = Array.from(countMap.entries())
+        .filter(([, count]) => count >= 10)
+        .map(([id]) => id);
+
+      const suspects: { drepId: string; rationaleCount: number; meanSimilarity: number }[] = [];
+
+      for (const drepId of eligibleDreps) {
+        const result = await detectRationaleFarming(drepId);
+        if (result.isSuspect) {
+          suspects.push({
+            drepId,
+            rationaleCount: result.rationaleCount,
+            meanSimilarity: result.meanSimilarity,
+          });
+        }
+      }
+
+      return { checked: eligibleDreps.length, suspects: suspects.length, details: suspects };
+    });
+
+    // Step 3: Template detection for recent proposals
+    const templateResult = await step.run('detect-template-usage', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get distinct proposal entity IDs that have rationale embeddings
+      const { data: proposalIds } = await supabase
+        .from('embeddings')
+        .select('entity_id')
+        .eq('entity_type', 'rationale')
+        .limit(500);
+
+      if (!proposalIds?.length) return { checked: 0, clustersFound: 0 };
+
+      const uniqueProposals = [...new Set(proposalIds.map((p) => p.entity_id))];
+      let totalClusters = 0;
+
+      for (const proposalId of uniqueProposals) {
+        const result = await detectTemplateUsage(proposalId);
+        totalClusters += result.templateClusters.length;
+      }
+
+      return { checked: uniqueProposals.length, clustersFound: totalClusters };
+    });
+
+    // Step 4: Profile-vote hypocrisy check
+    const hypocrisyResult = await step.run('detect-hypocrisy', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get DReps with both profile and rationale embeddings
+      const { data: profileDreps } = await supabase
+        .from('embeddings')
+        .select('entity_id')
+        .eq('entity_type', 'drep_profile')
+        .limit(500);
+
+      if (!profileDreps?.length) return { checked: 0, mismatches: 0 };
+
+      const drepIds = profileDreps.map((p) => p.entity_id);
+      let mismatches = 0;
+
+      for (const drepId of drepIds) {
+        const result = await detectProfileVoteHypocrisy(drepId);
+        if (result.isMismatch) {
+          mismatches++;
+        }
+      }
+
+      return { checked: drepIds.length, mismatches };
+    });
+
+    // Step 5: Enhanced sybil detection with rationale embedding correlation
+    const sybilResult = await step.run('enhanced-sybil-detection', async () => {
+      const supabase = getSupabaseAdmin();
+
+      // Get SPO votes for standard sybil detection
+      const { data: spoVotes } = await supabase
+        .from('spo_votes')
+        .select('pool_id, proposal_tx_hash, proposal_index, vote')
+        .limit(5000);
+
+      if (!spoVotes?.length) return { pairs: 0, highConfidence: 0 };
+
+      // Build vote map
+      const poolVoteMap = new Map<string, Map<string, 'Yes' | 'No' | 'Abstain'>>();
+      for (const v of spoVotes) {
+        const key = `${v.proposal_tx_hash}:${v.proposal_index}`;
+        const votes = poolVoteMap.get(v.pool_id) ?? new Map();
+        votes.set(key, v.vote as 'Yes' | 'No' | 'Abstain');
+        poolVoteMap.set(v.pool_id, votes);
+      }
+
+      // Run standard detection
+      const standardFlags = detectSybilPairs(poolVoteMap);
+
+      // Enhance with embedding correlation
+      const enhancedFlags = await enhanceSybilWithEmbeddings(standardFlags);
+
+      const highConfidenceCount = enhancedFlags.filter((f) => f.highConfidence).length;
+
+      return {
+        pairs: enhancedFlags.length,
+        highConfidence: highConfidenceCount,
+      };
+    });
+
+    // Step 6: Store results summary
+    await step.run('store-results', async () => {
+      const supabase = getSupabaseAdmin();
+
+      const summary = {
+        timestamp: new Date().toISOString(),
+        farming: farmingResult,
+        templates: templateResult,
+        hypocrisy: hypocrisyResult,
+        sybil: sybilResult,
+      };
+
+      // Store as a gaming_signals record in a lightweight table
+      // Using the existing sync_health pattern: upsert by key
+      await supabase.from('kv_store').upsert(
+        {
+          key: 'gaming_signals_latest',
+          value: summary,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'key' },
+      );
+
+      logger.info('[detect-gaming-signals] Scan complete', summary);
+    });
+
+    return {
+      farming: farmingResult,
+      templates: templateResult,
+      hypocrisy: hypocrisyResult,
+      sybil: sybilResult,
+    };
+  },
+);

--- a/lib/cc/blocDetection.ts
+++ b/lib/cc/blocDetection.ts
@@ -5,9 +5,19 @@
  * (Jaccard overlap of cited articles). Vote agreement is near-uniform (~99.8%)
  * so reasoning similarity is the primary clustering metric.
  *
- * Algorithm: members are connected if reasoning_similarity_pct >= threshold.
+ * Enhanced (when `embedding_cc_blocs` flag is ON):
+ * - Uses embedding cosine similarity between CC member rationale centroids
+ *   instead of Jaccard article-overlap as the similarity metric.
+ * - Union-Find algorithm is preserved unchanged.
+ *
+ * Algorithm: members are connected if similarity >= threshold.
  * Connected components with >= 2 members form a bloc; singletons = "Independent".
  */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { computeCentroid } from '@/lib/embeddings/quality';
+import { cosineSimilarity } from '@/lib/embeddings/query';
 
 export interface AgreementEntry {
   memberA: string;
@@ -153,4 +163,85 @@ export function detectBlocs(
   }
 
   return results;
+}
+
+/**
+ * Enhanced bloc detection using embedding cosine similarity when available.
+ *
+ * When `embedding_cc_blocs` flag is ON:
+ * - Fetches CC member rationale embeddings
+ * - Computes per-member rationale centroids
+ * - Replaces Jaccard `reasoningSimilarityPct` with embedding cosine similarity (scaled to 0-100)
+ * - Falls back to original Jaccard metric for members without embeddings
+ *
+ * When flag is OFF: delegates directly to `detectBlocs()` with original data.
+ */
+export async function detectBlocsWithEmbeddings(
+  agreements: AgreementEntry[],
+  threshold: number = DEFAULT_THRESHOLD,
+): Promise<BlocAssignment[]> {
+  const embeddingEnabled = await getFeatureFlag('embedding_cc_blocs', false);
+
+  if (!embeddingEnabled) {
+    return detectBlocs(agreements, threshold);
+  }
+
+  // Collect all CC member IDs
+  const memberSet = new Set<string>();
+  for (const a of agreements) {
+    memberSet.add(a.memberA);
+    memberSet.add(a.memberB);
+  }
+  const memberIds = Array.from(memberSet);
+
+  if (memberIds.length === 0) return [];
+
+  // Fetch rationale embeddings for CC members
+  const supabase = getSupabaseAdmin();
+  const { data: embeddings } = await supabase
+    .from('embeddings')
+    .select('secondary_id, embedding')
+    .eq('entity_type', 'rationale')
+    .in('secondary_id', memberIds)
+    .limit(2000);
+
+  if (!embeddings?.length) {
+    // No embedding data — fall back to Jaccard
+    return detectBlocs(agreements, threshold);
+  }
+
+  // Compute per-member rationale centroids
+  const memberEmbeddings = new Map<string, number[][]>();
+  for (const e of embeddings) {
+    if (e.secondary_id) {
+      const group = memberEmbeddings.get(e.secondary_id) ?? [];
+      group.push(e.embedding as unknown as number[]);
+      memberEmbeddings.set(e.secondary_id, group);
+    }
+  }
+
+  const memberCentroids = new Map<string, number[]>();
+  for (const [memberId, embs] of memberEmbeddings) {
+    if (embs.length >= 1) {
+      memberCentroids.set(memberId, computeCentroid(embs));
+    }
+  }
+
+  // Override reasoningSimilarityPct with embedding cosine similarity where available
+  const enhancedAgreements: AgreementEntry[] = agreements.map((a) => {
+    const centroidA = memberCentroids.get(a.memberA);
+    const centroidB = memberCentroids.get(a.memberB);
+
+    if (centroidA && centroidB) {
+      const sim = cosineSimilarity(centroidA, centroidB);
+      // Scale cosine similarity (typically 0-1 for related content) to 0-100 percentage
+      const similarityPct = Math.round(Math.max(0, sim) * 100 * 100) / 100;
+      return { ...a, reasoningSimilarityPct: similarityPct };
+    }
+
+    // No embedding data for one or both — keep original Jaccard metric
+    return a;
+  });
+
+  return detectBlocs(enhancedAgreements, threshold);
 }

--- a/lib/ghi/components.ts
+++ b/lib/ghi/components.ts
@@ -10,8 +10,12 @@
  */
 
 import { createClient } from '@/lib/supabase';
+import { getSupabaseAdmin } from '@/lib/supabase';
 import { calculateTreasuryHealthScore } from '@/lib/treasury';
 import { computeEDI, type EDIResult } from './ediMetrics';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { computePairwiseDiversity } from '@/lib/embeddings/quality';
+import { cosineSimilarity } from '@/lib/embeddings/query';
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -270,7 +274,95 @@ export async function computeDeliberationQuality({
     }
   }
 
-  const raw = rationaleScore * 0.5 + debateDiversityScore * 0.3 + independenceScore * 0.2;
+  // --- Check if embedding-enhanced deliberation is enabled ---
+  const embeddingEnabled = await getFeatureFlag('embedding_ghi_deliberation', false);
+
+  let semanticDiversityScore = 0;
+  let reasoningCoherenceScore = 0;
+
+  if (embeddingEnabled) {
+    // --- Sub-signal 4: Semantic Argument Diversity (embedding-based) ---
+    // Get all rationale embeddings for recent proposals and compute pairwise diversity
+    const adminSupabase = getSupabaseAdmin();
+    const { data: rationaleEmbeddings } = await adminSupabase
+      .from('embeddings')
+      .select('entity_id, secondary_id, embedding')
+      .eq('entity_type', 'rationale')
+      .limit(500);
+
+    if (rationaleEmbeddings?.length && rationaleEmbeddings.length >= 2) {
+      // Group by proposal (entity_id contains tx_hash:index)
+      const proposalGroups = new Map<string, number[][]>();
+      for (const re of rationaleEmbeddings) {
+        // Extract proposal key from entity_id (format: "tx_hash:index")
+        const proposalKey = re.entity_id;
+        const group = proposalGroups.get(proposalKey) ?? [];
+        group.push(re.embedding as unknown as number[]);
+        proposalGroups.set(proposalKey, group);
+      }
+
+      // Compute diversity per proposal, then average
+      let totalDiversity = 0;
+      let proposalCount = 0;
+      for (const embeddings of proposalGroups.values()) {
+        if (embeddings.length >= 2) {
+          totalDiversity += computePairwiseDiversity(embeddings);
+          proposalCount++;
+        }
+      }
+
+      if (proposalCount > 0) {
+        // Pairwise diversity returns 0-1 (1 = maximally diverse). Scale to 0-100.
+        semanticDiversityScore = Math.round((totalDiversity / proposalCount) * 100);
+      }
+    }
+
+    // --- Sub-signal 5: Reasoning Coherence (rationale-proposal relevance) ---
+    // For each rationale, compute similarity to its proposal's embedding
+    const { data: proposalEmbeddings } = await adminSupabase
+      .from('embeddings')
+      .select('entity_id, embedding')
+      .eq('entity_type', 'proposal')
+      .limit(500);
+
+    if (rationaleEmbeddings?.length && proposalEmbeddings?.length) {
+      const proposalEmbeddingMap = new Map<string, number[]>(
+        proposalEmbeddings.map((pe) => [pe.entity_id, pe.embedding as unknown as number[]]),
+      );
+
+      let totalCoherence = 0;
+      let coherenceCount = 0;
+
+      for (const re of rationaleEmbeddings) {
+        const proposalEmb = proposalEmbeddingMap.get(re.entity_id);
+        if (proposalEmb) {
+          const similarity = cosineSimilarity(re.embedding as unknown as number[], proposalEmb);
+          // Cosine similarity ranges -1 to 1; map to 0-100
+          totalCoherence += Math.max(0, similarity) * 100;
+          coherenceCount++;
+        }
+      }
+
+      if (coherenceCount > 0) {
+        reasoningCoherenceScore = Math.round(totalCoherence / coherenceCount);
+      }
+    }
+  }
+
+  // --- Compose final score ---
+  let raw: number;
+  if (embeddingEnabled) {
+    // Enhanced composition with semantic signals
+    raw =
+      rationaleScore * 0.35 +
+      debateDiversityScore * 0.2 +
+      independenceScore * 0.15 +
+      semanticDiversityScore * 0.2 +
+      reasoningCoherenceScore * 0.1;
+  } else {
+    // Original 3-signal composition
+    raw = rationaleScore * 0.5 + debateDiversityScore * 0.3 + independenceScore * 0.2;
+  }
 
   return {
     raw: Math.min(100, Math.max(0, Math.round(raw))),
@@ -278,6 +370,10 @@ export async function computeDeliberationQuality({
       rationaleQuality: Math.round(rationaleScore),
       debateDiversity: Math.round(debateDiversityScore),
       votingIndependence: Math.round(independenceScore),
+      ...(embeddingEnabled && {
+        semanticDiversity: semanticDiversityScore,
+        reasoningCoherence: reasoningCoherenceScore,
+      }),
     },
   };
 }

--- a/lib/scoring/calibration.ts
+++ b/lib/scoring/calibration.ts
@@ -599,6 +599,30 @@ export const DRIFT_THRESHOLDS = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Embedding-Enhanced Deliberation Weights
+// ---------------------------------------------------------------------------
+
+/**
+ * Enhanced GHI deliberation quality weights when `embedding_ghi_deliberation` flag is ON.
+ * Adds semantic diversity and reasoning coherence sub-signals.
+ * Must sum to 1.0.
+ *
+ * Compared to base weights (rationale 0.5, debate 0.3, independence 0.2):
+ * - Rationale quality reduced from 0.5 → 0.35 (still dominant)
+ * - Debate diversity reduced from 0.3 → 0.2
+ * - Voting independence reduced from 0.2 → 0.15
+ * - Semantic diversity added at 0.2 (embedding-based argument spread)
+ * - Reasoning coherence added at 0.1 (rationale-proposal relevance)
+ */
+export const EMBEDDING_DELIBERATION_WEIGHTS = {
+  rationaleQuality: 0.35,
+  debateDiversity: 0.2,
+  votingIndependence: 0.15,
+  semanticDiversity: 0.2,
+  reasoningCoherence: 0.1,
+} as const;
+
+// ---------------------------------------------------------------------------
 // Piecewise Linear Calibration Function
 // ---------------------------------------------------------------------------
 

--- a/lib/scoring/gamingDetection.ts
+++ b/lib/scoring/gamingDetection.ts
@@ -1,0 +1,215 @@
+/**
+ * Gaming Detection — Embedding-Based Anti-Gaming Signals
+ *
+ * Detects suspicious patterns using semantic embedding analysis:
+ * 1. Rationale Farming: DReps producing many near-identical rationales
+ * 2. Template Detection: Cross-DRep clusters using identical reasoning
+ * 3. Profile-Vote Hypocrisy: Mismatch between stated profile and actual voting rationales
+ *
+ * All functions are gated behind the `embedding_anti_gaming` feature flag.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { computePairwiseDiversity, computeCentroid } from '@/lib/embeddings/quality';
+import { cosineSimilarity } from '@/lib/embeddings/query';
+
+// ---------------------------------------------------------------------------
+// Rationale Farm Detection
+// ---------------------------------------------------------------------------
+
+export interface RationaleFarmResult {
+  isSuspect: boolean;
+  rationaleCount: number;
+  meanSimilarity: number;
+}
+
+/**
+ * Detect rationale farming: DRep with >= 10 rationales and mean pairwise
+ * cosine similarity > 0.92 is flagged as suspect.
+ *
+ * A high mean similarity across many rationales suggests copy-paste or
+ * template-based rationale generation rather than genuine deliberation.
+ */
+export async function detectRationaleFarming(drepId: string): Promise<RationaleFarmResult> {
+  const supabase = getSupabaseAdmin();
+
+  const { data: embeddings } = await supabase
+    .from('embeddings')
+    .select('embedding')
+    .eq('entity_type', 'rationale')
+    .eq('secondary_id', drepId)
+    .limit(200);
+
+  if (!embeddings?.length) {
+    return { isSuspect: false, rationaleCount: 0, meanSimilarity: 0 };
+  }
+
+  const vectors = embeddings.map((e) => e.embedding as unknown as number[]);
+  const rationaleCount = vectors.length;
+
+  if (rationaleCount < 10) {
+    return { isSuspect: false, rationaleCount, meanSimilarity: 0 };
+  }
+
+  // Compute mean pairwise similarity (inverse of diversity)
+  const diversity = computePairwiseDiversity(vectors);
+  const meanSimilarity = 1 - diversity;
+
+  return {
+    isSuspect: meanSimilarity > 0.92,
+    rationaleCount,
+    meanSimilarity: Math.round(meanSimilarity * 1000) / 1000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Template Detection
+// ---------------------------------------------------------------------------
+
+export interface TemplateCluster {
+  drepIds: string[];
+  centroidDistance: number;
+}
+
+export interface TemplateDetectionResult {
+  templateClusters: TemplateCluster[];
+}
+
+/**
+ * Detect template usage across DReps for a specific proposal.
+ * Cross-DRep cluster: > 5 rationales from different DReps with centroid distance < 0.05.
+ *
+ * This signals coordinated or template-based voting where multiple DReps
+ * submit semantically identical rationales.
+ */
+export async function detectTemplateUsage(
+  proposalEntityId: string,
+): Promise<TemplateDetectionResult> {
+  const supabase = getSupabaseAdmin();
+
+  // Get all rationale embeddings for this proposal
+  const { data: embeddings } = await supabase
+    .from('embeddings')
+    .select('secondary_id, embedding')
+    .eq('entity_type', 'rationale')
+    .eq('entity_id', proposalEntityId)
+    .limit(500);
+
+  if (!embeddings?.length || embeddings.length < 6) {
+    return { templateClusters: [] };
+  }
+
+  // Group by DRep (secondary_id = voter_id)
+  const drepEmbeddings = new Map<string, number[]>();
+  for (const e of embeddings) {
+    if (e.secondary_id) {
+      drepEmbeddings.set(e.secondary_id, e.embedding as unknown as number[]);
+    }
+  }
+
+  if (drepEmbeddings.size < 6) {
+    return { templateClusters: [] };
+  }
+
+  // Simple greedy clustering: find groups of DReps with very similar rationales
+  const entries = Array.from(drepEmbeddings.entries());
+  const clustered = new Set<string>();
+  const clusters: TemplateCluster[] = [];
+
+  for (let i = 0; i < entries.length; i++) {
+    if (clustered.has(entries[i][0])) continue;
+
+    const clusterMembers: string[] = [entries[i][0]];
+    const clusterVectors: number[][] = [entries[i][1]];
+
+    for (let j = i + 1; j < entries.length; j++) {
+      if (clustered.has(entries[j][0])) continue;
+
+      // Check similarity against all current cluster members
+      const similarities = clusterVectors.map((v) => cosineSimilarity(v, entries[j][1]));
+      const minSim = Math.min(...similarities);
+
+      if (minSim > 0.95) {
+        clusterMembers.push(entries[j][0]);
+        clusterVectors.push(entries[j][1]);
+      }
+    }
+
+    if (clusterMembers.length > 5) {
+      const centroid = computeCentroid(clusterVectors);
+      // Centroid distance = mean distance from centroid
+      const distances = clusterVectors.map((v) => 1 - cosineSimilarity(v, centroid));
+      const centroidDistance = distances.reduce((sum, d) => sum + d, 0) / distances.length;
+
+      if (centroidDistance < 0.05) {
+        clusters.push({
+          drepIds: clusterMembers.sort(),
+          centroidDistance: Math.round(centroidDistance * 10000) / 10000,
+        });
+        for (const id of clusterMembers) {
+          clustered.add(id);
+        }
+      }
+    }
+  }
+
+  return { templateClusters: clusters };
+}
+
+// ---------------------------------------------------------------------------
+// Profile-Vote Hypocrisy
+// ---------------------------------------------------------------------------
+
+export interface HypocrisyResult {
+  consistencyScore: number; // 0-100
+  isMismatch: boolean;
+}
+
+/**
+ * Detect profile-vote hypocrisy: compare a DRep's profile embedding against
+ * the centroid of their rationale embeddings.
+ *
+ * Consistency score < 20 = mismatch flag (profile says one thing, votes say another).
+ */
+export async function detectProfileVoteHypocrisy(drepId: string): Promise<HypocrisyResult> {
+  const supabase = getSupabaseAdmin();
+
+  // Get DRep profile embedding
+  const { data: profileData } = await supabase
+    .from('embeddings')
+    .select('embedding')
+    .eq('entity_type', 'drep_profile')
+    .eq('entity_id', drepId)
+    .is('secondary_id', null)
+    .single();
+
+  if (!profileData?.embedding) {
+    return { consistencyScore: 50, isMismatch: false };
+  }
+
+  // Get DRep rationale embeddings
+  const { data: rationaleData } = await supabase
+    .from('embeddings')
+    .select('embedding')
+    .eq('entity_type', 'rationale')
+    .eq('secondary_id', drepId)
+    .limit(100);
+
+  if (!rationaleData?.length || rationaleData.length < 3) {
+    // Not enough rationales to assess; return neutral
+    return { consistencyScore: 50, isMismatch: false };
+  }
+
+  const profileEmb = profileData.embedding as unknown as number[];
+  const rationaleEmbs = rationaleData.map((r) => r.embedding as unknown as number[]);
+  const rationaleCentroid = computeCentroid(rationaleEmbs);
+
+  // Cosine similarity: -1 to 1. Map to 0-100 consistency score.
+  const similarity = cosineSimilarity(profileEmb, rationaleCentroid);
+  const consistencyScore = Math.round(Math.max(0, similarity) * 100);
+
+  return {
+    consistencyScore,
+    isMismatch: consistencyScore < 20,
+  };
+}

--- a/lib/scoring/sybilDetection.ts
+++ b/lib/scoring/sybilDetection.ts
@@ -2,13 +2,25 @@
  * Sybil Detection for SPO Score V3.
  * Flags SPO pairs with >95% vote correlation (same votes on same proposals).
  * Does NOT affect scores directly — creates a deterrent and audit trail.
+ *
+ * Enhanced (when `embedding_anti_gaming` flag is ON):
+ * - Also checks rationale embedding correlation
+ * - High confidence sybil: vote correlation > 95% AND rationale correlation > 90%
  */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { computeCentroid } from '@/lib/embeddings/quality';
+import { cosineSimilarity } from '@/lib/embeddings/query';
 
 export interface SybilFlag {
   poolA: string;
   poolB: string;
   agreementRate: number;
   sharedVotes: number;
+  /** Rationale embedding correlation (0-1). Only present when embedding-enhanced. */
+  rationaleCorrelation?: number;
+  /** True when both vote AND rationale correlation thresholds are met. */
+  highConfidence?: boolean;
 }
 
 /**
@@ -56,4 +68,73 @@ export function detectSybilPairs(
   }
 
   return flags;
+}
+
+/**
+ * Enhanced sybil detection combining vote correlation with rationale embedding correlation.
+ * When `embedding_anti_gaming` flag is ON, this enriches standard sybil flags
+ * with rationale similarity data and a high-confidence classification.
+ *
+ * High confidence sybil: vote correlation > 95% AND rationale correlation > 90%.
+ */
+export async function enhanceSybilWithEmbeddings(flags: SybilFlag[]): Promise<SybilFlag[]> {
+  if (flags.length === 0) return flags;
+
+  const supabase = getSupabaseAdmin();
+
+  // Collect all pool IDs that need rationale embeddings
+  const poolIds = new Set<string>();
+  for (const flag of flags) {
+    poolIds.add(flag.poolA);
+    poolIds.add(flag.poolB);
+  }
+
+  // Fetch rationale embeddings for these entities
+  // For SPOs, the secondary_id stores the voter (pool) ID
+  const { data: embeddings } = await supabase
+    .from('embeddings')
+    .select('secondary_id, embedding')
+    .eq('entity_type', 'rationale')
+    .in('secondary_id', Array.from(poolIds))
+    .limit(2000);
+
+  if (!embeddings?.length) {
+    // No embedding data — return original flags unchanged
+    return flags;
+  }
+
+  // Group embeddings by pool and compute centroids
+  const poolEmbeddings = new Map<string, number[][]>();
+  for (const e of embeddings) {
+    if (e.secondary_id) {
+      const group = poolEmbeddings.get(e.secondary_id) ?? [];
+      group.push(e.embedding as unknown as number[]);
+      poolEmbeddings.set(e.secondary_id, group);
+    }
+  }
+
+  const poolCentroids = new Map<string, number[]>();
+  for (const [poolId, embs] of poolEmbeddings) {
+    if (embs.length >= 2) {
+      poolCentroids.set(poolId, computeCentroid(embs));
+    }
+  }
+
+  // Enrich each flag with rationale correlation
+  return flags.map((flag) => {
+    const centroidA = poolCentroids.get(flag.poolA);
+    const centroidB = poolCentroids.get(flag.poolB);
+
+    if (!centroidA || !centroidB) {
+      return flag; // No embedding data for one or both — return as-is
+    }
+
+    const rationaleCorrelation = Math.round(cosineSimilarity(centroidA, centroidB) * 1000) / 1000;
+
+    return {
+      ...flag,
+      rationaleCorrelation,
+      highConfidence: flag.agreementRate > 0.95 && rationaleCorrelation > 0.9,
+    };
+  });
 }


### PR DESCRIPTION
## Summary
- GHI deliberation quality: semantic argument diversity + reasoning coherence (new composition weights when `embedding_ghi_deliberation` ON)
- Anti-gaming: rationale farm detection, template detection, profile-vote hypocrisy, enhanced sybil with embedding correlation
- CC bloc detection: embedding cosine similarity replaces Jaccard when `embedding_cc_blocs` ON (Union-Find unchanged)
- Inngest batch job (`detect-gaming-signals`) runs every 12h for gaming signal detection
- All gated behind 3 feature flags (default OFF)

## Impact
- **What changed**: New semantic scoring signals for governance health, anti-gaming, and CC analysis using embedding infrastructure from PR #429
- **User-facing**: No — behind feature flags, disabled by default
- **Risk**: Low — additive signals only, existing scoring unchanged when flags OFF. All 696 existing tests pass unchanged.
- **Scope**: Modified `lib/ghi/components.ts`, `lib/scoring/calibration.ts`, `lib/scoring/sybilDetection.ts`, `lib/cc/blocDetection.ts`, `app/api/inngest/route.ts`. New files: `lib/scoring/gamingDetection.ts`, `inngest/functions/detect-gaming-signals.ts`, `__tests__/scoring/gamingDetection.test.ts`

## Test plan
- [x] `npm run preflight` passes (696 tests, 0 failures)
- [x] Gaming detection tests pass (11 new tests)
- [x] Existing scoring tests unchanged and passing
- [x] Existing GHI tests unchanged and passing
- [x] Existing embeddings tests unchanged and passing
- [x] Flag OFF produces identical behavior (original code paths preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)