### PR TITLE
feat: per-user feature flags, edge case scenarios, activity trail (P2)

### DIFF
--- a/app/admin/users/UsersClient.tsx
+++ b/app/admin/users/UsersClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { getStoredSession } from '@/lib/supabaseAuth';
 import {
   useSegment,
@@ -22,11 +22,13 @@ import {
   MessageSquare,
   Copy,
   Check,
+  CheckCheck,
   Loader2,
   AlertCircle,
   Wallet,
   UserCog,
   FlaskConical,
+  Clock,
 } from 'lucide-react';
 
 interface InspectResult {
@@ -159,6 +161,39 @@ function StatCard({
   );
 }
 
+interface ActivityEvent {
+  type: 'poll_vote' | 'draft_created' | 'draft_updated' | 'review_submitted' | 'drep_vote';
+  timestamp: string;
+  details: Record<string, unknown>;
+}
+
+const activityIcons: Record<ActivityEvent['type'], typeof Vote> = {
+  poll_vote: Vote,
+  draft_created: FileText,
+  draft_updated: FileText,
+  review_submitted: MessageSquare,
+  drep_vote: CheckCheck,
+};
+
+function activityDescription(event: ActivityEvent): string {
+  switch (event.type) {
+    case 'poll_vote':
+      return `Voted in poll: ${String(event.details.proposalTitle ?? 'Unknown')}`;
+    case 'draft_created':
+      return `Created proposal draft: ${String(event.details.title ?? 'Untitled')}`;
+    case 'draft_updated':
+      return `Updated proposal draft: ${String(event.details.title ?? 'Untitled')}`;
+    case 'review_submitted':
+      return `Submitted review on: ${String(event.details.draftTitle ?? 'Unknown')}`;
+    case 'drep_vote': {
+      const vote = String(event.details.vote ?? 'unknown').toLowerCase();
+      return `Voted ${vote} on: ${String(event.details.proposalTitle ?? 'Unknown')}`;
+    }
+    default:
+      return 'Unknown activity';
+  }
+}
+
 export function UsersClient() {
   const router = useRouter();
   const { setOverride, enterSandbox } = useSegment();
@@ -209,6 +244,27 @@ export function UsersClient() {
       }),
     );
   }, []);
+
+  const stakeAddress = data?.segment?.stakeAddress ?? null;
+
+  const activityQuery = useQuery({
+    queryKey: ['admin-user-activity', stakeAddress],
+    queryFn: async (): Promise<{ events: ActivityEvent[] }> => {
+      const token = getStoredSession();
+      const res = await fetch(
+        `/api/admin/users/activity?address=${encodeURIComponent(stakeAddress!)}`,
+        {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        },
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+    enabled: !!stakeAddress,
+  });
 
   const handleImpersonate = useCallback(() => {
     if (!data?.user) return;
@@ -557,6 +613,56 @@ export function UsersClient() {
                   icon={MessageSquare}
                 />
               </div>
+            </CardContent>
+          </Card>
+
+          {/* Recent Activity */}
+          <Card className="bg-card/50">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Recent Activity
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {activityQuery.isLoading && (
+                <div className="flex items-center gap-2 text-muted-foreground py-4 justify-center">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span className="text-sm">Loading activity...</span>
+                </div>
+              )}
+              {activityQuery.isError && (
+                <div className="flex items-center gap-2 text-destructive py-4">
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  <span className="text-sm">Failed to load activity</span>
+                </div>
+              )}
+              {activityQuery.isSuccess && activityQuery.data.events.length === 0 && (
+                <p className="text-sm text-muted-foreground py-4 text-center">No recent activity</p>
+              )}
+              {activityQuery.isSuccess && activityQuery.data.events.length > 0 && (
+                <div className="space-y-1">
+                  {activityQuery.data.events.map((event, i) => {
+                    const Icon = activityIcons[event.type];
+                    return (
+                      <div
+                        key={`${event.type}-${event.timestamp}-${i}`}
+                        className="flex items-start gap-3 rounded-md px-2 py-2 hover:bg-muted/30 transition-colors"
+                      >
+                        <Icon className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm leading-snug truncate">
+                            {activityDescription(event)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {formatTimeAgo(event.timestamp)}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
             </CardContent>
           </Card>
 

--- a/app/api/admin/feature-flags/targeting/route.ts
+++ b/app/api/admin/feature-flags/targeting/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/supabaseAuth';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { logAdminAction } from '@/lib/adminAudit';
+import { setUserFlagOverride, invalidateFlagCache } from '@/lib/featureFlags';
+import { createClient } from '@/lib/supabase';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET: Returns targeting overrides for a specific flag.
+ * Query: ?key=flagName
+ */
+export const GET = withRouteHandler(async (request) => {
+  const auth = await requireAuth(request);
+  if (auth instanceof NextResponse) return auth;
+
+  if (!isAdminWallet(auth.wallet)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const key = searchParams.get('key');
+
+  if (!key) {
+    return NextResponse.json({ error: 'Missing query param: key' }, { status: 400 });
+  }
+
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('feature_flags')
+    .select('targeting')
+    .eq('key', key)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json({ error: 'Flag not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ key, targeting: data.targeting ?? {} });
+});
+
+/**
+ * POST: Set or remove a per-user flag override.
+ * Body: { key: string, walletAddress: string, enabled: boolean | null }
+ * enabled: null removes the override.
+ */
+export const POST = withRouteHandler(async (request) => {
+  const auth = await requireAuth(request);
+  if (auth instanceof NextResponse) return auth;
+
+  if (!isAdminWallet(auth.wallet)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { key, walletAddress, enabled } = body;
+
+  if (typeof key !== 'string' || typeof walletAddress !== 'string') {
+    return NextResponse.json(
+      { error: 'Invalid body: { key: string, walletAddress: string, enabled: boolean | null }' },
+      { status: 400 },
+    );
+  }
+
+  if (enabled !== null && typeof enabled !== 'boolean') {
+    return NextResponse.json({ error: 'enabled must be boolean or null' }, { status: 400 });
+  }
+
+  const success = await setUserFlagOverride(key, walletAddress, enabled);
+  if (!success) {
+    return NextResponse.json({ error: 'Failed to update targeting' }, { status: 500 });
+  }
+
+  invalidateFlagCache();
+
+  const action = enabled === null ? 'remove' : enabled ? 'enable' : 'disable';
+  logAdminAction(auth.wallet, 'set_user_flag_override', key, {
+    walletAddress,
+    action,
+  });
+
+  return NextResponse.json({ key, walletAddress, enabled });
+});

--- a/app/api/admin/preview/scenarios/route.ts
+++ b/app/api/admin/preview/scenarios/route.ts
@@ -45,13 +45,16 @@ export const POST = withRouteHandler(
       return NextResponse.json({ error: 'Cohort not found' }, { status: 404 });
     }
 
+    const edgeCases = body.edgeCases === true;
+
     logger.info('[admin/preview/scenarios] Starting scenario generation', {
       cohortId,
       cohortName: cohort.name,
+      edgeCases,
       requestedBy: context.wallet,
     });
 
-    const result = await generateScenario(cohortId);
+    const result = await generateScenario(cohortId, { edgeCases });
 
     const statusCode = result.errors.length > 0 ? 207 : 200;
 

--- a/app/api/admin/users/activity/route.ts
+++ b/app/api/admin/users/activity/route.ts
@@ -1,0 +1,227 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { isAdminWallet } from '@/lib/adminAuth';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+
+interface ActivityEvent {
+  type: 'poll_vote' | 'draft_created' | 'draft_updated' | 'review_submitted' | 'drep_vote';
+  timestamp: string;
+  details: Record<string, unknown>;
+}
+
+export const GET = withRouteHandler(
+  async (request: NextRequest, ctx: RouteContext) => {
+    if (!isAdminWallet(ctx.wallet!)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const url = new URL(request.url);
+    const address = url.searchParams.get('address')?.trim();
+    const daysParam = url.searchParams.get('days');
+    const days = daysParam ? Math.min(Math.max(parseInt(daysParam, 10) || 30, 1), 365) : 30;
+
+    if (!address) {
+      return NextResponse.json({ error: 'Required: address query param' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const since = new Date(Date.now() - days * 86_400_000).toISOString();
+
+    const events: ActivityEvent[] = [];
+
+    // Run all queries in parallel
+    const [pollVotes, drafts, reviews, drepVotes] = await Promise.all([
+      // 1. Poll votes
+      supabase
+        .from('poll_responses')
+        .select('created_at, vote, proposal_tx_hash, proposal_index')
+        .eq('stake_address', address)
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(50),
+
+      // 2. Proposal drafts
+      supabase
+        .from('proposal_drafts')
+        .select('id, title, status, created_at, updated_at')
+        .eq('owner_stake_address', address)
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(50),
+
+      // 3. Draft reviews
+      supabase
+        .from('draft_reviews')
+        .select('id, draft_id, created_at, feedback_text')
+        .eq('reviewer_stake_address', address)
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(50),
+
+      // 4. DRep votes (look up by drep_id if the address is a drep)
+      // First find drep_id from user_wallets
+      (async () => {
+        const { data: wallet } = await supabase
+          .from('user_wallets')
+          .select('drep_id')
+          .eq('stake_address', address)
+          .not('drep_id', 'is', null)
+          .limit(1)
+          .maybeSingle();
+
+        if (!wallet?.drep_id) return { data: null };
+
+        return supabase
+          .from('drep_votes')
+          .select('vote, proposal_tx_hash, proposal_index, block_time')
+          .eq('drep_id', wallet.drep_id)
+          .gte('created_at', since)
+          .order('created_at', { ascending: false })
+          .limit(50);
+      })(),
+    ]);
+
+    // Collect all proposal keys we need to look up titles for
+    const proposalKeys = new Set<string>();
+
+    if (pollVotes.data) {
+      for (const pv of pollVotes.data) {
+        proposalKeys.add(`${pv.proposal_tx_hash}:${pv.proposal_index}`);
+      }
+    }
+
+    if (drepVotes.data) {
+      for (const dv of drepVotes.data) {
+        proposalKeys.add(`${dv.proposal_tx_hash}:${dv.proposal_index}`);
+      }
+    }
+
+    // Batch look up proposal titles
+    const proposalTitles = new Map<string, string>();
+    if (proposalKeys.size > 0) {
+      const keys = Array.from(proposalKeys);
+      // Build filter: each key is tx_hash + proposal_index
+      const txHashes = [...new Set(keys.map((k) => k.split(':')[0]))];
+
+      if (txHashes.length > 0) {
+        const { data: proposals } = await supabase
+          .from('proposals')
+          .select('tx_hash, proposal_index, title')
+          .in('tx_hash', txHashes);
+
+        if (proposals) {
+          for (const p of proposals) {
+            proposalTitles.set(`${p.tx_hash}:${p.proposal_index}`, p.title ?? 'Untitled proposal');
+          }
+        }
+      }
+    }
+
+    // Also look up draft titles for reviews
+    const draftIds = new Set<string>();
+    if (reviews.data) {
+      for (const r of reviews.data) {
+        draftIds.add(r.draft_id);
+      }
+    }
+
+    const draftTitles = new Map<string, string>();
+    if (draftIds.size > 0) {
+      const { data: draftData } = await supabase
+        .from('proposal_drafts')
+        .select('id, title')
+        .in('id', Array.from(draftIds));
+
+      if (draftData) {
+        for (const d of draftData) {
+          draftTitles.set(d.id, d.title || 'Untitled draft');
+        }
+      }
+    }
+
+    // Build events from poll votes
+    if (pollVotes.data) {
+      for (const pv of pollVotes.data) {
+        const key = `${pv.proposal_tx_hash}:${pv.proposal_index}`;
+        events.push({
+          type: 'poll_vote',
+          timestamp: pv.created_at ?? new Date(0).toISOString(),
+          details: {
+            vote: pv.vote,
+            proposalTitle: proposalTitles.get(key) ?? 'Untitled proposal',
+          },
+        });
+      }
+    }
+
+    // Build events from drafts (created + updated as separate events)
+    if (drafts.data) {
+      for (const d of drafts.data) {
+        events.push({
+          type: 'draft_created',
+          timestamp: d.created_at,
+          details: {
+            title: d.title || 'Untitled draft',
+            status: d.status,
+          },
+        });
+
+        // Add an update event if updated_at is meaningfully later than created_at
+        if (d.updated_at && d.updated_at !== d.created_at) {
+          const createdMs = new Date(d.created_at).getTime();
+          const updatedMs = new Date(d.updated_at).getTime();
+          // Only show update if it's at least 60 seconds after creation
+          if (updatedMs - createdMs > 60_000) {
+            events.push({
+              type: 'draft_updated',
+              timestamp: d.updated_at,
+              details: {
+                title: d.title || 'Untitled draft',
+                status: d.status,
+              },
+            });
+          }
+        }
+      }
+    }
+
+    // Build events from reviews
+    if (reviews.data) {
+      for (const r of reviews.data) {
+        events.push({
+          type: 'review_submitted',
+          timestamp: r.created_at,
+          details: {
+            draftTitle: draftTitles.get(r.draft_id) ?? 'Unknown draft',
+          },
+        });
+      }
+    }
+
+    // Build events from drep votes
+    if (drepVotes.data) {
+      for (const dv of drepVotes.data) {
+        const key = `${dv.proposal_tx_hash}:${dv.proposal_index}`;
+        events.push({
+          type: 'drep_vote',
+          timestamp: dv.block_time
+            ? new Date(dv.block_time * 1000).toISOString()
+            : new Date(0).toISOString(),
+          details: {
+            vote: dv.vote,
+            proposalTitle: proposalTitles.get(key) ?? 'Untitled proposal',
+          },
+        });
+      }
+    }
+
+    // Sort by timestamp descending, limit to 50
+    events.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    const limited = events.slice(0, 50);
+
+    return NextResponse.json({ events: limited });
+  },
+  { auth: 'required', rateLimit: { max: 30, window: 60 } },
+);

--- a/components/admin/FeatureFlagAdmin.tsx
+++ b/components/admin/FeatureFlagAdmin.tsx
@@ -1,10 +1,21 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
-import { Loader2, CheckCircle2, XCircle, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import {
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  ChevronDown,
+  ChevronRight,
+  Users,
+  Trash2,
+  Plus,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getStoredSession } from '@/lib/supabaseAuth';
@@ -14,6 +25,7 @@ interface FlagDetail {
   enabled: boolean;
   description: string | null;
   category: string;
+  targeting?: { wallets?: Record<string, boolean> };
   updatedAt: string;
 }
 
@@ -97,6 +109,63 @@ export function FeatureFlagAdmin() {
     });
   };
 
+  // --- User override targeting ---
+  const [expandedTargeting, setExpandedTargeting] = useState<string | null>(null);
+  const [newOverrideWallet, setNewOverrideWallet] = useState('');
+  const [newOverrideEnabled, setNewOverrideEnabled] = useState(true);
+  const [savingOverride, setSavingOverride] = useState(false);
+
+  const toggleTargeting = (key: string) => {
+    setExpandedTargeting((prev) => (prev === key ? null : key));
+    setNewOverrideWallet('');
+    setNewOverrideEnabled(true);
+  };
+
+  const getOverrides = (flag: FlagDetail): [string, boolean][] => {
+    const wallets = flag.targeting?.wallets;
+    if (!wallets) return [];
+    return Object.entries(wallets);
+  };
+
+  const saveOverride = useCallback(
+    async (key: string, walletAddress: string, enabled: boolean | null) => {
+      setSavingOverride(true);
+      try {
+        const token = getStoredSession();
+        const res = await fetch('/api/admin/feature-flags/targeting', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ key, walletAddress, enabled }),
+        });
+        if (res.ok) {
+          // Update local state
+          setFlags((prev) =>
+            prev.map((f) => {
+              if (f.key !== key) return f;
+              const wallets = { ...(f.targeting?.wallets ?? {}) };
+              if (enabled === null) {
+                delete wallets[walletAddress];
+              } else {
+                wallets[walletAddress] = enabled;
+              }
+              return { ...f, targeting: { ...f.targeting, wallets } };
+            }),
+          );
+          setNewOverrideWallet('');
+          setNewOverrideEnabled(true);
+        }
+      } catch {
+        // silent
+      } finally {
+        setSavingOverride(false);
+      }
+    },
+    [],
+  );
+
   if (loading) {
     return (
       <div className="flex items-center gap-2 text-muted-foreground py-12 justify-center">
@@ -155,46 +224,147 @@ export function FeatureFlagAdmin() {
             </CardHeader>
             {!isCollapsed && (
               <CardContent className="pt-0 pb-2 px-4 space-y-1">
-                {catFlags.map((flag) => (
-                  <div
-                    key={flag.key}
-                    className={cn(
-                      'flex items-center gap-3 rounded-md px-3 py-2 transition-colors',
-                      'hover:bg-muted/50',
-                    )}
-                  >
-                    <Switch
-                      checked={flag.enabled}
-                      onCheckedChange={(checked) => toggle(flag.key, checked)}
-                      disabled={toggling === flag.key}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <code className="text-xs font-mono font-medium">{flag.key}</code>
-                        <Badge
-                          variant={flag.enabled ? 'default' : 'secondary'}
-                          className="text-[9px] px-1 py-0"
-                        >
-                          {flag.enabled ? 'ON' : 'OFF'}
-                        </Badge>
+                {catFlags.map((flag) => {
+                  const overrides = getOverrides(flag);
+                  const isTargetingOpen = expandedTargeting === flag.key;
+                  return (
+                    <div key={flag.key}>
+                      <div
+                        className={cn(
+                          'flex items-center gap-3 rounded-md px-3 py-2 transition-colors',
+                          'hover:bg-muted/50',
+                        )}
+                      >
+                        <Switch
+                          checked={flag.enabled}
+                          onCheckedChange={(checked) => toggle(flag.key, checked)}
+                          disabled={toggling === flag.key}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <code className="text-xs font-mono font-medium">{flag.key}</code>
+                            <Badge
+                              variant={flag.enabled ? 'default' : 'secondary'}
+                              className="text-[9px] px-1 py-0"
+                            >
+                              {flag.enabled ? 'ON' : 'OFF'}
+                            </Badge>
+                            {overrides.length > 0 && (
+                              <Badge variant="outline" className="text-[9px] px-1 py-0 gap-0.5">
+                                <Users className="h-2.5 w-2.5" />
+                                {overrides.length}
+                              </Badge>
+                            )}
+                          </div>
+                          {flag.description && (
+                            <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">
+                              {flag.description}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5 shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 w-6 p-0"
+                            onClick={() => toggleTargeting(flag.key)}
+                            title="User overrides"
+                          >
+                            <Users className="h-3 w-3 text-muted-foreground" />
+                          </Button>
+                          {toggling === flag.key ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                          ) : flag.enabled ? (
+                            <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                          ) : (
+                            <XCircle className="h-3.5 w-3.5 text-red-500" />
+                          )}
+                        </div>
                       </div>
-                      {flag.description && (
-                        <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-1">
-                          {flag.description}
-                        </p>
+
+                      {/* User Overrides Panel */}
+                      {isTargetingOpen && (
+                        <div className="ml-12 mr-3 mb-2 mt-1 rounded-md border border-border/50 bg-muted/30 p-3 space-y-2">
+                          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                            User Overrides
+                          </p>
+
+                          {overrides.length === 0 && (
+                            <p className="text-[11px] text-muted-foreground">
+                              No per-user overrides. Global value applies to all users.
+                            </p>
+                          )}
+
+                          {overrides.map(([wallet, value]) => (
+                            <div key={wallet} className="flex items-center gap-2 text-xs">
+                              <code className="flex-1 min-w-0 truncate font-mono text-[11px]">
+                                {wallet}
+                              </code>
+                              <Badge
+                                variant={value ? 'default' : 'secondary'}
+                                className="text-[9px] px-1 py-0 shrink-0"
+                              >
+                                {value ? 'ON' : 'OFF'}
+                              </Badge>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-5 w-5 p-0 shrink-0 text-destructive hover:text-destructive"
+                                onClick={() => saveOverride(flag.key, wallet, null)}
+                                disabled={savingOverride}
+                                title="Remove override"
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </Button>
+                            </div>
+                          ))}
+
+                          {/* Add override form */}
+                          <div className="flex items-center gap-2 pt-1 border-t border-border/30">
+                            <Input
+                              placeholder="stake1... or addr1..."
+                              value={newOverrideWallet}
+                              onChange={(e) => setNewOverrideWallet(e.target.value)}
+                              className="h-7 text-[11px] font-mono flex-1"
+                            />
+                            <div className="flex items-center gap-1 shrink-0">
+                              <span className="text-[10px] text-muted-foreground">
+                                {newOverrideEnabled ? 'ON' : 'OFF'}
+                              </span>
+                              <Switch
+                                checked={newOverrideEnabled}
+                                onCheckedChange={setNewOverrideEnabled}
+                                className="scale-75"
+                              />
+                            </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-7 px-2 text-[11px] gap-1 shrink-0"
+                              onClick={() => {
+                                if (newOverrideWallet.trim()) {
+                                  saveOverride(
+                                    flag.key,
+                                    newOverrideWallet.trim(),
+                                    newOverrideEnabled,
+                                  );
+                                }
+                              }}
+                              disabled={!newOverrideWallet.trim() || savingOverride}
+                            >
+                              {savingOverride ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                <Plus className="h-3 w-3" />
+                              )}
+                              Add
+                            </Button>
+                          </div>
+                        </div>
                       )}
                     </div>
-                    <div className="flex items-center shrink-0">
-                      {toggling === flag.key ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                      ) : flag.enabled ? (
-                        <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
-                      ) : (
-                        <XCircle className="h-3.5 w-3.5 text-red-500" />
-                      )}
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
               </CardContent>
             )}
           </Card>

--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -341,7 +341,7 @@ export function GovernadaHeader() {
           'Content-Type': 'application/json',
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
-        body: JSON.stringify({ cohortId: sandboxCohortId }),
+        body: JSON.stringify({ cohortId: sandboxCohortId, edgeCases: true }),
       });
       if (!res.ok) {
         setSandboxActionStatus('Failed to generate scenarios');

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -7,8 +7,10 @@
  * Flags are cached for 60s in memory to avoid per-request DB hits.
  * Toggle instantly via the admin UI at /admin/flags — no redeploy needed.
  *
- * Targeting (future): the `targeting` JSONB column supports per-wallet overrides:
+ * Targeting: the `targeting` JSONB column supports per-wallet overrides:
  *   { "wallets": { "stake1...": true } }  — enable for specific wallet even if globally off
+ * Use getFeatureFlag(key, default, walletAddress) to check per-user targeting.
+ * Use setUserFlagOverride(key, wallet, enabled|null) to manage overrides.
  *
  * ---------------------------------------------------------------------------
  * ACTIVE FLAGS (in feature_flags table, toggleable via /admin/flags)
@@ -89,10 +91,35 @@ async function loadFlags(): Promise<Map<string, boolean>> {
 // Server-side API
 // ---------------------------------------------------------------------------
 
-export async function getFeatureFlag(key: string, defaultValue = true): Promise<boolean> {
+export async function getFeatureFlag(
+  key: string,
+  defaultValue = true,
+  walletAddress?: string,
+): Promise<boolean> {
   const envOverride = process.env[`FF_${key.toUpperCase()}`];
   if (envOverride !== undefined) {
     return envOverride === 'true' || envOverride === '1';
+  }
+
+  // Check per-user targeting before returning global value
+  if (walletAddress) {
+    try {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from('feature_flags')
+        .select('targeting')
+        .eq('key', key)
+        .single();
+
+      if (data?.targeting) {
+        const targeting = data.targeting as { wallets?: Record<string, boolean> };
+        if (targeting.wallets && walletAddress in targeting.wallets) {
+          return targeting.wallets[walletAddress];
+        }
+      }
+    } catch {
+      // Fall through to global value on error
+    }
   }
 
   const flags = await loadFlags();
@@ -141,6 +168,59 @@ export async function setFeatureFlag(key: string, enabled: boolean): Promise<boo
     return true;
   } catch (err) {
     logger.error('[featureFlags] Unexpected error updating flag', { error: err });
+    return false;
+  }
+}
+
+/**
+ * Set or remove a per-user feature flag override.
+ * Pass `enabled: null` to remove the override for this wallet.
+ */
+export async function setUserFlagOverride(
+  key: string,
+  walletAddress: string,
+  enabled: boolean | null,
+): Promise<boolean> {
+  try {
+    const { getSupabaseAdmin } = await import('./supabase');
+    const supabase = getSupabaseAdmin();
+
+    // Read current targeting
+    const { data, error: readError } = await supabase
+      .from('feature_flags')
+      .select('targeting')
+      .eq('key', key)
+      .single();
+
+    if (readError || !data) {
+      logger.error('[featureFlags] Flag not found for targeting update', { key });
+      return false;
+    }
+
+    const targeting = (data.targeting as { wallets?: Record<string, boolean> }) ?? {};
+    const wallets = { ...(targeting.wallets ?? {}) };
+
+    if (enabled === null) {
+      delete wallets[walletAddress];
+    } else {
+      wallets[walletAddress] = enabled;
+    }
+
+    const updatedTargeting = { ...targeting, wallets };
+
+    const { error: writeError } = await supabase
+      .from('feature_flags')
+      .update({ targeting: updatedTargeting, updated_at: new Date().toISOString() })
+      .eq('key', key);
+
+    if (writeError) {
+      logger.error('[featureFlags] Failed to update targeting', { error: writeError.message });
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    logger.error('[featureFlags] Unexpected error updating targeting', { error: err });
     return false;
   }
 }

--- a/lib/preview/scenarios/generator.ts
+++ b/lib/preview/scenarios/generator.ts
@@ -18,6 +18,10 @@ import {
   SCORE_RANGES,
   VERSION_EDIT_SUMMARIES,
   VERSION_NAMES,
+  EDGE_CASE_TITLES,
+  EDGE_CASE_ABSTRACTS,
+  EDGE_CASE_MOTIVATIONS,
+  EDGE_CASE_REVIEWS,
   type ReviewCategory,
   type ReviewerPersona,
 } from './templates';
@@ -96,7 +100,10 @@ function recentTimestamp(maxDaysAgo: number): string {
 // Core generator
 // ---------------------------------------------------------------------------
 
-export async function generateScenario(cohortId: string): Promise<ScenarioResult> {
+export async function generateScenario(
+  cohortId: string,
+  options?: { edgeCases?: boolean },
+): Promise<ScenarioResult> {
   const result: ScenarioResult = {
     proposalsCreated: 0,
     reviewsCreated: 0,
@@ -209,9 +216,15 @@ export async function generateScenario(cohortId: string): Promise<ScenarioResult
     }
   }
 
+  // 7. Append edge case drafts if requested
+  if (options?.edgeCases) {
+    await generateEdgeCaseDrafts(supabase, cohortId, proposalIndex, result);
+  }
+
   logger.info('[scenario-generator] Scenario generation complete', {
     cohortId,
     cohortName: cohort.name,
+    edgeCases: options?.edgeCases ?? false,
     ...result,
   });
 
@@ -470,6 +483,205 @@ function pickReviewCategory(): ReviewCategory {
   if (roll < 0.55) return 'constructive';
   if (roll < 0.8) return 'critical';
   return 'technical';
+}
+
+// ---------------------------------------------------------------------------
+// Edge case generation
+// ---------------------------------------------------------------------------
+
+/** Distribution of edge case drafts across statuses */
+const EDGE_CASE_STAGES: { status: DraftStatus; count: number }[] = [
+  { status: 'draft', count: 2 },
+  { status: 'community_review', count: 2 },
+  { status: 'draft', count: 1 },
+  { status: 'community_review', count: 1 },
+];
+
+async function generateEdgeCaseDrafts(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  cohortId: string,
+  startIndex: number,
+  result: ScenarioResult,
+): Promise<void> {
+  const edgeDraftIds: { id: string; status: DraftStatus; index: number }[] = [];
+
+  let ecIndex = 0;
+  for (const stage of EDGE_CASE_STAGES) {
+    for (let i = 0; i < stage.count; i++) {
+      const draftId = await createEdgeCaseDraft(
+        supabase,
+        stage.status,
+        cohortId,
+        startIndex + ecIndex,
+        ecIndex,
+      );
+
+      if (draftId) {
+        edgeDraftIds.push({ id: draftId, status: stage.status, index: ecIndex });
+        result.proposalsCreated++;
+
+        // Create initial version with edge case content
+        const versionCreated = await createEdgeCaseVersion(supabase, draftId, ecIndex);
+        if (versionCreated) result.versionsCreated++;
+      } else {
+        result.errors.push(
+          `Failed to create edge case draft #${ecIndex} at stage "${stage.status}"`,
+        );
+      }
+
+      ecIndex++;
+    }
+  }
+
+  // Generate edge case reviews on community_review drafts
+  const reviewableDrafts = edgeDraftIds.filter((d) => d.status === 'community_review');
+
+  for (const draft of reviewableDrafts) {
+    // Use 2-3 reviewers with edge case feedback
+    const reviewerCount = randInt(2, 3);
+    const reviewers = pickRandomN(REVIEWER_PERSONAS, reviewerCount);
+
+    for (let r = 0; r < reviewers.length; r++) {
+      const created = await createEdgeCaseReview(supabase, draft.id, reviewers[r], r);
+      if (created) result.reviewsCreated++;
+    }
+  }
+
+  logger.info('[scenario-generator] Edge case drafts generated', {
+    cohortId,
+    edgeDraftsCreated: edgeDraftIds.length,
+  });
+}
+
+async function createEdgeCaseDraft(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  status: DraftStatus,
+  cohortId: string,
+  globalIndex: number,
+  edgeCaseIndex: number,
+): Promise<string | null> {
+  const now = new Date();
+  const createdAt = recentTimestamp(30);
+  const stageEnteredAt = recentTimestamp(14);
+
+  const title = EDGE_CASE_TITLES[edgeCaseIndex % EDGE_CASE_TITLES.length];
+  const abstract = EDGE_CASE_ABSTRACTS[edgeCaseIndex % EDGE_CASE_ABSTRACTS.length];
+  const motivation = EDGE_CASE_MOTIVATIONS[edgeCaseIndex % EDGE_CASE_MOTIVATIONS.length];
+
+  const typeSpecific: { [key: string]: Json | undefined } = {
+    _scenarioSource: {
+      generatedAt: now.toISOString(),
+      edgeCase: true,
+      edgeCaseIndex,
+    },
+  };
+
+  const insertData: Database['public']['Tables']['proposal_drafts']['Insert'] = {
+    owner_stake_address: syntheticOwner(globalIndex),
+    title: title || 'Untitled Proposal',
+    abstract: abstract || '',
+    motivation: motivation || 'Motivation not provided.',
+    rationale: 'Edge case rationale for stress testing.',
+    proposal_type: 'InfoAction',
+    type_specific: typeSpecific,
+    status,
+    current_version: 1,
+    preview_cohort_id: cohortId,
+    created_at: createdAt,
+    stage_entered_at: stageEnteredAt,
+    community_review_started_at: status !== 'draft' ? recentTimestamp(21) : null,
+    fcp_started_at: null,
+    submitted_tx_hash: null,
+    submitted_at: null,
+  };
+
+  const { data, error } = await supabase
+    .from('proposal_drafts')
+    .insert(insertData)
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    logger.error('[scenario-generator] Failed to insert edge case draft', {
+      error: error?.message,
+      edgeCaseIndex,
+      status,
+    });
+    return null;
+  }
+
+  return data.id;
+}
+
+async function createEdgeCaseVersion(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  draftId: string,
+  edgeCaseIndex: number,
+): Promise<boolean> {
+  const title = EDGE_CASE_TITLES[edgeCaseIndex % EDGE_CASE_TITLES.length];
+  const abstract = EDGE_CASE_ABSTRACTS[edgeCaseIndex % EDGE_CASE_ABSTRACTS.length];
+  const motivation = EDGE_CASE_MOTIVATIONS[edgeCaseIndex % EDGE_CASE_MOTIVATIONS.length];
+
+  const content = {
+    title: title || 'Untitled Proposal',
+    abstract: abstract || '',
+    motivation: motivation || 'Motivation not provided.',
+    rationale: 'Edge case rationale for stress testing.',
+    proposalType: 'InfoAction' as const,
+    typeSpecific: {},
+  };
+
+  const { error } = await supabase.from('proposal_draft_versions').insert({
+    draft_id: draftId,
+    version_number: 1,
+    version_name: 'Edge case initial draft',
+    edit_summary: `Edge case draft #${edgeCaseIndex + 1} for stress testing.`,
+    content,
+  });
+
+  if (error) {
+    logger.error('[scenario-generator] Failed to insert edge case version', {
+      error: error.message,
+      draftId,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+async function createEdgeCaseReview(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  draftId: string,
+  reviewer: ReviewerPersona,
+  reviewIndex: number,
+): Promise<boolean> {
+  const feedbackText = EDGE_CASE_REVIEWS[reviewIndex % EDGE_CASE_REVIEWS.length];
+
+  const insertData: Database['public']['Tables']['draft_reviews']['Insert'] = {
+    draft_id: draftId,
+    reviewer_stake_address: reviewer.stakeAddress,
+    feedback_text: feedbackText,
+    feedback_themes: ['edge-case', 'stress-test'],
+    impact_score: randInt(1, 5),
+    feasibility_score: randInt(1, 5),
+    constitutional_score: randInt(1, 5),
+    value_score: randInt(1, 5),
+    created_at: recentTimestamp(14),
+  };
+
+  const { error } = await supabase.from('draft_reviews').insert(insertData);
+
+  if (error) {
+    logger.error('[scenario-generator] Failed to insert edge case review', {
+      error: error.message,
+      draftId,
+      reviewer: reviewer.name,
+    });
+    return false;
+  }
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/preview/scenarios/templates.ts
+++ b/lib/preview/scenarios/templates.ts
@@ -234,3 +234,43 @@ export const VERSION_NAMES: string[] = [
   'Scope clarification',
   'Governance alignment update',
 ];
+
+// ---------------------------------------------------------------------------
+// Edge case content templates for stress testing
+// ---------------------------------------------------------------------------
+
+/** Edge case titles — pathological inputs for UI resilience testing */
+export const EDGE_CASE_TITLES: string[] = [
+  '', // Empty title
+  'A', // Minimal single character
+  'Treasury Withdrawal Proposal \u2014 ' + 'Extended '.repeat(50) + 'Title', // Very long title (~500 chars)
+  '\u63D0\u6848: \u30AC\u30D0\u30CA\u30F3\u30B9\u6539\u5584 \uD83D\uDDF3\uFE0F Governance Am\u00E9lioration', // Unicode + emoji + CJK + diacritics
+  'Proposal with <script>alert("xss")</script> in title', // XSS attempt
+  '   Leading and trailing whitespace   ', // Whitespace
+];
+
+/** Edge case abstracts — boundary-length and special content */
+export const EDGE_CASE_ABSTRACTS: string[] = [
+  '', // Empty abstract
+  'Minimal.', // Very short
+  'Lorem ipsum '.repeat(400), // Very long (~5000 chars)
+  'Line 1\n\nLine 2\n\nLine 3\n\n# Heading\n\n- bullet\n- **bold**\n\n```code```', // Markdown content
+];
+
+/** Edge case motivations — realistic but pathological */
+export const EDGE_CASE_MOTIVATIONS: string[] = [
+  '', // Empty motivation
+  'Because.', // Single word
+  'The governance ecosystem requires ' + 'significant '.repeat(200) + 'improvement.', // Very long
+  'Motivation with special chars: <>&"\' and unicode \u2019\u2018\u201C\u201D\u2014\u2013\u2026', // Special chars and HTML entities
+];
+
+/** Edge case reviews — stress tests for review rendering */
+export const EDGE_CASE_REVIEWS: string[] = [
+  '', // Empty feedback
+  '\uD83D\uDC4D', // Just an emoji
+  'This is an extremely detailed review. '.repeat(100), // Very long review
+  '<img src=x onerror=alert(1)> Review with HTML injection attempt', // HTML injection
+  'Review with\n\n\n\nmultiple\n\n\n\nblank\n\n\n\nlines', // Excessive newlines
+  '| Column 1 | Column 2 |\n|----------|----------|\n| data     | data     |', // Markdown table in review
+];


### PR DESCRIPTION
## Summary
- **Per-user feature flag overrides**: `getFeatureFlag()` now checks per-wallet targeting before returning global value. New `/api/admin/feature-flags/targeting` endpoint. Admin Flags page shows user override management per flag.
- **Edge case scenario data**: 6 pathological templates (empty, max-length, Unicode/emoji, XSS attempts, whitespace, markdown injection) for drafts, abstracts, motivations, and reviews. Sandbox scenarios always include edge cases.
- **Activity trail**: New "Recent Activity" timeline in User State Inspector showing poll votes, draft creation, review submissions, and DRep votes aggregated from database tables.

## Impact
- **What changed**: Admin gets per-user flag control, stress-test data, and user activity visibility
- **User-facing**: No — admin-only features
- **Risk**: Low — `getFeatureFlag()` change is additive (new optional param), edge cases are sandbox-only, activity is read-only
- **Scope**: 9 files (2 new API routes, 7 modified). No migrations.

## Test plan
- [ ] In Flags admin, expand a flag, add a wallet override — verify it appears and can be toggled/removed
- [ ] Enter sandbox, generate scenarios — verify edge case drafts appear with pathological content
- [ ] Inspect a known active user — verify Recent Activity timeline shows their governance actions
- [ ] Verify existing feature flag behavior unchanged (no wallet param = global value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)