### PR TITLE
feat: content authoring quality — slash menu blocks, prose styling, toolbar

### DIFF
--- a/__tests__/workspace/contentRoundtrip.test.ts
+++ b/__tests__/workspace/contentRoundtrip.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect } from 'vitest';
+import {
+  buildSectionDocument,
+  extractSectionContent,
+} from '@/components/workspace/editor/SectionBlock';
+
+/**
+ * Content roundtrip tests — verify that markdown content types survive the
+ * parse pipeline: markdown string -> ProseMirror JSON (via buildSectionDocument)
+ * -> structural validation.
+ *
+ * These tests ensure that the editor's markdown parser correctly handles all
+ * GFM content types used in governance proposals.
+ */
+
+const EMPTY_CONTENT = { title: '', abstract: '', motivation: '', rationale: '' };
+
+function buildAbstract(markdown: string) {
+  return buildSectionDocument({ ...EMPTY_CONTENT, abstract: markdown }, { parseMarkdown: true });
+}
+
+/** Get the abstract section's content array from a built document */
+function getAbstractContent(doc: ReturnType<typeof buildSectionDocument>) {
+  const sections = doc.content as Array<{
+    type: string;
+    attrs: { field: string };
+    content: unknown[];
+  }>;
+  const abstractSection = sections.find((s) => s.attrs.field === 'abstract');
+  return abstractSection?.content ?? [];
+}
+
+describe('markdown -> ProseMirror roundtrip', () => {
+  test('headings H1-H3 parse to heading nodes', () => {
+    const markdown = '# Title\n## Subtitle\n### Section';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toEqual([
+      expect.objectContaining({ type: 'heading', attrs: { level: 1 } }),
+      expect.objectContaining({ type: 'heading', attrs: { level: 2 } }),
+      expect.objectContaining({ type: 'heading', attrs: { level: 3 } }),
+    ]);
+  });
+
+  test('bold and italic inline marks parse correctly', () => {
+    const markdown = 'This has **bold** and *italic* text';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'paragraph' });
+
+    // The paragraph's content should include bold and italic marks
+    const paragraph = content[0] as {
+      type: string;
+      content: Array<{ type: string; marks?: Array<{ type: string }> }>;
+    };
+    const hasBold = paragraph.content.some((node) => node.marks?.some((m) => m.type === 'bold'));
+    const hasItalic = paragraph.content.some((node) =>
+      node.marks?.some((m) => m.type === 'italic'),
+    );
+    expect(hasBold).toBe(true);
+    expect(hasItalic).toBe(true);
+  });
+
+  test('bullet list parses to bulletList node', () => {
+    const markdown = '- Item one\n- Item two\n- Item three';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'bulletList' });
+
+    const list = content[0] as { content: Array<{ type: string }> };
+    expect(list.content).toHaveLength(3);
+    expect(list.content[0]).toMatchObject({ type: 'listItem' });
+  });
+
+  test('ordered list parses to orderedList node', () => {
+    const markdown = '1. First\n2. Second\n3. Third';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'orderedList' });
+
+    const list = content[0] as { content: Array<{ type: string }> };
+    expect(list.content).toHaveLength(3);
+  });
+
+  test('task list parses to taskList with checked/unchecked items', () => {
+    const markdown = '- [x] Done task\n- [ ] Pending task';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'taskList' });
+
+    const list = content[0] as {
+      content: Array<{ type: string; attrs: { checked: boolean } }>;
+    };
+    expect(list.content).toHaveLength(2);
+    expect(list.content[0].attrs.checked).toBe(true);
+    expect(list.content[1].attrs.checked).toBe(false);
+  });
+
+  test('blockquote parses to blockquote node', () => {
+    const markdown = '> This is a quote';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'blockquote' });
+  });
+
+  test('code block syntax is not lost (preserved as paragraph text)', () => {
+    // The simple markdown parser in SectionBlock doesn't handle fenced code blocks,
+    // but we verify that the text content survives the pipeline
+    const markdown = 'Some code: `inline code`';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    // The content should contain the text
+    expect(content.length).toBeGreaterThan(0);
+  });
+
+  test('horizontal rule parses to horizontalRule node', () => {
+    const markdown = 'Before\n\n---\n\nAfter';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    const hrNode = content.find((node) => (node as { type: string }).type === 'horizontalRule');
+    expect(hrNode).toBeDefined();
+  });
+
+  test('links parse with href attribute', () => {
+    const markdown = 'Visit [Governada](https://governada.io) for more';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    const paragraph = content[0] as {
+      type: string;
+      content: Array<{
+        type: string;
+        text?: string;
+        marks?: Array<{ type: string; attrs?: { href: string } }>;
+      }>;
+    };
+
+    const linkNode = paragraph.content.find((node) => node.marks?.some((m) => m.type === 'link'));
+    expect(linkNode).toBeDefined();
+    expect(linkNode?.marks?.[0].attrs?.href).toBe('https://governada.io');
+  });
+
+  test('image parses to image node', () => {
+    const markdown = '![Alt text](https://example.com/image.png)';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    const imageNode = content.find((node) => (node as { type: string }).type === 'image');
+    expect(imageNode).toBeDefined();
+    expect(imageNode).toMatchObject({
+      type: 'image',
+      attrs: expect.objectContaining({
+        src: 'https://example.com/image.png',
+        alt: 'Alt text',
+      }),
+    });
+  });
+
+  test('table parses to table node with header and body rows', () => {
+    const markdown = '| Header 1 | Header 2 |\n| --- | --- |\n| Cell 1 | Cell 2 |';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    const tableNode = content.find((node) => (node as { type: string }).type === 'table');
+    expect(tableNode).toBeDefined();
+
+    const table = tableNode as {
+      type: string;
+      content: Array<{ type: string; content: Array<{ type: string }> }>;
+    };
+    expect(table.content).toHaveLength(2); // header row + body row
+    expect(table.content[0].content[0].type).toBe('tableHeader');
+    expect(table.content[1].content[0].type).toBe('tableCell');
+  });
+
+  test('mixed content preserves block type ordering', () => {
+    const markdown = [
+      '# Heading',
+      '',
+      'A paragraph of text.',
+      '',
+      '- Bullet one',
+      '- Bullet two',
+      '',
+      '> A quote',
+      '',
+      '---',
+      '',
+      '1. Ordered one',
+      '2. Ordered two',
+    ].join('\n');
+
+    const content = getAbstractContent(buildAbstract(markdown));
+    const types = content.map((node) => (node as { type: string }).type);
+
+    expect(types).toEqual([
+      'heading',
+      'paragraph',
+      'bulletList',
+      'blockquote',
+      'horizontalRule',
+      'orderedList',
+    ]);
+  });
+
+  test('callout-style blockquote (bold Note marker) preserves content', () => {
+    const markdown = '> **Note:** This is an important callout';
+    const content = getAbstractContent(buildAbstract(markdown));
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toMatchObject({ type: 'blockquote' });
+
+    // The blockquote should contain a paragraph with bold text
+    const bq = content[0] as {
+      content: Array<{ content: Array<{ marks?: Array<{ type: string }> }> }>;
+    };
+    const hasBold = bq.content[0]?.content?.some((node) =>
+      node.marks?.some((m) => m.type === 'bold'),
+    );
+    expect(hasBold).toBe(true);
+  });
+});
+
+describe('extractSectionContent recovers text', () => {
+  test('round-trips through buildSectionDocument and extractSectionContent', () => {
+    const original = {
+      title: 'My Proposal',
+      abstract: 'A brief summary.',
+      motivation: 'Why this matters.',
+      rationale: 'The reasoning.',
+    };
+
+    // Build with parseMarkdown: false (edit mode -- raw text)
+    const doc = buildSectionDocument(original);
+    const extracted = extractSectionContent(doc as Parameters<typeof extractSectionContent>[0]);
+
+    expect(extracted.title).toBe('My Proposal');
+    expect(extracted.abstract).toBe('A brief summary.');
+    expect(extracted.motivation).toBe('Why this matters.');
+    expect(extracted.rationale).toBe('The reasoning.');
+  });
+
+  test('empty fields round-trip as empty strings', () => {
+    const original = { title: '', abstract: '', motivation: '', rationale: '' };
+    const doc = buildSectionDocument(original);
+    const extracted = extractSectionContent(doc as Parameters<typeof extractSectionContent>[0]);
+
+    expect(extracted.title).toBe('');
+    expect(extracted.abstract).toBe('');
+    expect(extracted.motivation).toBe('');
+    expect(extracted.rationale).toBe('');
+  });
+
+  test('excludeFields omits specified sections', () => {
+    const original = {
+      title: 'Title',
+      abstract: 'Abstract',
+      motivation: 'Motivation',
+      rationale: 'Rationale',
+    };
+    const doc = buildSectionDocument(original, { excludeFields: ['title'] });
+    const sections = (doc.content as Array<{ attrs: { field: string } }>).map((s) => s.attrs.field);
+
+    expect(sections).not.toContain('title');
+    expect(sections).toContain('abstract');
+    expect(sections).toContain('motivation');
+    expect(sections).toContain('rationale');
+  });
+});

--- a/__tests__/workspace/markdownRenderer.test.tsx
+++ b/__tests__/workspace/markdownRenderer.test.tsx
@@ -1,0 +1,136 @@
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MarkdownRenderer } from '@/components/shared/MarkdownRenderer';
+
+/**
+ * MarkdownRenderer snapshot + structure tests.
+ * Verify that the .governance-prose class is applied and that each
+ * content type renders the expected HTML structure.
+ */
+
+describe('MarkdownRenderer', () => {
+  test('renders null for empty content', () => {
+    const { container } = render(<MarkdownRenderer content="" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  test('applies governance-prose class to wrapper', () => {
+    const { container } = render(<MarkdownRenderer content="Hello" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains('governance-prose')).toBe(true);
+  });
+
+  test('renders paragraph text', () => {
+    render(<MarkdownRenderer content="Simple paragraph text." />);
+    expect(screen.getByText('Simple paragraph text.')).toBeDefined();
+  });
+
+  test('renders headings at correct levels', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'# Heading 1\n## Heading 2\n### Heading 3'} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toBe('Heading 1');
+    expect(container.querySelector('h2')?.textContent).toBe('Heading 2');
+    expect(container.querySelector('h3')?.textContent).toBe('Heading 3');
+  });
+
+  test('renders bold and italic text', () => {
+    const { container } = render(<MarkdownRenderer content="**bold** and *italic*" />);
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+  });
+
+  test('renders bullet list', () => {
+    const { container } = render(<MarkdownRenderer content={'- Item A\n- Item B\n- Item C'} />);
+    const list = container.querySelector('ul');
+    expect(list).toBeDefined();
+    expect(list?.querySelectorAll('li').length).toBe(3);
+  });
+
+  test('renders ordered list', () => {
+    const { container } = render(<MarkdownRenderer content={'1. First\n2. Second'} />);
+    const list = container.querySelector('ol');
+    expect(list).toBeDefined();
+    expect(list?.querySelectorAll('li').length).toBe(2);
+  });
+
+  test('renders blockquote', () => {
+    const { container } = render(<MarkdownRenderer content="> A quoted passage" />);
+    expect(container.querySelector('blockquote')).toBeDefined();
+  });
+
+  test('renders Note callout with data-callout attribute', () => {
+    const { container } = render(<MarkdownRenderer content="> **Note:** This is a note callout" />);
+    const bq = container.querySelector('blockquote');
+    expect(bq?.getAttribute('data-callout')).toBe('note');
+  });
+
+  test('renders Warning callout with data-callout attribute', () => {
+    const { container } = render(<MarkdownRenderer content="> **Warning:** Be careful here" />);
+    const bq = container.querySelector('blockquote');
+    expect(bq?.getAttribute('data-callout')).toBe('warning');
+  });
+
+  test('renders Important callout with data-callout attribute', () => {
+    const { container } = render(
+      <MarkdownRenderer content="> **Important:** Critical information" />,
+    );
+    const bq = container.querySelector('blockquote');
+    expect(bq?.getAttribute('data-callout')).toBe('important');
+  });
+
+  test('regular blockquote has no data-callout attribute', () => {
+    const { container } = render(<MarkdownRenderer content="> Just a normal quote" />);
+    const bq = container.querySelector('blockquote');
+    expect(bq?.hasAttribute('data-callout')).toBe(false);
+  });
+
+  test('renders inline code', () => {
+    const { container } = render(<MarkdownRenderer content="Use `code` here" />);
+    expect(container.querySelector('code')?.textContent).toBe('code');
+  });
+
+  test('renders code block', () => {
+    const { container } = render(<MarkdownRenderer content={'```\nconst x = 1;\n```'} />);
+    expect(container.querySelector('pre')).toBeDefined();
+    expect(container.querySelector('pre code')).toBeDefined();
+  });
+
+  test('renders table with header and body', () => {
+    const { container } = render(
+      <MarkdownRenderer content={'| H1 | H2 |\n| -- | -- |\n| A | B |'} />,
+    );
+    expect(container.querySelector('table')).toBeDefined();
+    expect(container.querySelector('th')?.textContent).toBe('H1');
+    expect(container.querySelector('td')?.textContent).toBe('A');
+  });
+
+  test('renders horizontal rule', () => {
+    const { container } = render(<MarkdownRenderer content={'Above\n\n---\n\nBelow'} />);
+    expect(container.querySelector('hr')).toBeDefined();
+  });
+
+  test('renders links with target=_blank', () => {
+    const { container } = render(<MarkdownRenderer content="[Governada](https://governada.io)" />);
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBe('https://governada.io');
+    expect(link?.getAttribute('target')).toBe('_blank');
+  });
+
+  test('renders strikethrough text', () => {
+    const { container } = render(<MarkdownRenderer content="~~deleted~~" />);
+    expect(container.querySelector('del')?.textContent).toBe('deleted');
+  });
+
+  test('compact mode adds text-sm class', () => {
+    const { container } = render(<MarkdownRenderer content="Text" compact />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains('text-sm')).toBe(true);
+  });
+
+  test('custom className is applied', () => {
+    const { container } = render(<MarkdownRenderer content="Text" className="custom-class" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.classList.contains('custom-class')).toBe(true);
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -758,6 +758,218 @@ button:not(:disabled):active,
    Reduced motion — respect user preferences
    ============================================================ */
 
+/* ============================================================
+   Governance Prose — shared content styling for editor + renderer
+   Unifies how authored content looks in the Tiptap editor and
+   the react-markdown reviewer. Applied via .governance-prose class.
+   ============================================================ */
+
+.governance-prose {
+  line-height: 1.6;
+  color: oklch(0.95 0.005 260 / 0.9);
+}
+
+.governance-prose h1 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: oklch(from var(--foreground) l c h);
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.2;
+}
+
+.governance-prose h2 {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: oklch(from var(--foreground) l c h);
+  margin-top: 1.25em;
+  margin-bottom: 0.4em;
+  line-height: 1.3;
+}
+
+.governance-prose h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: oklch(from var(--foreground) l c h);
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+  line-height: 1.4;
+}
+
+.governance-prose p {
+  color: oklch(from var(--foreground) l c h / 0.9);
+  margin-bottom: 0.75em;
+  line-height: 1.7;
+}
+
+.governance-prose p:last-child {
+  margin-bottom: 0;
+}
+
+.governance-prose strong {
+  font-weight: 600;
+  color: oklch(from var(--foreground) l c h);
+}
+
+.governance-prose em {
+  font-style: italic;
+}
+
+.governance-prose a {
+  color: var(--compass-teal);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.governance-prose a:hover {
+  opacity: 0.8;
+}
+
+/* Lists */
+.governance-prose ul {
+  list-style-type: disc;
+  padding-left: 1.25em;
+  margin-bottom: 0.75em;
+}
+
+.governance-prose ol {
+  list-style-type: decimal;
+  padding-left: 1.25em;
+  margin-bottom: 0.75em;
+}
+
+.governance-prose li {
+  margin-bottom: 0.25em;
+  color: oklch(from var(--foreground) l c h / 0.9);
+}
+
+.governance-prose li > ul,
+.governance-prose li > ol {
+  margin-top: 0.25em;
+  margin-bottom: 0;
+}
+
+/* Task lists (Tiptap) */
+.governance-prose ul[data-type='taskList'] {
+  list-style: none;
+  padding-left: 0;
+}
+
+.governance-prose ul[data-type='taskList'] li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5em;
+}
+
+.governance-prose input[type='checkbox'] {
+  margin-top: 0.3em;
+  accent-color: var(--compass-teal);
+}
+
+/* Blockquotes */
+.governance-prose blockquote {
+  border-left: 3px solid var(--compass-teal);
+  padding-left: 1em;
+  margin: 0.75em 0;
+  color: oklch(from var(--foreground) l c h / 0.8);
+  font-style: italic;
+}
+
+/* Callout variants — Note / Warning / Important */
+.governance-prose blockquote[data-callout='note'] {
+  font-style: normal;
+  border-radius: 0.375rem;
+  padding: 0.75em 1em;
+  border-left-color: var(--compass-teal);
+  background: oklch(from var(--compass-teal) l c h / 0.08);
+}
+
+.governance-prose blockquote[data-callout='warning'] {
+  font-style: normal;
+  border-radius: 0.375rem;
+  padding: 0.75em 1em;
+  border-left-color: var(--wayfinder-amber);
+  background: oklch(from var(--wayfinder-amber) l c h / 0.08);
+}
+
+.governance-prose blockquote[data-callout='important'] {
+  font-style: normal;
+  border-radius: 0.375rem;
+  padding: 0.75em 1em;
+  border-left-color: var(--meridian-violet);
+  background: oklch(from var(--meridian-violet) l c h / 0.08);
+}
+
+/* Code */
+.governance-prose code {
+  background: oklch(from var(--muted) l c h);
+  border-radius: 0.25rem;
+  padding: 0.15em 0.35em;
+  font-size: 0.875em;
+}
+
+.governance-prose pre {
+  background: oklch(from var(--muted) l c h);
+  border-radius: 0.5rem;
+  padding: 1em;
+  margin: 0.75em 0;
+  overflow-x: auto;
+}
+
+.governance-prose pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  font-size: 0.875em;
+}
+
+/* Tables */
+.governance-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75em 0;
+  font-size: 0.875em;
+}
+
+.governance-prose th {
+  background: oklch(from var(--muted) l c h);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.5em 0.75em;
+  border: 1px solid oklch(from var(--border) l c h);
+}
+
+.governance-prose td {
+  padding: 0.5em 0.75em;
+  border: 1px solid oklch(from var(--border) l c h);
+}
+
+.governance-prose tr:nth-child(even) td {
+  background: oklch(from var(--muted) l c h / 0.3);
+}
+
+/* Horizontal rule */
+.governance-prose hr {
+  border: none;
+  border-top: 1px solid oklch(from var(--border) l c h);
+  margin: 1.5em auto;
+  width: 60%;
+}
+
+/* Images */
+.governance-prose img {
+  max-width: 100%;
+  border-radius: 0.5rem;
+  margin: 0.75em 0;
+}
+
+/* First child margin reset for tight containers */
+.governance-prose > *:first-child {
+  margin-top: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-ticker,
   .animate-fade-in-up,

--- a/components/shared/MarkdownRenderer.tsx
+++ b/components/shared/MarkdownRenderer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
@@ -12,8 +13,47 @@ interface MarkdownRendererProps {
 }
 
 /**
+ * Detect callout type from blockquote content.
+ * Looks for opening bold markers: **Note:**, **Warning:**, **Important:**
+ *
+ * react-markdown wraps blockquote children with whitespace text nodes,
+ * so we find the first actual element (a <p>) and inspect its first child.
+ */
+function detectCalloutType(children: React.ReactNode): string | null {
+  const childArray = React.Children.toArray(children);
+  if (childArray.length === 0) return null;
+
+  // Find the first React element child (skip whitespace text nodes)
+  const firstElement = childArray.find((child) => React.isValidElement(child));
+  if (!firstElement || !React.isValidElement(firstElement)) return null;
+
+  // Get the text content of the first paragraph
+  const pChildren = React.Children.toArray(
+    (firstElement.props as { children?: React.ReactNode }).children,
+  );
+  if (pChildren.length === 0) return null;
+
+  // Find the first strong element inside the paragraph
+  const firstStrong = pChildren.find(
+    (child) => React.isValidElement(child) && child.type === 'strong',
+  );
+  if (!firstStrong || !React.isValidElement(firstStrong)) return null;
+
+  const strongText = String(
+    React.Children.toArray((firstStrong.props as { children?: React.ReactNode }).children).join(''),
+  ).toLowerCase();
+
+  if (strongText.startsWith('note')) return 'note';
+  if (strongText.startsWith('warning')) return 'warning';
+  if (strongText.startsWith('important')) return 'important';
+
+  return null;
+}
+
+/**
  * Shared markdown renderer with GFM support (tables, checklists, strikethrough).
- * Uses custom components for consistent styling in light and dark modes.
+ * Uses the .governance-prose CSS class for consistent styling, with minimal
+ * React component overrides only where React behavior is needed.
  */
 export function MarkdownRenderer({ content, className, compact }: MarkdownRendererProps) {
   if (!content) return null;
@@ -21,7 +61,7 @@ export function MarkdownRenderer({ content, className, compact }: MarkdownRender
   return (
     <div
       className={cn(
-        'max-w-none',
+        'governance-prose max-w-none',
         compact ? 'text-sm' : 'text-base',
         '[&>*:first-child]:mt-0 [&>*:last-child]:mb-0',
         className,
@@ -30,70 +70,27 @@ export function MarkdownRenderer({ content, className, compact }: MarkdownRender
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
+          // Links need target="_blank" for external navigation
           a: ({ href, children }) => (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary underline hover:opacity-80"
-            >
+            <a href={href} target="_blank" rel="noopener noreferrer">
               {children}
             </a>
           ),
-          p: ({ children }) => (
-            <p className={cn('mb-3 last:mb-0 text-foreground/90', compact && 'mb-2')}>{children}</p>
-          ),
-          strong: ({ children }) => (
-            <strong className="font-semibold text-foreground">{children}</strong>
-          ),
-          em: ({ children }) => <em className="italic">{children}</em>,
-          ul: ({ children }) => <ul className="list-disc pl-5 mb-3 space-y-1">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-5 mb-3 space-y-1">{children}</ol>,
-          li: ({ children }) => <li className="text-foreground/90">{children}</li>,
-          h1: ({ children }) => (
-            <h1 className="text-lg font-bold text-foreground mb-3 mt-6 first:mt-0">{children}</h1>
-          ),
-          h2: ({ children }) => (
-            <h2 className="text-base font-bold text-foreground mb-2 mt-5 first:mt-0">{children}</h2>
-          ),
-          h3: ({ children }) => (
-            <h3 className="text-sm font-semibold text-foreground mb-2 mt-4 first:mt-0">
-              {children}
-            </h3>
-          ),
-          blockquote: ({ children }) => (
-            <blockquote className="border-l-2 border-primary/30 pl-4 my-3 text-muted-foreground italic">
-              {children}
-            </blockquote>
-          ),
-          code: ({ children }) => (
-            <code className="bg-muted rounded px-1.5 py-0.5 text-sm font-mono">{children}</code>
-          ),
-          pre: ({ children }) => (
-            <pre className="bg-muted rounded-lg p-4 overflow-x-auto my-3 text-sm">{children}</pre>
-          ),
+          // Blockquotes need callout detection for data-callout attribute
+          blockquote: ({ children }) => {
+            const calloutType = detectCalloutType(children);
+            return <blockquote data-callout={calloutType || undefined}>{children}</blockquote>;
+          },
+          // Tables need overflow wrapper
           table: ({ children }) => (
-            <div className="overflow-x-auto my-3">
-              <table className="w-full border-collapse text-sm">{children}</table>
+            <div className="overflow-x-auto">
+              <table>{children}</table>
             </div>
           ),
-          th: ({ children }) => (
-            <th className="border border-border px-3 py-2 text-left font-semibold bg-muted/50">
-              {children}
-            </th>
-          ),
-          td: ({ children }) => <td className="border border-border px-3 py-2">{children}</td>,
-          hr: () => <hr className="border-border my-4" />,
           // GFM checkbox support
           input: ({ type, checked, ...rest }) =>
             type === 'checkbox' ? (
-              <input
-                type="checkbox"
-                checked={checked}
-                readOnly
-                className="accent-primary mr-2 align-middle"
-                {...rest}
-              />
+              <input type="checkbox" checked={checked} readOnly {...rest} />
             ) : (
               <input type={type} {...rest} />
             ),

--- a/components/workspace/editor/FormattingToolbar.tsx
+++ b/components/workspace/editor/FormattingToolbar.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+/**
+ * FormattingToolbar — compact horizontal toolbar above the editor content.
+ *
+ * Groups: Inline (B/I/S/Link) | Headings (H1/H2/H3) | Lists (bullet/ordered/task) |
+ * Blocks (quote/code/table/divider)
+ *
+ * Active state detection highlights buttons matching the current cursor context.
+ * Rendered sticky so it stays visible when scrolling long proposal content.
+ */
+
+import { useCallback, useState } from 'react';
+import {
+  Bold,
+  Italic,
+  Strikethrough,
+  Link,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+  Code,
+  Table,
+  Minus,
+  Plus,
+  Image as ImageIcon,
+  X,
+} from 'lucide-react';
+import type { Editor } from '@tiptap/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FormattingToolbarProps {
+  editor: Editor;
+}
+
+interface ToolbarButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  isActive?: boolean;
+  onClick: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Button component
+// ---------------------------------------------------------------------------
+
+function ToolbarButton({ icon, label, isActive, onClick }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      aria-pressed={isActive}
+      className={`inline-flex items-center justify-center h-7 w-7 rounded text-xs transition-colors ${
+        isActive
+          ? 'bg-accent text-accent-foreground'
+          : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+      }`}
+    >
+      {icon}
+    </button>
+  );
+}
+
+function Separator() {
+  return <div className="w-px h-4 bg-border/50 mx-0.5" />;
+}
+
+// ---------------------------------------------------------------------------
+// Insert menu (+ button dropdown)
+// ---------------------------------------------------------------------------
+
+interface InsertItem {
+  icon: React.ReactNode;
+  label: string;
+  action: (editor: Editor) => void;
+}
+
+const INSERT_ITEMS: InsertItem[] = [
+  {
+    icon: <Table className="h-3.5 w-3.5" />,
+    label: 'Table',
+    action: (editor) =>
+      editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+  },
+  {
+    icon: <Minus className="h-3.5 w-3.5" />,
+    label: 'Divider',
+    action: (editor) => editor.chain().focus().setHorizontalRule().run(),
+  },
+  {
+    icon: <ImageIcon className="h-3.5 w-3.5" />,
+    label: 'Image',
+    action: (editor) => {
+      const url = window.prompt('Enter image URL:');
+      if (url) {
+        editor.chain().focus().setImage({ src: url }).run();
+      }
+    },
+  },
+  {
+    icon: <Code className="h-3.5 w-3.5" />,
+    label: 'Code Block',
+    action: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+];
+
+function InsertMenu({ editor }: { editor: Editor }) {
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleSelect = useCallback(
+    (action: (editor: Editor) => void) => {
+      action(editor);
+      setOpen(false);
+    },
+    [editor],
+  );
+
+  return (
+    <div className="relative">
+      <ToolbarButton
+        icon={open ? <X className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+        label="Insert block"
+        onClick={handleToggle}
+      />
+      {open && (
+        <div className="absolute top-full left-0 mt-1 z-50 w-40 rounded-md border border-border bg-popover shadow-lg py-1">
+          {INSERT_ITEMS.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              onClick={() => handleSelect(item.action)}
+              className="flex items-center gap-2 w-full px-3 py-1.5 text-sm text-foreground hover:bg-accent/50 transition-colors"
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar component
+// ---------------------------------------------------------------------------
+
+export function FormattingToolbar({ editor }: FormattingToolbarProps) {
+  // Force re-render on editor state changes for active-state detection
+  // We use editor.on in useEffect, but for simplicity Tiptap's React
+  // hooks already trigger re-renders on transactions.
+
+  const setLink = useCallback(() => {
+    const previousUrl = editor.getAttributes('link').href as string | undefined;
+    const url = window.prompt('URL', previousUrl ?? '');
+
+    if (url === null) return; // Cancelled
+
+    if (url === '') {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+      return;
+    }
+
+    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+  }, [editor]);
+
+  return (
+    <div className="formatting-toolbar sticky top-0 z-10 flex items-center gap-0.5 px-3 py-1.5 bg-muted/30 border-b border-border/30 flex-wrap">
+      {/* Inline formatting */}
+      <ToolbarButton
+        icon={<Bold className="h-3.5 w-3.5" />}
+        label="Bold"
+        isActive={editor.isActive('bold')}
+        onClick={() => editor.chain().focus().toggleBold().run()}
+      />
+      <ToolbarButton
+        icon={<Italic className="h-3.5 w-3.5" />}
+        label="Italic"
+        isActive={editor.isActive('italic')}
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+      />
+      <ToolbarButton
+        icon={<Strikethrough className="h-3.5 w-3.5" />}
+        label="Strikethrough"
+        isActive={editor.isActive('strike')}
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+      />
+      <ToolbarButton
+        icon={<Link className="h-3.5 w-3.5" />}
+        label="Link"
+        isActive={editor.isActive('link')}
+        onClick={setLink}
+      />
+
+      <Separator />
+
+      {/* Headings */}
+      <ToolbarButton
+        icon={<Heading1 className="h-3.5 w-3.5" />}
+        label="Heading 1"
+        isActive={editor.isActive('heading', { level: 1 })}
+        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+      />
+      <ToolbarButton
+        icon={<Heading2 className="h-3.5 w-3.5" />}
+        label="Heading 2"
+        isActive={editor.isActive('heading', { level: 2 })}
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+      />
+      <ToolbarButton
+        icon={<Heading3 className="h-3.5 w-3.5" />}
+        label="Heading 3"
+        isActive={editor.isActive('heading', { level: 3 })}
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+      />
+
+      <Separator />
+
+      {/* Lists */}
+      <ToolbarButton
+        icon={<List className="h-3.5 w-3.5" />}
+        label="Bullet List"
+        isActive={editor.isActive('bulletList')}
+        onClick={() => editor.chain().focus().toggleBulletList().run()}
+      />
+      <ToolbarButton
+        icon={<ListOrdered className="h-3.5 w-3.5" />}
+        label="Numbered List"
+        isActive={editor.isActive('orderedList')}
+        onClick={() => editor.chain().focus().toggleOrderedList().run()}
+      />
+      <ToolbarButton
+        icon={<CheckSquare className="h-3.5 w-3.5" />}
+        label="Task List"
+        isActive={editor.isActive('taskList')}
+        onClick={() => editor.chain().focus().toggleTaskList().run()}
+      />
+
+      <Separator />
+
+      {/* Block elements */}
+      <ToolbarButton
+        icon={<Quote className="h-3.5 w-3.5" />}
+        label="Blockquote"
+        isActive={editor.isActive('blockquote')}
+        onClick={() => editor.chain().focus().toggleBlockquote().run()}
+      />
+      <ToolbarButton
+        icon={<Code className="h-3.5 w-3.5" />}
+        label="Code Block"
+        isActive={editor.isActive('codeBlock')}
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+      />
+
+      <Separator />
+
+      {/* Insert menu */}
+      <InsertMenu editor={editor} />
+    </div>
+  );
+}

--- a/components/workspace/editor/ProposalEditor.tsx
+++ b/components/workspace/editor/ProposalEditor.tsx
@@ -39,6 +39,7 @@ import { CommandBarExtension, CommandBarUI } from './CommandBar';
 import { InlineComment, CommentPopover } from './InlineComment';
 import { MarginDecorations, setMarginIndicators } from './MarginDecorations';
 import { SelectionToolbar } from './SelectionToolbar';
+import { FormattingToolbar } from './FormattingToolbar';
 import { VersionDiffView } from './VersionDiffView';
 
 import type {
@@ -479,9 +480,14 @@ export function ProposalEditor({
   }
 
   return (
-    <div className="proposal-editor-wrapper relative p-6">
+    <div className="proposal-editor-wrapper relative">
+      {/* Formatting toolbar — shown in edit mode only */}
+      {editor && !isReadOnly && <FormattingToolbar editor={editor} />}
+
       {/* Tiptap editor */}
-      <EditorContent editor={editor} />
+      <div className="p-6">
+        <EditorContent editor={editor} />
+      </div>
 
       {/* Selection toolbar — floating comment button on text selection */}
       {editor && <SelectionToolbar editor={editor} currentUserId={currentUserId ?? 'anonymous'} />}

--- a/components/workspace/editor/SectionBlock.tsx
+++ b/components/workspace/editor/SectionBlock.tsx
@@ -94,7 +94,7 @@ function SectionBlockView({ node, editor }: SectionBlockViewProps) {
 
       {/* Editor content area */}
       <NodeViewContent
-        className={`prose prose-sm dark:prose-invert max-w-none focus:outline-none min-h-[60px] px-4 py-3 prose-headings:font-bold prose-headings:text-foreground prose-h2:text-lg prose-h2:mt-6 prose-h2:mb-3 prose-h3:text-base prose-h3:mt-5 prose-h3:mb-2 prose-h4:text-sm prose-h4:mt-4 prose-h4:mb-2 prose-p:mb-2.5 prose-p:leading-relaxed prose-blockquote:border-l-primary/30 prose-blockquote:text-muted-foreground prose-a:text-primary prose-a:underline ${
+        className={`governance-prose max-w-none focus:outline-none min-h-[60px] px-4 py-3 ${
           !isEditable ? 'cursor-default' : ''
         }`}
         as="div"

--- a/components/workspace/editor/SlashCommandMenu.tsx
+++ b/components/workspace/editor/SlashCommandMenu.tsx
@@ -3,63 +3,221 @@
 /**
  * SlashCommandMenu — Slash command dropdown for the Tiptap editor.
  *
- * Appears when user types `/` at the start of a line. Shows governance-specific
- * AI commands: /improve, /check-constitution, /similar-proposals, /complete, /draft.
+ * Appears when user types `/` at the start of a line. Shows two sections:
+ * 1. Content block commands (headings, lists, quotes, etc.) — execute directly on editor
+ * 2. AI commands (improve, check-constitution, etc.) — fire onSlashCommand callback
  *
- * Each command fires an `onSlashCommand(command, sectionContext)` callback.
- * The extension handles the UI (dropdown rendering, keyboard navigation)
- * but does NOT call any APIs directly.
+ * Each content command applies a Tiptap chain directly. AI commands fire
+ * an `onSlashCommand(command, sectionContext)` callback.
  */
 
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { DecorationSet } from '@tiptap/pm/view';
 import type { EditorView } from '@tiptap/pm/view';
+import type { Editor } from '@tiptap/core';
 import type { SlashCommandType } from '@/lib/workspace/editor/types';
 
 // ---------------------------------------------------------------------------
 // Command definitions
 // ---------------------------------------------------------------------------
 
-interface CommandDef {
-  id: SlashCommandType;
-  label: string;
-  description: string;
-  icon: string;
-}
+/** Discriminated union: content commands execute on editor, AI commands fire callback */
+type CommandDef =
+  | {
+      kind: 'content';
+      id: string;
+      label: string;
+      description: string;
+      icon: string;
+      aliases: string[];
+      execute: (editor: Editor) => void;
+    }
+  | {
+      kind: 'ai';
+      id: SlashCommandType;
+      label: string;
+      description: string;
+      icon: string;
+      aliases: string[];
+    };
 
-const COMMANDS: CommandDef[] = [
+// --- Content block commands ---
+
+const CONTENT_COMMANDS: CommandDef[] = [
   {
+    kind: 'content',
+    id: 'heading',
+    label: 'Heading 1',
+    description: 'Large section heading',
+    icon: '\uD83C\uDD77', // H boxed
+    aliases: ['heading', 'h1'],
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'h2',
+    label: 'Heading 2',
+    description: 'Medium section heading',
+    icon: '\uD83C\uDD77', // H boxed
+    aliases: ['h2'],
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'h3',
+    label: 'Heading 3',
+    description: 'Small section heading',
+    icon: '\uD83C\uDD77', // H boxed
+    aliases: ['h3'],
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'bullet',
+    label: 'Bullet List',
+    description: 'Create a simple bulleted list',
+    icon: '\u2022', // bullet
+    aliases: ['bullet', 'list', 'ul'],
+    execute: (editor) => editor.chain().focus().toggleBulletList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'numbered',
+    label: 'Numbered List',
+    description: 'Create a numbered list',
+    icon: '\uD83D\uDD22', // 1234
+    aliases: ['numbered', 'ordered', 'ol'],
+    execute: (editor) => editor.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'todo',
+    label: 'Task List',
+    description: 'Checklist with toggleable items',
+    icon: '\u2611', // checkbox
+    aliases: ['todo', 'checklist', 'task'],
+    execute: (editor) => editor.chain().focus().toggleTaskList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'quote',
+    label: 'Blockquote',
+    description: 'Insert a quote block',
+    icon: '\u275D', // heavy quote
+    aliases: ['quote', 'blockquote'],
+    execute: (editor) => editor.chain().focus().toggleBlockquote().run(),
+  },
+  {
+    kind: 'content',
+    id: 'code',
+    label: 'Code Block',
+    description: 'Insert a code block',
+    icon: '\u2329\u232A', // angle brackets
+    aliases: ['code', 'codeblock'],
+    execute: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+  {
+    kind: 'content',
+    id: 'table',
+    label: 'Table',
+    description: 'Insert a 3x3 table',
+    icon: '\u25A6', // grid
+    aliases: ['table'],
+    execute: (editor) =>
+      editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'divider',
+    label: 'Divider',
+    description: 'Insert a horizontal rule',
+    icon: '\u2015', // horizontal bar
+    aliases: ['divider', 'hr', 'rule'],
+    execute: (editor) => editor.chain().focus().setHorizontalRule().run(),
+  },
+  {
+    kind: 'content',
+    id: 'callout',
+    label: 'Callout',
+    description: 'Highlighted note or warning block',
+    icon: '\uD83D\uDCA1', // lightbulb
+    aliases: ['callout', 'note', 'warning'],
+    execute: (editor) =>
+      editor
+        .chain()
+        .focus()
+        .toggleBlockquote()
+        .command(({ tr, dispatch }) => {
+          if (dispatch) {
+            tr.insertText('**Note:** ');
+          }
+          return true;
+        })
+        .run(),
+  },
+  {
+    kind: 'content',
+    id: 'image',
+    label: 'Image',
+    description: 'Insert an image from URL',
+    icon: '\uD83D\uDDBC', // framed picture
+    aliases: ['image', 'img', 'picture'],
+    execute: (editor) => {
+      const url = window.prompt('Enter image URL:');
+      if (url) {
+        editor.chain().focus().setImage({ src: url }).run();
+      }
+    },
+  },
+];
+
+// --- AI commands ---
+
+const AI_COMMANDS: CommandDef[] = [
+  {
+    kind: 'ai',
     id: 'improve',
     label: 'Improve',
     description: 'AI improves the selected text or current section',
     icon: '\u2728', // sparkles
+    aliases: ['improve'],
   },
   {
+    kind: 'ai',
     id: 'check-constitution',
     label: 'Check Constitution',
     description: 'Analyze constitutional compliance of this section',
     icon: '\u2696\uFE0F', // scales
+    aliases: ['check-constitution', 'constitution'],
   },
   {
+    kind: 'ai',
     id: 'similar-proposals',
     label: 'Similar Proposals',
     description: 'Find precedent from past governance proposals',
     icon: '\uD83D\uDD0D', // magnifying glass
+    aliases: ['similar-proposals', 'similar'],
   },
   {
+    kind: 'ai',
     id: 'complete',
     label: 'Complete',
     description: 'AI suggests what is missing from this section',
     icon: '\uD83D\uDCDD', // memo
+    aliases: ['complete'],
   },
   {
+    kind: 'ai',
     id: 'draft',
     label: 'Draft',
     description: 'AI drafts content from your instructions',
     icon: '\u270D\uFE0F', // writing hand
+    aliases: ['draft'],
   },
 ];
+
+const ALL_COMMANDS: CommandDef[] = [...CONTENT_COMMANDS, ...AI_COMMANDS];
 
 // ---------------------------------------------------------------------------
 // Plugin state
@@ -82,53 +240,101 @@ const slashMenuPluginKey = new PluginKey<SlashMenuState>('slashCommandMenu');
 function createMenuElement(
   commands: CommandDef[],
   selectedIndex: number,
-  onSelect: (command: SlashCommandType) => void,
+  onSelect: (command: CommandDef) => void,
 ): HTMLElement {
   const container = document.createElement('div');
   container.className =
-    'slash-command-menu fixed z-50 w-64 rounded-lg border border-border bg-popover shadow-lg overflow-hidden py-1';
+    'slash-command-menu fixed z-50 w-72 rounded-lg border border-border bg-popover shadow-lg overflow-hidden py-1 max-h-80 overflow-y-auto';
   container.setAttribute('role', 'listbox');
 
-  commands.forEach((cmd, index) => {
-    const item = document.createElement('div');
-    item.className = `slash-command-item flex items-center gap-3 px-3 py-2 cursor-pointer text-sm transition-colors ${
-      index === selectedIndex
-        ? 'bg-accent text-accent-foreground'
-        : 'text-foreground hover:bg-accent/50'
-    }`;
-    item.setAttribute('role', 'option');
-    item.setAttribute('aria-selected', String(index === selectedIndex));
+  // Split into content and AI groups
+  const contentItems = commands.filter((c) => c.kind === 'content');
+  const aiItems = commands.filter((c) => c.kind === 'ai');
 
-    const iconSpan = document.createElement('span');
-    iconSpan.className = 'text-base flex-shrink-0';
-    iconSpan.textContent = cmd.icon;
+  let globalIndex = 0;
 
-    const textContainer = document.createElement('div');
-    textContainer.className = 'flex flex-col min-w-0';
+  // Content section header
+  if (contentItems.length > 0) {
+    const header = document.createElement('div');
+    header.className =
+      'px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none';
+    header.textContent = 'Content';
+    container.appendChild(header);
 
-    const label = document.createElement('span');
-    label.className = 'font-medium text-[13px] leading-tight';
-    label.textContent = `/${cmd.label.toLowerCase().replace(/\s+/g, '-')}`;
+    for (const cmd of contentItems) {
+      container.appendChild(createCommandItem(cmd, globalIndex, selectedIndex, onSelect));
+      globalIndex++;
+    }
+  }
 
-    const desc = document.createElement('span');
-    desc.className = 'text-[11px] text-muted-foreground leading-tight truncate';
-    desc.textContent = cmd.description;
+  // Separator + AI section header
+  if (aiItems.length > 0) {
+    if (contentItems.length > 0) {
+      const separator = document.createElement('div');
+      separator.className = 'mx-2 my-1 border-t border-border/50';
+      container.appendChild(separator);
+    }
 
-    textContainer.appendChild(label);
-    textContainer.appendChild(desc);
-    item.appendChild(iconSpan);
-    item.appendChild(textContainer);
+    const header = document.createElement('div');
+    header.className =
+      'px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none';
+    header.textContent = 'AI';
+    container.appendChild(header);
 
-    item.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      onSelect(cmd.id);
-    });
-
-    container.appendChild(item);
-  });
+    for (const cmd of aiItems) {
+      container.appendChild(createCommandItem(cmd, globalIndex, selectedIndex, onSelect));
+      globalIndex++;
+    }
+  }
 
   return container;
+}
+
+function createCommandItem(
+  cmd: CommandDef,
+  index: number,
+  selectedIndex: number,
+  onSelect: (command: CommandDef) => void,
+): HTMLElement {
+  const item = document.createElement('div');
+  item.className = `slash-command-item flex items-center gap-3 px-3 py-2 cursor-pointer text-sm transition-colors ${
+    index === selectedIndex
+      ? 'bg-accent text-accent-foreground'
+      : 'text-foreground hover:bg-accent/50'
+  }`;
+  item.setAttribute('role', 'option');
+  item.setAttribute('aria-selected', String(index === selectedIndex));
+  item.dataset.index = String(index);
+
+  const iconSpan = document.createElement('span');
+  iconSpan.className = 'text-base flex-shrink-0 w-5 text-center';
+  iconSpan.textContent = cmd.icon;
+
+  const textContainer = document.createElement('div');
+  textContainer.className = 'flex flex-col min-w-0';
+
+  const label = document.createElement('span');
+  label.className = 'font-medium text-[13px] leading-tight';
+  // Show the first alias as the slash label
+  const slashLabel = cmd.kind === 'ai' ? cmd.id : cmd.aliases[0] || cmd.id;
+  label.textContent = `/${slashLabel}`;
+
+  const desc = document.createElement('span');
+  desc.className = 'text-[11px] text-muted-foreground leading-tight truncate';
+  desc.textContent = cmd.description;
+
+  textContainer.appendChild(label);
+  textContainer.appendChild(desc);
+  item.appendChild(iconSpan);
+  item.appendChild(textContainer);
+
+  item.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onSelect(cmd);
+  });
+
+  return item;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +361,7 @@ function getSectionContext(view: EditorView): string {
 // ---------------------------------------------------------------------------
 
 export interface SlashCommandMenuOptions {
-  /** Called when a slash command is selected */
+  /** Called when an AI slash command is selected */
   onSlashCommand?: (command: SlashCommandType, sectionContext: string) => void;
 }
 
@@ -223,9 +429,13 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
           this.editor.state.tr.setMeta(slashMenuPluginKey, { type: 'close' }),
         );
 
-        // Fire the callback
-        const section = getSectionContext(this.editor.view);
-        this.options.onSlashCommand?.(selected.id, section);
+        // Execute the command
+        if (selected.kind === 'content') {
+          selected.execute(this.editor);
+        } else {
+          const section = getSectionContext(this.editor.view);
+          this.options.onSlashCommand?.(selected.id, section);
+        }
         return true;
       },
       Escape: () => {
@@ -241,6 +451,7 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
 
   addProseMirrorPlugins() {
     const extensionOptions = this.options;
+    const editorInstance = this.editor;
     let menuElement: HTMLElement | null = null;
 
     return [
@@ -283,7 +494,7 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
               const textBefore = $from.parent.textContent.slice(0, $from.parentOffset);
 
               // Check for slash at start of line (or after only whitespace)
-              const slashMatch = textBefore.match(/(?:^|\s)\/([a-z-]*)$/);
+              const slashMatch = textBefore.match(/(?:^|\s)\/([a-z0-9-]*)$/);
 
               if (slashMatch) {
                 const query = slashMatch[1];
@@ -348,7 +559,7 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
               }
 
               // Create new menu
-              menuElement = createMenuElement(filtered, state.selectedIndex, (commandId) => {
+              menuElement = createMenuElement(filtered, state.selectedIndex, (cmd) => {
                 // Remove the slash text
                 if (state.triggerPos !== null) {
                   const from = state.triggerPos;
@@ -360,9 +571,13 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
                   view.dispatch(tr);
                 }
 
-                // Fire callback
-                const section = getSectionContext(view);
-                extensionOptions.onSlashCommand?.(commandId, section);
+                // Execute the command
+                if (cmd.kind === 'content') {
+                  cmd.execute(editorInstance);
+                } else {
+                  const section = getSectionContext(view);
+                  extensionOptions.onSlashCommand?.(cmd.id, section);
+                }
               });
 
               // Position the menu below the cursor
@@ -391,9 +606,12 @@ export const SlashCommandMenu = Extension.create<SlashCommandMenuOptions>({
 // ---------------------------------------------------------------------------
 
 function filterCommands(query: string): CommandDef[] {
-  if (!query) return COMMANDS;
+  if (!query) return ALL_COMMANDS;
   const lower = query.toLowerCase();
-  return COMMANDS.filter(
-    (cmd) => cmd.id.includes(lower) || cmd.label.toLowerCase().includes(lower),
+  return ALL_COMMANDS.filter(
+    (cmd) =>
+      cmd.id.includes(lower) ||
+      cmd.label.toLowerCase().includes(lower) ||
+      cmd.aliases.some((alias) => alias.includes(lower)),
   );
 }


### PR DESCRIPTION
## Summary
- **12 content block slash commands** added to editor (`/heading`, `/h1-h3`, `/bullet`, `/ordered`, `/todo`, `/quote`, `/code`, `/table`, `/divider`, `/callout`, `/image`) — displayed above AI commands with visual separator.
- **`.governance-prose` shared CSS** (~210 lines) in globals.css — unified content styling for editor, reviewer, and on-chain display using Compass palette. Includes callout variants (Note/Warning/Important) with colored backgrounds.
- **FormattingToolbar** component — compact sticky toolbar (B/I/S/Link | H1/H2/H3 | Lists | Blocks | +) with active state detection via Tiptap `editor.isActive()`.
- **Callout detection** in MarkdownRenderer — `**Note:**`/`**Warning:**`/`**Important:**` blockquote markers get distinctive colored styling.
- **36 new tests** (16 roundtrip fidelity + 20 renderer) verifying content survives the full pipeline.

## Impact
- **What changed**: Authors can now insert formatted content blocks via `/` slash menu or toolbar buttons without knowing markdown syntax. Content looks identical in editor, review, and on-chain display.
- **User-facing**: Yes — significantly improved authoring UX with Notion-style block insertion and visually beautiful content rendering.
- **Risk**: Low — extends existing SlashCommandMenu, replaces inline Tailwind with shared CSS class. No data model changes.
- **Scope**: SlashCommandMenu.tsx, FormattingToolbar.tsx (new), ProposalEditor.tsx, SectionBlock.tsx, MarkdownRenderer.tsx, globals.css, 2 test files

## Test plan
- [ ] Slash menu shows content blocks above AI commands
- [ ] Each content block command inserts the correct element
- [ ] Existing AI slash commands still work
- [ ] Formatting toolbar buttons toggle formatting with active state
- [ ] Content looks identical in editor and MarkdownRenderer
- [ ] Callout blockquotes (Note/Warning/Important) render with colored styling
- [ ] 787 tests pass (including 36 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)