### PR TITLE
feat: Sentry context enrichment — segment, flags, governance state

### DIFF
--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -12,6 +12,8 @@ import { GovernadaSidebar } from './GovernadaSidebar';
 import { EpochContextBar } from './EpochContextBar';
 import { SyncFreshnessBanner } from '@/components/SyncFreshnessBanner';
 import { useTranslation } from '@/lib/i18n/useTranslation';
+import { useSentryContext } from '@/hooks/useSentryContext';
+import { useSentryFeatureFlags } from '@/hooks/useSentryFeatureFlags';
 
 const ConstellationScene = dynamic(
   () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
@@ -108,6 +110,13 @@ function BackgroundGlobe({
   );
 }
 
+/** Invisible component that syncs user segment and feature flags to Sentry. */
+function SentryContextSync() {
+  useSentryContext();
+  useSentryFeatureFlags();
+  return null;
+}
+
 /**
  * Governada layout shell — sidebar on desktop, bottom bar on mobile.
  * Sidebar is persona-adaptive via the nav config.
@@ -136,6 +145,7 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
   return (
     <SegmentProvider>
       <TierThemeProvider score={null}>
+        <SentryContextSync />
         <Suspense fallback={null}>
           <DeepLinkHandler />
         </Suspense>

--- a/hooks/useSentryContext.ts
+++ b/hooks/useSentryContext.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Syncs SegmentProvider state to Sentry user context and tags.
+ * Hashes stakeAddress with SHA-256 (truncated to 16 hex chars) for privacy.
+ */
+async function hashAddress(address: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(address);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hashHex.slice(0, 16);
+}
+
+export function useSentryContext() {
+  const {
+    segment,
+    realSegment,
+    stakeAddress,
+    drepId,
+    poolId,
+    delegatedDrep,
+    delegatedPool,
+    tier,
+    isViewingAs,
+    dimensionOverrides,
+  } = useSegment();
+
+  const lastHashRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!stakeAddress) {
+      // Disconnected — clear user context
+      lastHashRef.current = null;
+      Sentry.setUser(null);
+      Sentry.setTag('segment', 'anonymous');
+      Sentry.setTag('tier', undefined);
+      Sentry.setTag('isViewingAs', undefined);
+      Sentry.setContext('governance', null);
+      return;
+    }
+
+    // Hash the stake address and set Sentry context
+    let cancelled = false;
+
+    void hashAddress(stakeAddress).then((hashedAddress) => {
+      if (cancelled) return;
+
+      lastHashRef.current = hashedAddress;
+
+      Sentry.setUser({ id: hashedAddress });
+      Sentry.setTag('segment', segment);
+      Sentry.setTag('tier', tier ?? 'none');
+      Sentry.setTag('isViewingAs', String(isViewingAs));
+      Sentry.setContext('governance', {
+        segment,
+        realSegment,
+        drepId,
+        poolId,
+        delegatedDrep,
+        delegatedPool,
+        tier,
+        isViewingAs,
+        engagementLevel: dimensionOverrides.engagementLevel ?? null,
+        credibilityTier: dimensionOverrides.credibilityTier ?? null,
+        governanceLevel: dimensionOverrides.governanceLevel ?? null,
+        governanceDepth: dimensionOverrides.governanceDepth ?? null,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    stakeAddress,
+    segment,
+    realSegment,
+    drepId,
+    poolId,
+    delegatedDrep,
+    delegatedPool,
+    tier,
+    isViewingAs,
+    dimensionOverrides,
+  ]);
+}

--- a/hooks/useSentryFeatureFlags.ts
+++ b/hooks/useSentryFeatureFlags.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { fetchClientFlags } from '@/lib/featureFlags';
+
+/**
+ * Loads feature flags and sets them as Sentry context.
+ * Re-fetches when the tab regains focus (visibilitychange).
+ */
+export function useSentryFeatureFlags() {
+  useEffect(() => {
+    function syncFlags() {
+      void fetchClientFlags().then((flags) => {
+        Sentry.setContext('featureFlags', flags);
+      });
+    }
+
+    // Initial load
+    syncFlags();
+
+    // Re-fetch when tab becomes visible again
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        syncFlags();
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, []);
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -21,11 +21,45 @@ export async function register() {
   }
 }
 
+import { createHash } from 'crypto';
+
+function extractSessionPayload(
+  cookieHeader: string | undefined,
+): { walletAddress?: string } | null {
+  if (!cookieHeader) return null;
+  const match = cookieHeader.match(/drepscore_session=([^;]+)/);
+  if (!match) return null;
+  try {
+    const parts = match[1].split('.');
+    if (parts.length < 2) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf-8'));
+    return payload as { walletAddress?: string };
+  } catch {
+    return null;
+  }
+}
+
+function hashAddressServer(address: string): string {
+  return createHash('sha256').update(address).digest('hex').slice(0, 16);
+}
+
 export async function onRequestError(
   error: { digest: string } & Error,
   request: { path: string; method: string; headers: Record<string, string> },
   context: { routerKind: string; routePath: string; routeType: string; renderSource: string },
 ) {
   const Sentry = await import('@sentry/nextjs');
-  Sentry.captureRequestError(error, request, context);
+
+  const payload = extractSessionPayload(request.headers.cookie ?? request.headers.Cookie);
+  const hashedAddress = payload?.walletAddress ? hashAddressServer(payload.walletAddress) : null;
+
+  Sentry.withScope((scope) => {
+    if (hashedAddress) {
+      scope.setUser({ id: hashedAddress });
+      scope.setTag('hashedAddress', hashedAddress);
+    }
+    scope.setTag('routePath', context.routePath);
+    scope.setTag('routeType', context.routeType);
+    Sentry.captureRequestError(error, request, context);
+  });
 }


### PR DESCRIPTION
## Summary
- Add `useSentryContext` hook that syncs SegmentProvider state (segment, tier, governance context, dimension overrides) to every Sentry event
- Add `useSentryFeatureFlags` hook that attaches active feature flag state to Sentry context
- Enrich server-side `onRequestError` with hashed wallet address and route tags
- Wire both hooks via `SentryContextSync` component inside `GovernadaShell`

## Impact
- **What changed**: Every Sentry error event now carries user segment, governance state, feature flags, and hashed wallet address for correlation
- **User-facing**: No — purely backend/monitoring improvement
- **Risk**: Low — additive only, no existing behavior changed. Sentry context is ambient (attached to all events automatically)
- **Scope**: 2 new hooks, GovernadaShell.tsx (+5 lines), instrumentation.ts (+35 lines)

## Test plan
- [ ] Connect wallet → verify Sentry dashboard shows segment/tier tags on next error
- [ ] Disconnect wallet → verify Sentry context clears (segment = anonymous)
- [ ] Use View As admin → verify `isViewingAs` tag reflects override
- [ ] Trigger server error → verify hashed address and route tags in Sentry event

🤖 Generated with [Claude Code](https://claude.com/claude-code)