### PR TITLE
feat: admin testing framework — inspector, sandbox mode, registry cleanup

### DIFF
--- a/app/admin/users/UsersClient.tsx
+++ b/app/admin/users/UsersClient.tsx
@@ -1,0 +1,507 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Search,
+  User,
+  Shield,
+  Vote,
+  FileText,
+  MessageSquare,
+  Copy,
+  Check,
+  Loader2,
+  AlertCircle,
+  Wallet,
+  UserCog,
+} from 'lucide-react';
+
+interface InspectResult {
+  user: {
+    id: string;
+    wallet_address: string;
+    display_name: string | null;
+    last_active: string | null;
+    governance_depth: string;
+  } | null;
+  segment: {
+    detected: string;
+    segments: string[];
+    drepId: string | null;
+    poolId: string | null;
+    stakeAddress: string | null;
+    delegatedDrep: string | null;
+    delegatedPool: string | null;
+    tier: string | null;
+  };
+  drepProfile: {
+    id: string;
+    name: string | null;
+    bio: string | null;
+    score: number | null;
+    tier: string | null;
+    claimed: boolean;
+  } | null;
+  wallets: Array<{
+    stake_address: string;
+    payment_address: string;
+    drep_id: string | null;
+    pool_id: string | null;
+  }>;
+  activity: {
+    pollVotes: number;
+    proposalDrafts: number;
+    draftReviews: number;
+  };
+}
+
+function truncateAddress(addr: string, chars = 12): string {
+  if (addr.length <= chars * 2 + 3) return addr;
+  return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+function segmentColor(segment: string): string {
+  switch (segment) {
+    case 'drep':
+      return 'bg-chart-1/20 text-chart-1 border-chart-1/30';
+    case 'spo':
+      return 'bg-chart-2/20 text-chart-2 border-chart-2/30';
+    case 'cc':
+      return 'bg-chart-3/20 text-chart-3 border-chart-3/30';
+    case 'citizen':
+      return 'bg-chart-4/20 text-chart-4 border-chart-4/30';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function tierColor(tier: string | null): string {
+  switch (tier) {
+    case 'stellar':
+      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+    case 'established':
+      return 'bg-blue-500/20 text-blue-400 border-blue-500/30';
+    case 'emerging':
+      return 'bg-green-500/20 text-green-400 border-green-500/30';
+    case 'nascent':
+      return 'bg-zinc-500/20 text-zinc-400 border-zinc-500/30';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+function formatTimeAgo(dateStr: string | null): string {
+  if (!dateStr) return 'Never';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  const diffMonths = Math.floor(diffDays / 30);
+  return `${diffMonths}mo ago`;
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: number;
+  icon: typeof Vote;
+}) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-card/50 p-4">
+      <div className="flex items-center gap-2 text-muted-foreground mb-1">
+        <Icon className="h-4 w-4" />
+        <span className="text-xs font-medium">{label}</span>
+      </div>
+      <p className="text-2xl font-bold">{value}</p>
+    </div>
+  );
+}
+
+export function UsersClient() {
+  const [searchInput, setSearchInput] = useState('');
+
+  const inspect = useMutation({
+    mutationFn: async (address: string): Promise<InspectResult> => {
+      const token = getStoredSession();
+      const res = await fetch(`/api/admin/users/inspect?address=${encodeURIComponent(address)}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+  });
+
+  const handleSearch = () => {
+    const trimmed = searchInput.trim();
+    if (!trimmed) return;
+    inspect.mutate(trimmed);
+  };
+
+  const data = inspect.data;
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">User Inspector</h1>
+        <p className="text-sm text-muted-foreground">
+          Look up any user by wallet address, stake address, DRep ID, or pool ID.
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="flex gap-2">
+        <Input
+          placeholder="Search by wallet, stake address, DRep ID, or pool ID..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          className="flex-1"
+        />
+        <Button onClick={handleSearch} disabled={inspect.isPending || !searchInput.trim()}>
+          {inspect.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Search className="h-4 w-4" />
+          )}
+          <span className="ml-2">Inspect</span>
+        </Button>
+      </div>
+
+      {/* Error */}
+      {inspect.isError && (
+        <Card className="border-destructive/50">
+          <CardContent className="pt-4 pb-4 flex items-center gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-destructive">Inspection failed</p>
+              <p className="text-xs text-muted-foreground">{inspect.error.message}</p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* No user found */}
+      {data && !data.user && (
+        <Card>
+          <CardContent className="pt-6 pb-6 text-center">
+            <User className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+            <p className="text-sm text-muted-foreground">
+              No user found for this address. They may not have connected to Governada yet.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Results */}
+      {data && data.user && (
+        <div className="space-y-4">
+          {/* Identity */}
+          <Card className="bg-card/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <User className="h-4 w-4" />
+                Identity
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Wallet Address</p>
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-mono">
+                      {truncateAddress(data.user.wallet_address)}
+                    </code>
+                    <CopyButton text={data.user.wallet_address} />
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">User ID</p>
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-mono">{data.user.id.slice(0, 8)}...</code>
+                    <CopyButton text={data.user.id} />
+                  </div>
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Display Name</p>
+                  <p className="text-sm">{data.user.display_name || '--'}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Last Active</p>
+                  <p className="text-sm">{formatTimeAgo(data.user.last_active)}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Governance Depth</p>
+                  <p className="text-sm capitalize">{data.user.governance_depth}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Segment Detection */}
+          <Card className="bg-card/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Shield className="h-4 w-4" />
+                Segment Detection
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex items-center gap-3 flex-wrap">
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Detected Segment</p>
+                  <Badge variant="outline" className={segmentColor(data.segment.detected)}>
+                    {data.segment.detected.toUpperCase()}
+                  </Badge>
+                </div>
+                {data.segment.tier && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Tier</p>
+                    <Badge variant="outline" className={tierColor(data.segment.tier)}>
+                      {data.segment.tier}
+                    </Badge>
+                  </div>
+                )}
+                {data.segment.segments.length > 0 && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">All Segments</p>
+                    <div className="flex gap-1">
+                      {data.segment.segments.map((s) => (
+                        <Badge key={s} variant="outline" className="text-xs">
+                          {s}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                {data.segment.drepId && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">DRep ID</p>
+                    <div className="flex items-center gap-2">
+                      <code className="text-sm font-mono">
+                        {truncateAddress(data.segment.drepId)}
+                      </code>
+                      <CopyButton text={data.segment.drepId} />
+                    </div>
+                  </div>
+                )}
+                {data.segment.poolId && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Pool ID</p>
+                    <div className="flex items-center gap-2">
+                      <code className="text-sm font-mono">
+                        {truncateAddress(data.segment.poolId)}
+                      </code>
+                      <CopyButton text={data.segment.poolId} />
+                    </div>
+                  </div>
+                )}
+                {data.segment.stakeAddress && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Stake Address</p>
+                    <div className="flex items-center gap-2">
+                      <code className="text-sm font-mono">
+                        {truncateAddress(data.segment.stakeAddress)}
+                      </code>
+                      <CopyButton text={data.segment.stakeAddress} />
+                    </div>
+                  </div>
+                )}
+                {data.segment.delegatedDrep && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Delegated DRep</p>
+                    <div className="flex items-center gap-2">
+                      <code className="text-sm font-mono">
+                        {truncateAddress(data.segment.delegatedDrep)}
+                      </code>
+                      <CopyButton text={data.segment.delegatedDrep} />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Wallets */}
+          {data.wallets.length > 0 && (
+            <Card className="bg-card/50">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <Wallet className="h-4 w-4" />
+                  Linked Wallets
+                  <Badge variant="outline" className="ml-1 text-xs">
+                    {data.wallets.length}
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {data.wallets.map((w, i) => (
+                    <div
+                      key={i}
+                      className="rounded-md border border-border/40 bg-background/50 p-3 space-y-1.5"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground w-16 shrink-0">Stake</span>
+                        <code className="text-xs font-mono">
+                          {truncateAddress(w.stake_address, 16)}
+                        </code>
+                        <CopyButton text={w.stake_address} />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground w-16 shrink-0">Payment</span>
+                        <code className="text-xs font-mono">
+                          {truncateAddress(w.payment_address, 16)}
+                        </code>
+                        <CopyButton text={w.payment_address} />
+                      </div>
+                      {w.drep_id && (
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground w-16 shrink-0">DRep</span>
+                          <code className="text-xs font-mono">
+                            {truncateAddress(w.drep_id, 16)}
+                          </code>
+                          <CopyButton text={w.drep_id} />
+                        </div>
+                      )}
+                      {w.pool_id && (
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-muted-foreground w-16 shrink-0">Pool</span>
+                          <code className="text-xs font-mono">
+                            {truncateAddress(w.pool_id, 16)}
+                          </code>
+                          <CopyButton text={w.pool_id} />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* DRep Profile */}
+          {data.drepProfile && (
+            <Card className="bg-card/50">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base flex items-center gap-2">
+                  <UserCog className="h-4 w-4" />
+                  DRep Profile
+                  {data.drepProfile.claimed && (
+                    <Badge variant="outline" className="text-xs bg-green-500/20 text-green-400">
+                      Claimed
+                    </Badge>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Name</p>
+                    <p className="text-sm">{String(data.drepProfile.name ?? '--')}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Score</p>
+                    <p className="text-sm">
+                      {data.drepProfile.score != null
+                        ? `${data.drepProfile.score.toFixed(1)} / 100`
+                        : '--'}
+                    </p>
+                  </div>
+                </div>
+                {data.drepProfile.bio && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Bio</p>
+                    <p className="text-sm text-muted-foreground line-clamp-3">
+                      {String(data.drepProfile.bio)}
+                    </p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Governance Activity */}
+          <Card className="bg-card/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Vote className="h-4 w-4" />
+                Governance Activity
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-3 gap-3">
+                <StatCard label="Poll Votes" value={data.activity.pollVotes} icon={Vote} />
+                <StatCard
+                  label="Proposals Authored"
+                  value={data.activity.proposalDrafts}
+                  icon={FileText}
+                />
+                <StatCard
+                  label="Reviews Submitted"
+                  value={data.activity.draftReviews}
+                  icon={MessageSquare}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Quick Actions */}
+          <Card className="bg-card/50">
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center gap-3">
+                <Button variant="outline" size="sm" disabled>
+                  <UserCog className="h-4 w-4 mr-2" />
+                  Impersonate
+                </Button>
+                <span className="text-xs text-muted-foreground">Coming soon</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,7 @@
+export const dynamic = 'force-dynamic';
+
+import { UsersClient } from './UsersClient';
+
+export default function UsersPage() {
+  return <UsersClient />;
+}

--- a/app/api/admin/sandbox/route.ts
+++ b/app/api/admin/sandbox/route.ts
@@ -1,0 +1,223 @@
+/**
+ * Admin Sandbox API — manage admin sandbox cohorts for testing.
+ *
+ * Sandbox cohorts are special preview cohorts that let admins test
+ * the full authoring/review workflow without polluting production data.
+ * They are identified by a `[ADMIN_SANDBOX]` prefix in the description
+ * field of preview_cohorts.
+ *
+ * GET  — List admin's sandbox cohorts
+ * POST — Create or reset a sandbox cohort
+ *
+ * NOTE: Ideally preview_cohorts would have an `is_admin_sandbox` boolean
+ * column, but we use the description prefix convention to avoid a migration.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { SANDBOX_DESCRIPTION_PREFIX } from '@/lib/admin/sandbox';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/sandbox — list sandbox cohorts for the current admin
+ */
+export const GET = withRouteHandler(
+  async (_request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: cohorts, error } = await supabase
+      .from('preview_cohorts')
+      .select('*')
+      .eq('created_by', context.wallet)
+      .like('description', `${SANDBOX_DESCRIPTION_PREFIX}%`)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      logger.error('Failed to list sandbox cohorts', {
+        context: 'admin/sandbox',
+        error: error.message,
+      });
+      return NextResponse.json({ error: 'Failed to fetch sandbox cohorts' }, { status: 500 });
+    }
+
+    return NextResponse.json({ cohorts: cohorts ?? [] });
+  },
+  { auth: 'required' },
+);
+
+/**
+ * POST /api/admin/sandbox — create or reset a sandbox cohort
+ *
+ * Body: { action: 'create' | 'reset', cohortId?: string }
+ * - 'create': creates a new sandbox cohort or returns existing one
+ * - 'reset': clears all data in the specified sandbox cohort
+ */
+export const POST = withRouteHandler(
+  async (request: NextRequest, context) => {
+    if (!context.wallet || !isAdminWallet(context.wallet)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const action = typeof body.action === 'string' ? body.action : 'create';
+
+    const supabase = getSupabaseAdmin();
+
+    // -----------------------------------------------------------------------
+    // Action: create (or return existing)
+    // -----------------------------------------------------------------------
+    if (action === 'create') {
+      // Check if admin already has a sandbox cohort
+      const { data: existing } = await supabase
+        .from('preview_cohorts')
+        .select('*')
+        .eq('created_by', context.wallet)
+        .like('description', `${SANDBOX_DESCRIPTION_PREFIX}%`)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (existing) {
+        return NextResponse.json({ cohort: existing, created: false });
+      }
+
+      // Create a new sandbox cohort
+      const now = new Date();
+      const dateStr = now.toISOString().split('T')[0];
+      const name = `Admin Sandbox — ${dateStr}`;
+      const description = `${SANDBOX_DESCRIPTION_PREFIX} Created by admin for testing. Wallet: ${context.wallet.slice(0, 20)}...`;
+
+      const { data: cohort, error } = await supabase
+        .from('preview_cohorts')
+        .insert({
+          name,
+          description,
+          created_by: context.wallet,
+        })
+        .select()
+        .single();
+
+      if (error || !cohort) {
+        logger.error('Failed to create sandbox cohort', {
+          context: 'admin/sandbox',
+          error: error?.message,
+        });
+        return NextResponse.json({ error: 'Failed to create sandbox cohort' }, { status: 500 });
+      }
+
+      logger.info('[admin/sandbox] Created sandbox cohort', {
+        cohortId: cohort.id,
+        wallet: context.wallet.slice(0, 20) + '...',
+      });
+
+      return NextResponse.json({ cohort, created: true }, { status: 201 });
+    }
+
+    // -----------------------------------------------------------------------
+    // Action: reset — clear all data in the sandbox cohort
+    // -----------------------------------------------------------------------
+    if (action === 'reset') {
+      const cohortId = typeof body.cohortId === 'string' ? body.cohortId.trim() : '';
+      if (!cohortId) {
+        return NextResponse.json({ error: 'Missing cohortId for reset' }, { status: 400 });
+      }
+
+      // Verify the cohort exists and is an admin sandbox owned by this wallet
+      const { data: cohort, error: cohortError } = await supabase
+        .from('preview_cohorts')
+        .select('id, description, created_by')
+        .eq('id', cohortId)
+        .maybeSingle();
+
+      if (cohortError || !cohort) {
+        return NextResponse.json({ error: 'Sandbox cohort not found' }, { status: 404 });
+      }
+
+      if (
+        !cohort.description?.startsWith(SANDBOX_DESCRIPTION_PREFIX) ||
+        cohort.created_by !== context.wallet
+      ) {
+        return NextResponse.json({ error: 'Not a sandbox cohort owned by you' }, { status: 403 });
+      }
+
+      // Clean up data in FK order: reviews -> versions -> drafts
+      const { data: existingDrafts } = await supabase
+        .from('proposal_drafts')
+        .select('id')
+        .eq('preview_cohort_id', cohortId);
+
+      const draftIds = (existingDrafts ?? []).map((d) => d.id);
+      let deletedReviews = 0;
+      let deletedVersions = 0;
+      let deletedDrafts = 0;
+
+      if (draftIds.length > 0) {
+        const { count: reviewCount, error: reviewError } = await supabase
+          .from('draft_reviews')
+          .delete({ count: 'exact' })
+          .in('draft_id', draftIds);
+
+        if (reviewError) {
+          logger.error('[admin/sandbox] Failed to cleanup reviews', {
+            cohortId,
+            error: reviewError.message,
+          });
+        }
+        deletedReviews = reviewCount ?? 0;
+
+        const { count: versionCount, error: versionError } = await supabase
+          .from('proposal_draft_versions')
+          .delete({ count: 'exact' })
+          .in('draft_id', draftIds);
+
+        if (versionError) {
+          logger.error('[admin/sandbox] Failed to cleanup versions', {
+            cohortId,
+            error: versionError.message,
+          });
+        }
+        deletedVersions = versionCount ?? 0;
+
+        const { count: draftCount, error: draftError } = await supabase
+          .from('proposal_drafts')
+          .delete({ count: 'exact' })
+          .eq('preview_cohort_id', cohortId);
+
+        if (draftError) {
+          logger.error('[admin/sandbox] Failed to cleanup drafts', {
+            cohortId,
+            error: draftError.message,
+          });
+        }
+        deletedDrafts = draftCount ?? 0;
+      }
+
+      logger.info('[admin/sandbox] Reset sandbox cohort', {
+        cohortId,
+        deletedReviews,
+        deletedVersions,
+        deletedDrafts,
+      });
+
+      return NextResponse.json({
+        success: true,
+        deleted: {
+          reviews: deletedReviews,
+          versions: deletedVersions,
+          drafts: deletedDrafts,
+        },
+      });
+    }
+
+    return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
+  },
+  { auth: 'required' },
+);

--- a/app/api/admin/users/inspect/route.ts
+++ b/app/api/admin/users/inspect/route.ts
@@ -1,0 +1,225 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, ctx: RouteContext) => {
+    if (!isAdminWallet(ctx.wallet!)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const address = new URL(request.url).searchParams.get('address')?.trim();
+    if (!address) {
+      return NextResponse.json({ error: 'Required: address query param' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    // --- 1. Find user record ---
+    // Try wallet_address first, then check user_wallets by stake_address / payment_address
+    let userId: string | null = null;
+    let userRow: {
+      id: string;
+      wallet_address: string;
+      last_active: string | null;
+      created_at?: string;
+      claimed_drep_id: string | null;
+      display_name: string | null;
+      governance_depth: string;
+    } | null = null;
+
+    // Direct match on users.wallet_address
+    const { data: directUser } = await supabase
+      .from('users')
+      .select('id, wallet_address, last_active, claimed_drep_id, display_name, governance_depth')
+      .eq('wallet_address', address)
+      .maybeSingle();
+
+    if (directUser) {
+      userRow = directUser;
+      userId = directUser.id;
+    }
+
+    // If not found, try user_wallets (stake address, payment address, drep_id, pool_id)
+    if (!userId) {
+      const { data: walletMatch } = await supabase
+        .from('user_wallets')
+        .select('user_id, stake_address, payment_address, drep_id, pool_id, segments')
+        .or(
+          `stake_address.eq.${address},payment_address.eq.${address},drep_id.eq.${address},pool_id.eq.${address}`,
+        )
+        .limit(1)
+        .maybeSingle();
+
+      if (walletMatch) {
+        userId = walletMatch.user_id;
+        const { data: linkedUser } = await supabase
+          .from('users')
+          .select(
+            'id, wallet_address, last_active, claimed_drep_id, display_name, governance_depth',
+          )
+          .eq('id', userId)
+          .single();
+        if (linkedUser) userRow = linkedUser;
+      }
+    }
+
+    // --- 2. Gather wallet info (all wallets for this user) ---
+    let wallets: Array<{
+      stake_address: string;
+      payment_address: string;
+      drep_id: string | null;
+      pool_id: string | null;
+      segments: string[] | null;
+    }> = [];
+
+    if (userId) {
+      const { data: userWallets } = await supabase
+        .from('user_wallets')
+        .select('stake_address, payment_address, drep_id, pool_id, segments')
+        .eq('user_id', userId);
+      wallets = userWallets ?? [];
+    }
+
+    // Derive segment info from wallet data
+    const primaryWallet = wallets[0] ?? null;
+    const drepId = wallets.find((w) => w.drep_id)?.drep_id ?? userRow?.claimed_drep_id ?? null;
+    const poolId = wallets.find((w) => w.pool_id)?.pool_id ?? null;
+    const stakeAddress = primaryWallet?.stake_address ?? null;
+
+    // --- 3. DRep profile from dreps table ---
+    let drepProfile: {
+      id: string;
+      info: Record<string, unknown> | null;
+      metadata: Record<string, unknown> | null;
+      score: number | null;
+      current_tier: string | null;
+    } | null = null;
+
+    if (drepId) {
+      const { data: drep } = await supabase
+        .from('dreps')
+        .select('id, info, metadata, score, current_tier')
+        .eq('id', drepId)
+        .maybeSingle();
+      if (drep) {
+        drepProfile = {
+          ...drep,
+          info: drep.info as Record<string, unknown> | null,
+          metadata: drep.metadata as Record<string, unknown> | null,
+        };
+      }
+    }
+
+    // --- 4. Segment detection ---
+    const segments = primaryWallet?.segments ?? [];
+    const detectedSegment = segments.includes('drep')
+      ? 'drep'
+      : segments.includes('spo')
+        ? 'spo'
+        : segments.includes('cc')
+          ? 'cc'
+          : userId
+            ? 'citizen'
+            : 'unknown';
+
+    // Look up delegation info from dreps table if we have a DRep match
+    // and from user's wallet data for delegation targets
+    let delegatedDrep: string | null = null;
+    const delegatedPool: string | null = null;
+
+    if (stakeAddress) {
+      // Check if there's delegation info in poll_responses
+      const { data: recentPoll } = await supabase
+        .from('poll_responses')
+        .select('delegated_drep_id')
+        .eq('stake_address', stakeAddress)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (recentPoll?.delegated_drep_id) {
+        delegatedDrep = recentPoll.delegated_drep_id;
+      }
+    }
+
+    // --- 5. Activity counts ---
+    const activityQueries = await Promise.all([
+      // Poll responses count
+      stakeAddress
+        ? supabase
+            .from('poll_responses')
+            .select('id', { count: 'exact', head: true })
+            .eq('stake_address', stakeAddress)
+        : Promise.resolve({ count: 0 }),
+
+      // Proposal drafts count
+      stakeAddress
+        ? supabase
+            .from('proposal_drafts')
+            .select('id', { count: 'exact', head: true })
+            .eq('owner_stake_address', stakeAddress)
+        : Promise.resolve({ count: 0 }),
+
+      // Draft reviews count
+      stakeAddress
+        ? supabase
+            .from('draft_reviews')
+            .select('id', { count: 'exact', head: true })
+            .eq('reviewer_stake_address', stakeAddress)
+        : Promise.resolve({ count: 0 }),
+    ]);
+
+    return NextResponse.json({
+      user: userRow
+        ? {
+            id: userRow.id,
+            wallet_address: userRow.wallet_address,
+            display_name: userRow.display_name,
+            last_active: userRow.last_active,
+            governance_depth: userRow.governance_depth,
+          }
+        : null,
+      segment: {
+        detected: detectedSegment,
+        segments,
+        drepId,
+        poolId,
+        stakeAddress,
+        delegatedDrep,
+        delegatedPool,
+        tier: drepProfile?.current_tier ?? null,
+      },
+      drepProfile: drepProfile
+        ? {
+            id: drepProfile.id,
+            name:
+              (drepProfile.info as Record<string, unknown> | null)?.givenName ??
+              (drepProfile.metadata as Record<string, unknown> | null)?.name ??
+              null,
+            bio:
+              (drepProfile.metadata as Record<string, unknown> | null)?.bio ??
+              (drepProfile.info as Record<string, unknown> | null)?.motivations ??
+              null,
+            score: drepProfile.score,
+            tier: drepProfile.current_tier,
+            claimed: userRow?.claimed_drep_id === drepProfile.id,
+          }
+        : null,
+      wallets: wallets.map((w) => ({
+        stake_address: w.stake_address,
+        payment_address: w.payment_address,
+        drep_id: w.drep_id,
+        pool_id: w.pool_id,
+      })),
+      activity: {
+        pollVotes: activityQueries[0].count ?? 0,
+        proposalDrafts: activityQueries[1].count ?? 0,
+        draftReviews: activityQueries[2].count ?? 0,
+      },
+    });
+  },
+  { auth: 'required', rateLimit: { max: 30, window: 60 } },
+);

--- a/app/api/workspace/drafts/[draftId]/reviews/route.ts
+++ b/app/api/workspace/drafts/[draftId]/reviews/route.ts
@@ -7,6 +7,7 @@ import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { SubmitReviewSchema } from '@/lib/api/schemas/workspace';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { SANDBOX_DESCRIPTION_PREFIX } from '@/lib/admin/sandbox';
 import type { DraftReview } from '@/lib/workspace/types';
 
 export const dynamic = 'force-dynamic';
@@ -49,6 +50,26 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   }
 
   const admin = getSupabaseAdmin();
+  const sandboxCohortId = request.headers.get('x-sandbox-cohort') || null;
+
+  // If sandbox header present, verify the draft is visible to this sandbox
+  if (sandboxCohortId) {
+    const { data: draft } = await admin
+      .from('proposal_drafts')
+      .select('id, preview_cohort_id')
+      .eq('id', draftId)
+      .maybeSingle();
+
+    if (!draft) {
+      return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+    }
+
+    // Sandbox users can see reviews on sandbox-scoped drafts or real drafts
+    if (draft.preview_cohort_id && draft.preview_cohort_id !== sandboxCohortId) {
+      return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+    }
+  }
+
   const { data, error } = await admin
     .from('draft_reviews')
     .select('*')
@@ -146,14 +167,33 @@ export const POST = withRouteHandler(
     const body = SubmitReviewSchema.parse(await request.json());
     const admin = getSupabaseAdmin();
 
+    // Sandbox support: verify the cohort is a valid admin sandbox
+    const sandboxCohortId = request.headers.get('x-sandbox-cohort') || null;
+    if (sandboxCohortId) {
+      const { data: sandboxCohort } = await admin
+        .from('preview_cohorts')
+        .select('id, description')
+        .eq('id', sandboxCohortId)
+        .maybeSingle();
+
+      if (!sandboxCohort?.description?.startsWith(SANDBOX_DESCRIPTION_PREFIX)) {
+        return NextResponse.json({ error: 'Invalid sandbox cohort' }, { status: 403 });
+      }
+    }
+
     // Verify draft exists and is in community_review stage
     const { data: draft } = await admin
       .from('proposal_drafts')
-      .select('id, owner_stake_address, status')
+      .select('id, owner_stake_address, status, preview_cohort_id')
       .eq('id', draftId)
       .single();
 
     if (!draft) {
+      return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+    }
+
+    // Sandbox scoping: sandbox users can review sandbox-scoped or real drafts
+    if (sandboxCohortId && draft.preview_cohort_id && draft.preview_cohort_id !== sandboxCohortId) {
       return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
     }
 

--- a/app/api/workspace/drafts/route.ts
+++ b/app/api/workspace/drafts/route.ts
@@ -9,6 +9,7 @@ import { CreateDraftSchema } from '@/lib/api/schemas/workspace';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { logger } from '@/lib/logger';
 import { isPreviewAddress } from '@/lib/preview';
+import { SANDBOX_DESCRIPTION_PREFIX } from '@/lib/admin/sandbox';
 import type { ProposalDraft } from '@/lib/workspace/types';
 
 export const dynamic = 'force-dynamic';
@@ -22,6 +23,9 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const statusFilter = request.nextUrl.searchParams.get('status');
 
   const admin = getSupabaseAdmin();
+
+  // Sandbox support: if sandbox header present, scope reads to that cohort
+  const sandboxCohortId = request.headers.get('x-sandbox-cohort') || null;
 
   // Community-reviewable drafts mode: fetch by status (no owner filter)
   if (statusFilter) {
@@ -56,7 +60,10 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
     let query = admin.from('proposal_drafts').select('*').in('status', statuses);
 
-    if (previewCohortId) {
+    if (sandboxCohortId) {
+      // Sandbox mode: see sandbox cohort's drafts + real drafts
+      query = query.or(`preview_cohort_id.eq.${sandboxCohortId},preview_cohort_id.is.null`);
+    } else if (previewCohortId) {
       // Preview user: see their cohort's drafts + real drafts
       query = query.or(`preview_cohort_id.eq.${previewCohortId},preview_cohort_id.is.null`);
     } else {
@@ -101,9 +108,25 @@ export const POST = withRouteHandler(
     const body = CreateDraftSchema.parse(await request.json());
     const admin = getSupabaseAdmin();
 
-    // Tag preview drafts with the user's cohort so cohort members can see them
+    // Sandbox support: scope writes to preview cohort if sandbox header present
+    const sandboxCohortId = request.headers.get('x-sandbox-cohort') || null;
+
+    // Determine preview cohort: sandbox header takes precedence, then preview address
     let previewCohortId: string | null = null;
-    if (isPreviewAddress(body.stakeAddress)) {
+
+    if (sandboxCohortId) {
+      // Verify the cohort exists and is an admin sandbox
+      const { data: sandboxCohort } = await admin
+        .from('preview_cohorts')
+        .select('id, description')
+        .eq('id', sandboxCohortId)
+        .maybeSingle();
+
+      if (sandboxCohort?.description?.startsWith(SANDBOX_DESCRIPTION_PREFIX)) {
+        previewCohortId = sandboxCohortId;
+      }
+    } else if (isPreviewAddress(body.stakeAddress)) {
+      // Tag preview drafts with the user's cohort so cohort members can see them
       const { data: previewUser } = await admin
         .from('users')
         .select('id')

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -11,6 +11,7 @@ import {
   LayoutDashboard,
   Shield,
   TrendingUp,
+  UserSearch,
   Vote,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -38,6 +39,11 @@ const NAV_ITEMS = [
     icon: Database,
   },
   { type: 'divider' as const },
+  {
+    label: 'Users',
+    href: '/admin/users',
+    icon: UserSearch,
+  },
   {
     label: 'Integrity',
     href: '/admin/integrity',

--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
@@ -17,12 +17,18 @@ import {
   Layers,
   HelpCircle,
   CheckCheck,
+  FlaskConical,
+  RotateCcw,
+  Sparkles,
+  X,
+  Loader2,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { DepthPickerDropdown } from './DepthPickerDropdown';
 import { DepthPromptModal } from './DepthPromptModal';
 import { LanguagePicker } from './LanguagePicker';
 import { cn } from '@/lib/utils';
+import { getStoredSession } from '@/lib/supabaseAuth';
 import { HELP_ITEMS } from '@/lib/nav/config';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { useWallet } from '@/utils/wallet-context';
@@ -185,6 +191,9 @@ export function GovernadaHeader() {
     setOverride,
     dimensionOverrides,
     setDimensionOverrides,
+    sandboxCohortId,
+    enterSandbox,
+    exitSandbox,
   } = useSegment();
   const { data: adminData } = useAdminCheck(isAuthenticated);
   const isAdmin = adminData?.isAdmin === true;
@@ -199,6 +208,129 @@ export function GovernadaHeader() {
     preset: SegmentPreset;
     firstId: string;
   } | null>(null);
+
+  // Sandbox state
+  const [sandboxLoading, setSandboxLoading] = useState(false);
+  const [sandboxCohortName, setSandboxCohortName] = useState<string | null>(null);
+  const [sandboxActionStatus, setSandboxActionStatus] = useState<string | null>(null);
+
+  // Fetch sandbox cohort name when active
+  useEffect(() => {
+    if (!sandboxCohortId || !isAdmin) {
+      setSandboxCohortName(null);
+      return;
+    }
+    const fetchName = async () => {
+      try {
+        const token = getStoredSession();
+        const res = await fetch('/api/admin/sandbox', {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const cohort = (data.cohorts ?? []).find(
+          (c: { id: string; name: string }) => c.id === sandboxCohortId,
+        );
+        if (cohort) setSandboxCohortName(cohort.name);
+      } catch {
+        // Ignore fetch errors
+      }
+    };
+    fetchName();
+  }, [sandboxCohortId, isAdmin]);
+
+  const handleEnterSandbox = useCallback(async () => {
+    setSandboxLoading(true);
+    setSandboxActionStatus(null);
+    try {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/sandbox', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ action: 'create' }),
+      });
+      if (!res.ok) {
+        setSandboxActionStatus('Failed to create sandbox');
+        return;
+      }
+      const data = await res.json();
+      if (data.cohort?.id) {
+        enterSandbox(data.cohort.id);
+        setSandboxCohortName(data.cohort.name ?? null);
+        setSandboxActionStatus(data.created ? 'Sandbox created' : 'Sandbox activated');
+      }
+    } catch {
+      setSandboxActionStatus('Failed to create sandbox');
+    } finally {
+      setSandboxLoading(false);
+    }
+  }, [enterSandbox]);
+
+  const handleResetSandbox = useCallback(async () => {
+    if (!sandboxCohortId) return;
+    setSandboxLoading(true);
+    setSandboxActionStatus(null);
+    try {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/sandbox', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ action: 'reset', cohortId: sandboxCohortId }),
+      });
+      if (!res.ok) {
+        setSandboxActionStatus('Failed to reset sandbox');
+        return;
+      }
+      const data = await res.json();
+      const d = data.deleted ?? {};
+      setSandboxActionStatus(`Reset: ${d.drafts ?? 0} drafts, ${d.reviews ?? 0} reviews removed`);
+    } catch {
+      setSandboxActionStatus('Failed to reset sandbox');
+    } finally {
+      setSandboxLoading(false);
+    }
+  }, [sandboxCohortId]);
+
+  const handleGenerateScenarios = useCallback(async () => {
+    if (!sandboxCohortId) return;
+    setSandboxLoading(true);
+    setSandboxActionStatus(null);
+    try {
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/preview/scenarios', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ cohortId: sandboxCohortId }),
+      });
+      if (!res.ok) {
+        setSandboxActionStatus('Failed to generate scenarios');
+        return;
+      }
+      const data = await res.json();
+      setSandboxActionStatus(
+        `Generated: ${data.proposalsCreated ?? 0} proposals, ${data.reviewsCreated ?? 0} reviews`,
+      );
+    } catch {
+      setSandboxActionStatus('Failed to generate scenarios');
+    } finally {
+      setSandboxLoading(false);
+    }
+  }, [sandboxCohortId]);
+
+  const handleExitSandbox = useCallback(() => {
+    exitSandbox();
+    setSandboxCohortName(null);
+    setSandboxActionStatus(null);
+  }, [exitSandbox]);
 
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
@@ -287,13 +419,14 @@ export function GovernadaHeader() {
                   className={cn(
                     'flex items-center gap-1.5 text-xs font-medium px-2.5 py-1.5 rounded-full transition-colors cursor-pointer',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                    hasOverride || hasDimensionOverrides
+                    hasOverride || hasDimensionOverrides || sandboxCohortId
                       ? 'bg-amber-500/15 text-amber-600 dark:text-amber-400 hover:bg-amber-500/25'
                       : 'text-muted-foreground bg-muted hover:bg-accent hover:text-accent-foreground',
                   )}
                   aria-label="User menu"
                 >
                   {(() => {
+                    if (sandboxCohortId) return <FlaskConical className="h-3.5 w-3.5" />;
                     if (hasOverride || hasDimensionOverrides)
                       return <Eye className="h-3.5 w-3.5" />;
                     const SegmentIcon = SEGMENT_ICONS[segment];
@@ -427,6 +560,95 @@ export function GovernadaHeader() {
                                 <DropdownMenuItem onClick={() => setDimensionOverrides({})}>
                                   Reset all dimensions
                                 </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                        {/* Sandbox mode controls */}
+                        <DropdownMenuSeparator />
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <FlaskConical className="h-4 w-4" />
+                            Sandbox{sandboxCohortId ? ' (active)' : ''}
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent className="w-64">
+                            {!sandboxCohortId ? (
+                              <>
+                                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                                  Test workflows without affecting production data
+                                </DropdownMenuLabel>
+                                <DropdownMenuItem
+                                  disabled={sandboxLoading}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    handleEnterSandbox();
+                                  }}
+                                >
+                                  {sandboxLoading ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <FlaskConical className="h-4 w-4" />
+                                  )}
+                                  Enter Sandbox
+                                </DropdownMenuItem>
+                              </>
+                            ) : (
+                              <>
+                                <DropdownMenuLabel className="text-xs">
+                                  <span className="text-amber-500">Sandbox active</span>
+                                  {sandboxCohortName && (
+                                    <span className="block text-muted-foreground font-normal mt-0.5 truncate">
+                                      {sandboxCohortName}
+                                    </span>
+                                  )}
+                                </DropdownMenuLabel>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  disabled={sandboxLoading}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    handleGenerateScenarios();
+                                  }}
+                                >
+                                  {sandboxLoading ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <Sparkles className="h-4 w-4" />
+                                  )}
+                                  Generate Scenarios
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  disabled={sandboxLoading}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    handleResetSandbox();
+                                  }}
+                                >
+                                  {sandboxLoading ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <RotateCcw className="h-4 w-4" />
+                                  )}
+                                  Reset Sandbox
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    handleExitSandbox();
+                                  }}
+                                >
+                                  <X className="h-4 w-4" />
+                                  Exit Sandbox
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                            {sandboxActionStatus && (
+                              <>
+                                <DropdownMenuSeparator />
+                                <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                                  {sandboxActionStatus}
+                                </div>
                               </>
                             )}
                           </DropdownMenuSubContent>

--- a/components/providers/SegmentProvider.tsx
+++ b/components/providers/SegmentProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, useEffect, useCallback, type React
 import { useWallet } from '@/utils/wallet-context';
 import type { DimensionOverrides } from '@/lib/admin/viewAsRegistry';
 import { isPreviewAddress } from '@/lib/preview';
+import { SANDBOX_STORAGE_KEY } from '@/lib/admin/sandbox';
 import type { EngagementLevel } from '@/lib/citizen/engagementLevel';
 import type { CredibilityTier } from '@/lib/citizenCredibility';
 import type { GovernanceLevel } from '@/lib/governanceLevels';
@@ -47,6 +48,12 @@ export interface SegmentState {
   previewSessionId: string | null;
   /** Preview cohort ID (data namespace for shared preview data) */
   previewCohortId: string | null;
+  /** Active sandbox cohort ID (admin-only, writes scoped here) */
+  sandboxCohortId: string | null;
+  /** Enter sandbox mode with a cohort */
+  enterSandbox: (cohortId: string) => void;
+  /** Exit sandbox mode */
+  exitSandbox: () => void;
 }
 
 const STORAGE_KEY = 'governada_segment';
@@ -75,6 +82,9 @@ const DEFAULT_STATE: SegmentState = {
   isPreviewMode: false,
   previewSessionId: null,
   previewCohortId: null,
+  sandboxCohortId: null,
+  enterSandbox: noop,
+  exitSandbox: noop,
 };
 
 const SegmentContext = createContext<SegmentState>(DEFAULT_STATE);
@@ -129,6 +139,9 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
       | 'isPreviewMode'
       | 'previewSessionId'
       | 'previewCohortId'
+      | 'sandboxCohortId'
+      | 'enterSandbox'
+      | 'exitSandbox'
     >
   >({
     isLoading: false,
@@ -144,6 +157,35 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
   const [dimensionOverrides, setDimensionOverrides] = useState<DimensionOverrides>({});
   const [previewSessionId, setPreviewSessionId] = useState<string | null>(null);
   const [previewCohortId, setPreviewCohortId] = useState<string | null>(null);
+  const [sandboxCohortId, setSandboxCohortId] = useState<string | null>(null);
+
+  // Restore sandbox state from sessionStorage on mount
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem(SANDBOX_STORAGE_KEY);
+      if (stored) setSandboxCohortId(stored);
+    } catch {
+      /* sessionStorage unavailable */
+    }
+  }, []);
+
+  const enterSandbox = useCallback((cohortId: string) => {
+    setSandboxCohortId(cohortId);
+    try {
+      sessionStorage.setItem(SANDBOX_STORAGE_KEY, cohortId);
+    } catch {
+      /* sessionStorage unavailable */
+    }
+  }, []);
+
+  const exitSandbox = useCallback(() => {
+    setSandboxCohortId(null);
+    try {
+      sessionStorage.removeItem(SANDBOX_STORAGE_KEY);
+    } catch {
+      /* sessionStorage unavailable */
+    }
+  }, []);
 
   const detect = useCallback(async (stakeAddress: string) => {
     const cached = loadCached(stakeAddress);
@@ -277,6 +319,9 @@ export function SegmentProvider({ children }: { children: ReactNode }) {
     isPreviewMode: isPreviewAddress(effectiveAddress),
     previewSessionId,
     previewCohortId,
+    sandboxCohortId,
+    enterSandbox,
+    exitSandbox,
   };
 
   return <SegmentContext.Provider value={value}>{children}</SegmentContext.Provider>;

--- a/docs/strategy/context/strategic-state.md
+++ b/docs/strategy/context/strategic-state.md
@@ -1,7 +1,7 @@
 # Strategic State — Governada
 
-Last updated: 2026-03-12
-Updated by: Strategy session (Phase 2+3 re-evaluation)
+Last updated: 2026-03-18
+Updated by: Strategy session (Admin testing framework plan)
 
 ---
 
@@ -40,16 +40,18 @@ Updated by: Strategy session (Phase 2+3 re-evaluation)
 
 ## Recent Decisions
 
-| Date       | Decision                                       | Rationale                                                                                   | Ref                   |
-| ---------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------- |
-| 2026-03-12 | Phase 2+3 strategic re-evaluation              | Old phases too narrow for launch. Merged engagement + viral/identity + rep activation.      | V3.1 vision update    |
-| 2026-03-12 | Community Intelligence feature-flagged         | Not enough citizen data at launch. Collect from day one, surface when threshold is reached. | V3.1 strategy session |
-| 2026-03-12 | Email opt-in for epoch digest                  | Web3-first identity. Email for notifications only, never for auth.                          | V3.1 strategy session |
-| 2026-03-12 | Maximum buzz launch (not quiet rollout)        | Citizens get value without claimed DRep profiles. DReps will jump in if launch has buzz.    | V3.1 strategy session |
-| 2026-03-10 | Consolidated audit suite from 11 to 6 commands | Reduce overlap, clearer ownership, persona-first auditing                                   | V3.0 vision update    |
-| 2026-03-09 | V3.0 UX philosophy: "Restraint as Craft"       | Audit system was biased toward additive changes, producing clutter                          | `vision-changelog.md` |
-| 2026-03-09 | Page-level JTBD constraints                    | Every page gets ONE job in <8 words, information budget is zero-sum                         | `ux-constraints.md`   |
-| 2026-03-08 | Hub card system for persona adaptation         | Cards compose per persona instead of one-size-fits-all dashboard                            | Phase 0 MLE           |
+| Date       | Decision                                       | Rationale                                                                                                                                                                                           | Ref                                |
+| ---------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 2026-03-12 | Phase 2+3 strategic re-evaluation              | Old phases too narrow for launch. Merged engagement + viral/identity + rep activation.                                                                                                              | V3.1 vision update                 |
+| 2026-03-12 | Community Intelligence feature-flagged         | Not enough citizen data at launch. Collect from day one, surface when threshold is reached.                                                                                                         | V3.1 strategy session              |
+| 2026-03-12 | Email opt-in for epoch digest                  | Web3-first identity. Email for notifications only, never for auth.                                                                                                                                  | V3.1 strategy session              |
+| 2026-03-18 | Admin testing framework — 3-mode architecture  | View As gains Sandbox + Impersonate modes. P0-P3 plan covering state inspector, sandbox, impersonation, cross-persona testing, activity trail, edge scenarios, per-user flags, parity verification. | `plans/admin-testing-framework.md` |
+| 2026-03-18 | Removed misleading "proposer" presets          | Proposer is a capability (having drafts), not a persona dimension. Cleaned up View As registry.                                                                                                     | viewAsRegistry.ts                  |
+| 2026-03-12 | Maximum buzz launch (not quiet rollout)        | Citizens get value without claimed DRep profiles. DReps will jump in if launch has buzz.                                                                                                            | V3.1 strategy session              |
+| 2026-03-10 | Consolidated audit suite from 11 to 6 commands | Reduce overlap, clearer ownership, persona-first auditing                                                                                                                                           | V3.0 vision update                 |
+| 2026-03-09 | V3.0 UX philosophy: "Restraint as Craft"       | Audit system was biased toward additive changes, producing clutter                                                                                                                                  | `vision-changelog.md`              |
+| 2026-03-09 | Page-level JTBD constraints                    | Every page gets ONE job in <8 words, information budget is zero-sum                                                                                                                                 | `ux-constraints.md`                |
+| 2026-03-08 | Hub card system for persona adaptation         | Cards compose per persona instead of one-size-fits-all dashboard                                                                                                                                    | Phase 0 MLE                        |
 
 ## Audit Score History
 

--- a/docs/strategy/context/world-class-patterns.md
+++ b/docs/strategy/context/world-class-patterns.md
@@ -950,6 +950,60 @@ _(Patterns for structured proposal processes, stage gates, and deliberation pipe
 - **Applicable to**: Cardano governance proposals starting as informal Forum/community discussions, then importing into Governada's structured lifecycle. The link between discussion and formal proposal is preserved.
 - **Adoption difficulty**: Medium — import pipeline + discussion linking + stage management
 
+#### Configurable Staged Pipeline (Aragon StagedProposalProcessor)
+
+- **Source**: Aragon StagedProposalProcessor — https://docs.aragon.org/spp/1.x/index.html
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: Configurable sequential stages where each stage can be: Normal (bodies approve before advancing), Optimistic (any body can veto), Time-Locked (pure delay, no bodies). Stages have configurable thresholds for required approvals/vetoes and timing constraints. Different governance pipelines composed by mixing stage types.
+- **Why it's world-class**: Maximum flexibility. Any governance pipeline can be configured by composing stage types. The separation of "stage type" from "stage configuration" means the same engine handles simple votes, multi-body approvals, and time-locked delays. The optimistic governance variant (pass by default unless vetoed) inverts the approval model entirely.
+- **Applicable to**: Proposal lifecycle stages configurable per governance action type. Treasury Withdrawals might require more review stages than Info Actions. The FCP stage could use the optimistic model (advances unless critical concern raised).
+- **Adoption difficulty**: Medium — needs stage configuration schema, per-type pipeline definitions, stage engine refactor
+
+#### Support Threshold Gating (CONSUL Democracy)
+
+- **Source**: CONSUL Democracy — https://consuldemocracy.org/
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: Proposals must reach 1% citizen support before advancing to a formal vote. Below the threshold, proposals stay in "gathering support" indefinitely. After majority vote, the city council has 30 days to assess feasibility — if they reject, they MUST publish reasons or propose an alternative.
+- **Why it's world-class**: The threshold prevents waste-of-time proposals from consuming governance resources. The mandatory response to rejection creates accountability. Used by 350+ governments, 100M+ citizens. Won UN Public Service Award 2018.
+- **Applicable to**: Before a ~$100K deposit is committed, proposals should demonstrate community viability through a measurable threshold (minimum reviews, engagement metrics, or confidence score). Prevents premature submission of unsupported proposals.
+- **Adoption difficulty**: Easy — engagement data exists, need threshold computation + gate logic
+
+#### Transaction Simulation Before Signing (Rabby / Tenderly)
+
+- **Source**: Rabby Wallet — https://rabby.io/ + Tenderly Transaction Simulator — https://tenderly.co/transaction-simulator
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: Before signing, show a full simulation of what the transaction WILL DO: asset changes (deposit locked), approval scopes, state changes, gas costs. Not "confirm this transaction" but "here is what will happen if you confirm." Tenderly runs the transaction against a fork of the live chain state.
+- **Why it's world-class**: Transforms blind trust into informed consent. Users see the effects before committing. In high-stakes crypto transactions, the difference between "are you sure?" and "here is exactly what happens" is the difference between anxiety and confidence.
+- **Applicable to**: Governance action submission should show a full simulation panel: deposit lock amount and return conditions, voting timeline (how many epochs), which governance bodies will vote and at what thresholds, what happens on ratification vs. expiry vs. drop. This is more valuable than any confirmation dialog.
+- **Adoption difficulty**: Medium — needs epoch_params data for thresholds, governance calendar computation, deposit return logic
+
+#### Multi-Friction Confirmation Scaling (Destructive Action UX Research)
+
+- **Source**: Smashing Magazine UX research — https://www.smashingmagazine.com/2024/09/how-manage-dangerous-actions-user-interfaces/
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: Different friction levels for different severity: (1) Undo-over-confirm for reversible actions (e.g., archive), (2) Inline confirmation ("click again to confirm") for medium-stakes, (3) Type-to-confirm for high-stakes irreversible actions (e.g., GitHub repo deletion), (4) Cooldown timer + external verification for the highest stakes. Key finding: confirmation dialogs are "wrong in 90% of instances" because users habitually click through.
+- **Why it's world-class**: Acknowledges that not all destructive actions are equal. The severity gradient ensures friction is proportional to consequence. The insight that undo > confirm for reversible actions prevents "confirmation fatigue."
+- **Applicable to**: Proposal management needs scaled friction: archive draft = undo button (no dialog), delete private draft = inline confirm, withdraw from community review = type-to-confirm, submit on-chain ($100K) = cooldown timer + simulation panel + wallet signature. Never use a simple "Are you sure?" for irreversible actions.
+- **Adoption difficulty**: Easy — component patterns, no new data required
+
+#### Approval Chain Visibility at Signing (Ironclad Contextual Signature)
+
+- **Source**: Ironclad CLM — https://ironcladapp.com/ — Contextual Signature feature (2024)
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: At signing time, show the full approval chain history: who reviewed the contract, what changed, when, and what was flagged. Executive summary of 12 key terms alongside the approval journey. The signer sees context, not just the final document.
+- **Why it's world-class**: When signing something with financial/legal consequences, context collapse is the enemy. Showing the approval chain creates confidence that due diligence happened. The journey to the signature matters as much as the signature itself.
+- **Applicable to**: When a proposer clicks "Submit On-Chain" (committing ~$100K), they should see a summary panel showing: version count, review summary (N reviews, average scores), constitutional check results, team approvals, time in review, key concerns raised and how they were addressed. The submission moment should surface the journey.
+- **Adoption difficulty**: Easy — all data exists (versions, reviews, checks, team), need summary panel component
+
+#### Stale Review Dismissal (GitHub PR Reviews)
+
+- **Source**: GitHub Required Reviews — https://docs.github.com/articles/approving-a-pull-request-with-required-reviews
+- **Discovered**: 2026-03-18 (explore-feature: proposal management lifecycle)
+- **What they do**: If you push new commits after a review approval, the approval is automatically dismissed and marked "stale." Re-review is required before merge. Configurable: admins choose whether stale reviews block merge or just show a warning.
+- **Why it's world-class**: Prevents the "approved an old version" problem. Ensures approvals are for the CURRENT state of the work. The automatic dismissal removes the burden from reviewers to track what changed.
+- **Applicable to**: Proposal community reviews should track which version they reviewed. If the proposal content changes significantly after review, reviews are marked stale and reviewers are notified to re-review. Prevents proposals from getting approved, then quietly revised before submission.
+- **Adoption difficulty**: Easy — need version_number column on draft_reviews + stale detection on content change
+
 ### Embedded AI & Intelligence Patterns
 
 _(Patterns for AI that's a tool, not a chatbot — workflow-embedded intelligence)_

--- a/docs/strategy/plans/admin-testing-framework.md
+++ b/docs/strategy/plans/admin-testing-framework.md
@@ -1,0 +1,420 @@
+# Admin Testing & Quality Assurance Framework
+
+**Status:** Plan — pending founder approval
+**Date:** 2026-03-18
+**Context:** The platform has View As persona switching and preview cohorts, but three critical admin use cases are unserved: sandboxed workflow testing, user bug reproduction, and pre-ship feature validation with real data.
+
+---
+
+## Strategic Frame
+
+Governada serves 6 personas across 4 governance roles, each with multiple sub-states (delegation, claim status, engagement level, credibility tier). The combinatorial surface is large. Before launch, the founder needs absolute confidence that every persona x state combination works correctly — and after launch, needs to rapidly reproduce and fix any issue a user reports.
+
+**The core problem:** The current tools were designed for two different audiences (admin quick-switching vs. external tester cohorts) and neither fully serves the admin's own testing needs. The admin can switch personas but can't safely interact with data. The preview system isolates data but requires invite code ceremony. There's no way to see what a specific user sees.
+
+---
+
+## Architecture: Three Admin Modes
+
+The View As system gains three mutually exclusive modes, all accessible from the existing profile nav dropdown:
+
+### Mode 1: Observe (current default)
+
+Switch persona, see real production data, writes go to production. This is what exists today. No changes needed — it's the right tool for quick layout/navigation checks.
+
+### Mode 2: Sandbox
+
+Switch persona, enter a cohort data namespace, writes are isolated. For workflow testing: author a proposal, submit a review, see it in the queue — all without touching production.
+
+**How it works:**
+
+- Admin clicks "Enter Sandbox" in the View As dropdown
+- System auto-creates (or lets admin select) a personal sandbox cohort
+- `SegmentProvider` gains `sandboxCohortId` state
+- All write endpoints check for sandbox context and scope writes to the cohort
+- Reads are hybrid: real governance data (proposals, DReps, votes) from production + sandboxed data (drafts, reviews, annotations) from the cohort namespace
+- Scenario data can be generated into the sandbox on demand
+- Admin can switch personas within the same sandbox, seeing cross-persona interactions
+- "Exit Sandbox" clears the cohort scope and returns to Observe mode
+
+**Key constraint:** Sandbox mode must use identical code paths to production. The only difference is the `preview_cohort_id` filter on write operations. No separate "sandbox API routes."
+
+### Mode 3: Impersonate
+
+Load a specific user's real detected state — their segment, delegation, DRep ID, scores, flags — and see the app through their eyes. For bug reproduction.
+
+**How it works:**
+
+- Admin clicks "Impersonate User" in the View As dropdown
+- Enters a wallet address, stake address, or searches by DRep/SPO name
+- System calls the segment detection API for that address
+- All SegmentProvider overrides are set to match that user's actual state
+- Data reads are filtered to show what that user would see (their delegation, their DRep, their votes)
+- Writes are blocked — impersonation is read-only by default
+- Admin can optionally enter sandbox mode while impersonating (see their view + test fixes safely)
+- A banner clearly indicates impersonation state with the user's address
+
+---
+
+## P0: Foundation (build first — everything else depends on these)
+
+### P0-A: User State Inspector
+
+**What:** New admin page at `/admin/users` that shows the complete computed state for any wallet address.
+
+**Why:** Prerequisite for impersonation and bug reproduction. When a user reports an issue, the admin's first question is "what's their state?" — today this requires manually querying 5+ tables.
+
+**Components:**
+
+1. **Search bar** — accepts wallet address, stake address, DRep bech32 ID, or pool ID. Fuzzy match against `users`, `drep_profiles`, `spo_profiles` tables.
+
+2. **Identity panel** — wallet address, stake address, first seen date, last active, authentication method
+
+3. **Segment detection** — run the same detection logic used by SegmentProvider:
+   - Detected segment (citizen/drep/spo/cc)
+   - DRep ID (if any) + claim status
+   - Pool ID (if any) + claim status
+   - CC membership status
+   - Delegation target (DRep + pool)
+
+4. **Computed dimensions:**
+   - Engagement level (Registered → Champion) + underlying metrics
+   - Credibility tier (standard/enhanced/full) + weight
+   - Governance level (observer → champion) + qualifying actions
+   - Governance depth preference
+
+5. **Feature flags** — which flags are enabled for this user (including any per-user overrides from P2)
+
+6. **Governance activity summary:**
+   - Poll votes cast (count + recent)
+   - Proposals authored (drafts + submitted)
+   - Reviews submitted
+   - DRep votes (if DRep segment)
+   - Delegation history
+
+7. **"Impersonate" button** — loads this user's state into View As (see Mode 3 above)
+
+**API:** `GET /api/admin/users/inspect?address=<addr>` — aggregates data from users, drep_profiles, spo_profiles, poll_votes, proposal_drafts, draft_reviews, and the segment detection endpoint. Single call, server-side aggregation.
+
+**Effort:** Medium (1 API route + 1 admin page). Most data already queryable, just needs aggregation.
+
+### P0-B: Admin Sandbox Mode
+
+**What:** "Enter Sandbox" toggle in the View As dropdown that scopes the admin into a cohort namespace for isolated write operations.
+
+**Why:** The admin's three use cases all need write isolation. Without this, testing workflows means either polluting production or going through the invite code ceremony.
+
+**Components:**
+
+1. **Sandbox activation UI** — button in View As dropdown:
+   - "Enter Sandbox" → creates or selects a sandbox cohort
+   - Shows active sandbox name + "Exit" button when in sandbox
+   - Persona switching works normally within sandbox
+
+2. **SegmentProvider extension:**
+   - New state: `sandboxCohortId: string | null`
+   - New method: `enterSandbox(cohortId?: string)` / `exitSandbox()`
+   - Exposed via `useSegment()` hook
+   - Persisted in sessionStorage (survives page navigation, cleared on tab close)
+
+3. **Write endpoint instrumentation:**
+   - All workspace write endpoints (`/api/workspace/drafts`, `/api/workspace/reviews`, etc.) check for `X-Sandbox-Cohort` header
+   - If present, insert with `preview_cohort_id = cohortId`
+   - Read queries for sandboxed tables include `OR preview_cohort_id = cohortId` filter
+   - Non-workspace writes (real governance actions) are blocked in sandbox mode
+
+4. **Sandbox management:**
+   - Auto-create personal sandbox: `Admin Sandbox — <date>`
+   - "Reset Sandbox" button — clears all data in the cohort (reuses existing cleanup logic from scenario generator)
+   - "Generate Scenarios" — populates sandbox with scenario data (reuses existing generator)
+   - Sandbox cohorts are hidden from the preview management page (tagged `is_admin_sandbox: true`)
+
+**Effort:** Medium-Large. SegmentProvider changes are small. The main work is instrumenting write endpoints to respect sandbox context — but there are only ~8 write endpoints in the workspace system.
+
+**Critical design decision:** Sandbox mode passes `sandboxCohortId` via request header, not URL parameter. This keeps URLs shareable and avoids polluting the routing layer.
+
+---
+
+## P1: Bug Reproduction & Cross-Persona Testing
+
+### P1-A: User Impersonation
+
+**What:** Load a real user's detected state into the View As system and see the app exactly as they see it.
+
+**Why:** When a user reports "I can't see my delegation" or "my score looks wrong," the admin needs to see their exact view — not a generic persona approximation.
+
+**Depends on:** P0-A (User State Inspector provides the data, impersonation applies it)
+
+**Components:**
+
+1. **Impersonation activation:**
+   - "Impersonate" button on User State Inspector page
+   - Also accessible from View As dropdown → "Impersonate User..." → address input
+   - Loads the user's full detected state into SegmentProvider overrides
+
+2. **Data scoping:**
+   - Override `stakeAddress` in the context so data queries return this user's records
+   - Their poll votes, their delegation, their DRep profile, their drafts
+   - Read-only mode: all write endpoints return 403 when impersonating (unless sandbox is also active)
+
+3. **Visual indicator:**
+   - Amber banner (like current View As) but with user's truncated address
+   - "Exit Impersonation" button
+   - Clear distinction from persona switching (impersonation = real user, View As = synthetic persona)
+
+4. **Impersonate + Sandbox combo:**
+   - Admin can impersonate a user AND enter sandbox simultaneously
+   - Use case: "I see the bug as this user. Let me enter sandbox and test a fix from their perspective."
+   - Reads: user's real data. Writes: sandboxed.
+
+**Effort:** Medium. Most infrastructure exists from P0. The new piece is overriding `stakeAddress` for data scoping, which affects how hooks like `useDelegation`, `useVoteHistory`, etc. fetch data.
+
+### P1-B: Cross-Persona Data Sharing in Sandbox
+
+**What:** Within a single sandbox cohort, the admin can switch personas and see data created by other personas in the same sandbox.
+
+**Why:** Governance is inherently multi-party. A proposal goes through: author creates draft → reviewers submit feedback → DRep reads reviews → DRep votes. Testing this flow requires seeing the same data from multiple perspectives.
+
+**Depends on:** P0-B (Sandbox mode provides the cohort namespace)
+
+**How it works:**
+
+- Sandbox data is scoped by `preview_cohort_id`, NOT by the admin's current persona
+- When admin creates a draft as "Citizen", then switches to "DRep", the draft appears in the review queue
+- Each persona switch within sandbox shows the same cohort data through a different lens
+- The admin essentially plays all roles in the governance workflow
+
+**This is almost free** if P0-B is implemented correctly. The scenario generator already creates data this way — synthetic proposers + synthetic reviewers all share the same cohort. The admin just needs to be another participant in the same namespace.
+
+**Effort:** Small. The sandbox scoping from P0-B handles this automatically. The only additional work is ensuring that switching personas within sandbox doesn't reset the cohort context.
+
+---
+
+## P2: Enhanced Observability & Testing Depth
+
+### P2-A: Activity Trail (Per-User Event History)
+
+**What:** Within the User State Inspector (P0-A), show the user's recent activity: pages visited, actions taken, errors encountered.
+
+**Why:** When a user says "I clicked the button and nothing happened," the admin needs their event sequence — not just their current state.
+
+**Depends on:** P0-A (inspector page hosts this), PostHog event instrumentation
+
+**Components:**
+
+1. **PostHog API integration:**
+   - Query PostHog Events API: `GET /api/admin/users/activity?address=<addr>&days=7`
+   - Server-side proxy to PostHog API (keeps API key server-side)
+   - Filter by `distinct_id` = wallet address
+   - Return: event name, timestamp, properties, page URL
+
+2. **Activity timeline UI:**
+   - Chronological list of events within the User State Inspector
+   - Filter by event type (page views, actions, errors)
+   - Expandable event details (properties, page context)
+   - "Jump to Sentry" link for error events (if Sentry event ID captured)
+
+3. **Event instrumentation gaps to fill:**
+   - Current PostHog usage is minimal. Before this feature is useful, key user actions need instrumentation:
+   - Page views (via PostHog autocapture or manual `$pageview`)
+   - Delegation actions, poll votes, draft creation, review submission
+   - Error boundaries should capture to both Sentry and PostHog
+   - Use `noun_verb` event naming convention per CLAUDE.md
+
+**Effort:** Medium. PostHog API integration is straightforward. The larger effort is instrumenting events across the app — but this has independent value for analytics regardless.
+
+**Phasing note:** Ship the API integration and timeline UI first, even with sparse events. Instrumentation can be added incrementally — each new event immediately appears in the trail.
+
+### P2-B: Edge Case Scenario Data
+
+**What:** Extend the scenario generator to produce pathological data alongside happy-path scenarios.
+
+**Why:** Production bugs come from edge cases: empty fields, maximum-length content, boundary conditions, Unicode. The current generator only creates representative, well-formed data.
+
+**Depends on:** P0-B (sandbox provides the destination for edge case data)
+
+**Edge case templates to add:**
+
+1. **Empty/minimal content:**
+   - Proposal with empty abstract
+   - Proposal with title only (no motivation/rationale)
+   - Review with empty feedback text
+   - Draft with no type-specific data
+
+2. **Maximum-length content:**
+   - Title at 500 characters
+   - Abstract at 5,000 characters
+   - Motivation with 50+ paragraphs
+   - Review with extremely long feedback
+
+3. **Unicode and special characters:**
+   - Titles with emojis, RTL text, CJK characters
+   - Content with markdown injection attempts
+   - Names with diacritics and special symbols
+
+4. **Boundary conditions:**
+   - Proposal with 0 votes
+   - DRep with 0 delegators
+   - Proposal at exactly the voting threshold
+   - Draft at status transition boundaries (just entered community review, FCP about to expire)
+
+5. **Temporal edge cases:**
+   - Draft created 1 second ago
+   - Draft in community review for 90 days (stale)
+   - Review submitted after FCP ended
+   - Version created in the future (clock skew)
+
+**Implementation:** Add an `edgeCases: boolean` parameter to `generateScenario()`. When true, append edge case templates after the standard distribution. Each edge case is clearly labeled in the data (`_scenarioSource.edgeCase: true`).
+
+**Effort:** Small-Medium. Template additions to the existing generator. No new infrastructure.
+
+### P2-C: Per-User Feature Flag Overrides
+
+**What:** Enable/disable specific feature flags for individual wallet addresses.
+
+**Why:** Two use cases: (a) beta-test a feature with one specific user before broader rollout, (b) disable a broken feature for an affected user while debugging.
+
+**Depends on:** Nothing — the `targeting` JSONB column already exists in `feature_flags` table.
+
+**Components:**
+
+1. **Flag evaluation update:**
+   - `getFeatureFlag(key, defaultValue)` gains an optional `walletAddress` parameter
+   - Check `targeting` column for per-wallet overrides before returning global value
+   - Targeting format: `{ "wallets": { "<address>": true/false } }`
+   - Wallet-level override takes precedence over global flag
+
+2. **Client-side flag evaluation:**
+   - `useFeatureFlag(key)` passes current wallet address
+   - `fetchClientFlags()` sends wallet address, server evaluates per-user
+
+3. **Admin UI update:**
+   - Expand the existing Flags admin page
+   - Per-flag: "User Overrides" section showing wallet addresses with explicit on/off
+   - Add/remove wallet overrides
+   - Also accessible from User State Inspector: "Override flag X for this user"
+
+4. **Audit logging:**
+   - All per-user flag changes logged to `admin_audit_log`
+   - Include: flag key, wallet address, old value, new value, admin who changed it
+
+**Effort:** Small-Medium. The database column exists. Main work is updating `getFeatureFlag()` to check targeting and adding the UI to the flags page.
+
+---
+
+## P3: Production Confidence
+
+### P3-A: Write-Path Parity Verification
+
+**What:** A verification mechanism that confirms sandbox mode behavior matches production behavior.
+
+**Why:** If sandbox mode uses different code paths or RLS policies behave differently, the admin is testing a different system than what users experience. This undermines all sandbox testing.
+
+**Approach — not a feature, but a discipline:**
+
+1. **Same code paths (architectural constraint):**
+   - Sandbox mode MUST NOT have separate API routes or handlers
+   - The only difference is a `preview_cohort_id` filter on writes
+   - Code review rule: any PR that adds a workspace write endpoint must handle sandbox context
+
+2. **RLS parity test suite:**
+   - Vitest integration tests that run the same queries with and without sandbox context
+   - Verify: same rows returned for production reads, sandbox writes don't leak
+   - Run as part of `npm run preflight`
+
+3. **Sandbox health check:**
+   - Admin button: "Verify Sandbox Parity"
+   - Runs a sequence of operations in sandbox and verifies:
+     - Draft creation succeeds and is cohort-scoped
+     - Draft is visible within the same cohort
+     - Draft is NOT visible outside the cohort
+     - Review on a cohort draft succeeds
+     - Production data is still readable
+   - Reports pass/fail for each check
+
+4. **Drift detection (ongoing):**
+   - If a new write endpoint is added without sandbox support, the parity tests fail
+   - This catches regressions before they reach production
+
+**Effort:** Medium. The test suite is the main investment. The health check is a nice-to-have built on top of it.
+
+---
+
+## Implementation Sequence
+
+```
+P0-A: User State Inspector          ████████░░  ~4 hours
+P0-B: Admin Sandbox Mode            ████████████░░  ~6 hours
+  ↓
+P1-B: Cross-Persona Sharing         ██░░  ~1 hour (nearly free from P0-B)
+P1-A: User Impersonation            ██████░░  ~4 hours
+  ↓
+P2-C: Per-User Feature Flags        ████░░  ~2 hours
+P2-B: Edge Case Scenarios           ████░░  ~2 hours
+P2-A: Activity Trail                ██████░░  ~4 hours (+ ongoing instrumentation)
+  ↓
+P3-A: Write-Path Parity             ██████░░  ~3 hours (test suite + health check)
+```
+
+**Total estimated scope:** ~26 hours of implementation across 8 work packages.
+
+**Recommended chunking:**
+
+- **Build 1 (P0):** State Inspector + Sandbox Mode → 2 PRs, 1 build session
+- **Build 2 (P1):** Impersonation + Cross-Persona → 1-2 PRs, 1 build session
+- **Build 3 (P2):** Feature flags + Edge cases + Activity trail → 3 PRs, 1 build session
+- **Build 4 (P3):** Parity tests → 1 PR, 1 build session
+
+---
+
+## What NOT to Build
+
+- **Separate staging environment.** Sandbox mode against production data is better than a stale staging copy. The data is real, the behavior is identical, only writes are isolated.
+
+- **Full session replay.** PostHog has session replay but it's heavyweight for our scale. The activity trail (event sequence) is sufficient for bug reproduction. If we need visual replay later, PostHog's native feature can be enabled without custom code.
+
+- **Admin-to-user messaging.** Not an admin testing concern. If we need to communicate with users about known issues, that's a separate feature (status banners, not DMs).
+
+- **A/B test management.** Feature flags + per-user overrides cover controlled rollout. Full A/B testing with statistical significance is premature for our user base.
+
+- **Custom analytics dashboard.** PostHog's native dashboards cover analytics needs. Building our own would duplicate effort. The admin panel should link to PostHog, not recreate it.
+
+---
+
+## Database Changes
+
+### New columns (existing tables)
+
+```sql
+-- preview_cohorts: distinguish admin sandboxes from tester cohorts
+ALTER TABLE preview_cohorts ADD COLUMN is_admin_sandbox boolean DEFAULT false;
+```
+
+### No new tables needed
+
+The existing `preview_cohorts`, `preview_sessions`, `admin_audit_log`, and `feature_flags` tables cover all storage needs. The User State Inspector is purely a read aggregation — no new persistence.
+
+---
+
+## Feature Flags for Rollout
+
+| Flag                   | Controls                               | Default |
+| ---------------------- | -------------------------------------- | ------- |
+| `admin_sandbox_mode`   | Sandbox toggle in View As dropdown     | off     |
+| `admin_user_inspector` | /admin/users page                      | off     |
+| `admin_impersonation`  | Impersonate button + mode              | off     |
+| `admin_edge_scenarios` | Edge case toggle in scenario generator | off     |
+
+All gated behind admin auth — these flags only matter for admin wallets.
+
+---
+
+## Success Criteria
+
+After full implementation, the admin can:
+
+1. **In under 60 seconds:** look up any user, see their full state, and impersonate them to reproduce a reported bug
+2. **In under 30 seconds:** enter sandbox mode, switch to any persona, and start testing a workflow with isolated data
+3. **In one sandbox session:** author a proposal as Citizen, switch to DRep, review it, switch back — verifying the full governance loop
+4. **Before any release:** generate edge case data, test as every persona, and have confidence that writes in sandbox match production behavior
+5. **For any user:** enable or disable a specific feature flag without affecting anyone else

--- a/docs/strategy/plans/workspace-foundation.md
+++ b/docs/strategy/plans/workspace-foundation.md
@@ -1,0 +1,817 @@
+# Workspace Foundation: Linear + Cursor Architectural Primitives
+
+> **Status:** Approved — Session 1a + 1b in progress
+> **Created:** 2026-03-18
+> **Prerequisite for:** Proposal lifecycle management, Author portfolio view, Submission ceremony, Post-submission monitoring
+> **Estimated effort:** 4-6 sessions across Tier 0-2 + content authoring track
+
+---
+
+## Why This Exists
+
+The Author and Review workspaces are converging on a specific archetype: a keyboard-driven, panel-composed, real-time professional workspace with embedded AI — what you get when you cross Linear's workflow engine with Cursor's intelligent editing surface.
+
+The editor layer (Tiptap + AI inline diffs + agent chat) is already at Cursor quality. What's missing is the Linear-grade workspace SHELL: centralized keyboard handling, composable persistent panels, unified command palette, optimistic mutations, and shared workspace state.
+
+Building proposal lifecycle features (portfolio view, submission ceremony, team approval gates) on top of the current ad-hoc component structure means retrofitting every piece later. This plan establishes the architectural primitives first.
+
+---
+
+## Current State
+
+### What's solid (don't touch)
+
+- **Tiptap editor** with 6+ custom extensions (SectionBlock, AIDiffMark, InlineComment, SlashCommandMenu, CommandBar, AICompletion) — Cursor-quality editing
+- **Agent chat panel** with SSE streaming, tool call indicators, inline diff injection
+- **Design token system** — Compass palette, spacing scale, three density modes via ModeProvider
+- **TanStack Query** for data fetching with optimistic update patterns in engagement components
+- **shadcn/ui component library** — 29 components, consistent styling
+
+### What needs work
+
+| Area                   | Current                                                                | Target                                                            |
+| ---------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| **Panel layout**       | Custom drag resize in WorkspaceLayout.tsx, no persistence, no snap     | `react-resizable-panels` with `autoSaveId`, collapse/restore      |
+| **Keyboard shortcuts** | Scattered addEventListener in 5+ components, no registry               | Centralized CommandRegistry with chord support, help overlay      |
+| **Command palette**    | `cmdk` installed but unused. CommandBar is AI-only Cmd+K               | Unified palette: navigation + actions + search + AI               |
+| **Workspace state**    | StudioProvider (React Context, per-session) + scattered useState       | Zustand store, URL-synced, localStorage-persisted                 |
+| **Optimistic UI**      | Only in engagement components (CitizenEndorsements, ProposalSentiment) | Every workspace mutation: save, archive, stage transition, review |
+| **Focus management**   | Basic escape handlers, no restoration                                  | Focus graph: trap, restore, keyboard indicators                   |
+
+### Key dependency status
+
+| Package                   | Installed  | Notes                                     |
+| ------------------------- | ---------- | ----------------------------------------- |
+| `cmdk`                    | ✓ v1.1.1   | In package.json, no component scaffolded  |
+| `framer-motion`           | ✓ v12.36.0 | In package.json, barely used in workspace |
+| `react-resizable-panels`  | ✗          | Need to add                               |
+| `zustand`                 | ✗          | Need to add                               |
+| `react-hotkeys-hook`      | ✗          | Need to add (or custom ~50 lines)         |
+| `@tanstack/react-virtual` | ✗          | Tier 2, not blocking                      |
+
+---
+
+## Tier 0: Foundation Primitives
+
+**Goal:** Establish the three core primitives everything else builds on. Must complete before any proposal lifecycle feature work.
+
+### 0.1 — Workspace State Store (Zustand)
+
+Replace scattered `useState` + `StudioProvider` Context with a single Zustand store.
+
+**File:** `lib/workspace/store.ts`
+
+```typescript
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PanelId = 'agent' | 'intel' | 'notes' | 'vote' | 'reviews' | 'team';
+type ViewMode = 'kanban' | 'list';
+type FocusLevel = 0 | 1 | 2; // 0=normal, 1=panel hidden, 2=zen
+
+interface WorkspaceState {
+  // --- Active entity ---
+  currentDraftId: string | null;
+  currentProposalId: string | null;
+
+  // --- Panel state ---
+  sidebarCollapsed: boolean;
+  contextPanel: PanelId | null; // null = closed
+  focusLevel: FocusLevel;
+
+  // --- Author dashboard ---
+  authorViewMode: ViewMode;
+  authorFilter: string; // search text
+
+  // --- Review workspace ---
+  reviewQueueIndex: number;
+
+  // --- Actions ---
+  setCurrentDraft: (id: string | null) => void;
+  setCurrentProposal: (id: string | null) => void;
+  toggleSidebar: () => void;
+  openPanel: (panel: PanelId) => void;
+  closePanel: () => void;
+  togglePanel: (panel: PanelId) => void;
+  setFocusLevel: (level: FocusLevel) => void;
+  setAuthorViewMode: (mode: ViewMode) => void;
+  setAuthorFilter: (filter: string) => void;
+  setReviewQueueIndex: (index: number) => void;
+}
+```
+
+**Persistence:** Panel preferences (sidebarCollapsed, contextPanel, authorViewMode, focusLevel) persist to localStorage via Zustand `persist` middleware. Entity selection (currentDraftId, currentProposalId) syncs to URL searchParams via a `useSyncToURL` hook, NOT persisted to localStorage.
+
+**Migration path:**
+
+- `StudioProvider` → read from Zustand store. Keep the Context wrapper as a thin adapter initially for backwards compatibility, then remove once all consumers migrate.
+- `WorkspaceLayout` panel state (chatCollapsed, chatWidth, queueExpanded) → Zustand store.
+- `ReviewWorkspace` selectedIndex → `reviewQueueIndex` in store.
+- `AuthorWorkspace` → `authorViewMode` and `authorFilter` from store.
+
+**Acceptance criteria:**
+
+- [ ] Panel open/closed state survives page refresh
+- [ ] Deep-linking: `/workspace/author?draft=abc` opens that draft
+- [ ] `useWorkspace()` hook available from any workspace component
+- [ ] StudioProvider consumers still work during migration (thin adapter)
+
+---
+
+### 0.2 — Command Registry + Palette
+
+Centralize all workspace actions into a single registry that powers the Cmd+K palette, keyboard shortcuts, and context menus.
+
+**File:** `lib/workspace/commands.ts`
+
+```typescript
+interface Command {
+  id: string; // e.g. 'navigate.author', 'draft.archive'
+  label: string; // e.g. 'Go to Author', 'Archive Draft'
+  shortcut?: string; // e.g. 'g a', 'mod+shift+c', 'a'
+  icon?: React.ComponentType; // Lucide icon
+  section: 'navigation' | 'actions' | 'ai' | 'view';
+  when?: () => boolean; // Context predicate (e.g. only show 'Archive' when a draft is selected)
+  execute: () => void;
+}
+
+interface CommandRegistry {
+  register: (command: Command) => () => void; // returns unregister fn
+  getAll: () => Command[];
+  getBySection: (section: string) => Command[];
+  execute: (id: string) => void;
+}
+```
+
+**Component:** `components/ui/command-palette.tsx` (scaffolded from cmdk)
+
+```
+┌─────────────────────────────────────┐
+│ 🔍  Type a command...          ⌘K   │
+├─────────────────────────────────────┤
+│ Navigation                          │
+│   Go to Author               G A   │
+│   Go to Review               G R   │
+│   Go to Home                 G H   │
+│                                     │
+│ Actions                             │
+│   New Proposal               N     │
+│   Archive Draft              A     │
+│   Duplicate Draft            D     │
+│   Save Version              ⌘S     │
+│                                     │
+│ AI                                  │
+│   Improve Selection         ⌘K     │
+│   Constitutional Check       /check │
+│   Find Similar Proposals     /sim   │
+│                                     │
+│ View                                │
+│   Toggle Agent Panel     ⌘⇧C      │
+│   Toggle Sidebar         ⌘B        │
+│   Switch to Kanban           V K   │
+│   Switch to List             V L   │
+└─────────────────────────────────────┘
+```
+
+**Keyboard engine:** `lib/workspace/keyboard.ts`
+
+```typescript
+// Chord support: 'g a' means press G, then A within 500ms
+// Modifier support: 'mod+shift+c' (mod = Cmd on Mac, Ctrl elsewhere)
+// Single key: 'a', 'escape', 'j', 'k'
+// Context-aware: skip when focus is in input/textarea/contentEditable
+
+function createKeyboardEngine(registry: CommandRegistry): {
+  attach: () => () => void; // returns cleanup fn
+  isChording: boolean; // true during chord sequence
+  pendingChord: string; // first key of an active chord
+};
+```
+
+**Migration path:**
+
+- `WorkspaceLayout` Cmd+Shift+C handler → register as command `view.toggle-agent`
+- `useKeyboardShortcuts` (review workspace Y/N/A/S) → register as commands `review.vote-yes`, etc.
+- `CommandBar` Cmd+K → becomes the AI section of the unified palette (Cmd+K opens palette, typing `/` filters to AI commands)
+- `SlashCommandMenu` → register slash commands into the same registry, render in palette when triggered from editor
+
+**Acceptance criteria:**
+
+- [ ] Cmd+K opens unified palette from anywhere in workspace
+- [ ] Keyboard shortcuts display next to every command (passive learning)
+- [ ] `?` key opens a keyboard shortcut help overlay
+- [ ] Chord navigation works: G+A goes to Author, G+R to Review, G+H to Home
+- [ ] J/K list navigation in Author portfolio and Review queue
+- [ ] All existing shortcuts still work (backwards compatible)
+- [ ] Commands respect focus context (no J/K capture in editor)
+
+---
+
+### 0.3 — Panel System (react-resizable-panels)
+
+Replace custom drag resize with `react-resizable-panels` for persistence, collapse, keyboard resize, and accessibility.
+
+**Package:** `react-resizable-panels` (by bvaughn, ~10KB)
+
+**New component:** `components/workspace/layout/WorkspacePanels.tsx`
+
+```typescript
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+
+interface WorkspacePanelsProps {
+  sidebar?: ReactNode; // Left: navigation/queue rail
+  main: ReactNode; // Center: editor/portfolio/content
+  context?: ReactNode; // Right: agent/intel/notes panel
+  toolbar: ReactNode;
+  statusBar: ReactNode;
+  layoutId: string; // autoSaveId for persistence (e.g. 'author', 'review', 'amendment')
+}
+
+// Layout:
+// ┌──────────┬──────────────────────┬──────────────┐
+// │ sidebar  │       main           │   context    │
+// │ (collapse│  (flex, min 40%)     │  (collapse   │
+// │  to 48px)│                      │   to 0)      │
+// └──────────┴──────────────────────┴──────────────┘
+```
+
+**Key behaviors:**
+
+- `autoSaveId={layoutId}` — panel sizes persist to localStorage automatically
+- Sidebar collapses to icon rail (48px) via `collapsible` prop
+- Context panel collapses to 0 (hidden) — restores to last width on reopen
+- Resize handles: 4px wide, hover highlight, keyboard accessible (arrow keys)
+- On mobile (<lg): sidebar becomes a Sheet, context panel becomes a bottom Sheet
+
+**Migration path:**
+
+- `WorkspaceLayout.tsx` → replace with `WorkspacePanels` composition. Keep the component signature compatible initially.
+- `StudioPanel` → becomes the `context` slot content. Its internal tab switching stays.
+- Queue rail → becomes the `sidebar` slot content in review workspace.
+- Remove: custom drag handlers, manual width state, MIN_CHAT_WIDTH/MIN_EDITOR_WIDTH constants.
+
+**Acceptance criteria:**
+
+- [ ] Panel sizes persist across page refresh and navigation
+- [ ] Sidebar collapse/expand animates smoothly (200ms)
+- [ ] Context panel can be toggled via Cmd+Shift+C (registered as command)
+- [ ] Keyboard resize: focus handle, use arrow keys to adjust
+- [ ] Mobile: panels degrade to sheets
+- [ ] Both Author and Review workspaces use the same panel primitive with different `layoutId`
+
+---
+
+## Tier 1: Interaction Quality
+
+**Goal:** Make every interaction feel instant and keyboard-native. Build incrementally alongside feature work.
+
+### 1.1 — Optimistic Mutation Pattern
+
+**File:** `lib/workspace/mutations.ts`
+
+```typescript
+// Wrapper that standardizes optimistic update + rollback + toast feedback
+function useOptimisticMutation<TData, TVariables>(options: {
+  mutationFn: (vars: TVariables) => Promise<TData>;
+  queryKey: QueryKey;
+  optimisticUpdate: (old: TData, vars: TVariables) => TData;
+  successMessage?: string; // e.g. "Draft archived"
+  errorMessage?: string; // e.g. "Failed to archive draft"
+}): UseMutationResult;
+```
+
+**Visual feedback pattern:**
+
+- Mutation starts → item updates immediately (optimistic)
+- Background: subtle "Saving..." indicator in status bar (not a spinner on the item)
+- Success → brief "Saved ✓" (auto-dismiss 1.5s)
+- Error → toast with rollback: "Failed to save. Changes reverted." + retry action
+- No loading spinners on individual items. Ever.
+
+**Apply to:**
+
+- `useUpdateDraft` — auto-save shows optimistic content
+- `useCreateDraft` — new draft appears in portfolio immediately
+- Archive/delete — card moves/disappears instantly
+- Stage transitions — status badge updates instantly
+- Review submission — review appears in list instantly
+- Team operations — member added/removed instantly
+
+**Acceptance criteria:**
+
+- [ ] Every workspace mutation feels instant (<50ms perceived)
+- [ ] Status bar shows save state (idle/saving/saved/error)
+- [ ] Failed mutations rollback cleanly with user-visible error
+- [ ] No loading spinners on mutation targets
+
+---
+
+### 1.2 — Focus Management
+
+**File:** `lib/workspace/focus.ts`
+
+```typescript
+interface FocusManager {
+  // Push/pop focus context (like a stack)
+  pushFocus: (elementOrSelector: HTMLElement | string) => void;
+  popFocus: () => void; // restores previous focus
+
+  // Track active list for J/K navigation
+  setActiveList: (id: string, length: number) => void;
+  activeListId: string | null;
+  activeIndex: number;
+  moveUp: () => void;
+  moveDown: () => void;
+}
+```
+
+**Behaviors:**
+
+- Modal/panel opens → focus pushed, trapped within
+- Modal/panel closes → focus restored to previous element
+- J/K in lists → active item gets `data-focused="true"` + visible ring
+- Enter on focused item → navigate to detail
+- Escape in detail → return to list, restore focus to previous item
+- All focus indicators respect `data-mode` density (ring size adapts)
+
+**Acceptance criteria:**
+
+- [ ] Opening command palette, then pressing Escape, returns focus to editor cursor
+- [ ] J/K navigation shows visible focus indicator on active list item
+- [ ] Tab order is logical within each panel (doesn't escape to other panels)
+- [ ] Screen reader announces focused items correctly
+
+---
+
+### 1.3 — Toast/Notification System
+
+**File:** `components/ui/toast.tsx` (or adopt sonner)
+
+Lightweight toast for mutation feedback. Not a full notification system — just transient status messages.
+
+**Behaviors:**
+
+- Appears bottom-right, auto-dismiss after 2s
+- Stacks (max 3 visible)
+- Types: success (green check), error (red X + retry), info (neutral)
+- Keyboard: Escape dismisses all
+
+**Consider:** `sonner` (by Emiliano Horcada, same author as vaul/drawer). Tiny, unstyled, great DX. Or shadcn/ui toast (Radix-based). Either works.
+
+**Acceptance criteria:**
+
+- [ ] Mutation success/error messages appear as toasts
+- [ ] Toasts don't overlap workspace content
+- [ ] Error toasts include a retry action
+
+---
+
+## Content Authoring Quality (Parallel Track)
+
+**Goal:** Make content creation intuitive and visually beautiful in the editor, AND ensure visual consistency across the entire pipeline: author → reviewer → on-chain display. This is the "Notion-esque" layer on top of the "Linear + Cursor" workspace shell.
+
+**Runs in parallel with:** Sessions 1-2 (touches editor + CSS, not workspace shell)
+
+### Why It Matters
+
+The content pipeline has a **markdown bottleneck**: Tiptap ProseMirror JSON → markdown string → `proposal_drafts` table → CIP-108 JSON-LD → `proposals.meta_json` → `MarkdownRenderer` (react-markdown). Whatever the author creates must:
+
+1. Be intuitive to create (Notion-style block insertion, not raw markdown syntax)
+2. Look beautiful in the editor while drafting
+3. Look identical when reviewers read it
+4. Serialize to standard GFM (GitHub Flavored Markdown) for CIP-108 compatibility — other governance tools will render this with their own markdown parsers
+
+### CA.1 — Expand Slash Command Menu with Content Blocks
+
+**File:** `components/workspace/editor/SlashCommandMenu.tsx`
+
+The current menu has 5 AI commands only. Add content block commands:
+
+| Command                           | Inserts                      | Tiptap Node                         |
+| --------------------------------- | ---------------------------- | ----------------------------------- |
+| `/heading` or `/h1`, `/h2`, `/h3` | Heading at cursor            | `heading` (already in StarterKit)   |
+| `/bullet` or `/list`              | Bullet list                  | `bulletList` (StarterKit)           |
+| `/numbered` or `/ordered`         | Ordered list                 | `orderedList` (StarterKit)          |
+| `/checklist` or `/todo`           | Task list                    | `taskList` (already registered)     |
+| `/quote` or `/blockquote`         | Blockquote                   | `blockquote` (StarterKit)           |
+| `/code`                           | Code block                   | `codeBlock` (StarterKit)            |
+| `/table`                          | 3×3 table                    | `table` (already registered)        |
+| `/divider` or `/hr`               | Horizontal rule              | `horizontalRule` (StarterKit)       |
+| `/image`                          | Image (URL prompt)           | `image` (already registered)        |
+| `/callout`                        | Styled blockquote with emoji | `blockquote` with marker convention |
+
+**Callout convention (GFM-compatible):**
+
+```markdown
+> **Note:** This proposal affects treasury parameters...
+> **Warning:** Constitutional guardrail conflict detected...
+> **Important:** Requires supermajority approval...
+```
+
+Renders as a regular blockquote in other tools. Governada's renderer detects the `**Note:**` / `**Warning:**` / `**Important:**` markers and applies distinctive styling (colored left border, icon, background tint).
+
+**Command sections in the menu:**
+
+```
+┌──────────────────────────────────┐
+│ Content                          │
+│   Heading           /h1 /h2 /h3 │
+│   Bullet List            /bullet │
+│   Numbered List         /ordered │
+│   Checklist               /todo  │
+│   Quote                  /quote  │
+│   Code Block              /code  │
+│   Table                  /table  │
+│   Divider                   /hr  │
+│   Callout              /callout  │
+│   Image                  /image  │
+│                                  │
+│ AI                               │
+│   Improve Text          /improve │
+│   Constitutional Check    /check │
+│   Similar Proposals         /sim │
+│   Complete Section     /complete │
+│   Draft from Instructions /draft │
+└──────────────────────────────────┘
+```
+
+**Acceptance criteria:**
+
+- [ ] All 10 content block commands work from the slash menu
+- [ ] Each inserts the correct Tiptap node at cursor position
+- [ ] Menu shows content blocks first, AI commands second
+- [ ] Commands filter as user types (e.g., `/ta` matches `/table`)
+- [ ] Callouts use GFM-compatible blockquote+marker convention
+
+---
+
+### CA.2 — Shared Governance Prose Styling
+
+**File:** `app/globals.css` (new `.governance-prose` class)
+
+Create a single CSS class that defines the visual treatment of ALL content block types, used by both the Tiptap editor and the MarkdownRenderer.
+
+```css
+/* Shared prose styling for governance content */
+.governance-prose h1 {
+  /* ... */
+}
+.governance-prose h2 {
+  /* ... */
+}
+.governance-prose h3 {
+  /* ... */
+}
+.governance-prose p {
+  /* ... */
+}
+.governance-prose ul {
+  /* ... */
+}
+.governance-prose ol {
+  /* ... */
+}
+.governance-prose blockquote {
+  /* base blockquote styling */
+}
+.governance-prose blockquote:has(> p > strong:first-child) {
+  /* Callout detection: blockquotes starting with **Note:**/
+  **warning: * *; /**Important:** */
+}
+.governance-prose pre {
+  /* code block with language header */
+}
+.governance-prose table {
+  /* styled table with header row */
+}
+.governance-prose hr {
+  /* styled divider */
+}
+.governance-prose img {
+  /* responsive, rounded, caption support */
+}
+.governance-prose input[type='checkbox'] {
+  /* styled task list checkboxes */
+}
+```
+
+**Design direction (Compass language):**
+
+- Headings: Space Grotesk, foreground color, graduated sizing (h1=1.5rem, h2=1.25rem, h3=1.1rem)
+- Blockquotes: left border 3px `--compass-teal`, padding-left 1rem, slightly muted text
+- Callout (Note): left border `--compass-teal`, teal-tinted background, info icon
+- Callout (Warning): left border `--wayfinder-amber`, amber-tinted background, warning icon
+- Callout (Important): left border `--meridian-violet`, violet-tinted background, alert icon
+- Code blocks: `--muted` background, rounded corners, language badge top-right if specified
+- Tables: border-collapse, header row with muted background, alternating row tint
+- Horizontal rules: centered, 60% width, 1px `--border` with subtle gradient fade
+- Task list checkboxes: custom styled (not browser default), compass-teal when checked
+
+**Apply to:**
+
+1. Tiptap editor — wrap `.ProseMirror` content area with `.governance-prose`
+2. `MarkdownRenderer.tsx` — replace inline Tailwind component overrides with `.governance-prose` class
+3. `ProposalContent.tsx` — review view inherits from the same class
+4. `AnnotatableText.tsx` — annotatable view inherits from the same class
+
+**Acceptance criteria:**
+
+- [ ] A heading created in the editor looks identical to the same heading in the review view
+- [ ] A callout created via `/callout` renders with distinctive styling in editor, review, AND on-chain display
+- [ ] The `.governance-prose` class is the single source of truth — no duplicate styling
+- [ ] All block types adapt to density modes (tighter spacing in Work mode)
+
+---
+
+### CA.3 — Formatting Toolbar
+
+**File:** `components/workspace/editor/FormattingToolbar.tsx`
+
+A compact toolbar above the editor content area for users who prefer clicking over typing. Think Notion's floating toolbar + a persistent block insertion bar.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ B  I  S  ~  🔗  │  H1 H2 H3  │  • ① ☑  │  ❝  </>  ▤  ―  │  + │
+│ (inline format)  │ (headings) │ (lists)  │ (blocks)        │add │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **Inline section** (left): Bold, Italic, Strikethrough, Link — toggle on selection
+- **Heading section**: H1, H2, H3 — toggles at block level
+- **List section**: Bullet, Ordered, Checklist
+- **Block section**: Quote, Code, Table, Divider
+- **Add button** (+): Opens the same command menu as `/` (content blocks + AI)
+- Shows active states (bold button highlighted when cursor is in bold text)
+- Collapses to essential items on narrow screens
+
+**Acceptance criteria:**
+
+- [ ] Every content block type is accessible without knowing markdown or slash commands
+- [ ] Active formatting state is visually indicated (highlighted buttons)
+- [ ] Toolbar is compact and doesn't compete with the content area
+- [ ] Works alongside slash commands (both paths to the same result)
+
+---
+
+### CA.4 — Roundtrip Fidelity Verification
+
+**Scope:** Verify that content survives the full pipeline without loss.
+
+**Test matrix:**
+
+| Content Type                 | Create in Tiptap | Save to DB | Load back in Tiptap | Render in MarkdownRenderer | CIP-108 output |
+| ---------------------------- | ---------------- | ---------- | ------------------- | -------------------------- | -------------- |
+| Headings (H1-H3)             | ✓                | Check      | Check               | Check                      | Check          |
+| Bold/Italic/Strikethrough    | ✓                | Check      | Check               | Check                      | Check          |
+| Bullet/Ordered lists         | ✓                | Check      | Check               | Check                      | Check          |
+| Nested lists                 | ✓                | Check      | Check               | Check                      | Check          |
+| Task lists                   | ✓                | Check      | Check               | Check                      | Check          |
+| Blockquotes                  | ✓                | Check      | Check               | Check                      | Check          |
+| Callouts (marker convention) | ✓                | Check      | Check               | Check                      | Check          |
+| Code blocks (with language)  | ✓                | Check      | Check               | Check                      | Check          |
+| Tables                       | ✓                | Check      | Check               | Check                      | Check          |
+| Images                       | ✓                | Check      | Check               | Check                      | Check          |
+| Horizontal rules             | ✓                | Check      | Check               | Check                      | Check          |
+| Links                        | ✓                | Check      | Check               | Check                      | Check          |
+| Mixed nesting                | ✓                | Check      | Check               | Check                      | Check          |
+
+Write as a Vitest test suite that creates each content type in a headless Tiptap editor, serializes to markdown, parses back, and asserts structural equality.
+
+**Acceptance criteria:**
+
+- [ ] All content types roundtrip without loss
+- [ ] CIP-108 output is valid GFM (parseable by any CommonMark/GFM renderer)
+- [ ] Test suite runs as part of `npm run test`
+
+---
+
+## Tier 2: Polish & Performance
+
+**Goal:** The final 20% that makes the workspace feel world-class. Non-blocking — ship after core features work.
+
+### 2.1 — View Transitions
+
+**Config:** `next.config.ts` → `viewTransition: true`
+
+GPU-accelerated route transitions between workspace pages. Browser-native, zero JavaScript. Elements with matching `viewTransitionName` CSS properties animate position/size/opacity automatically.
+
+**Apply to:**
+
+- `/workspace/author` → `/workspace/author/[draftId]` (card expands into editor)
+- `/workspace/review` proposal queue navigation
+- Panel open/close animations (if browser supports)
+
+**Acceptance criteria:**
+
+- [ ] Route navigation within workspace has smooth morphing (no flash of white)
+- [ ] Graceful degradation: browsers without View Transitions get instant navigation (no break)
+
+---
+
+### 2.2 — List Virtualization
+
+**Package:** `@tanstack/react-virtual` (~5KB, fits TanStack ecosystem)
+
+**Apply when:**
+
+- Author portfolio > 50 proposals (unlikely near-term, but future-proof)
+- Review queue > 100 proposals (more likely)
+- Any scrollable list that could grow unbounded
+
+**Not needed yet** — current proposal counts are small. Add when performance data justifies it.
+
+**Acceptance criteria:**
+
+- [ ] Lists of 500+ items render without jank
+- [ ] Scroll position preserved on navigation/return
+- [ ] Keyboard navigation (J/K) works with virtualized items
+
+---
+
+### 2.3 — Motion & Animation
+
+**Library:** `framer-motion` (already installed as v12.36.0)
+
+**Apply to:**
+
+- Staggered card entry in portfolio view (cards fade+slide in sequence)
+- Layout animation on status change (card moves between kanban columns)
+- Panel resize spring physics (smoother than CSS ease-out)
+- Skeleton shimmer/pulse on loading states
+
+**Rules (from Linear's design philosophy):**
+
+- Duration: 150-250ms maximum. Over 300ms feels sluggish.
+- Only animate `transform` and `opacity`. Never width/height/top/left.
+- Springs over easing: `type: "spring", stiffness: 300, damping: 30`
+- Enter animations yes, exit animations minimal (fade out <100ms or instant)
+- **No animation on keyboard navigation.** Focus changes must be instant.
+
+**Acceptance criteria:**
+
+- [ ] Portfolio view cards animate on entry (staggered fade+slide)
+- [ ] Kanban column transitions animate card movement
+- [ ] All animations respect `prefers-reduced-motion`
+
+---
+
+### 2.4 — Density Mode → Workspace CSS
+
+Connect the existing `ModeProvider` (browse/work/analyze) to workspace-specific styling.
+
+The `data-mode` attribute already renders on the root element. Add CSS custom property overrides:
+
+```css
+/* globals.css additions */
+[data-mode='work'] {
+  --workspace-gap: var(--space-xs); /* 4px — tighter in work mode */
+  --workspace-card-padding: var(--space-sm); /* 8px */
+  --workspace-font-size: 13px;
+  --workspace-line-height: 1.4;
+}
+
+[data-mode='analyze'] {
+  --workspace-gap: var(--space-2xs); /* 2px — maximum density */
+  --workspace-card-padding: var(--space-xs);
+  --workspace-font-size: 12px;
+  --workspace-line-height: 1.3;
+}
+```
+
+Workspace components consume these tokens instead of hardcoded spacing.
+
+**Acceptance criteria:**
+
+- [ ] Workspace visually tightens in Work mode, maximizes density in Analyze mode
+- [ ] Mode switching is instant (CSS-only, no re-render)
+
+---
+
+## Execution Plan
+
+### Session order and dependencies
+
+```
+Session 1a: Tier 0.1 + 0.3 (parallel-safe — workspace shell)
+├── 0.1: Zustand store + useWorkspace hook + StudioProvider adapter
+└── 0.3: Install react-resizable-panels + WorkspacePanels component + migrate WorkspaceLayout
+
+Session 1b: CA.1 + CA.2 + CA.3 (parallel with 1a — editor + CSS, no overlap)
+├── CA.1: Expand SlashCommandMenu with 10 content block commands
+├── CA.2: Create .governance-prose shared CSS + apply to editor + MarkdownRenderer
+├── CA.3: Formatting toolbar component
+└── CA.4: Roundtrip fidelity test suite
+
+Session 2: Tier 0.2
+├── Command registry + keyboard engine
+├── Scaffold command-palette.tsx from cmdk
+├── Register all existing shortcuts as commands (including new content blocks from 1b)
+└── Wire Cmd+K, chord navigation, ? help overlay
+
+Session 3: Tier 1.1 + 1.3 (parallel-safe)
+├── 1.1: useOptimisticMutation wrapper + apply to draft hooks
+└── 1.3: Toast system (sonner or shadcn) + wire to mutations
+
+Session 4: Tier 1.2 + 2.4
+├── 1.2: FocusManager + J/K list navigation + focus restoration
+└── 2.4: Density mode CSS tokens for workspace
+
+Session 5: Tier 2.1 + 2.2 + 2.3
+├── 2.1: View Transitions config
+├── 2.2: @tanstack/react-virtual on largest lists (if needed)
+└── 2.3: framer-motion staggered entry + layout animations
+```
+
+### What gets shipped per session
+
+| Session | Deliverable                                 | PR scope                                                             |
+| ------- | ------------------------------------------- | -------------------------------------------------------------------- |
+| 1a      | Panel persistence + workspace state         | ~8-12 files (store, panels, layout migration)                        |
+| 1b      | Beautiful content authoring                 | ~6-8 files (slash menu, prose CSS, toolbar, fidelity tests)          |
+| 2       | Command palette + keyboard system           | ~6-10 files (registry, palette, help overlay, command registrations) |
+| 3       | Optimistic mutations + toasts               | ~8-12 files (mutation wrapper, hook updates, toast component)        |
+| 4       | Focus management + density CSS              | ~5-8 files (focus manager, list nav hook, CSS tokens)                |
+| 5       | Polish: transitions, virtualization, motion | ~5-8 files (config, animation wrappers, CSS)                         |
+
+### Parallel execution opportunities
+
+Sessions 1a and 1b are fully parallel — 1a touches workspace shell (store, panels, layout), 1b touches editor internals (slash menu, CSS, toolbar). Zero file overlap. Both can run as separate worktree agents simultaneously.
+
+Session 3's two items (mutations + toasts) can also parallelize. Session 2 is sequential (palette depends on registry). Sessions 4-5 are lightweight and can parallelize freely.
+
+---
+
+## Package Additions
+
+| Package                  | Version | Size (gzip) | Purpose                                                 |
+| ------------------------ | ------- | ----------- | ------------------------------------------------------- |
+| `zustand`                | ^5.x    | ~2KB        | Workspace state management                              |
+| `react-resizable-panels` | ^2.x    | ~10KB       | Panel layout with persistence                           |
+| `react-hotkeys-hook`     | ^5.x    | ~3KB        | Keyboard shortcut engine (or custom)                    |
+| `sonner`                 | ^2.x    | ~5KB        | Toast notifications (optional, shadcn toast also works) |
+
+Total added: ~20KB gzipped. No heavy dependencies.
+
+**Packages NOT needed (decided against):**
+
+- `jotai` — Zustand is simpler for this use case (single store > atomic state)
+- `@tanstack/react-virtual` — Tier 2, add only if perf data justifies
+- `react-virtuoso` — Same, defer until needed
+
+---
+
+## Migration Checklist
+
+Components that need updates during Tier 0:
+
+| Component                                         | Change                                                            | Tier |
+| ------------------------------------------------- | ----------------------------------------------------------------- | ---- |
+| `components/studio/StudioProvider.tsx`            | Adapter: read from Zustand, keep Context API for backwards compat | 0.1  |
+| `components/workspace/layout/WorkspaceLayout.tsx` | Replace with WorkspacePanels composition                          | 0.3  |
+| `components/studio/StudioPanel.tsx`               | Becomes context slot content in WorkspacePanels                   | 0.3  |
+| `hooks/useKeyboardShortcuts.ts`                   | Register commands instead of raw addEventListener                 | 0.2  |
+| `components/workspace/editor/CommandBar.tsx`      | Becomes AI section of unified palette                             | 0.2  |
+| `components/workspace/author/AuthorWorkspace.tsx` | Read viewMode/filter from store                                   | 0.1  |
+| `app/workspace/editor/[draftId]/page.tsx`         | Sync draftId to store                                             | 0.1  |
+| `app/workspace/review/page.tsx`                   | Sync selectedIndex to store                                       | 0.1  |
+
+---
+
+## What This Unblocks
+
+Once Tier 0 is complete, the proposal lifecycle work from the exploration has a solid foundation:
+
+| Feature                                                  | Depends on                                              |
+| -------------------------------------------------------- | ------------------------------------------------------- |
+| **Portfolio view** (3-column kanban)                     | WorkspacePanels (0.3) + Zustand viewMode (0.1)          |
+| **Quick actions** (archive, duplicate, delete from list) | Command registry (0.2) + Optimistic mutations (1.1)     |
+| **Keyboard-first portfolio** (J/K, Enter, D, A)          | Command registry (0.2) + Focus management (1.2)         |
+| **Submission ceremony** (full-page flow)                 | WorkspacePanels (0.3) + Zustand context (0.1)           |
+| **Post-submission dashboard**                            | WorkspacePanels (0.3) + Zustand currentProposalId (0.1) |
+| **Team approval gates**                                  | Optimistic mutations (1.1) + Toast feedback (1.3)       |
+
+---
+
+## Risks
+
+| Risk                                                     | Likelihood | Mitigation                                                                                                                                                |
+| -------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Zustand migration breaks existing workspace flows        | Medium     | Keep StudioProvider as thin adapter during migration. Both old and new consumers work simultaneously. Remove adapter in a follow-up PR.                   |
+| react-resizable-panels doesn't match current layout feel | Low        | Library is used by shadcn/ui, Vercel dashboard, and hundreds of production apps. Test in isolation first.                                                 |
+| Command palette conflicts with editor Cmd+K              | Medium     | When editor is focused, Cmd+K routes to editor CommandBar (AI). When editor is NOT focused, Cmd+K opens palette. Clear priority rules in keyboard engine. |
+| Session count underestimate                              | Medium     | Tier 2 items are explicitly deferrable. Ship Tier 0 + 1, assess if Tier 2 is needed before building.                                                      |
+
+---
+
+## What We Are NOT Doing
+
+- **Real-time collaboration (CRDT/multiplayer editing)** — Not in scope. Team collaboration uses version-based editing, not real-time cursors.
+- **Full sync engine (Linear-style IndexedDB + delta sync)** — Overkill for our scale. TanStack Query + Supabase is sufficient.
+- **Custom animation engine** — framer-motion is already installed. Use it, don't build our own.
+- **Replacing Tiptap** — Tiptap + custom extensions are the right foundation. We're extending (slash commands, toolbar, prose styling), not replacing.
+- **Custom block format** — All content serializes to standard GFM markdown. No proprietary block syntax that breaks in other CIP-108 renderers.
+- **Full Notion block system** — We're adding Notion-style block insertion UX, not Notion's database/page architecture. Blocks are markdown elements, not custom data types.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -21,7 +21,7 @@ export async function register() {
   }
 }
 
-/** Decode base64url to string � works in both Node.js and Edge runtimes. */
+/** Decode base64url to string -- works in both Node.js and Edge runtimes. */
 function decodeBase64Url(input: string): string {
   // Convert base64url to standard base64
   const base64 = input.replace(/-/g, '+').replace(/_/g, '/');

--- a/lib/admin/sandbox.ts
+++ b/lib/admin/sandbox.ts
@@ -1,0 +1,29 @@
+/**
+ * Sandbox utilities — client-side helpers for admin sandbox mode.
+ *
+ * When an admin enters sandbox mode, writes are scoped to a preview cohort
+ * so they can test the full authoring/review workflow without polluting
+ * production data. The sandbox cohort ID is stored in sessionStorage and
+ * attached to API requests via the `X-Sandbox-Cohort` header.
+ */
+
+/**
+ * Get sandbox headers to include in fetch requests.
+ * Returns empty object if not in sandbox mode.
+ */
+export function getSandboxHeaders(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const cohortId = sessionStorage.getItem('governada_sandbox');
+    if (!cohortId) return {};
+    return { 'X-Sandbox-Cohort': cohortId };
+  } catch {
+    return {};
+  }
+}
+
+/** Storage key for sandbox cohort ID */
+export const SANDBOX_STORAGE_KEY = 'governada_sandbox';
+
+/** Marker prefix used in cohort description to identify admin sandboxes */
+export const SANDBOX_DESCRIPTION_PREFIX = '[ADMIN_SANDBOX]';

--- a/lib/admin/viewAsRegistry.ts
+++ b/lib/admin/viewAsRegistry.ts
@@ -76,6 +76,13 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     segment: 'citizen',
     overrides: { delegatedDrep: 'drep_always_no_confidence' },
   },
+  {
+    id: 'citizen-delegated-preview',
+    label: 'Delegated (representative)',
+    description: 'Citizen delegated to a representative DRep — for preview cohorts',
+    segment: 'citizen',
+    overrides: { delegatedDrep: 'preview_representative_drep' },
+  },
 
   // -- DRep --
   {
@@ -94,6 +101,13 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     requiresPicker: 'drep',
     pickerTitle: 'Claim a DRep profile',
     pickerDescription: 'View the app as this DRep.',
+  },
+  {
+    id: 'drep-claimed-preview',
+    label: 'Claimed (representative)',
+    description: 'A claimed DRep with a representative profile — for preview cohorts',
+    segment: 'drep',
+    overrides: { drepId: 'preview_representative_drep' },
   },
 
   // -- SPO --
@@ -114,6 +128,13 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     pickerTitle: 'Claim an SPO profile',
     pickerDescription: 'View the app as this pool operator.',
   },
+  {
+    id: 'spo-claimed-preview',
+    label: 'Claimed (representative)',
+    description: 'A claimed SPO with a representative profile — for preview cohorts',
+    segment: 'spo',
+    overrides: { poolId: 'preview_representative_spo' },
+  },
 
   // -- DRep + SPO (dual role) --
   {
@@ -128,6 +149,16 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     pickerDescription: 'Select the DRep identity for the dual-role simulation.',
     secondaryPickerTitle: 'Step 2: Pick a Stake Pool',
     secondaryPickerDescription: 'Select the SPO identity for the dual-role simulation.',
+  },
+  {
+    id: 'drep-spo-dual-preview',
+    label: 'DRep + SPO (dual role)',
+    description: 'Dual-role DRep and SPO with representative profiles — for preview cohorts',
+    segment: 'drep',
+    overrides: {
+      drepId: 'preview_representative_drep',
+      poolId: 'preview_representative_spo',
+    },
   },
 
   // -- CC Member --
@@ -148,24 +179,12 @@ export const SEGMENT_PRESETS: SegmentPreset[] = [
     pickerTitle: 'Claim a CC member profile',
     pickerDescription: 'View the app as this committee member.',
   },
-
-  // -- Proposer (capability overlay — works with any segment) --
   {
-    id: 'citizen-proposer',
-    label: 'Citizen + Active Proposer',
-    description: 'A citizen who has an active proposal draft',
-    segment: 'citizen',
-    overrides: { delegatedDrep: 'drep_always_abstain' },
-  },
-  {
-    id: 'drep-proposer',
-    label: 'DRep + Active Proposer',
-    description: 'A DRep who is also authoring a proposal',
-    segment: 'drep',
+    id: 'cc-claimed-preview',
+    label: 'Claimed (representative)',
+    description: 'A claimed CC member with a representative profile — for preview cohorts',
+    segment: 'cc',
     overrides: {},
-    requiresPicker: 'drep',
-    pickerTitle: 'Pick a DRep',
-    pickerDescription: 'View as a DRep who also has active proposal drafts.',
   },
 
   // -- Anonymous --


### PR DESCRIPTION
## Summary
- **User State Inspector** (`/admin/users`): Search any user by wallet/stake/DRep/pool ID. Shows full computed state — identity, segment detection, linked wallets, DRep profile, governance activity (poll votes, proposals, reviews).
- **Admin Sandbox Mode**: Enter sandbox from the View As dropdown to test authoring/review workflows without touching production data. Writes scoped to isolated cohort namespace. Generate scenario data or reset sandbox from the menu.
- **Workspace endpoint instrumentation**: Drafts and reviews routes respect `X-Sandbox-Cohort` header for write isolation.
- **View As registry cleanup**: Removed misleading `citizen-proposer` and `drep-proposer` presets (proposer is a capability, not a persona). Added 5 representative preview presets for claimed DRep/SPO/CC, delegated citizen, and dual-role — all preview-invite-compatible (no picker required).
- **Architecture plan**: `docs/strategy/plans/admin-testing-framework.md` — P0-P3 roadmap covering inspector, sandbox, impersonation, cross-persona testing, activity trail, edge scenarios, per-user flags, parity verification.

## Impact
- **What changed**: Admin gets two new tools — user state inspector for debugging and sandbox mode for safe workflow testing
- **User-facing**: No — admin-only features behind wallet auth
- **Risk**: Low — new pages and optional header injection, no changes to production write paths unless sandbox header is present
- **Scope**: 16 files (6 new, 10 modified). No migrations. No Inngest changes.

## Test plan
- [ ] Verify `/admin/users` loads and search works for known wallet addresses
- [ ] Verify "Enter Sandbox" creates a cohort and activates sandbox mode indicator
- [ ] Verify "Generate Scenarios" populates sandbox with proposal drafts
- [ ] Verify "Reset Sandbox" clears all sandbox data
- [ ] Verify "Exit Sandbox" returns to normal mode
- [ ] Verify View As registry shows new representative presets in preview invite dropdown
- [ ] Verify no regression to existing View As persona switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)