### PR TITLE
feat: user impersonation + cross-persona sandbox sharing

### DIFF
--- a/app/admin/users/UsersClient.tsx
+++ b/app/admin/users/UsersClient.tsx
@@ -1,8 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { getStoredSession } from '@/lib/supabaseAuth';
+import {
+  useSegment,
+  type SegmentOverride,
+  type UserSegment,
+} from '@/components/providers/SegmentProvider';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -20,6 +26,7 @@ import {
   AlertCircle,
   Wallet,
   UserCog,
+  FlaskConical,
 } from 'lucide-react';
 
 interface InspectResult {
@@ -153,7 +160,10 @@ function StatCard({
 }
 
 export function UsersClient() {
+  const router = useRouter();
+  const { setOverride, enterSandbox } = useSegment();
   const [searchInput, setSearchInput] = useState('');
+  const [sandboxLoading, setSandboxLoading] = useState(false);
 
   const inspect = useMutation({
     mutationFn: async (address: string): Promise<InspectResult> => {
@@ -176,6 +186,68 @@ export function UsersClient() {
   };
 
   const data = inspect.data;
+
+  const buildOverrideFromData = useCallback(
+    (inspectData: InspectResult): SegmentOverride => ({
+      segment: inspectData.segment.detected as UserSegment,
+      drepId: inspectData.segment.drepId,
+      poolId: inspectData.segment.poolId,
+      delegatedDrep: inspectData.segment.delegatedDrep,
+      delegatedPool: inspectData.segment.delegatedPool,
+    }),
+    [],
+  );
+
+  const storeImpersonation = useCallback((inspectData: InspectResult) => {
+    if (!inspectData.user) return;
+    sessionStorage.setItem(
+      'governada_impersonate',
+      JSON.stringify({
+        address: inspectData.user.wallet_address,
+        segment: inspectData.segment.detected,
+        displayName: inspectData.user.display_name,
+      }),
+    );
+  }, []);
+
+  const handleImpersonate = useCallback(() => {
+    if (!data?.user) return;
+    const override = buildOverrideFromData(data);
+    setOverride(override);
+    storeImpersonation(data);
+    router.push('/');
+  }, [data, buildOverrideFromData, storeImpersonation, setOverride, router]);
+
+  const handleImpersonateInSandbox = useCallback(async () => {
+    if (!data?.user) return;
+    setSandboxLoading(true);
+    try {
+      const override = buildOverrideFromData(data);
+      setOverride(override);
+      storeImpersonation(data);
+
+      // Create or get a sandbox cohort
+      const token = getStoredSession();
+      const res = await fetch('/api/admin/sandbox', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ action: 'create' }),
+      });
+      if (res.ok) {
+        const sandboxData = await res.json();
+        if (sandboxData.cohort?.id) {
+          enterSandbox(sandboxData.cohort.id);
+        }
+      }
+
+      router.push('/');
+    } finally {
+      setSandboxLoading(false);
+    }
+  }, [data, buildOverrideFromData, storeImpersonation, setOverride, enterSandbox, router]);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
@@ -492,11 +564,23 @@ export function UsersClient() {
           <Card className="bg-card/50">
             <CardContent className="pt-4 pb-4">
               <div className="flex items-center gap-3">
-                <Button variant="outline" size="sm" disabled>
+                <Button variant="outline" size="sm" onClick={handleImpersonate}>
                   <UserCog className="h-4 w-4 mr-2" />
                   Impersonate
                 </Button>
-                <span className="text-xs text-muted-foreground">Coming soon</span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleImpersonateInSandbox}
+                  disabled={sandboxLoading}
+                >
+                  {sandboxLoading ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <FlaskConical className="h-4 w-4 mr-2" />
+                  )}
+                  Impersonate in Sandbox
+                </Button>
               </div>
             </CardContent>
           </Card>

--- a/app/api/workspace/drafts/route.ts
+++ b/app/api/workspace/drafts/route.ts
@@ -86,12 +86,20 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     return NextResponse.json({ error: 'Missing stakeAddress or status' }, { status: 400 });
   }
 
-  const { data, error } = await admin
-    .from('proposal_drafts')
-    .select('*')
-    .eq('owner_stake_address', stakeAddress)
-    .neq('status', 'archived')
-    .order('updated_at', { ascending: false });
+  let ownerQuery = admin.from('proposal_drafts').select('*').neq('status', 'archived');
+
+  if (sandboxCohortId) {
+    // Sandbox mode: show drafts owned by this persona OR any draft in the sandbox cohort.
+    // This allows cross-persona visibility — drafts created as "Citizen" are visible
+    // when the admin switches to "DRep" within the same sandbox.
+    ownerQuery = ownerQuery.or(
+      `owner_stake_address.eq.${stakeAddress},preview_cohort_id.eq.${sandboxCohortId}`,
+    );
+  } else {
+    ownerQuery = ownerQuery.eq('owner_stake_address', stakeAddress);
+  }
+
+  const { data, error } = await ownerQuery.order('updated_at', { ascending: false });
 
   if (error) {
     return NextResponse.json({ error: 'Failed to fetch drafts' }, { status: 500 });

--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -22,6 +22,7 @@ import {
   Sparkles,
   X,
   Loader2,
+  UserCog,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { DepthPickerDropdown } from './DepthPickerDropdown';
@@ -179,6 +180,11 @@ function NotificationBell({ unreadCount }: { unreadCount: number }) {
   );
 }
 
+function truncateImpersonateAddress(addr: string): string {
+  if (addr.length <= 20) return addr;
+  return `${addr.slice(0, 8)}...${addr.slice(-8)}`;
+}
+
 export function GovernadaHeader() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -208,6 +214,32 @@ export function GovernadaHeader() {
     preset: SegmentPreset;
     firstId: string;
   } | null>(null);
+
+  // Impersonation state (persisted in sessionStorage)
+  const [impersonation, setImpersonation] = useState<{
+    address: string;
+    segment: string;
+    displayName: string | null;
+  } | null>(null);
+
+  // Load impersonation from sessionStorage on mount
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem('governada_impersonate');
+      if (stored) {
+        setImpersonation(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  const handleExitImpersonation = useCallback(() => {
+    setOverride(null);
+    sessionStorage.removeItem('governada_impersonate');
+    setImpersonation(null);
+    router.push('/admin/users');
+  }, [setOverride, router]);
 
   // Sandbox state
   const [sandboxLoading, setSandboxLoading] = useState(false);
@@ -677,6 +709,8 @@ export function GovernadaHeader() {
                     logout();
                     disconnect();
                     sessionStorage.removeItem('governada_segment');
+                    sessionStorage.removeItem('governada_impersonate');
+                    setImpersonation(null);
                   }}
                 >
                   <LogOut className="h-4 w-4" />
@@ -699,6 +733,30 @@ export function GovernadaHeader() {
           )}
         </div>
       </div>
+      {/* Impersonation banner */}
+      {isAdmin && impersonation && (
+        <div className="mx-auto max-w-7xl flex items-center justify-between h-8 px-6 bg-violet-500/15 border-t border-violet-500/20">
+          <div className="flex items-center gap-2 text-xs text-violet-400">
+            <UserCog className="h-3.5 w-3.5" />
+            <span>
+              Impersonating:{' '}
+              <span className="font-medium">
+                {impersonation.displayName || truncateImpersonateAddress(impersonation.address)}
+              </span>
+              <span className="text-violet-400/60 ml-1.5">({impersonation.segment})</span>
+            </span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-violet-400 hover:text-violet-300 hover:bg-violet-500/20"
+            onClick={handleExitImpersonation}
+          >
+            <X className="h-3 w-3 mr-1" />
+            Exit
+          </Button>
+        </div>
+      )}
       {/* Primary picker (or first step of dual-role picker) */}
       {isAdmin && pickerPreset?.requiresPicker && !pendingDualOverride && (
         <AdminViewAsPicker


### PR DESCRIPTION
## Summary
- **User Impersonation**: "Impersonate" button in User State Inspector loads a real user's detected segment, DRep ID, pool ID, and delegation into the View As override system. See the app exactly as they see it.
- **Impersonate + Sandbox combo**: "Impersonate in Sandbox" button combines persona override with sandbox mode — see a user's view while safely testing fixes.
- **Impersonation banner**: Violet banner in GovernadaHeader shows who is being impersonated, with one-click exit back to /admin/users.
- **Cross-persona sandbox fix**: Owner-specific drafts query now includes sandbox cohort drafts, so switching personas within a sandbox shows all drafts created in that sandbox regardless of which persona created them.

## Impact
- **What changed**: Admin can now impersonate any user to reproduce bugs, and switch personas within sandbox to test cross-role workflows
- **User-facing**: No — admin-only features
- **Risk**: Low — extends existing View As override mechanism, no new write paths
- **Scope**: 3 files modified (UsersClient, GovernadaHeader, drafts route)

## Test plan
- [ ] Search for a known user in User Inspector, click "Impersonate" — verify Hub shows their segment/delegation
- [ ] Verify violet impersonation banner appears with user info
- [ ] Click "Exit" on banner — verify returns to /admin/users and clears override
- [ ] Click "Impersonate in Sandbox" — verify both persona override AND sandbox mode activate
- [ ] In sandbox, create a draft as Citizen, switch to DRep — verify draft visible in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)