### PR TITLE
feat: production simulation scenarios — lifecycle generator with template reviews

### DIFF
--- a/app/admin/preview/PreviewClient.tsx
+++ b/app/admin/preview/PreviewClient.tsx
@@ -40,6 +40,12 @@ import {
   Users,
   Eye,
   MessageSquare,
+  Sparkles,
+  FileText,
+  Star,
+  Loader2,
+  CheckCircle2,
+  AlertTriangle,
 } from 'lucide-react';
 
 // ---- Types ----
@@ -420,6 +426,116 @@ function CohortSessions({ cohortId }: { cohortId: string }) {
   );
 }
 
+interface ScenarioResult {
+  proposalsCreated: number;
+  reviewsCreated: number;
+  versionsCreated: number;
+  errors: string[];
+}
+
+function CohortScenario({ cohortId }: { cohortId: string }) {
+  const [result, setResult] = useState<ScenarioResult | null>(null);
+
+  const generateScenario = useMutation({
+    mutationFn: async (): Promise<ScenarioResult> => {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/preview/scenarios', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ cohortId }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? 'Failed to generate scenario');
+      }
+      return res.json();
+    },
+    onSuccess: (data) => {
+      setResult(data);
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+          <Sparkles className="h-3.5 w-3.5" />
+          Scenario Data
+        </h4>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => generateScenario.mutate()}
+          disabled={generateScenario.isPending}
+        >
+          {generateScenario.isPending ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Generating...
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-3.5 w-3.5" />
+              Generate Scenario
+            </>
+          )}
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Populates this cohort with realistic proposal drafts at various lifecycle stages, synthetic
+        community reviews, and version history. Existing scenario data will be replaced.
+      </p>
+
+      {result && (
+        <div className="rounded-md border border-border/50 bg-card/50 p-3 space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            {result.errors.length === 0 ? (
+              <>
+                <CheckCircle2 className="h-4 w-4 text-green-400" />
+                Scenario generated successfully
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-4 w-4 text-yellow-400" />
+                Scenario generated with warnings
+              </>
+            )}
+          </div>
+          <div className="grid grid-cols-3 gap-3 text-xs">
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <FileText className="h-3 w-3" />
+              <span>{result.proposalsCreated} proposals</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <Star className="h-3 w-3" />
+              <span>{result.reviewsCreated} reviews</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-muted-foreground">
+              <FileText className="h-3 w-3" />
+              <span>{result.versionsCreated} versions</span>
+            </div>
+          </div>
+          {result.errors.length > 0 && (
+            <div className="text-xs text-destructive space-y-1">
+              {result.errors.map((err, i) => (
+                <p key={i}>{err}</p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {generateScenario.isError && !result && (
+        <p className="text-sm text-destructive">{(generateScenario.error as Error).message}</p>
+      )}
+    </div>
+  );
+}
+
 function CohortFeedback({ cohortId }: { cohortId: string }) {
   const { data: feedback, isLoading } = useQuery({
     queryKey: ['admin-preview-feedback', cohortId],
@@ -582,6 +698,7 @@ export function PreviewClient() {
             </CardHeader>
             {isExpanded && (
               <CardContent className="space-y-6 border-t border-border/40 pt-4">
+                <CohortScenario cohortId={cohort.id} />
                 <CohortInvites cohortId={cohort.id} />
                 <CohortSessions cohortId={cohort.id} />
                 <CohortFeedback cohortId={cohort.id} />

--- a/app/api/admin/preview/scenarios/route.ts
+++ b/app/api/admin/preview/scenarios/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Admin Scenario Generator API — populate preview cohorts with realistic data.
+ *
+ * POST /api/admin/preview/scenarios
+ * Body: { cohortId: string }
+ *
+ * Generates proposal drafts at various lifecycle stages, synthetic reviews,
+ * and version history. All data is tagged with `preview_cohort_id`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { generateScenario } from '@/lib/preview/scenarios/generator';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/admin/preview/scenarios — generate scenario data for a cohort
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const cohortId = typeof body.cohortId === 'string' ? body.cohortId.trim() : '';
+
+    if (!cohortId) {
+      return NextResponse.json({ error: 'Missing cohortId' }, { status: 400 });
+    }
+
+    // Verify cohort exists
+    const supabase = getSupabaseAdmin();
+    const { data: cohort, error: cohortError } = await supabase
+      .from('preview_cohorts')
+      .select('id, name')
+      .eq('id', cohortId)
+      .single();
+
+    if (cohortError || !cohort) {
+      return NextResponse.json({ error: 'Cohort not found' }, { status: 404 });
+    }
+
+    logger.info('[admin/preview/scenarios] Starting scenario generation', {
+      cohortId,
+      cohortName: cohort.name,
+      requestedBy: context.wallet,
+    });
+
+    const result = await generateScenario(cohortId);
+
+    const statusCode = result.errors.length > 0 ? 207 : 200;
+
+    return NextResponse.json(
+      {
+        proposalsCreated: result.proposalsCreated,
+        reviewsCreated: result.reviewsCreated,
+        versionsCreated: result.versionsCreated,
+        errors: result.errors,
+      },
+      { status: statusCode },
+    );
+  },
+  { auth: 'required' },
+);

--- a/lib/preview/scenarios/generator.ts
+++ b/lib/preview/scenarios/generator.ts
@@ -1,0 +1,531 @@
+/**
+ * Scenario Generator — populates preview cohorts with realistic governance data.
+ *
+ * Queries real on-chain proposals from the `proposals` table, creates
+ * `proposal_drafts` at various lifecycle stages, and generates synthetic
+ * community reviews using template-based content. All data is tagged with
+ * `preview_cohort_id` so it stays isolated from production.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { logger } from '@/lib/logger';
+import type { DraftStatus, ProposalType } from '@/lib/workspace/types';
+import type { Database, Json } from '@/types/database';
+import {
+  REVIEWER_PERSONAS,
+  REVIEW_TEMPLATES,
+  FEEDBACK_THEMES,
+  SCORE_RANGES,
+  VERSION_EDIT_SUMMARIES,
+  VERSION_NAMES,
+  type ReviewCategory,
+  type ReviewerPersona,
+} from './templates';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScenarioResult {
+  proposalsCreated: number;
+  reviewsCreated: number;
+  versionsCreated: number;
+  errors: string[];
+}
+
+type ProposalRow = Database['public']['Tables']['proposals']['Row'];
+
+/** Distribution of drafts across lifecycle stages */
+const STAGE_DISTRIBUTION: { status: DraftStatus; count: number }[] = [
+  { status: 'draft', count: 2 },
+  { status: 'community_review', count: 3 },
+  { status: 'final_comment', count: 2 },
+  { status: 'submitted', count: 2 },
+  { status: 'archived', count: 1 },
+];
+
+const TOTAL_NEEDED = STAGE_DISTRIBUTION.reduce((sum, s) => sum + s.count, 0);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a random integer in [min, max] inclusive */
+function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/** Pick a random element from an array */
+function pickRandom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/** Pick N random unique elements from an array */
+function pickRandomN<T>(arr: T[], n: number): T[] {
+  const shuffled = [...arr].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, Math.min(n, arr.length));
+}
+
+/** Map on-chain proposal_type strings to our ProposalType enum */
+function normalizeProposalType(raw: string): ProposalType {
+  const mapping: Record<string, ProposalType> = {
+    InfoAction: 'InfoAction',
+    TreasuryWithdrawals: 'TreasuryWithdrawals',
+    ParameterChange: 'ParameterChange',
+    HardForkInitiation: 'HardForkInitiation',
+    NoConfidence: 'NoConfidence',
+    NewCommittee: 'NewCommittee',
+    NewConstitution: 'NewConstitution',
+  };
+  return mapping[raw] ?? 'InfoAction';
+}
+
+/** Generate a synthetic owner stake address for a draft */
+function syntheticOwner(index: number): string {
+  return `stake_preview_proposer_${String(index + 1).padStart(2, '0')}`;
+}
+
+/** Create a realistic ISO timestamp within the last N days */
+function recentTimestamp(maxDaysAgo: number): string {
+  const now = Date.now();
+  const offset = Math.random() * maxDaysAgo * 24 * 60 * 60 * 1000;
+  return new Date(now - offset).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Core generator
+// ---------------------------------------------------------------------------
+
+export async function generateScenario(cohortId: string): Promise<ScenarioResult> {
+  const result: ScenarioResult = {
+    proposalsCreated: 0,
+    reviewsCreated: 0,
+    versionsCreated: 0,
+    errors: [],
+  };
+
+  const supabase = getSupabaseAdmin();
+
+  // 1. Verify cohort exists
+  const { data: cohort, error: cohortError } = await supabase
+    .from('preview_cohorts')
+    .select('id, name')
+    .eq('id', cohortId)
+    .single();
+
+  if (cohortError || !cohort) {
+    result.errors.push(`Cohort not found: ${cohortId}`);
+    return result;
+  }
+
+  // 2. Clean up any existing scenario data for this cohort
+  await cleanupExistingScenario(supabase, cohortId, result);
+
+  // 3. Fetch real proposals for content
+  const { data: proposals, error: proposalError } = await supabase
+    .from('proposals')
+    .select('*')
+    .not('title', 'is', null)
+    .not('abstract', 'is', null)
+    .order('block_time', { ascending: false })
+    .limit(50);
+
+  if (proposalError || !proposals || proposals.length === 0) {
+    result.errors.push(
+      `Failed to fetch source proposals: ${proposalError?.message ?? 'no proposals found'}`,
+    );
+    return result;
+  }
+
+  // Pick diverse proposals across types
+  const selectedProposals = selectDiverseProposals(proposals, TOTAL_NEEDED);
+
+  if (selectedProposals.length < TOTAL_NEEDED) {
+    logger.warn('[scenario-generator] Not enough diverse proposals, using what we have', {
+      found: selectedProposals.length,
+      needed: TOTAL_NEEDED,
+    });
+  }
+
+  // 4. Create drafts distributed across lifecycle stages
+  let proposalIndex = 0;
+  const createdDraftIds: { id: string; status: DraftStatus }[] = [];
+
+  for (const stage of STAGE_DISTRIBUTION) {
+    for (let i = 0; i < stage.count && proposalIndex < selectedProposals.length; i++) {
+      const source = selectedProposals[proposalIndex];
+      const draftId = await createDraft(supabase, source, stage.status, cohortId, proposalIndex);
+
+      if (draftId) {
+        createdDraftIds.push({ id: draftId, status: stage.status });
+        result.proposalsCreated++;
+
+        // Create initial version for every draft
+        const versionCreated = await createInitialVersion(supabase, draftId, source);
+        if (versionCreated) result.versionsCreated++;
+      } else {
+        result.errors.push(
+          `Failed to create draft for "${source.title}" at stage "${stage.status}"`,
+        );
+      }
+
+      proposalIndex++;
+    }
+  }
+
+  // 5. Generate reviews for community_review and final_comment drafts
+  const reviewableDrafts = createdDraftIds.filter(
+    (d) => d.status === 'community_review' || d.status === 'final_comment',
+  );
+
+  for (const draft of reviewableDrafts) {
+    const reviewCount = randInt(3, 8);
+    const reviewers = pickRandomN(REVIEWER_PERSONAS, reviewCount);
+    const sourceProposal = selectedProposals.find((_, idx) => {
+      // Find the index of this draft in the creation order
+      const draftEntry = createdDraftIds.find((d) => d.id === draft.id);
+      return draftEntry !== undefined && createdDraftIds.indexOf(draftEntry) === idx;
+    });
+
+    const title = sourceProposal?.title ?? 'this proposal';
+
+    for (const reviewer of reviewers) {
+      const created = await createReview(supabase, draft.id, reviewer, title);
+      if (created) result.reviewsCreated++;
+    }
+  }
+
+  // 6. Create revision versions for drafts in later stages
+  const revisedDrafts = createdDraftIds.filter(
+    (d) =>
+      d.status === 'community_review' || d.status === 'final_comment' || d.status === 'submitted',
+  );
+
+  for (const draft of revisedDrafts) {
+    const versionCount = randInt(1, 3);
+    for (let v = 0; v < versionCount; v++) {
+      const created = await createRevisionVersion(supabase, draft.id, v + 2);
+      if (created) result.versionsCreated++;
+    }
+  }
+
+  logger.info('[scenario-generator] Scenario generation complete', {
+    cohortId,
+    cohortName: cohort.name,
+    ...result,
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal selection
+// ---------------------------------------------------------------------------
+
+/** Select proposals with good type diversity */
+function selectDiverseProposals(proposals: ProposalRow[], count: number): ProposalRow[] {
+  // Group by type
+  const byType = new Map<string, ProposalRow[]>();
+  for (const p of proposals) {
+    if (!p.title || !p.abstract) continue;
+    const list = byType.get(p.proposal_type) ?? [];
+    list.push(p);
+    byType.set(p.proposal_type, list);
+  }
+
+  const selected: ProposalRow[] = [];
+  const types = Array.from(byType.keys());
+
+  // Round-robin across types until we have enough
+  let typeIndex = 0;
+  while (selected.length < count && types.length > 0) {
+    const type = types[typeIndex % types.length];
+    const pool = byType.get(type);
+    if (pool && pool.length > 0) {
+      selected.push(pool.shift()!);
+    } else {
+      // Exhausted this type, remove it
+      types.splice(typeIndex % types.length, 1);
+      if (types.length === 0) break;
+      continue;
+    }
+    typeIndex++;
+  }
+
+  return selected;
+}
+
+// ---------------------------------------------------------------------------
+// Draft creation
+// ---------------------------------------------------------------------------
+
+async function createDraft(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  source: ProposalRow,
+  status: DraftStatus,
+  cohortId: string,
+  index: number,
+): Promise<string | null> {
+  const now = new Date();
+  const createdAt = recentTimestamp(30);
+  const stageEnteredAt = recentTimestamp(14);
+
+  // Build type-specific data
+  const typeSpecific: { [key: string]: Json | undefined } = {
+    _scenarioSource: {
+      txHash: source.tx_hash,
+      proposalIndex: source.proposal_index,
+      generatedAt: now.toISOString(),
+    },
+  };
+
+  if (source.proposal_type === 'TreasuryWithdrawals' && source.withdrawal_amount) {
+    typeSpecific.withdrawalAmount = source.withdrawal_amount;
+  }
+
+  // Extract motivation/rationale from meta_json if available
+  const metaJson = source.meta_json as Record<string, unknown> | null;
+  const body = (metaJson?.body as Record<string, string | undefined>) ?? {};
+
+  const insertData: Database['public']['Tables']['proposal_drafts']['Insert'] = {
+    owner_stake_address: syntheticOwner(index),
+    title: source.title ?? 'Untitled Proposal',
+    abstract: source.abstract ?? '',
+    motivation: body.motivation ?? 'Motivation not available from source proposal.',
+    rationale: body.rationale ?? 'Rationale not available from source proposal.',
+    proposal_type: normalizeProposalType(source.proposal_type),
+    type_specific: typeSpecific,
+    status,
+    current_version: status === 'draft' ? 1 : randInt(2, 4),
+    preview_cohort_id: cohortId,
+    created_at: createdAt,
+    stage_entered_at: stageEnteredAt,
+    community_review_started_at: status !== 'draft' ? recentTimestamp(21) : null,
+    fcp_started_at:
+      status === 'final_comment' || status === 'submitted' || status === 'archived'
+        ? recentTimestamp(10)
+        : null,
+    submitted_tx_hash: status === 'submitted' || status === 'archived' ? source.tx_hash : null,
+    submitted_at: status === 'submitted' || status === 'archived' ? recentTimestamp(7) : null,
+  };
+
+  const { data, error } = await supabase
+    .from('proposal_drafts')
+    .insert(insertData)
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    logger.error('[scenario-generator] Failed to insert draft', {
+      error: error?.message,
+      title: source.title,
+      status,
+    });
+    return null;
+  }
+
+  return data.id;
+}
+
+// ---------------------------------------------------------------------------
+// Version creation
+// ---------------------------------------------------------------------------
+
+async function createInitialVersion(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  draftId: string,
+  source: ProposalRow,
+): Promise<boolean> {
+  const metaJson = source.meta_json as Record<string, unknown> | null;
+  const body = (metaJson?.body as Record<string, string | undefined>) ?? {};
+
+  const content = {
+    title: source.title ?? 'Untitled Proposal',
+    abstract: source.abstract ?? '',
+    motivation: body.motivation ?? 'Motivation not available from source proposal.',
+    rationale: body.rationale ?? 'Rationale not available from source proposal.',
+    proposalType: normalizeProposalType(source.proposal_type),
+    typeSpecific: {},
+  };
+
+  const { error } = await supabase.from('proposal_draft_versions').insert({
+    draft_id: draftId,
+    version_number: 1,
+    version_name: 'Initial draft',
+    edit_summary: 'Initial proposal draft created from governance action content.',
+    content,
+  });
+
+  if (error) {
+    logger.error('[scenario-generator] Failed to insert initial version', {
+      error: error.message,
+      draftId,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+async function createRevisionVersion(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  draftId: string,
+  versionNumber: number,
+): Promise<boolean> {
+  // Get the draft content for the revision base
+  const { data: draft, error: draftError } = await supabase
+    .from('proposal_drafts')
+    .select('title, abstract, motivation, rationale, proposal_type')
+    .eq('id', draftId)
+    .single();
+
+  if (draftError || !draft) return false;
+
+  const content = {
+    title: draft.title,
+    abstract: draft.abstract,
+    motivation: draft.motivation + '\n\n[Revised based on community feedback]',
+    rationale: draft.rationale,
+    proposalType: normalizeProposalType(draft.proposal_type),
+    typeSpecific: {},
+  };
+
+  const { error } = await supabase.from('proposal_draft_versions').insert({
+    draft_id: draftId,
+    version_number: versionNumber,
+    version_name: pickRandom(VERSION_NAMES),
+    edit_summary: pickRandom(VERSION_EDIT_SUMMARIES),
+    content,
+    created_at: recentTimestamp(14),
+  });
+
+  if (error) {
+    logger.error('[scenario-generator] Failed to insert revision version', {
+      error: error.message,
+      draftId,
+      versionNumber,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Review creation
+// ---------------------------------------------------------------------------
+
+async function createReview(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  draftId: string,
+  reviewer: ReviewerPersona,
+  proposalTitle: string,
+): Promise<boolean> {
+  // Pick a review category with realistic distribution
+  const category = pickReviewCategory();
+  const templates = REVIEW_TEMPLATES[category];
+  const template = pickRandom(templates);
+  const feedbackText = template.replace(/\{proposal_title\}/g, proposalTitle);
+
+  // Pick matching themes
+  const templateIndex = templates.indexOf(template);
+  const themePool = FEEDBACK_THEMES[category];
+  const themes =
+    templateIndex >= 0 && templateIndex < themePool.length
+      ? themePool[templateIndex]
+      : pickRandom(themePool);
+
+  // Generate scores within category range
+  const ranges = SCORE_RANGES[category];
+  const insertData: Database['public']['Tables']['draft_reviews']['Insert'] = {
+    draft_id: draftId,
+    reviewer_stake_address: reviewer.stakeAddress,
+    feedback_text: `[${reviewer.role}] ${feedbackText}`,
+    feedback_themes: themes,
+    impact_score: randInt(ranges.impact[0], ranges.impact[1]),
+    feasibility_score: randInt(ranges.feasibility[0], ranges.feasibility[1]),
+    constitutional_score: randInt(ranges.constitutional[0], ranges.constitutional[1]),
+    value_score: randInt(ranges.value[0], ranges.value[1]),
+    created_at: recentTimestamp(14),
+  };
+
+  const { error } = await supabase.from('draft_reviews').insert(insertData);
+
+  if (error) {
+    logger.error('[scenario-generator] Failed to insert review', {
+      error: error.message,
+      draftId,
+      reviewer: reviewer.name,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+/** Pick a review category with realistic distribution — more constructive/supportive, fewer purely critical */
+function pickReviewCategory(): ReviewCategory {
+  const roll = Math.random();
+  if (roll < 0.3) return 'supportive';
+  if (roll < 0.55) return 'constructive';
+  if (roll < 0.8) return 'critical';
+  return 'technical';
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+async function cleanupExistingScenario(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  cohortId: string,
+  result: ScenarioResult,
+): Promise<void> {
+  // Find existing drafts for this cohort
+  const { data: existingDrafts } = await supabase
+    .from('proposal_drafts')
+    .select('id')
+    .eq('preview_cohort_id', cohortId);
+
+  if (!existingDrafts || existingDrafts.length === 0) return;
+
+  const draftIds = existingDrafts.map((d) => d.id);
+
+  // Delete reviews, versions, then drafts (respecting FK order)
+  const { error: reviewError } = await supabase
+    .from('draft_reviews')
+    .delete()
+    .in('draft_id', draftIds);
+
+  if (reviewError) {
+    result.errors.push(`Failed to cleanup reviews: ${reviewError.message}`);
+  }
+
+  // Delete review responses first (FK to draft_reviews)
+  // We already deleted reviews, but responses have FK to reviews not drafts
+  // So delete responses for reviews that belong to these drafts
+  // Since we already deleted the reviews, responses should cascade or already be gone
+  // But let's be safe: delete versions
+  const { error: versionError } = await supabase
+    .from('proposal_draft_versions')
+    .delete()
+    .in('draft_id', draftIds);
+
+  if (versionError) {
+    result.errors.push(`Failed to cleanup versions: ${versionError.message}`);
+  }
+
+  const { error: draftError } = await supabase
+    .from('proposal_drafts')
+    .delete()
+    .eq('preview_cohort_id', cohortId);
+
+  if (draftError) {
+    result.errors.push(`Failed to cleanup drafts: ${draftError.message}`);
+  }
+
+  logger.info('[scenario-generator] Cleaned up existing scenario data', {
+    cohortId,
+    draftsRemoved: draftIds.length,
+  });
+}

--- a/lib/preview/scenarios/templates.ts
+++ b/lib/preview/scenarios/templates.ts
@@ -1,0 +1,236 @@
+/**
+ * Template-based review content for scenario generation.
+ *
+ * Provides realistic governance feedback without AI API calls.
+ * Each template uses `{proposal_title}` as a placeholder.
+ */
+
+// ---------------------------------------------------------------------------
+// Reviewer personas
+// ---------------------------------------------------------------------------
+
+export interface ReviewerPersona {
+  name: string;
+  role: string;
+  stakeAddress: string;
+}
+
+/**
+ * Synthetic reviewers with distinct governance perspectives.
+ * Stake addresses use the `preview_` prefix so they're clearly non-real.
+ */
+export const REVIEWER_PERSONAS: ReviewerPersona[] = [
+  {
+    name: 'Maria Cardoso',
+    role: 'Treasury Committee Analyst',
+    stakeAddress: 'stake_preview_treasury_analyst_01',
+  },
+  {
+    name: 'James Okonkwo',
+    role: 'DeFi Protocol Developer',
+    stakeAddress: 'stake_preview_defi_dev_02',
+  },
+  {
+    name: 'Anika Sharma',
+    role: 'Community Advocate',
+    stakeAddress: 'stake_preview_community_03',
+  },
+  {
+    name: 'Carlos Reyes',
+    role: 'Stake Pool Operator',
+    stakeAddress: 'stake_preview_spo_04',
+  },
+  {
+    name: 'Elena Vasquez',
+    role: 'Constitutional Committee Member',
+    stakeAddress: 'stake_preview_cc_member_05',
+  },
+  {
+    name: 'David Park',
+    role: 'Academic Researcher',
+    stakeAddress: 'stake_preview_researcher_06',
+  },
+  {
+    name: 'Fatima Al-Hassan',
+    role: 'Governance Tooling Builder',
+    stakeAddress: 'stake_preview_tooling_07',
+  },
+  {
+    name: 'Liam Chen',
+    role: 'DRep & Policy Analyst',
+    stakeAddress: 'stake_preview_drep_policy_08',
+  },
+  {
+    name: 'Sophia Andersen',
+    role: 'Treasury Auditor',
+    stakeAddress: 'stake_preview_auditor_09',
+  },
+  {
+    name: 'Raj Patel',
+    role: 'Infrastructure Engineer',
+    stakeAddress: 'stake_preview_infra_10',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Review feedback templates
+// ---------------------------------------------------------------------------
+
+export type ReviewCategory = 'supportive' | 'critical' | 'constructive' | 'technical';
+
+export const REVIEW_TEMPLATES: Record<ReviewCategory, string[]> = {
+  supportive: [
+    'This proposal addresses a critical gap in the ecosystem. The {proposal_title} initiative aligns well with Cardano governance priorities and demonstrates clear community benefit.',
+    'Strong proposal with clear deliverables. The budget allocation for {proposal_title} seems reasonable given the scope of work described.',
+    'I appreciate the thoroughness of this proposal. {proposal_title} fills an important need that multiple community members have identified over the past several epochs.',
+    'The team behind {proposal_title} has a solid track record. Their previous contributions give me confidence in their ability to deliver on this.',
+    'Well-structured proposal. {proposal_title} provides measurable outcomes and a realistic timeline. The phased approach is particularly sensible for a project of this scope.',
+    'This is exactly the kind of initiative Cardano governance should be funding. {proposal_title} creates lasting infrastructure value rather than one-off deliverables.',
+    '{proposal_title} represents good value for the treasury. The cost per deliverable is competitive with similar projects, and the expected impact justifies the investment.',
+    'I support this proposal. {proposal_title} addresses a real pain point I have seen discussed across multiple governance forums and town halls.',
+  ],
+  critical: [
+    'While the intent behind {proposal_title} is sound, the implementation timeline seems overly optimistic. I would recommend extending Phase 1 by at least 2 months to account for realistic development cycles.',
+    'The budget breakdown for {proposal_title} lacks detail in the operational costs section. Can the proposer provide a more granular breakdown of how the personnel budget is allocated?',
+    'I have concerns about the sustainability of {proposal_title} after the funding period ends. What is the plan for ongoing maintenance and operation once treasury funding concludes?',
+    '{proposal_title} overlaps significantly with an existing project that was funded 3 epochs ago. The proposer should clarify how this differs and whether collaboration was considered.',
+    'The success metrics for {proposal_title} are too vague. Statements like "increase adoption" need specific, measurable targets — how many users, by when, measured how?',
+    'I am not convinced {proposal_title} justifies the requested amount. Similar initiatives in other blockchain ecosystems have been delivered at roughly 40% of this cost.',
+    'The risk assessment in {proposal_title} is notably absent. What happens if the primary developer leaves? What are the technical risks? Where are the contingency plans?',
+    '{proposal_title} does not adequately address how it will handle the regulatory considerations that apply to this type of governance action. This needs to be resolved before on-chain submission.',
+  ],
+  constructive: [
+    'Consider adding a milestone-based payment structure for {proposal_title}. This would provide better accountability and reduce treasury risk while still supporting the team.',
+    'I would suggest the {proposal_title} team coordinate with the existing governance tooling projects to avoid duplicating effort. A brief alignment session could save months of parallel work.',
+    'The proposal could be strengthened by including a community feedback mechanism. For {proposal_title}, I recommend quarterly progress reports with community Q&A sessions.',
+    '{proposal_title} would benefit from a clearer escalation path. If milestones are missed, what remediation steps are proposed? This is standard practice for treasury-funded projects.',
+    'I recommend splitting {proposal_title} into two phases: a smaller proof-of-concept (Phase 1) funded at 30% of the total, then the full build contingent on Phase 1 delivery.',
+    'For {proposal_title}, consider establishing an advisory board of 3-5 community members who can provide ongoing governance oversight during the project lifecycle.',
+    'The {proposal_title} proposal would be more compelling with user research data. Even informal surveys from governance forums would strengthen the case for this investment.',
+    'One suggestion for {proposal_title}: document the intellectual property and licensing approach upfront. Open-source commitments should be explicit in the proposal text.',
+  ],
+  technical: [
+    'The technical architecture described in {proposal_title} would benefit from a formal security audit before on-chain submission. Has the team identified a qualified auditor?',
+    'Has the {proposal_title} team considered using CIP-68 for the metadata standard? It would simplify cross-platform integration and future-proof the solution.',
+    'The API design outlined in {proposal_title} should follow the emerging Cardano governance API standards. This ensures interoperability with other governance tools in the ecosystem.',
+    'For {proposal_title}, I recommend using Plutus V3 smart contracts rather than V2. The performance improvements and reduced execution costs would significantly benefit end users.',
+    'The data model in {proposal_title} needs to account for the upcoming Conway era changes. Specifically, the DRep credential format is evolving and the proposal should accommodate both old and new formats.',
+    '{proposal_title} should specify its approach to chain indexing. Will it use a custom indexer, Koios, or another solution? This has significant implications for reliability and cost.',
+    'The scalability section of {proposal_title} underestimates the growth trajectory. Based on current governance participation trends, the system should be designed for at least 10x the stated capacity.',
+    'I notice {proposal_title} plans to store data off-chain. The proposal should specify the data availability guarantees and what happens if the off-chain storage provider becomes unavailable.',
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Feedback themes (tags assigned to reviews)
+// ---------------------------------------------------------------------------
+
+export const FEEDBACK_THEMES: Record<ReviewCategory, string[][]> = {
+  supportive: [
+    ['ecosystem-alignment', 'clear-deliverables'],
+    ['budget-reasonable', 'scope-appropriate'],
+    ['community-need', 'well-researched'],
+    ['team-credibility', 'track-record'],
+    ['structured-approach', 'measurable-outcomes'],
+    ['infrastructure-value', 'long-term-benefit'],
+    ['cost-effective', 'good-value'],
+    ['community-demand', 'real-pain-point'],
+  ],
+  critical: [
+    ['timeline-concern', 'unrealistic-schedule'],
+    ['budget-detail', 'transparency'],
+    ['sustainability', 'long-term-viability'],
+    ['duplication-risk', 'coordination-needed'],
+    ['vague-metrics', 'accountability'],
+    ['cost-concern', 'overpriced'],
+    ['risk-management', 'contingency-missing'],
+    ['regulatory-concern', 'compliance'],
+  ],
+  constructive: [
+    ['milestone-payments', 'accountability'],
+    ['coordination', 'ecosystem-alignment'],
+    ['community-feedback', 'transparency'],
+    ['escalation-path', 'risk-management'],
+    ['phased-approach', 'risk-reduction'],
+    ['governance-oversight', 'advisory-board'],
+    ['user-research', 'evidence-based'],
+    ['ip-licensing', 'open-source'],
+  ],
+  technical: [
+    ['security-audit', 'technical-review'],
+    ['standards-compliance', 'interoperability'],
+    ['api-design', 'ecosystem-standards'],
+    ['smart-contracts', 'performance'],
+    ['future-proofing', 'conway-era'],
+    ['infrastructure', 'chain-indexing'],
+    ['scalability', 'capacity-planning'],
+    ['data-availability', 'reliability'],
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Score ranges per review category
+// ---------------------------------------------------------------------------
+
+export interface ScoreRange {
+  impact: [number, number];
+  feasibility: [number, number];
+  constitutional: [number, number];
+  value: [number, number];
+}
+
+/** Score ranges (1-5) for each category — critical reviews score lower, supportive higher */
+export const SCORE_RANGES: Record<ReviewCategory, ScoreRange> = {
+  supportive: {
+    impact: [4, 5],
+    feasibility: [4, 5],
+    constitutional: [4, 5],
+    value: [4, 5],
+  },
+  critical: {
+    impact: [2, 3],
+    feasibility: [1, 3],
+    constitutional: [2, 4],
+    value: [1, 3],
+  },
+  constructive: {
+    impact: [3, 4],
+    feasibility: [3, 4],
+    constitutional: [3, 5],
+    value: [3, 4],
+  },
+  technical: {
+    impact: [3, 5],
+    feasibility: [2, 4],
+    constitutional: [3, 5],
+    value: [3, 4],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Version history templates (edit summaries for revision history)
+// ---------------------------------------------------------------------------
+
+export const VERSION_EDIT_SUMMARIES: string[] = [
+  'Revised budget breakdown based on community feedback',
+  'Added milestone-based payment schedule',
+  'Expanded risk assessment section',
+  'Clarified success metrics and KPIs',
+  'Addressed constitutional alignment concerns',
+  'Updated timeline to incorporate reviewer suggestions',
+  'Added technical architecture details',
+  'Incorporated feedback from governance forum discussion',
+  'Refined abstract for clarity',
+  'Added community engagement plan',
+];
+
+export const VERSION_NAMES: string[] = [
+  'Community feedback revision',
+  'Budget clarification update',
+  'Technical detail expansion',
+  'Risk assessment addition',
+  'Metrics refinement',
+  'Timeline adjustment',
+  'Scope clarification',
+  'Governance alignment update',
+];


### PR DESCRIPTION
## Summary
- Add scenario generator that forks real governance proposals into preview cohorts
- Populates 10 proposals across all lifecycle stages: draft, community_review, final_comment, submitted, archived
- Generates 3-8 template-based reviewer annotations per reviewable proposal with diverse personas
- Creates revision history with realistic version names and edit summaries
- Admin API endpoint POST /api/admin/preview/scenarios
- Generate Scenario button in admin preview management UI

## Impact
- **What changed**: Preview cohorts can now be populated with realistic governance data at the click of a button
- **User-facing**: No — admin-only, behind preview_mode flag
- **Risk**: Low — only writes to proposal_drafts/draft_reviews/draft_versions with preview_cohort_id tag
- **Scope**: 3 new files (generator, templates, API route), 1 modified (PreviewClient)

## Test plan
- [ ] Create cohort in admin, click Generate Scenario
- [ ] Verify 10 proposals created across lifecycle stages
- [ ] Verify reviews generated for community_review/final_comment proposals
- [ ] Verify version history created
- [ ] Enter cohort as preview user, verify proposals visible in workspace
- [ ] Verify real users see no scenario data

🤖 Generated with [Claude Code](https://claude.com/claude-code)