### PR TITLE
test: write-path parity + feature flag targeting verification (P3)

### DIFF
--- a/__tests__/admin/feature-flag-targeting.test.ts
+++ b/__tests__/admin/feature-flag-targeting.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Feature Flag Per-User Targeting Tests
+ *
+ * Verifies the targeting logic in getFeatureFlag():
+ * - Global value returned when no wallet provided
+ * - Per-wallet override when wallet matches targeting.wallets
+ * - Falls through to global when wallet not in targeting
+ * - Env var override takes precedence over everything
+ * - setUserFlagOverride manages targeting correctly
+ *
+ * Since feature flags use Supabase, we mock the client at the module level
+ * following the same pattern as __tests__/api/health.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock Supabase — matches existing project pattern
+// ---------------------------------------------------------------------------
+
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+
+vi.mock('@/lib/supabase', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: (...args: unknown[]) => {
+        mockSelect(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => {
+            mockEq(...eqArgs);
+            return {
+              single: () => mockSingle(),
+            };
+          },
+          order: () => ({
+            order: () => ({
+              // For getAllFlags chain
+            }),
+          }),
+        };
+      },
+    }),
+  }),
+  getSupabaseAdmin: () => ({
+    from: () => ({
+      select: (...args: unknown[]) => {
+        mockSelect(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => {
+            mockEq(...eqArgs);
+            return {
+              single: () => mockSingle(),
+            };
+          },
+        };
+      },
+      update: (...args: unknown[]) => {
+        mockUpdate(...args);
+        return {
+          eq: () => mockUpdate(),
+        };
+      },
+    }),
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { getFeatureFlag, invalidateFlagCache } from '@/lib/featureFlags';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Feature Flag Targeting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateFlagCache();
+    // Clear any env overrides
+    delete process.env.FF_TEST_FLAG;
+  });
+
+  afterEach(() => {
+    delete process.env.FF_TEST_FLAG;
+  });
+
+  describe('Global flag value (no wallet)', () => {
+    it('returns default value when flag is not in cache or DB', async () => {
+      // loadFlags returns empty map (no data)
+      mockSelect.mockReturnValue({
+        eq: () => ({ single: () => Promise.resolve({ data: null, error: null }) }),
+        order: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+      });
+
+      // First call goes to loadFlags which hits supabase select
+      // Since we can't easily mock the full chain for loadFlags,
+      // test the env override path and structural constraints instead
+      const result = await getFeatureFlag('nonexistent_flag', false);
+      // Default value is false
+      expect(result).toBe(false);
+    });
+
+    it('env var override takes precedence over everything', async () => {
+      process.env.FF_TEST_FLAG = 'true';
+      const result = await getFeatureFlag('test_flag', false);
+      expect(result).toBe(true);
+    });
+
+    it('env var "1" is treated as true', async () => {
+      process.env.FF_TEST_FLAG = '1';
+      const result = await getFeatureFlag('test_flag', false);
+      expect(result).toBe(true);
+    });
+
+    it('env var "false" is treated as false', async () => {
+      process.env.FF_TEST_FLAG = 'false';
+      const result = await getFeatureFlag('test_flag', true);
+      expect(result).toBe(false);
+    });
+
+    it('env var "0" is treated as false', async () => {
+      process.env.FF_TEST_FLAG = '0';
+      const result = await getFeatureFlag('test_flag', true);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Per-wallet targeting', () => {
+    it('returns per-wallet override when wallet is in targeting.wallets', async () => {
+      const walletAddress = 'stake1_test_wallet_abc';
+
+      // Mock the targeting lookup: supabase.from().select('targeting').eq().single()
+      mockSingle.mockResolvedValue({
+        data: {
+          targeting: {
+            wallets: { [walletAddress]: true },
+          },
+        },
+        error: null,
+      });
+
+      const result = await getFeatureFlag('test_flag', false, walletAddress);
+      // Per-wallet override is true, even though default is false
+      expect(result).toBe(true);
+    });
+
+    it('returns false per-wallet override even when default is true', async () => {
+      const walletAddress = 'stake1_disabled_wallet';
+
+      mockSingle.mockResolvedValue({
+        data: {
+          targeting: {
+            wallets: { [walletAddress]: false },
+          },
+        },
+        error: null,
+      });
+
+      const result = await getFeatureFlag('test_flag', true, walletAddress);
+      // Per-wallet override is false, overriding default true
+      expect(result).toBe(false);
+    });
+
+    it('falls through to global when wallet is not in targeting.wallets', async () => {
+      const walletAddress = 'stake1_not_targeted';
+
+      mockSingle.mockResolvedValue({
+        data: {
+          targeting: {
+            wallets: { stake1_other_wallet: true },
+          },
+        },
+        error: null,
+      });
+
+      // Falls through to loadFlags -> default value
+      const result = await getFeatureFlag('test_flag', false, walletAddress);
+      expect(result).toBe(false);
+    });
+
+    it('falls through to global when targeting has no wallets key', async () => {
+      const walletAddress = 'stake1_any';
+
+      mockSingle.mockResolvedValue({
+        data: {
+          targeting: {},
+        },
+        error: null,
+      });
+
+      const result = await getFeatureFlag('test_flag', true, walletAddress);
+      expect(result).toBe(true);
+    });
+
+    it('falls through to global when targeting is null', async () => {
+      const walletAddress = 'stake1_any';
+
+      mockSingle.mockResolvedValue({
+        data: { targeting: null },
+        error: null,
+      });
+
+      const result = await getFeatureFlag('test_flag', true, walletAddress);
+      expect(result).toBe(true);
+    });
+
+    it('falls through to global when targeting lookup errors', async () => {
+      const walletAddress = 'stake1_error_case';
+
+      mockSingle.mockRejectedValue(new Error('DB connection lost'));
+
+      const result = await getFeatureFlag('test_flag', false, walletAddress);
+      // Should not throw, falls through to global (default)
+      expect(result).toBe(false);
+    });
+
+    it('env var still takes precedence over per-wallet targeting', async () => {
+      const walletAddress = 'stake1_targeted';
+      process.env.FF_TEST_FLAG = 'false';
+
+      // Even with targeting set to true for this wallet, env var wins
+      mockSingle.mockResolvedValue({
+        data: {
+          targeting: { wallets: { [walletAddress]: true } },
+        },
+        error: null,
+      });
+
+      const result = await getFeatureFlag('test_flag', true, walletAddress);
+      expect(result).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Architectural constraints for targeting
+// ---------------------------------------------------------------------------
+
+describe('Feature Flag Targeting Architecture', () => {
+  it('getFeatureFlag accepts optional walletAddress parameter', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    // Function signature must accept walletAddress as 3rd parameter
+    expect(content).toContain('walletAddress?: string');
+  });
+
+  it('targeting uses JSONB wallets map pattern', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    // Targeting structure: { wallets: { "stake1...": true/false } }
+    expect(content).toContain('targeting.wallets');
+    expect(content).toContain('walletAddress in targeting.wallets');
+  });
+
+  it('setUserFlagOverride is exported for managing per-wallet overrides', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    expect(content).toContain('export async function setUserFlagOverride');
+    // Must accept null to remove an override
+    expect(content).toContain('enabled: boolean | null');
+  });
+
+  it('setUserFlagOverride deletes wallet entry when enabled is null', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    // When enabled is null, the wallet key should be deleted from targeting
+    expect(content).toContain('delete wallets[walletAddress]');
+  });
+
+  it('FeatureFlag type includes targeting field', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    expect(content).toContain('targeting: Record<string, unknown>');
+  });
+
+  it('env var override is checked before targeting and cache', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/featureFlags.ts', 'utf-8');
+
+    // The env override block should appear before the targeting block
+    const envOverridePos = content.indexOf('FF_${key.toUpperCase()}');
+    const targetingPos = content.indexOf('Check per-user targeting');
+
+    expect(envOverridePos).toBeGreaterThan(-1);
+    expect(targetingPos).toBeGreaterThan(-1);
+    expect(envOverridePos).toBeLessThan(targetingPos);
+  });
+});

--- a/__tests__/admin/sandbox-parity.test.ts
+++ b/__tests__/admin/sandbox-parity.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Sandbox Write-Path Parity Tests
+ *
+ * Verifies that sandbox mode (X-Sandbox-Cohort header) uses identical code
+ * paths to production — only the cohort filter differs. Tests cover:
+ *
+ * 1. Sandbox utility functions (getSandboxHeaders, constants)
+ * 2. Architectural constraints (sandbox support wired in all write endpoints)
+ * 3. SegmentProvider sandbox state management
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getSandboxHeaders,
+  SANDBOX_DESCRIPTION_PREFIX,
+  SANDBOX_STORAGE_KEY,
+} from '@/lib/admin/sandbox';
+
+// ---------------------------------------------------------------------------
+// 1. Sandbox utility functions
+// ---------------------------------------------------------------------------
+
+describe('Sandbox Utilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getSandboxHeaders', () => {
+    it('returns empty object when running server-side (no window)', () => {
+      // In Node test environment, window is undefined by default
+      const headers = getSandboxHeaders();
+      expect(headers).toEqual({});
+    });
+
+    it('returns empty object when no sandbox is active', () => {
+      vi.stubGlobal('window', {});
+      vi.stubGlobal('sessionStorage', {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+      });
+
+      const headers = getSandboxHeaders();
+      expect(headers).toEqual({});
+    });
+
+    it('returns X-Sandbox-Cohort header when sandbox is active', () => {
+      const cohortId = 'test-cohort-abc-123';
+      vi.stubGlobal('window', {});
+      vi.stubGlobal('sessionStorage', {
+        getItem: (key: string) => (key === SANDBOX_STORAGE_KEY ? cohortId : null),
+        setItem: () => {},
+        removeItem: () => {},
+      });
+
+      const headers = getSandboxHeaders();
+      expect(headers).toEqual({ 'X-Sandbox-Cohort': cohortId });
+    });
+
+    it('returns empty object when sessionStorage throws', () => {
+      vi.stubGlobal('window', {});
+      vi.stubGlobal('sessionStorage', {
+        getItem: () => {
+          throw new Error('SecurityError: access denied');
+        },
+        setItem: () => {},
+        removeItem: () => {},
+      });
+
+      const headers = getSandboxHeaders();
+      expect(headers).toEqual({});
+    });
+  });
+
+  describe('Constants', () => {
+    it('SANDBOX_DESCRIPTION_PREFIX is the expected marker', () => {
+      expect(SANDBOX_DESCRIPTION_PREFIX).toBe('[ADMIN_SANDBOX]');
+    });
+
+    it('SANDBOX_STORAGE_KEY is the expected key', () => {
+      expect(SANDBOX_STORAGE_KEY).toBe('governada_sandbox');
+    });
+
+    it('SANDBOX_STORAGE_KEY matches the key used in getSandboxHeaders', () => {
+      // Ensures the storage key constant is the same one getSandboxHeaders reads from
+      const cohortId = 'verify-key-match';
+      vi.stubGlobal('window', {});
+      vi.stubGlobal('sessionStorage', {
+        getItem: (key: string) => (key === 'governada_sandbox' ? cohortId : null),
+        setItem: () => {},
+        removeItem: () => {},
+      });
+
+      const headers = getSandboxHeaders();
+      expect(headers['X-Sandbox-Cohort']).toBe(cohortId);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Architectural constraints — verify sandbox wiring in endpoints
+// ---------------------------------------------------------------------------
+
+describe('Sandbox Architectural Constraints', () => {
+  /**
+   * These tests read source files to verify that sandbox support remains
+   * wired into every write-path endpoint. If someone removes the sandbox
+   * header check from an endpoint, these tests catch the regression.
+   */
+
+  it('drafts route reads x-sandbox-cohort header', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('app/api/workspace/drafts/route.ts', 'utf-8');
+
+    // Both GET (read scoping) and POST (write scoping) must support sandbox
+    expect(content).toContain('x-sandbox-cohort');
+    expect(content).toContain('SANDBOX_DESCRIPTION_PREFIX');
+  });
+
+  it('drafts POST scopes writes to preview_cohort_id', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('app/api/workspace/drafts/route.ts', 'utf-8');
+
+    // The write path must set preview_cohort_id when sandbox is active
+    expect(content).toContain('preview_cohort_id');
+    // Must verify sandbox cohort is a valid admin sandbox before writing
+    expect(content).toContain('SANDBOX_DESCRIPTION_PREFIX');
+  });
+
+  it('reviews route has sandbox support for both read and write', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile(
+      'app/api/workspace/drafts/[draftId]/reviews/route.ts',
+      'utf-8',
+    );
+
+    // GET: sandbox scoping for reads
+    expect(content).toContain('x-sandbox-cohort');
+    // POST: sandbox validation for writes
+    expect(content).toContain('SANDBOX_DESCRIPTION_PREFIX');
+  });
+
+  it('reviews POST validates sandbox cohort before allowing writes', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile(
+      'app/api/workspace/drafts/[draftId]/reviews/route.ts',
+      'utf-8',
+    );
+
+    // Must verify cohort description starts with SANDBOX_DESCRIPTION_PREFIX
+    // Returns 403 if cohort is invalid — prevents arbitrary cohort header injection
+    expect(content).toContain('Invalid sandbox cohort');
+    expect(content).toContain('403');
+  });
+
+  it('sandbox utility module exports all required symbols', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('lib/admin/sandbox.ts', 'utf-8');
+
+    // Must export the header builder function
+    expect(content).toContain('export function getSandboxHeaders');
+    // Must export the storage key constant
+    expect(content).toContain('export const SANDBOX_STORAGE_KEY');
+    // Must export the description prefix constant
+    expect(content).toContain('export const SANDBOX_DESCRIPTION_PREFIX');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. SegmentProvider sandbox state
+// ---------------------------------------------------------------------------
+
+describe('SegmentProvider Sandbox Integration', () => {
+  it('exports sandbox state fields', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('components/providers/SegmentProvider.tsx', 'utf-8');
+
+    // State fields
+    expect(content).toContain('sandboxCohortId');
+    // Actions
+    expect(content).toContain('enterSandbox');
+    expect(content).toContain('exitSandbox');
+  });
+
+  it('SegmentProvider imports SANDBOX_STORAGE_KEY from sandbox module', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('components/providers/SegmentProvider.tsx', 'utf-8');
+
+    // Must import the constant, not hardcode the string
+    expect(content).toContain("from '@/lib/admin/sandbox'");
+    expect(content).toContain('SANDBOX_STORAGE_KEY');
+  });
+
+  it('SegmentProvider persists sandbox state to sessionStorage', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('components/providers/SegmentProvider.tsx', 'utf-8');
+
+    // enterSandbox must write to sessionStorage
+    expect(content).toContain('sessionStorage.setItem(SANDBOX_STORAGE_KEY');
+    // exitSandbox must clear sessionStorage
+    expect(content).toContain('sessionStorage.removeItem(SANDBOX_STORAGE_KEY');
+  });
+
+  it('SegmentProvider restores sandbox state on mount', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('components/providers/SegmentProvider.tsx', 'utf-8');
+
+    // Must read sessionStorage on mount to restore sandbox state across navigation
+    expect(content).toContain('sessionStorage.getItem(SANDBOX_STORAGE_KEY');
+  });
+
+  it('SegmentState type includes sandbox fields', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('components/providers/SegmentProvider.tsx', 'utf-8');
+
+    // Type definition must include sandbox fields
+    expect(content).toContain('sandboxCohortId: string | null');
+    expect(content).toContain('enterSandbox: (cohortId: string) => void');
+    expect(content).toContain('exitSandbox: () => void');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Write-path parity invariant
+// ---------------------------------------------------------------------------
+
+describe('Write-Path Parity Invariant', () => {
+  /**
+   * The key invariant: sandbox mode uses identical code paths to production.
+   * Only the cohort filter differs. These tests verify this by checking that
+   * sandbox endpoints do NOT have separate code branches for sandbox-specific
+   * business logic — they only add a filter/tag.
+   */
+
+  it('drafts route uses same insert for sandbox and production (only adds preview_cohort_id)', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('app/api/workspace/drafts/route.ts', 'utf-8');
+
+    // There should be exactly ONE insert call for proposal_drafts
+    // (not a separate sandbox insert and production insert)
+    const insertMatches = content.match(/\.insert\(/g);
+    // One for drafts, one for versions = 2 total inserts
+    expect(insertMatches).not.toBeNull();
+    expect(insertMatches!.length).toBeLessThanOrEqual(2);
+
+    // The insert should conditionally spread preview_cohort_id, not have a separate path
+    expect(content).toContain('preview_cohort_id');
+  });
+
+  it('reviews route uses same insert for sandbox and production', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile(
+      'app/api/workspace/drafts/[draftId]/reviews/route.ts',
+      'utf-8',
+    );
+
+    // Should be exactly ONE insert for draft_reviews
+    const insertMatches = content.match(/\.insert\(/g);
+    expect(insertMatches).not.toBeNull();
+    expect(insertMatches!.length).toBe(1);
+  });
+
+  it('drafts GET uses .or() filter for sandbox — not a separate query', async () => {
+    const fs = await import('fs/promises');
+    const content = await fs.readFile('app/api/workspace/drafts/route.ts', 'utf-8');
+
+    // Sandbox read scoping uses .or() to combine sandbox + real data
+    // rather than a completely different query
+    expect(content).toContain('.or(');
+    expect(content).toContain('preview_cohort_id.is.null');
+  });
+});


### PR DESCRIPTION
## Summary
- **Sandbox parity tests** (20): Verify `getSandboxHeaders` utility, architectural constraints (workspace endpoints have sandbox support), SegmentProvider sandbox integration, and the core invariant — sandbox uses identical write paths to production (single insert call, `.or()` filters, no separate code branches).
- **Feature flag targeting tests** (18): Per-wallet override logic with Supabase mocks, env var precedence over targeting, fallthrough to global value, structural verification of `getFeatureFlag` signature and `setUserFlagOverride` exports.
- **Test count**: 825 tests across 55 files (38 new)

## Impact
- **What changed**: Test coverage for the admin testing framework's core invariants
- **User-facing**: No — test files only
- **Risk**: None — additive tests, no production code changes
- **Scope**: 2 new test files

## Test plan
- [x] All 825 tests pass locally
- [x] Preflight clean (format + lint + types + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)