### PR TITLE
feat: preview feedback capture — floating widget, API, admin review

### DIFF
--- a/app/admin/preview/PreviewClient.tsx
+++ b/app/admin/preview/PreviewClient.tsx
@@ -31,7 +31,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Copy, Plus, Trash2, ChevronDown, ChevronRight, Users, Eye } from 'lucide-react';
+import {
+  Copy,
+  Plus,
+  Trash2,
+  ChevronDown,
+  ChevronRight,
+  Users,
+  Eye,
+  MessageSquare,
+} from 'lucide-react';
 
 // ---- Types ----
 
@@ -66,6 +75,16 @@ interface Session {
   created_at: string;
 }
 
+interface Feedback {
+  id: string;
+  sessionId: string;
+  page: string;
+  personaPresetId: string;
+  text: string;
+  createdAt: string;
+  cohortId: string | null;
+}
+
 // ---- API helpers ----
 
 function authHeaders(): Record<string, string> {
@@ -97,6 +116,16 @@ async function fetchSessions(cohortId?: string): Promise<Session[]> {
   if (!res.ok) throw new Error('Failed to fetch sessions');
   const data = await res.json();
   return data.sessions ?? [];
+}
+
+async function fetchFeedback(cohortId?: string): Promise<Feedback[]> {
+  const url = cohortId
+    ? `/api/admin/preview/feedback?cohort_id=${cohortId}`
+    : '/api/admin/preview/feedback';
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to fetch feedback');
+  const data = await res.json();
+  return data.feedback ?? [];
 }
 
 // ---- Components ----
@@ -391,6 +420,61 @@ function CohortSessions({ cohortId }: { cohortId: string }) {
   );
 }
 
+function CohortFeedback({ cohortId }: { cohortId: string }) {
+  const { data: feedback, isLoading } = useQuery({
+    queryKey: ['admin-preview-feedback', cohortId],
+    queryFn: () => fetchFeedback(cohortId),
+    staleTime: 10_000,
+  });
+
+  if (isLoading) return <p className="text-sm text-muted-foreground">Loading feedback...</p>;
+
+  if (!feedback || feedback.length === 0) {
+    return <p className="text-xs text-muted-foreground">No feedback yet.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+        <MessageSquare className="h-3.5 w-3.5" />
+        Feedback ({feedback.length})
+      </h4>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Page</TableHead>
+            <TableHead>Persona</TableHead>
+            <TableHead className="w-[40%]">Feedback</TableHead>
+            <TableHead>Date</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {feedback.map((entry) => (
+            <TableRow key={entry.id}>
+              <TableCell className="text-xs font-mono max-w-[150px] truncate">
+                {entry.page}
+              </TableCell>
+              <TableCell className="text-xs">{entry.personaPresetId}</TableCell>
+              <TableCell className="text-xs max-w-[300px]">
+                <span className="line-clamp-2" title={entry.text}>
+                  {entry.text}
+                </span>
+              </TableCell>
+              <TableCell className="text-xs whitespace-nowrap">
+                {new Date(entry.createdAt).toLocaleDateString()}{' '}
+                {new Date(entry.createdAt).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 export function PreviewClient() {
   const queryClient = useQueryClient();
   const [expandedCohort, setExpandedCohort] = useState<string | null>(null);
@@ -500,6 +584,7 @@ export function PreviewClient() {
               <CardContent className="space-y-6 border-t border-border/40 pt-4">
                 <CohortInvites cohortId={cohort.id} />
                 <CohortSessions cohortId={cohort.id} />
+                <CohortFeedback cohortId={cohort.id} />
               </CardContent>
             )}
           </Card>

--- a/app/api/admin/preview/feedback/route.ts
+++ b/app/api/admin/preview/feedback/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Admin Preview Feedback — list feedback from preview users.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/preview/feedback?cohort_id=... — list all feedback, optionally filtered by cohort
+ */
+export const GET = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const cohortId = request.nextUrl.searchParams.get('cohort_id');
+    const supabase = getSupabaseAdmin();
+
+    // Join feedback with preview_sessions to get cohort info
+    let query = supabase
+      .from('preview_feedback')
+      .select(
+        'id, session_id, page, persona_preset_id, text, created_at, preview_sessions!inner(cohort_id)',
+      )
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    if (cohortId) {
+      query = query.eq('preview_sessions.cohort_id', cohortId);
+    }
+
+    const { data: rows, error } = await query;
+
+    if (error) {
+      logger.error('Failed to list preview feedback', {
+        context: 'admin/preview/feedback',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to fetch feedback' }, { status: 500 });
+    }
+
+    const feedback = (rows ?? []).map((row) => {
+      const sessions = row.preview_sessions as unknown as { cohort_id: string } | null;
+      return {
+        id: row.id,
+        sessionId: row.session_id,
+        page: row.page,
+        personaPresetId: row.persona_preset_id,
+        text: row.text,
+        createdAt: row.created_at,
+        cohortId: sessions?.cohort_id ?? null,
+      };
+    });
+
+    return NextResponse.json({ feedback });
+  },
+  { auth: 'required' },
+);

--- a/app/api/preview/feedback/route.ts
+++ b/app/api/preview/feedback/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Preview Feedback — submit feedback from preview mode users.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isPreviewAddress } from '@/lib/preview';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/preview/feedback — save feedback from a preview user
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, context) => {
+    // Verify caller is a preview user
+    if (!context.wallet || !isPreviewAddress(context.wallet)) {
+      return NextResponse.json(
+        { error: 'Feedback is only available in preview mode' },
+        { status: 403 },
+      );
+    }
+
+    const body = await request.json();
+    const text = typeof body.text === 'string' ? body.text.trim() : '';
+    const page = typeof body.page === 'string' ? body.page : '/';
+    const personaPresetId =
+      typeof body.personaPresetId === 'string' ? body.personaPresetId : 'unknown';
+
+    if (!text) {
+      return NextResponse.json({ error: 'Feedback text is required' }, { status: 400 });
+    }
+
+    // Look up active preview session for this user
+    const supabase = getSupabaseAdmin();
+    const { data: session } = await supabase
+      .from('preview_sessions')
+      .select('id')
+      .eq('user_id', context.userId ?? '')
+      .eq('revoked', false)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!session) {
+      return NextResponse.json({ error: 'No active preview session' }, { status: 403 });
+    }
+
+    // Insert feedback
+    const { error } = await supabase.from('preview_feedback').insert({
+      session_id: session.id,
+      page,
+      persona_preset_id: personaPresetId,
+      text,
+    });
+
+    if (error) {
+      logger.error('Failed to save preview feedback', {
+        context: 'preview/feedback',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to save feedback' }, { status: 500 });
+    }
+
+    logger.info('Preview feedback saved', {
+      context: 'preview/feedback',
+      sessionId: session.id,
+      page,
+    });
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  },
+  { auth: 'required', rateLimit: { max: 20, window: 60 } },
+);

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -12,6 +12,7 @@ import { GovernadaSidebar } from './GovernadaSidebar';
 import { EpochContextBar } from './EpochContextBar';
 import { SyncFreshnessBanner } from '@/components/SyncFreshnessBanner';
 import { PreviewBanner } from '@/components/preview/PreviewBanner';
+import { FeedbackWidget } from '@/components/preview/FeedbackWidget';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { useSentryContext } from '@/hooks/useSentryContext';
 import { useSentryFeatureFlags } from '@/hooks/useSentryFeatureFlags';
@@ -196,6 +197,7 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
           </footer>
         )}
         {!isStudioMode && <GovernadaBottomNav />}
+        <FeedbackWidget />
       </TierThemeProvider>
     </SegmentProvider>
   );

--- a/components/preview/FeedbackWidget.tsx
+++ b/components/preview/FeedbackWidget.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { MessageSquarePlus, X, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { getStoredSession } from '@/lib/supabaseAuth';
+
+const RATE_LIMIT_MS = 30_000;
+
+/**
+ * Floating feedback widget for preview mode users.
+ * Renders a button in the bottom-right corner that opens an inline form
+ * for submitting feedback about the current page.
+ */
+export function FeedbackWidget() {
+  const { isPreviewMode } = useSegment();
+  const pathname = usePathname();
+
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cooldownUntil, setCooldownUntil] = useState(0);
+
+  // Read persona preset ID from sessionStorage
+  const [presetId, setPresetId] = useState('unknown');
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem('governada_preview');
+      if (raw) {
+        const meta = JSON.parse(raw);
+        setPresetId(meta.personaPresetId ?? meta.presetId ?? 'unknown');
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const isCoolingDown = Date.now() < cooldownUntil;
+
+  const handleSubmit = useCallback(async () => {
+    if (!text.trim() || submitting || isCoolingDown) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const token = getStoredSession();
+      const res = await fetch('/api/preview/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          text: text.trim(),
+          page: pathname,
+          personaPresetId: presetId,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: 'Failed to save feedback' }));
+        throw new Error(data.error ?? 'Failed to save feedback');
+      }
+
+      setSuccess(true);
+      setText('');
+      setCooldownUntil(Date.now() + RATE_LIMIT_MS);
+
+      setTimeout(() => {
+        setSuccess(false);
+        setOpen(false);
+      }, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [text, submitting, isCoolingDown, pathname, presetId]);
+
+  if (!isPreviewMode) return null;
+
+  return (
+    <>
+      {/* Floating trigger button */}
+      <Button
+        size="icon"
+        className="fixed bottom-20 lg:bottom-6 right-6 z-50 h-12 w-12 rounded-full shadow-lg"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Submit feedback"
+      >
+        {open ? <X className="h-5 w-5" /> : <MessageSquarePlus className="h-5 w-5" />}
+      </Button>
+
+      {/* Feedback form panel */}
+      {open && (
+        <div className="fixed bottom-36 lg:bottom-20 right-6 z-50 w-80 rounded-lg border border-border bg-card p-4 shadow-xl">
+          {success ? (
+            <div className="flex items-center gap-2 text-sm text-green-400">
+              <Check className="h-4 w-4" />
+              Feedback saved!
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">
+                  Page: <span className="font-mono">{pathname}</span>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Persona: <span className="font-mono">{presetId}</span>
+                </p>
+              </div>
+
+              <textarea
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+                rows={4}
+                placeholder="What did you notice?"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                disabled={submitting}
+              />
+
+              {error && <p className="text-xs text-destructive">{error}</p>}
+
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleSubmit}
+                disabled={!text.trim() || submitting || isCoolingDown}
+              >
+                {submitting ? 'Sending...' : isCoolingDown ? 'Please wait...' : 'Submit Feedback'}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add floating `FeedbackWidget` (bottom-right, preview mode only) with inline feedback form
- Auto-captures current page and persona context
- POST `/api/preview/feedback` with preview-user verification and session lookup
- Admin GET `/api/admin/preview/feedback` endpoint with cohort filtering
- Feedback tab in admin preview management page showing entries per cohort

## Impact
- **What changed**: Preview testers can now leave contextual feedback from any page
- **User-facing**: No — widget only visible in preview mode
- **Risk**: Low — entirely additive, gated behind isPreviewMode
- **Scope**: 3 new files, 2 modified files

## Test plan
- [ ] In preview mode, verify feedback button appears bottom-right
- [ ] Submit feedback, verify success state
- [ ] Verify 30s cooldown after submission
- [ ] Check admin preview page shows feedback entries
- [ ] Verify real users never see the feedback button

🤖 Generated with [Claude Code](https://claude.com/claude-code)