### PR TITLE
feat: preview mode UI — landing page, admin management, SegmentProvider

### DIFF
--- a/app/admin/preview/PreviewClient.tsx
+++ b/app/admin/preview/PreviewClient.tsx
@@ -1,0 +1,556 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { SEGMENT_PRESETS } from '@/lib/admin/viewAsRegistry';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Copy, Plus, Trash2, ChevronDown, ChevronRight, Users, Eye } from 'lucide-react';
+
+// ---- Types ----
+
+interface Cohort {
+  id: string;
+  name: string;
+  description: string | null;
+  invite_count: number;
+  session_count: number;
+  created_at: string;
+}
+
+interface Invite {
+  id: string;
+  cohort_id: string;
+  code: string;
+  persona_preset_id: string;
+  segment_overrides: Record<string, unknown>;
+  expires_at: string;
+  max_uses: number;
+  use_count: number;
+  revoked: boolean;
+  notes: string | null;
+  created_at: string;
+}
+
+interface Session {
+  id: string;
+  cohort_id: string;
+  persona_snapshot: Record<string, unknown>;
+  revoked: boolean;
+  created_at: string;
+}
+
+// ---- API helpers ----
+
+function authHeaders(): Record<string, string> {
+  const token = getStoredSession();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchCohorts(): Promise<Cohort[]> {
+  const res = await fetch('/api/admin/preview/cohorts', { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to fetch cohorts');
+  const data = await res.json();
+  return data.cohorts ?? [];
+}
+
+async function fetchInvites(cohortId: string): Promise<Invite[]> {
+  const res = await fetch(`/api/admin/preview/invites?cohort_id=${cohortId}`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to fetch invites');
+  const data = await res.json();
+  return data.invites ?? [];
+}
+
+async function fetchSessions(cohortId?: string): Promise<Session[]> {
+  const url = cohortId
+    ? `/api/admin/preview/sessions?cohort_id=${cohortId}`
+    : '/api/admin/preview/sessions';
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to fetch sessions');
+  const data = await res.json();
+  return data.sessions ?? [];
+}
+
+// ---- Components ----
+
+function CohortInvites({ cohortId }: { cohortId: string }) {
+  const queryClient = useQueryClient();
+  const [showCreateInvite, setShowCreateInvite] = useState(false);
+  const [presetId, setPresetId] = useState('');
+  const [expiryDays, setExpiryDays] = useState('7');
+  const [maxUses, setMaxUses] = useState('5');
+  const [notes, setNotes] = useState('');
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const { data: invites, isLoading } = useQuery({
+    queryKey: ['admin-preview-invites', cohortId],
+    queryFn: () => fetchInvites(cohortId),
+    staleTime: 10_000,
+  });
+
+  const createInvite = useMutation({
+    mutationFn: async () => {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/preview/invites', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          cohortId,
+          personaPresetId: presetId,
+          expiresInDays: parseInt(expiryDays, 10) || 7,
+          maxUses: parseInt(maxUses, 10) || 5,
+          notes: notes || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? 'Failed to create invite');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-preview-invites', cohortId] });
+      queryClient.invalidateQueries({ queryKey: ['admin-preview-cohorts'] });
+      setShowCreateInvite(false);
+      setPresetId('');
+      setExpiryDays('7');
+      setMaxUses('5');
+      setNotes('');
+    },
+  });
+
+  function copyCode(code: string, inviteId: string) {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopiedId(inviteId);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  }
+
+  function getPresetLabel(id: string): string {
+    const preset = SEGMENT_PRESETS.find((p) => p.id === id);
+    return preset ? `${preset.segment} / ${preset.label}` : id;
+  }
+
+  function getInviteStatus(invite: Invite): {
+    label: string;
+    variant: 'default' | 'secondary' | 'destructive' | 'outline';
+  } {
+    if (invite.revoked) return { label: 'Revoked', variant: 'destructive' };
+    if (new Date(invite.expires_at) < new Date()) return { label: 'Expired', variant: 'secondary' };
+    if (invite.use_count >= invite.max_uses) return { label: 'Exhausted', variant: 'secondary' };
+    return { label: 'Active', variant: 'default' };
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-muted-foreground">Invites</h4>
+        <Button size="sm" variant="outline" onClick={() => setShowCreateInvite(true)}>
+          <Plus className="h-3.5 w-3.5" />
+          Create Invite
+        </Button>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading invites...</p>}
+
+      {invites && invites.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Code</TableHead>
+              <TableHead>Persona</TableHead>
+              <TableHead>Uses</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invites.map((invite) => {
+              const status = getInviteStatus(invite);
+              return (
+                <TableRow key={invite.id}>
+                  <TableCell>
+                    <button
+                      onClick={() => copyCode(invite.code, invite.id)}
+                      className="inline-flex items-center gap-1.5 font-mono text-xs hover:text-foreground transition-colors"
+                      title="Copy code"
+                    >
+                      {invite.code}
+                      <Copy className="h-3 w-3 text-muted-foreground" />
+                      {copiedId === invite.id && (
+                        <span className="text-xs text-green-400">Copied</span>
+                      )}
+                    </button>
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {getPresetLabel(invite.persona_preset_id)}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {invite.use_count}/{invite.max_uses}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {new Date(invite.expires_at).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={status.variant} className="text-xs">
+                      {status.label}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {invites && invites.length === 0 && (
+        <p className="text-xs text-muted-foreground">No invites yet. Create one to get started.</p>
+      )}
+
+      {/* Create Invite Dialog */}
+      <Dialog open={showCreateInvite} onOpenChange={setShowCreateInvite}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Invite</DialogTitle>
+            <DialogDescription>
+              Generate a new invite code for this cohort. Testers use this code to access the
+              preview.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Persona Preset</label>
+              <Select value={presetId} onValueChange={setPresetId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select persona..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {SEGMENT_PRESETS.filter((p) => !p.requiresPicker).map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.segment} / {preset.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Expiry (days)</label>
+                <Input
+                  type="number"
+                  value={expiryDays}
+                  onChange={(e) => setExpiryDays(e.target.value)}
+                  min={1}
+                  max={90}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Max Uses</label>
+                <Input
+                  type="number"
+                  value={maxUses}
+                  onChange={(e) => setMaxUses(e.target.value)}
+                  min={1}
+                  max={100}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Notes (optional)</label>
+              <Input
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="e.g. Sent to beta testers batch 1"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateInvite(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => createInvite.mutate()}
+              disabled={!presetId || createInvite.isPending}
+            >
+              {createInvite.isPending ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+          {createInvite.isError && (
+            <p className="text-sm text-destructive">{(createInvite.error as Error).message}</p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function CohortSessions({ cohortId }: { cohortId: string }) {
+  const queryClient = useQueryClient();
+
+  const { data: sessions, isLoading } = useQuery({
+    queryKey: ['admin-preview-sessions', cohortId],
+    queryFn: () => fetchSessions(cohortId),
+    staleTime: 10_000,
+  });
+
+  const revokeSession = useMutation({
+    mutationFn: async (sessionId: string) => {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/preview/sessions', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ sessionId }),
+      });
+      if (!res.ok) throw new Error('Failed to revoke session');
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-preview-sessions', cohortId] });
+      queryClient.invalidateQueries({ queryKey: ['admin-preview-cohorts'] });
+    },
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading sessions...</p>;
+
+  if (!sessions || sessions.length === 0) {
+    return <p className="text-xs text-muted-foreground">No active sessions.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-sm font-medium text-muted-foreground">Active Sessions</h4>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Persona</TableHead>
+            <TableHead>Created</TableHead>
+            <TableHead className="w-[80px]">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sessions.map((session) => {
+            const segment =
+              (session.persona_snapshot as Record<string, string>)?.segment ?? 'unknown';
+            return (
+              <TableRow key={session.id}>
+                <TableCell className="text-xs capitalize">{segment}</TableCell>
+                <TableCell className="text-xs">
+                  {new Date(session.created_at).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => revokeSession.mutate(session.id)}
+                    disabled={revokeSession.isPending}
+                    title="Revoke session"
+                  >
+                    <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function PreviewClient() {
+  const queryClient = useQueryClient();
+  const [expandedCohort, setExpandedCohort] = useState<string | null>(null);
+  const [showCreateCohort, setShowCreateCohort] = useState(false);
+  const [cohortName, setCohortName] = useState('');
+  const [cohortDescription, setCohortDescription] = useState('');
+
+  const { data: cohorts, isLoading } = useQuery({
+    queryKey: ['admin-preview-cohorts'],
+    queryFn: fetchCohorts,
+    staleTime: 10_000,
+  });
+
+  const createCohort = useMutation({
+    mutationFn: async () => {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/preview/cohorts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ name: cohortName, description: cohortDescription || undefined }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? 'Failed to create cohort');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-preview-cohorts'] });
+      setShowCreateCohort(false);
+      setCohortName('');
+      setCohortDescription('');
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Eye className="h-5 w-5" />
+            Preview Management
+          </h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage preview cohorts, invite codes, and active sessions.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreateCohort(true)}>
+          <Plus className="h-4 w-4" />
+          Create Cohort
+        </Button>
+      </div>
+
+      {isLoading && (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Loading cohorts...
+          </CardContent>
+        </Card>
+      )}
+
+      {cohorts && cohorts.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            No cohorts yet. Create one to start managing preview access.
+          </CardContent>
+        </Card>
+      )}
+
+      {cohorts?.map((cohort) => {
+        const isExpanded = expandedCohort === cohort.id;
+        return (
+          <Card key={cohort.id}>
+            <CardHeader
+              className="cursor-pointer"
+              onClick={() => setExpandedCohort(isExpanded ? null : cohort.id)}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  {isExpanded ? (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  )}
+                  <CardTitle className="text-base">{cohort.name}</CardTitle>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <Copy className="h-3 w-3" />
+                    {cohort.invite_count} invites
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Users className="h-3 w-3" />
+                    {cohort.session_count} sessions
+                  </span>
+                  <span>{new Date(cohort.created_at).toLocaleDateString()}</span>
+                </div>
+              </div>
+              {cohort.description && (
+                <CardDescription className="ml-6">{cohort.description}</CardDescription>
+              )}
+            </CardHeader>
+            {isExpanded && (
+              <CardContent className="space-y-6 border-t border-border/40 pt-4">
+                <CohortInvites cohortId={cohort.id} />
+                <CohortSessions cohortId={cohort.id} />
+              </CardContent>
+            )}
+          </Card>
+        );
+      })}
+
+      {/* Create Cohort Dialog */}
+      <Dialog open={showCreateCohort} onOpenChange={setShowCreateCohort}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Cohort</DialogTitle>
+            <DialogDescription>
+              A cohort groups preview testers together so they share drafts and annotations within
+              their testing namespace.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={cohortName}
+                onChange={(e) => setCohortName(e.target.value)}
+                placeholder="e.g. Beta Testers March 2026"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Description (optional)</label>
+              <Input
+                value={cohortDescription}
+                onChange={(e) => setCohortDescription(e.target.value)}
+                placeholder="e.g. Internal team testing ahead of launch"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateCohort(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => createCohort.mutate()}
+              disabled={!cohortName.trim() || createCohort.isPending}
+            >
+              {createCohort.isPending ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+          {createCohort.isError && (
+            <p className="text-sm text-destructive">{(createCohort.error as Error).message}</p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/admin/preview/page.tsx
+++ b/app/admin/preview/page.tsx
@@ -1,0 +1,7 @@
+export const dynamic = 'force-dynamic';
+
+import { PreviewClient } from './PreviewClient';
+
+export default function AdminPreviewPage() {
+  return <PreviewClient />;
+}

--- a/app/preview/page.tsx
+++ b/app/preview/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { saveSession } from '@/lib/supabaseAuth';
+
+export default function PreviewPage() {
+  const router = useRouter();
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmed = code.trim().toUpperCase();
+    if (!trimmed) {
+      setError('Please enter an invite code');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/auth/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: trimmed }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error ?? 'Something went wrong');
+        return;
+      }
+
+      // Store session token for client-side auth (same key as wallet auth)
+      if (data.sessionToken) {
+        saveSession(data.sessionToken);
+      }
+
+      // Store preview metadata in sessionStorage
+      sessionStorage.setItem(
+        'governada_preview',
+        JSON.stringify({
+          previewSessionId: data.previewSessionId,
+          cohortId: data.cohortId,
+          personaPresetId: data.personaPresetId,
+          personaSnapshot: data.personaSnapshot ?? {},
+        }),
+      );
+
+      router.push('/governance');
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Preview Access</CardTitle>
+          <CardDescription>Enter your invite code to preview Governada</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              value={code}
+              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              placeholder="ABCD1234"
+              className="font-mono text-center text-lg tracking-widest"
+              maxLength={12}
+              autoFocus
+            />
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Verifying...' : 'Enter Preview'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Activity,
   BarChart3,
   Database,
+  Eye,
   Flag,
   LayoutDashboard,
   Shield,
@@ -51,6 +52,11 @@ const NAV_ITEMS = [
     label: 'Assemblies',
     href: '/admin/assemblies',
     icon: Vote,
+  },
+  {
+    label: 'Preview',
+    href: '/admin/preview',
+    icon: Eye,
   },
 ] as const;
 

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -11,6 +11,7 @@ import { GovernadaBottomNav } from './GovernadaBottomNav';
 import { GovernadaSidebar } from './GovernadaSidebar';
 import { EpochContextBar } from './EpochContextBar';
 import { SyncFreshnessBanner } from '@/components/SyncFreshnessBanner';
+import { PreviewBanner } from '@/components/preview/PreviewBanner';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { useSentryContext } from '@/hooks/useSentryContext';
 import { useSentryFeatureFlags } from '@/hooks/useSentryFeatureFlags';
@@ -150,6 +151,7 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
           <DeepLinkHandler />
         </Suspense>
         <SyncFreshnessBanner />
+        <PreviewBanner />
         {!isStudioMode && <GovernadaHeader />}
         {!isStudioMode && (
           <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />

--- a/components/preview/PreviewBanner.tsx
+++ b/components/preview/PreviewBanner.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Eye } from 'lucide-react';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { SEGMENT_PRESETS } from '@/lib/admin/viewAsRegistry';
+
+export function PreviewBanner() {
+  const { isPreviewMode } = useSegment();
+  const [personaLabel, setPersonaLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isPreviewMode) return;
+    try {
+      const raw = sessionStorage.getItem('governada_preview');
+      if (raw) {
+        const meta = JSON.parse(raw);
+        const presetId = meta.personaPresetId;
+        if (presetId) {
+          const preset = SEGMENT_PRESETS.find((p) => p.id === presetId);
+          setPersonaLabel(preset?.label ?? presetId);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [isPreviewMode]);
+
+  if (!isPreviewMode) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 flex items-center gap-2 bg-amber-900/80 border-b border-amber-700/50 py-1.5 px-4 text-sm text-amber-200">
+      <Eye className="h-4 w-4 shrink-0" />
+      <span className="font-medium">Preview Mode</span>
+      {personaLabel && (
+        <span className="text-amber-300/80">
+          &middot; Viewing as <span className="font-medium text-amber-100">{personaLabel}</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { useWallet } from '@/utils/wallet-context';
 import type { DimensionOverrides } from '@/lib/admin/viewAsRegistry';
+import { isPreviewAddress } from '@/lib/preview';
 import type { EngagementLevel } from '@/lib/citizen/engagementLevel';
 import type { CredibilityTier } from '@/lib/citizenCredibility';
 import type { GovernanceLevel } from '@/lib/governanceLevels';
@@ -40,6 +41,12 @@ export interface SegmentState {
   getGovernanceDepthOverride: () => GovernanceDepth | null;
   /** True when admin "View As" override is active — components should show preview mode */
   isViewingAs: boolean;
+  /** True when user is in invite-code-based preview mode */
+  isPreviewMode: boolean;
+  /** Preview session ID (from preview_sessions table) */
+  previewSessionId: string | null;
+  /** Preview cohort ID (data namespace for shared preview data) */
+  previewCohortId: string | null;
 }
 
 const STORAGE_KEY = 'governada_segment';
@@ -65,6 +72,9 @@ const DEFAULT_STATE: SegmentState = {
   getGovernanceLevelOverride: () => null,
   getGovernanceDepthOverride: () => null,
   isViewingAs: false,
+  isPreviewMode: false,
+  previewSessionId: null,
+  previewCohortId: null,
 };
 
 const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
@@ -114,6 +124,9 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
       | 'getGovernanceLevelOverride'
       | 'getGovernanceDepthOverride'
       | 'isViewingAs'
+      | 'isPreviewMode'
+      | 'previewSessionId'
+      | 'previewCohortId'
     >
   >({
     isLoading: false,
@@ -127,6 +140,8 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
   const [detectedSegment, setDetectedSegment] = useState<UserSegment>('anonymous');
   const [override, setOverride] = useState<SegmentOverride | null>(null);
   const [dimensionOverrides, setDimensionOverrides] = useState<DimensionOverrides>({});
+  const [previewSessionId, setPreviewSessionId] = useState<string | null>(null);
+  const [previewCohortId, setPreviewCohortId] = useState<string | null>(null);
 
   const detect = useCallback(async (stakeAddress: string) => {
     const cached = loadCached(stakeAddress);
@@ -171,6 +186,41 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    // Preview session: apply locked persona, skip on-chain detection
+    if (address && isPreviewAddress(address)) {
+      try {
+        const raw = sessionStorage.getItem('governada_preview');
+        if (raw) {
+          const meta = JSON.parse(raw);
+          const snap = meta.personaSnapshot ?? {};
+          setDetectedSegment(snap.segment ?? 'citizen');
+          setDetected({
+            isLoading: false,
+            stakeAddress: address,
+            drepId: snap.drepId ?? null,
+            poolId: snap.poolId ?? null,
+            delegatedDrep: snap.delegatedDrep ?? null,
+            delegatedPool: snap.delegatedPool ?? null,
+            tier: snap.tier ?? null,
+          });
+          if (snap.segment) {
+            setOverride({
+              segment: snap.segment,
+              ...(snap.drepId !== undefined ? { drepId: snap.drepId } : {}),
+              ...(snap.poolId !== undefined ? { poolId: snap.poolId } : {}),
+              ...(snap.delegatedDrep !== undefined ? { delegatedDrep: snap.delegatedDrep } : {}),
+              ...(snap.delegatedPool !== undefined ? { delegatedPool: snap.delegatedPool } : {}),
+            });
+          }
+          setPreviewSessionId(meta.previewSessionId ?? null);
+          setPreviewCohortId(meta.cohortId ?? null);
+        }
+      } catch {
+        /* ignore parse errors */
+      }
+      return;
+    }
+
     // Detect segment when wallet is connected (address available),
     // not just when fully authenticated (nonce signed)
     if ((!connected && !isAuthenticated) || !address) {
@@ -191,6 +241,15 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
     detect(address);
   }, [connected, isAuthenticated, address, detect]);
 
+  // Lock overrides in preview mode — persona is set by the invite code
+  const wrappedSetOverride = useCallback(
+    (newOverride: SegmentOverride | null) => {
+      if (isPreviewAddress(detected.stakeAddress)) return;
+      setOverride(newOverride);
+    },
+    [detected.stakeAddress],
+  );
+
   const value: SegmentState = {
     ...detected,
     segment: override?.segment ?? detectedSegment,
@@ -205,7 +264,7 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
       override && 'delegatedPool' in override
         ? (override.delegatedPool ?? null)
         : detected.delegatedPool,
-    setOverride,
+    setOverride: wrappedSetOverride,
     dimensionOverrides,
     setDimensionOverrides,
     getEngagementLevelOverride: () => dimensionOverrides.engagementLevel ?? null,
@@ -213,6 +272,9 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
     getGovernanceLevelOverride: () => dimensionOverrides.governanceLevel ?? null,
     getGovernanceDepthOverride: () => dimensionOverrides.governanceDepth ?? null,
     isViewingAs: override !== null,
+    isPreviewMode: isPreviewAddress(detected.stakeAddress),
+    previewSessionId,
+    previewCohortId,
   };
 
   return <SegmentContext.Provider value={value}>{children}</SegmentContext.Provider>;

--- a/hooks/useSentryContext.ts
+++ b/hooks/useSentryContext.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import * as Sentry from '@sentry/nextjs';
+import { isPreviewAddress } from '@/lib/preview';
 
 /**
  * Syncs SegmentProvider state to Sentry user context and tags.
@@ -57,6 +58,12 @@ export function useSentryContext() {
       Sentry.setTag('segment', segment);
       Sentry.setTag('tier', tier ?? 'none');
       Sentry.setTag('isViewingAs', String(isViewingAs));
+      // Preview mode context
+      const isPreview = isPreviewAddress(stakeAddress);
+      if (isPreview) {
+        Sentry.setTag('isPreview', 'true');
+      }
+
       Sentry.setContext('governance', {
         segment,
         realSegment,
@@ -66,6 +73,7 @@ export function useSentryContext() {
         delegatedPool,
         tier,
         isViewingAs,
+        isPreview,
         engagementLevel: dimensionOverrides.engagementLevel ?? null,
         credibilityTier: dimensionOverrides.credibilityTier ?? null,
         governanceLevel: dimensionOverrides.governanceLevel ?? null,


### PR DESCRIPTION
## Summary
- Add /preview landing page for invite code entry
- Integrate preview mode into SegmentProvider — detects preview addresses, applies locked persona
- Add persistent PreviewBanner with amber accent showing persona label
- Add /admin/preview management page — cohort CRUD, invite creation, session list
- Add Preview nav item in admin sidebar
- Enrich Sentry context with isPreview tag

## Impact
- **What changed**: Preview mode usable end-to-end
- **User-facing**: No — feature flag preview_mode is off
- **Risk**: Low — SegmentProvider changes behind isPreviewAddress() check
- **Scope**: SegmentProvider (+35 lines), 4 new files, 3 modified files

## Test plan
- [ ] Enable preview_mode flag, create cohort + invite via admin page
- [ ] Navigate to /preview, enter code, verify redirect with banner
- [ ] Verify workspace access with preview session
- [ ] Verify preview user blocked from /admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)