### PR TITLE
feat: Studio v6 — width, discovery walkthrough, image rendering

### DIFF
--- a/components/discovery/DiscoveryHub.tsx
+++ b/components/discovery/DiscoveryHub.tsx
@@ -13,9 +13,10 @@ import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { useDiscovery } from '@/hooks/useDiscovery';
 import { posthog } from '@/lib/posthog';
 import { DiscoveryFab } from './DiscoveryFab';
+import { DiscoveryHubContext } from './DiscoveryHubContext';
 import { DiscoveryPanel } from './DiscoveryPanel';
 
-export function DiscoveryHub() {
+export function DiscoveryHub({ hideFab = false }: { hideFab?: boolean }) {
   const [open, setOpen] = useState(false);
   const [openedAt, setOpenedAt] = useState<number | null>(null);
   const router = useRouter();
@@ -52,14 +53,14 @@ export function DiscoveryHub() {
   );
 
   return (
-    <>
-      <DiscoveryFab onClick={handleOpen} progress={explorationProgress.percent} />
+    <DiscoveryHubContext.Provider value={{ openHub: handleOpen }}>
+      {!hideFab && <DiscoveryFab onClick={handleOpen} progress={explorationProgress.percent} />}
 
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent side="right" showCloseButton className="w-[340px] sm:w-[380px] p-0">
           <DiscoveryPanel onStartTour={handleStartTour} onClose={handleClose} />
         </SheetContent>
       </Sheet>
-    </>
+    </DiscoveryHubContext.Provider>
   );
 }

--- a/components/discovery/DiscoveryHubContext.tsx
+++ b/components/discovery/DiscoveryHubContext.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+interface DiscoveryHubContextValue {
+  openHub: () => void;
+}
+
+const DiscoveryHubContext = createContext<DiscoveryHubContextValue | null>(null);
+
+export function useDiscoveryHub() {
+  return useContext(DiscoveryHubContext);
+}
+
+export { DiscoveryHubContext };

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -188,14 +188,12 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
         )}
         {!isStudioMode && <GovernadaBottomNav />}
 
-        {/* Discovery Layer — lazy-loaded, hidden in studio mode */}
-        {!isStudioMode && (
-          <SpotlightProvider>
-            <DiscoveryHub />
-            <EngagementNudge />
-            <MilestoneTrigger />
-          </SpotlightProvider>
-        )}
+        {/* Discovery Layer � always rendered for context, FAB hidden in studio */}
+        <SpotlightProvider>
+          <DiscoveryHub hideFab={isStudioMode} />
+          {!isStudioMode && <EngagementNudge />}
+          {!isStudioMode && <MilestoneTrigger />}
+        </SpotlightProvider>
       </TierThemeProvider>
     </SegmentProvider>
   );

--- a/components/studio/StudioActionBar.tsx
+++ b/components/studio/StudioActionBar.tsx
@@ -10,8 +10,8 @@ import {
   MinusCircle,
   Compass,
 } from 'lucide-react';
-import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { useDiscoveryHub } from '@/components/discovery/DiscoveryHubContext';
 
 type PanelId = 'agent' | 'intel' | 'notes' | 'vote';
 
@@ -89,6 +89,19 @@ function VoteButton({
   );
 }
 
+function ExplorerButton() {
+  const discovery = useDiscoveryHub();
+  return (
+    <button
+      onClick={() => discovery?.openHub()}
+      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors ml-1 cursor-pointer"
+      title="Explore Governada"
+    >
+      <Compass className="h-4 w-4" />
+    </button>
+  );
+}
+
 export function StudioActionBar({
   mode = 'author',
   currentVote,
@@ -145,13 +158,7 @@ export function StudioActionBar({
           )}
 
           {/* Governada Explorer */}
-          <Link
-            href="/governance"
-            className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors ml-1"
-            title="Explore Governada"
-          >
-            <Compass className="h-4 w-4" />
-          </Link>
+          <ExplorerButton />
         </div>
       </div>
     );

--- a/components/workspace/editor/ProposalEditor.tsx
+++ b/components/workspace/editor/ProposalEditor.tsx
@@ -26,6 +26,7 @@ import { Table } from '@tiptap/extension-table';
 import { TableRow } from '@tiptap/extension-table-row';
 import { TableCell } from '@tiptap/extension-table-cell';
 import { TableHeader } from '@tiptap/extension-table-header';
+import Image from '@tiptap/extension-image';
 import Document from '@tiptap/extension-document';
 
 import { SectionBlock, buildSectionDocument, extractSectionContent } from './SectionBlock';
@@ -284,6 +285,13 @@ export function ProposalEditor({
       TableHeader.configure({
         HTMLAttributes: {
           class: 'border border-border px-3 py-2 font-semibold bg-muted/50 text-left',
+        },
+      }),
+      Image.configure({
+        inline: false,
+        allowBase64: false,
+        HTMLAttributes: {
+          class: 'rounded-lg max-w-full my-3',
         },
       }),
     ],

--- a/components/workspace/editor/SectionBlock.tsx
+++ b/components/workspace/editor/SectionBlock.tsx
@@ -155,24 +155,28 @@ export const SectionBlock = Node.create<SectionBlockOptions>({
 /** Parse **bold**, *italic*, and [links](url) inline markers into Tiptap mark objects. */
 function parseInlineMarks(text: string): object[] {
   const result: object[] = [];
-  // Match [link](url), **bold**, *italic*, or plain text segments
-  const regex = /(\[([^\]]+)\]\(([^)]+)\)|\*\*(.+?)\*\*|\*(.+?)\*|([^[*]+))/g;
+  // Match ![image](url), [link](url), **bold**, *italic*, or plain text
+  const regex =
+    /(!\[([^\]]*?)\]\(([^)]+)\)|\[([^\]]+)\]\(([^)]+)\)|\*\*(.+?)\*\*|\*(.+?)\*|([^[!*]+))/g;
   let match;
 
   while ((match = regex.exec(text)) !== null) {
-    if (match[2] && match[3]) {
+    if (match[1] && match[1].startsWith('!')) {
+      // Image: ![alt](url)
+      result.push({ type: 'image', attrs: { src: match[3], alt: match[2] || '' } });
+    } else if (match[4] && match[5]) {
       // Link: [text](url)
       result.push({
         type: 'text',
-        text: match[2],
-        marks: [{ type: 'link', attrs: { href: match[3], target: '_blank' } }],
+        text: match[4],
+        marks: [{ type: 'link', attrs: { href: match[5], target: '_blank' } }],
       });
-    } else if (match[4]) {
-      result.push({ type: 'text', text: match[4], marks: [{ type: 'bold' }] });
-    } else if (match[5]) {
-      result.push({ type: 'text', text: match[5], marks: [{ type: 'italic' }] });
     } else if (match[6]) {
-      result.push({ type: 'text', text: match[6] });
+      result.push({ type: 'text', text: match[6], marks: [{ type: 'bold' }] });
+    } else if (match[7]) {
+      result.push({ type: 'text', text: match[7], marks: [{ type: 'italic' }] });
+    } else if (match[8]) {
+      result.push({ type: 'text', text: match[8] });
     }
   }
 
@@ -194,12 +198,26 @@ function markdownToContent(text: string): object[] {
 
   const flushParagraph = () => {
     if (currentParagraph.length > 0) {
-      const joined = currentParagraph.join('\n');
-      if (joined.trim()) {
-        blocks.push({
-          type: 'paragraph',
-          content: parseInlineMarks(joined.trim()),
-        });
+      if (currentParagraph.length === 1) {
+        const text = currentParagraph[0].trim();
+        if (text) {
+          blocks.push({ type: 'paragraph', content: parseInlineMarks(text) });
+        }
+      } else {
+        // Multiple consecutive lines = soft breaks between them
+        const content: object[] = [];
+        for (let i = 0; i < currentParagraph.length; i++) {
+          const lineText = currentParagraph[i].trim();
+          if (lineText) {
+            content.push(...parseInlineMarks(lineText));
+          }
+          if (i < currentParagraph.length - 1) {
+            content.push({ type: 'hardBreak' });
+          }
+        }
+        if (content.length > 0) {
+          blocks.push({ type: 'paragraph', content });
+        }
       }
       currentParagraph = [];
     }
@@ -255,6 +273,14 @@ function markdownToContent(text: string): object[] {
     if (/^[-*_]{3,}$/.test(trimmed)) {
       flushAll();
       blocks.push({ type: 'horizontalRule' });
+      continue;
+    }
+
+    // Standalone image: ![alt](url)
+    const imageMatch = trimmed.match(/^!\[([^\]]*)\]\(([^)]+)\)$/);
+    if (imageMatch) {
+      flushAll();
+      blocks.push({ type: 'image', attrs: { src: imageMatch[2], alt: imageMatch[1] || '' } });
       continue;
     }
 

--- a/components/workspace/review/ReviewWorkspace.tsx
+++ b/components/workspace/review/ReviewWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { CheckCircle2, Clock, AlertTriangle, ExternalLink, Vote } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useWallet } from '@/utils/wallet';
 import { useReviewQueue, useQueueState } from '@/hooks/useReviewQueue';
@@ -131,7 +132,6 @@ function ProposalMetaStrip({ item }: { item: ReviewQueueItem }) {
 // ---------------------------------------------------------------------------
 
 const PROPOSAL_SECTIONS = [
-  { id: 'title', label: 'Title' },
   { id: 'abstract', label: 'Abstract' },
   { id: 'motivation', label: 'Motivation' },
   { id: 'rationale', label: 'Rationale' },
@@ -146,7 +146,7 @@ function SectionTOC() {
   };
 
   return (
-    <nav className="hidden xl:block fixed left-4 top-1/3 space-y-1 z-10">
+    <nav className="hidden xl:block sticky top-16 self-start shrink-0 w-28 space-y-1 pr-2 pt-6">
       <p className="text-[10px] font-medium text-muted-foreground/50 uppercase tracking-wider mb-2">
         Sections
       </p>
@@ -356,7 +356,7 @@ function StudioReviewInner({
   progress,
   goNext,
   goPrev,
-  handleVoteSuccess,
+  handleVoteSuccess: _handleVoteSuccess,
   handleEditorReady,
   handleQueueJump,
   editorRef,
@@ -555,7 +555,7 @@ function StudioReviewInner({
 
         {/* Editor area (scrollable) */}
         <div className="flex-1 min-w-0 overflow-y-auto">
-          <div className="max-w-3xl mx-auto px-6 py-6">
+          <div className={cn('mx-auto px-6 py-6', isFullWidth ? 'max-w-6xl' : 'max-w-4xl')}>
             {/* Proposal metadata strip */}
             <ProposalMetaStrip item={selectedItem} />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@supabase/supabase-js": "^2.99.1",
         "@tanstack/react-query": "^5.90.21",
         "@tiptap/extension-character-count": "^3.20.4",
+        "@tiptap/extension-image": "^3.20.4",
         "@tiptap/extension-link": "^3.20.4",
         "@tiptap/extension-placeholder": "^3.20.4",
         "@tiptap/extension-table": "^3.20.4",
@@ -12670,6 +12671,19 @@
       "peerDependencies": {
         "@tiptap/core": "^3.20.4",
         "@tiptap/pm": "^3.20.4"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.20.4.tgz",
+      "integrity": "sha512-57w2TevHQljTh6Xiry9duIm7NNOQAUSTwtwRn4GGLoKwHR8qXTxzp513ASrFOgR2kgs2TP471Au6RHf947P+jg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.20.4"
       }
     },
     "node_modules/@tiptap/extension-italic": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@supabase/supabase-js": "^2.99.1",
     "@tanstack/react-query": "^5.90.21",
     "@tiptap/extension-character-count": "^3.20.4",
+    "@tiptap/extension-image": "^3.20.4",
     "@tiptap/extension-link": "^3.20.4",
     "@tiptap/extension-placeholder": "^3.20.4",
     "@tiptap/extension-table": "^3.20.4",


### PR DESCRIPTION
## Summary
- **Responsive content width**: Default widened from `max-w-3xl` (768px) to `max-w-4xl` (896px). Full-width mode now expands to `max-w-6xl` (1152px) for meaningful expansion.
- **SectionTOC**: Removed "Title" entry (excluded from display). Changed from viewport-fixed to sticky sidebar for proper content-relative positioning — no more overlap at narrow widths.
- **Discovery walkthrough**: DiscoveryHub always rendered (FAB hidden in studio). New `DiscoveryHubContext` lets the compass icon in StudioActionBar open the guided walkthrough sheet programmatically — users can access tours from within the studio.
- **Markdown image rendering**: Added `@tiptap/extension-image` + parser support for `![alt](url)` syntax. Proposals with embedded images (IPFS, HackMD, Ideascale) now render inline.
- **Soft line breaks**: Consecutive non-empty lines now produce `hardBreak` nodes instead of being collapsed into a single paragraph. Preserves the proposer's intended line structure.

## Impact
- **What changed**: Layout, discovery access, and markdown rendering improvements
- **User-facing**: Yes — wider content area, accessible walkthroughs, images render, line breaks preserved
- **Risk**: Low — UI-only, no data changes. Discovery context is additive.
- **Scope**: 8 component files + 1 new context file + package.json

## Test plan
- [ ] Open /workspace/review — content should be noticeably wider than before
- [ ] Toggle full-width mode — content should expand to ~1152px
- [ ] SectionTOC should show Abstract/Motivation/Rationale (no Title), positioned as sidebar column
- [ ] Click compass icon in bottom nav — Discovery walkthrough sheet should open
- [ ] Check a proposal with images (e.g., Amaru Treasury Withdrawal) — images should render inline
- [ ] Check line breaks in proposal text — consecutive lines should preserve breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)