### PR TITLE
feat: preview mode backend — invite-code auth, cohorts, admin APIs

### DIFF
--- a/app/api/admin/preview/cohorts/route.ts
+++ b/app/api/admin/preview/cohorts/route.ts
@@ -1,0 +1,113 @@
+/**
+ * Admin Preview Cohorts — CRUD for preview data namespaces.
+ *
+ * Cohorts group preview sessions so testers share drafts, votes, and
+ * annotations within their testing group without polluting real data.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/preview/cohorts — list all cohorts with counts
+ */
+export const GET = withRouteHandler(
+  async (_request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: cohorts, error } = await supabase
+      .from('preview_cohorts')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      logger.error('Failed to list preview cohorts', {
+        context: 'admin/preview/cohorts',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to fetch cohorts' }, { status: 500 });
+    }
+
+    // Get invite and session counts per cohort
+    const cohortIds = (cohorts ?? []).map((c: { id: string }) => c.id);
+
+    const [inviteCounts, sessionCounts] = await Promise.all([
+      cohortIds.length > 0
+        ? supabase.from('preview_invites').select('cohort_id').in('cohort_id', cohortIds)
+        : Promise.resolve({ data: [] }),
+      cohortIds.length > 0
+        ? supabase.from('preview_sessions').select('cohort_id').in('cohort_id', cohortIds)
+        : Promise.resolve({ data: [] }),
+    ]);
+
+    const inviteCountMap = new Map<string, number>();
+    for (const row of inviteCounts.data ?? []) {
+      inviteCountMap.set(row.cohort_id, (inviteCountMap.get(row.cohort_id) ?? 0) + 1);
+    }
+
+    const sessionCountMap = new Map<string, number>();
+    for (const row of sessionCounts.data ?? []) {
+      sessionCountMap.set(row.cohort_id, (sessionCountMap.get(row.cohort_id) ?? 0) + 1);
+    }
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const result = (cohorts ?? []).map((c: any) => ({
+      ...c,
+      invite_count: inviteCountMap.get(c.id) ?? 0,
+      session_count: sessionCountMap.get(c.id) ?? 0,
+    }));
+
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return NextResponse.json({ cohorts: result });
+  },
+  { auth: 'required' },
+);
+
+/**
+ * POST /api/admin/preview/cohorts — create a new cohort
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    if (!name) {
+      return NextResponse.json({ error: 'Missing cohort name' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: cohort, error } = await supabase
+      .from('preview_cohorts')
+      .insert({
+        name,
+        description: typeof body.description === 'string' ? body.description : null,
+        created_by: context.wallet,
+      })
+      .select()
+      .single();
+
+    if (error || !cohort) {
+      logger.error('Failed to create preview cohort', {
+        context: 'admin/preview/cohorts',
+        error: error?.message,
+      });
+      return NextResponse.json({ error: 'Failed to create cohort' }, { status: 500 });
+    }
+
+    return NextResponse.json({ cohort }, { status: 201 });
+  },
+  { auth: 'required' },
+);

--- a/app/api/admin/preview/invites/route.ts
+++ b/app/api/admin/preview/invites/route.ts
@@ -1,0 +1,124 @@
+/**
+ * Admin Preview Invites — create and list invite codes within cohorts.
+ *
+ * Each invite maps to a persona preset from the View As registry,
+ * so testers experience the app as a specific user segment.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { SEGMENT_PRESETS } from '@/lib/admin/viewAsRegistry';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/preview/invites?cohort_id=... — list invites
+ */
+export const GET = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const cohortId = request.nextUrl.searchParams.get('cohort_id');
+    const supabase = getSupabaseAdmin();
+
+    let query = supabase
+      .from('preview_invites')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (cohortId) {
+      query = query.eq('cohort_id', cohortId);
+    }
+
+    const { data: invites, error } = await query;
+
+    if (error) {
+      logger.error('Failed to list preview invites', {
+        context: 'admin/preview/invites',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to fetch invites' }, { status: 500 });
+    }
+
+    return NextResponse.json({ invites: invites ?? [] });
+  },
+  { auth: 'required' },
+);
+
+/**
+ * POST /api/admin/preview/invites — create a new invite code
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const cohortId = typeof body.cohortId === 'string' ? body.cohortId : '';
+    const personaPresetId = typeof body.personaPresetId === 'string' ? body.personaPresetId : '';
+
+    if (!cohortId) {
+      return NextResponse.json({ error: 'Missing cohortId' }, { status: 400 });
+    }
+    if (!personaPresetId) {
+      return NextResponse.json({ error: 'Missing personaPresetId' }, { status: 400 });
+    }
+
+    // Validate persona preset exists
+    const preset = SEGMENT_PRESETS.find((p) => p.id === personaPresetId);
+    if (!preset) {
+      return NextResponse.json(
+        { error: `Invalid personaPresetId: ${personaPresetId}` },
+        { status: 400 },
+      );
+    }
+
+    const segmentOverrides =
+      body.segmentOverrides && typeof body.segmentOverrides === 'object'
+        ? body.segmentOverrides
+        : {};
+    const expiresInDays =
+      typeof body.expiresInDays === 'number' && body.expiresInDays > 0 ? body.expiresInDays : 7;
+    const maxUses = typeof body.maxUses === 'number' && body.maxUses > 0 ? body.maxUses : 10;
+    const notes = typeof body.notes === 'string' ? body.notes : null;
+
+    const code = crypto.randomUUID().slice(0, 8).toUpperCase();
+    const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: invite, error } = await supabase
+      .from('preview_invites')
+      .insert({
+        cohort_id: cohortId,
+        code,
+        persona_preset_id: personaPresetId,
+        segment_overrides: segmentOverrides,
+        expires_at: expiresAt,
+        max_uses: maxUses,
+        use_count: 0,
+        revoked: false,
+        notes,
+        created_by: context.wallet,
+      })
+      .select()
+      .single();
+
+    if (error || !invite) {
+      logger.error('Failed to create preview invite', {
+        context: 'admin/preview/invites',
+        error: error?.message,
+      });
+      return NextResponse.json({ error: 'Failed to create invite' }, { status: 500 });
+    }
+
+    return NextResponse.json({ invite }, { status: 201 });
+  },
+  { auth: 'required' },
+);

--- a/app/api/admin/preview/sessions/route.ts
+++ b/app/api/admin/preview/sessions/route.ts
@@ -1,0 +1,89 @@
+/**
+ * Admin Preview Sessions — list and revoke active preview sessions.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/preview/sessions?cohort_id=... — list active sessions
+ */
+export const GET = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const cohortId = request.nextUrl.searchParams.get('cohort_id');
+    const supabase = getSupabaseAdmin();
+
+    let query = supabase
+      .from('preview_sessions')
+      .select('*')
+      .eq('revoked', false)
+      .order('created_at', { ascending: false });
+
+    if (cohortId) {
+      query = query.eq('cohort_id', cohortId);
+    }
+
+    const { data: sessions, error } = await query;
+
+    if (error) {
+      logger.error('Failed to list preview sessions', {
+        context: 'admin/preview/sessions',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to fetch sessions' }, { status: 500 });
+    }
+
+    return NextResponse.json({ sessions: sessions ?? [] });
+  },
+  { auth: 'required' },
+);
+
+/**
+ * DELETE /api/admin/preview/sessions — revoke a session
+ */
+export const DELETE = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : '';
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Missing sessionId' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { error } = await supabase
+      .from('preview_sessions')
+      .update({ revoked: true })
+      .eq('id', sessionId);
+
+    if (error) {
+      logger.error('Failed to revoke preview session', {
+        context: 'admin/preview/sessions',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to revoke session' }, { status: 500 });
+    }
+
+    logger.info('Preview session revoked', {
+      context: 'admin/preview/sessions',
+      sessionId,
+      revokedBy: context.wallet,
+    });
+
+    return NextResponse.json({ revoked: true });
+  },
+  { auth: 'required' },
+);

--- a/app/api/auth/preview/route.ts
+++ b/app/api/auth/preview/route.ts
@@ -1,0 +1,137 @@
+/**
+ * Preview Auth — invite-code-based authentication for preview mode.
+ *
+ * Creates a synthetic wallet address and session for testers, scoped
+ * to a cohort for shared data namespaces.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { createSessionToken, SESSION_MAX_AGE_SECONDS } from '@/lib/supabaseAuth';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { generatePreviewAddress } from '@/lib/preview';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+export const POST = withRouteHandler(
+  async (request: NextRequest) => {
+    // Gate behind feature flag
+    const enabled = await getFeatureFlag('preview_mode', false);
+    if (!enabled) {
+      return NextResponse.json(
+        { error: 'Preview mode is not currently available' },
+        { status: 403 },
+      );
+    }
+
+    const body = await request.json();
+    const code = typeof body.code === 'string' ? body.code.trim() : '';
+    if (!code) {
+      return NextResponse.json({ error: 'Missing invite code' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    // Look up the invite
+    const { data: invite, error: inviteError } = await supabase
+      .from('preview_invites')
+      .select('*')
+      .eq('code', code)
+      .eq('revoked', false)
+      .gt('expires_at', new Date().toISOString())
+      .maybeSingle();
+
+    if (inviteError) {
+      logger.error('Preview invite lookup failed', {
+        context: 'auth/preview',
+        error: inviteError.message,
+      });
+      return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+    }
+
+    if (!invite) {
+      return NextResponse.json({ error: 'Invalid or expired invite code' }, { status: 401 });
+    }
+
+    if (invite.use_count >= invite.max_uses) {
+      return NextResponse.json({ error: 'Invite code has been fully used' }, { status: 401 });
+    }
+
+    // Generate synthetic address and create user
+    const syntheticAddress = generatePreviewAddress(code);
+
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .upsert(
+        { wallet_address: syntheticAddress, last_active: new Date().toISOString() },
+        { onConflict: 'wallet_address' },
+      )
+      .select('id')
+      .single();
+
+    if (userError || !user) {
+      logger.error('Preview user upsert failed', {
+        context: 'auth/preview',
+        error: userError?.message,
+      });
+      return NextResponse.json({ error: 'Failed to create preview user' }, { status: 500 });
+    }
+
+    // Create preview session row
+    const { data: previewSession, error: sessionError } = await supabase
+      .from('preview_sessions')
+      .insert({
+        invite_id: invite.id,
+        user_id: user.id,
+        cohort_id: invite.cohort_id,
+        persona_snapshot: invite.segment_overrides ?? {},
+      })
+      .select('id')
+      .single();
+
+    if (sessionError || !previewSession) {
+      logger.error('Preview session insert failed', {
+        context: 'auth/preview',
+        error: sessionError?.message,
+      });
+      return NextResponse.json({ error: 'Failed to create preview session' }, { status: 500 });
+    }
+
+    // Increment invite use count
+    await supabase
+      .from('preview_invites')
+      .update({ use_count: invite.use_count + 1 })
+      .eq('id', invite.id);
+
+    // Create JWT session
+    const sessionToken = await createSessionToken(user.id, syntheticAddress);
+
+    const response = NextResponse.json({
+      sessionToken,
+      userId: user.id,
+      previewSessionId: previewSession.id,
+      personaPresetId: invite.persona_preset_id,
+      cohortId: invite.cohort_id,
+    });
+
+    response.cookies.set('drepscore_session', sessionToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_MAX_AGE_SECONDS,
+    });
+
+    logger.info('Preview session created', {
+      context: 'auth/preview',
+      userId: user.id,
+      cohortId: invite.cohort_id,
+      presetId: invite.persona_preset_id,
+    });
+
+    return response;
+  },
+  { auth: 'none', rateLimit: { max: 10, window: 60 } },
+);

--- a/app/api/workspace/drafts/route.ts
+++ b/app/api/workspace/drafts/route.ts
@@ -29,6 +29,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       .from('proposal_drafts')
       .select('*')
       .in('status', statuses)
+      .is('preview_cohort_id', null)
       .order('updated_at', { ascending: false })
       .limit(50);
 

--- a/lib/preview.ts
+++ b/lib/preview.ts
@@ -1,0 +1,17 @@
+/**
+ * Preview Mode Utilities
+ *
+ * Synthetic wallet addresses for preview users. These addresses are never
+ * valid Cardano addresses — they exist only in the `users` table to give
+ * preview sessions a stable identity for drafts, votes, and annotations.
+ */
+
+export const PREVIEW_ADDRESS_PREFIX = 'preview_';
+
+export function isPreviewAddress(address: string | null): boolean {
+  return !!address && address.startsWith(PREVIEW_ADDRESS_PREFIX);
+}
+
+export function generatePreviewAddress(code: string): string {
+  return `${PREVIEW_ADDRESS_PREFIX}${code}_${crypto.randomUUID().slice(0, 8)}`;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -102,6 +102,21 @@ export function middleware(request: NextRequest) {
     }
   }
 
+  // Block preview users from admin routes
+  if (pathname.startsWith('/admin')) {
+    const session = request.cookies.get('drepscore_session');
+    if (session?.value) {
+      try {
+        const payload = JSON.parse(atob(session.value.split('.')[1]));
+        if (payload.walletAddress?.startsWith('preview_')) {
+          return withLocale(NextResponse.redirect(new URL('/', request.url)), request);
+        }
+      } catch {
+        /* pass through */
+      }
+    }
+  }
+
   // ── CORS for public API ───────────────────────────────────────────
   if (pathname.startsWith('/api/v1')) {
     if (request.method === 'OPTIONS') {

--- a/types/database.ts
+++ b/types/database.ts
@@ -3727,6 +3727,173 @@ export type Database = {
         };
         Relationships: [];
       };
+      preview_cohorts: {
+        Row: {
+          created_at: string;
+          created_by: string;
+          description: string | null;
+          id: string;
+          name: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by: string;
+          description?: string | null;
+          id?: string;
+          name: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: string;
+          description?: string | null;
+          id?: string;
+          name?: string;
+        };
+        Relationships: [];
+      };
+      preview_feedback: {
+        Row: {
+          created_at: string;
+          id: string;
+          page: string;
+          persona_preset_id: string;
+          session_id: string;
+          text: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          page: string;
+          persona_preset_id: string;
+          session_id: string;
+          text: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          page?: string;
+          persona_preset_id?: string;
+          session_id?: string;
+          text?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'preview_feedback_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'preview_sessions';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      preview_invites: {
+        Row: {
+          code: string;
+          cohort_id: string;
+          created_at: string;
+          created_by: string;
+          expires_at: string;
+          id: string;
+          max_uses: number;
+          notes: string | null;
+          persona_preset_id: string;
+          revoked: boolean;
+          segment_overrides: Json;
+          use_count: number;
+        };
+        Insert: {
+          code: string;
+          cohort_id: string;
+          created_at?: string;
+          created_by: string;
+          expires_at: string;
+          id?: string;
+          max_uses?: number;
+          notes?: string | null;
+          persona_preset_id: string;
+          revoked?: boolean;
+          segment_overrides?: Json;
+          use_count?: number;
+        };
+        Update: {
+          code?: string;
+          cohort_id?: string;
+          created_at?: string;
+          created_by?: string;
+          expires_at?: string;
+          id?: string;
+          max_uses?: number;
+          notes?: string | null;
+          persona_preset_id?: string;
+          revoked?: boolean;
+          segment_overrides?: Json;
+          use_count?: number;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'preview_invites_cohort_id_fkey';
+            columns: ['cohort_id'];
+            isOneToOne: false;
+            referencedRelation: 'preview_cohorts';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      preview_sessions: {
+        Row: {
+          cohort_id: string;
+          created_at: string;
+          id: string;
+          invite_id: string;
+          last_active: string;
+          persona_snapshot: Json;
+          revoked: boolean;
+          user_id: string;
+        };
+        Insert: {
+          cohort_id: string;
+          created_at?: string;
+          id?: string;
+          invite_id: string;
+          last_active?: string;
+          persona_snapshot: Json;
+          revoked?: boolean;
+          user_id: string;
+        };
+        Update: {
+          cohort_id?: string;
+          created_at?: string;
+          id?: string;
+          invite_id?: string;
+          last_active?: string;
+          persona_snapshot?: Json;
+          revoked?: boolean;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'preview_sessions_cohort_id_fkey';
+            columns: ['cohort_id'];
+            isOneToOne: false;
+            referencedRelation: 'preview_cohorts';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'preview_sessions_invite_id_fkey';
+            columns: ['invite_id'];
+            isOneToOne: false;
+            referencedRelation: 'preview_invites';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'preview_sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       profile_views: {
         Row: {
           drep_id: string;
@@ -3990,6 +4157,7 @@ export type Database = {
           last_constitutional_check_at: string | null;
           motivation: string;
           owner_stake_address: string;
+          preview_cohort_id: string | null;
           proposal_type: string;
           rationale: string;
           stage_entered_at: string | null;
@@ -4015,6 +4183,7 @@ export type Database = {
           last_constitutional_check_at?: string | null;
           motivation?: string;
           owner_stake_address: string;
+          preview_cohort_id?: string | null;
           proposal_type?: string;
           rationale?: string;
           stage_entered_at?: string | null;
@@ -4040,6 +4209,7 @@ export type Database = {
           last_constitutional_check_at?: string | null;
           motivation?: string;
           owner_stake_address?: string;
+          preview_cohort_id?: string | null;
           proposal_type?: string;
           rationale?: string;
           stage_entered_at?: string | null;
@@ -4052,7 +4222,15 @@ export type Database = {
           type_specific?: Json;
           updated_at?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: 'proposal_drafts_preview_cohort_id_fkey';
+            columns: ['preview_cohort_id'];
+            isOneToOne: false;
+            referencedRelation: 'preview_cohorts';
+            referencedColumns: ['id'];
+          },
+        ];
       };
       proposal_engagement_events: {
         Row: {


### PR DESCRIPTION
## Summary
- Add preview mode infrastructure for letting external testers access Governada without Cardano wallets
- Introduce **cohort model** for shared data namespaces — multiple preview users within a cohort see each other's workspace data
- Invite-code authentication reusing existing JWT infrastructure (`createSessionToken` is auth-method-agnostic)
- Admin APIs for cohort/invite/session management (`/api/admin/preview/*`)
- Middleware blocks preview users from `/admin` routes
- Draft scoping: community-reviewable drafts query excludes preview data for real users

## Impact
- **What changed**: New auth path + 4 new API routes + 4 DB tables + middleware guard + draft scoping
- **User-facing**: No — feature flag `preview_mode` is off by default. Zero impact on existing users
- **Risk**: Low — entirely additive, gated behind feature flag, no existing behavior modified
- **Scope**: `lib/preview.ts`, 4 new API routes, `middleware.ts`, `drafts/route.ts`, migration, types

## Test plan
- [ ] Enable `preview_mode` flag via `/admin/flags`
- [ ] Create cohort via `POST /api/admin/preview/cohorts`
- [ ] Create invite via `POST /api/admin/preview/invites`
- [ ] Authenticate via `POST /api/auth/preview` with invite code
- [ ] Verify preview user cannot access `/admin`
- [ ] Verify community-reviewable drafts exclude preview data

🤖 Generated with [Claude Code](https://claude.com/claude-code)