### PR TITLE
feat: portfolio integration — wire mutations, team drafts, lineage, transfer dialog

### DIFF
--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -17,6 +17,7 @@ import { useSaveStatus } from '@/lib/workspace/save-status';
 import { useParams, useRouter } from 'next/navigation';
 import { useSyncEntityToURL } from '@/hooks/useSyncEntityToURL';
 import { useDraft, useUpdateDraft } from '@/hooks/useDrafts';
+import { useQuery } from '@tanstack/react-query';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useAgent } from '@/hooks/useAgent';
 import { useFeedbackThemes } from '@/hooks/useFeedbackThemes';
@@ -46,6 +47,64 @@ import type {
   SlashCommandType,
 } from '@/lib/workspace/editor/types';
 import type { Editor } from '@tiptap/core';
+
+// ---------------------------------------------------------------------------
+// LineageBanner — shows "Based on: [title]" if this draft supersedes another
+// ---------------------------------------------------------------------------
+
+function LineageBanner({ supersedesId }: { supersedesId: string }) {
+  const { data, isLoading } = useQuery<{ draft: { title: string; status: string } }>({
+    queryKey: ['author-draft-lineage', supersedesId],
+    queryFn: async () => {
+      const headers: Record<string, string> = {};
+      try {
+        const { getStoredSession } = await import('@/lib/supabaseAuth');
+        const token = getStoredSession();
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+      } catch {
+        // No session
+      }
+      const res = await fetch(`/api/workspace/drafts/${encodeURIComponent(supersedesId)}`, {
+        headers,
+      });
+      if (!res.ok) throw new Error('Source draft not found');
+      return res.json();
+    },
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  if (isLoading) return null;
+
+  const sourceTitle = data?.draft?.title;
+  const sourceStatus = data?.draft?.status;
+
+  return (
+    <div className="border-l-2 border-teal-500/60 pl-3 py-1.5 mb-4">
+      <p className="text-xs text-muted-foreground">
+        <span className="mr-1">{'\u21A9'}</span>
+        Based on:{' '}
+        {sourceTitle ? (
+          <>
+            <a
+              href={`/workspace/author/${supersedesId}`}
+              className="text-teal-400 hover:text-teal-300 underline underline-offset-2"
+            >
+              {sourceTitle}
+            </a>
+            {sourceStatus && (
+              <span className="ml-1.5 text-muted-foreground/70">
+                ({sourceStatus.replace(/_/g, ' ')})
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="italic">a previous draft</span>
+        )}
+      </p>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // AuthorPanelWrapper — thin wrapper that connects StudioPanel to StudioProvider
@@ -392,6 +451,7 @@ function WorkspaceEditorPage() {
           }
           main={
             <div className="max-w-3xl mx-auto px-6 py-6">
+              {draft.supersedesId && <LineageBanner supersedesId={draft.supersedesId} />}
               <ProposalEditor
                 content={content}
                 mode={mode}

--- a/components/workspace/author/AuthorWorkspace.tsx
+++ b/components/workspace/author/AuthorWorkspace.tsx
@@ -4,10 +4,11 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { FeatureGate, useFeatureFlag } from '@/components/FeatureGate';
-import { useDrafts, useCreateDraft } from '@/hooks/useDrafts';
+import { useDrafts, useCreateDraft, useTeamDrafts } from '@/hooks/useDrafts';
 import { useRegisterDraftListCommands } from '@/hooks/useRegisterDraftListCommands';
 import { PortfolioView } from './PortfolioView';
 import { PortfolioSearch } from './PortfolioSearch';
+import { TeamProposalsSection } from './TeamProposalsSection';
 import { TypeSelectorDialog } from './TypeSelectorDialog';
 import { AmendmentEntryDialog } from './AmendmentEntryDialog';
 import { Button } from '@/components/ui/button';
@@ -17,7 +18,9 @@ import type { ProposalType } from '@/lib/workspace/types';
 function AuthorWorkspaceInner() {
   const router = useRouter();
   const { stakeAddress } = useSegment();
-  const { data, isLoading } = useDrafts(stakeAddress);
+  const [showArchived, setShowArchived] = useState(false);
+  const { data, isLoading } = useDrafts(stakeAddress, { includeArchived: showArchived });
+  const { data: teamData, isLoading: teamLoading } = useTeamDrafts(stakeAddress);
   const createDraft = useCreateDraft();
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -25,7 +28,6 @@ function AuthorWorkspaceInner() {
   const [pendingAmendmentType, setPendingAmendmentType] = useState<'direct' | 'intent' | null>(
     null,
   );
-  const [showArchived, setShowArchived] = useState(false);
 
   const constitutionEditorFlag = useFeatureFlag('author_constitution_editor');
 
@@ -107,6 +109,8 @@ function AuthorWorkspaceInner() {
         isLoading={isLoading}
         showArchived={showArchived}
       />
+
+      <TeamProposalsSection drafts={teamData?.drafts ?? []} isLoading={teamLoading} />
 
       <TypeSelectorDialog
         open={selectorOpen}

--- a/components/workspace/author/DraftQuickActions.tsx
+++ b/components/workspace/author/DraftQuickActions.tsx
@@ -32,6 +32,7 @@ import {
   useDeleteDraft,
   useExportDraft,
 } from '@/hooks/useDraftActions';
+import { TransferDialog } from './TransferDialog';
 import type { ProposalDraft, DraftStatus } from '@/lib/workspace/types';
 
 // ---------------------------------------------------------------------------
@@ -76,6 +77,7 @@ function canTransfer(status: DraftStatus): boolean {
 export function DraftQuickActions({ draft, router }: DraftQuickActionsProps) {
   const [open, setOpen] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [transferOpen, setTransferOpen] = useState(false);
   const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const archiveMutation = useArchiveDraft(draft.ownerStakeAddress);
@@ -144,116 +146,126 @@ export function DraftQuickActions({ draft, router }: DraftQuickActionsProps) {
   );
 
   const handleTransfer = useCallback(() => {
-    // TODO: Transfer ownership — open dialog when API endpoint is ready
     setOpen(false);
+    setTransferOpen(true);
   }, []);
 
   const isSubmitted = draft.status === 'submitted';
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="h-6 w-6 text-muted-foreground hover:text-foreground"
-          aria-label="Draft actions"
-        >
-          <MoreHorizontal className="h-4 w-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        {/* Edit */}
-        {canEdit(draft.status) && (
-          <DropdownMenuItem onSelect={handleEdit}>
-            <Pencil className="h-4 w-4" />
-            Edit
-            <DropdownMenuShortcut>Enter</DropdownMenuShortcut>
-          </DropdownMenuItem>
-        )}
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="h-6 w-6 text-muted-foreground hover:text-foreground"
+            aria-label="Draft actions"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {/* Edit */}
+          {canEdit(draft.status) && (
+            <DropdownMenuItem onSelect={handleEdit}>
+              <Pencil className="h-4 w-4" />
+              Edit
+              <DropdownMenuShortcut>Enter</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          )}
 
-        {/* Duplicate / Fork & Revise */}
-        <DropdownMenuItem onSelect={handleDuplicate}>
-          {isSubmitted ? (
+          {/* Duplicate / Fork & Revise */}
+          <DropdownMenuItem onSelect={handleDuplicate}>
+            {isSubmitted ? (
+              <>
+                <GitFork className="h-4 w-4" />
+                Fork &amp; Revise
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4" />
+                Duplicate
+              </>
+            )}
+            <DropdownMenuShortcut>d</DropdownMenuShortcut>
+          </DropdownMenuItem>
+
+          {/* Archive */}
+          {canArchive(draft.status) && (
+            <DropdownMenuItem onSelect={handleArchive}>
+              <Archive className="h-4 w-4" />
+              Archive
+              <DropdownMenuShortcut>a</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          )}
+
+          {/* Unarchive */}
+          {canUnarchive(draft.status) && (
+            <DropdownMenuItem onSelect={handleUnarchive}>
+              <ArchiveRestore className="h-4 w-4" />
+              Unarchive
+            </DropdownMenuItem>
+          )}
+
+          {/* Export sub-menu */}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Download className="h-4 w-4" />
+              Export
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem onSelect={() => handleExport('markdown')}>
+                Markdown
+                <DropdownMenuShortcut>e</DropdownMenuShortcut>
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => handleExport('cip108')}>
+                CIP-108 JSON
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          {/* Transfer */}
+          {canTransfer(draft.status) && (
             <>
-              <GitFork className="h-4 w-4" />
-              Fork &amp; Revise
-            </>
-          ) : (
-            <>
-              <Copy className="h-4 w-4" />
-              Duplicate
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={handleTransfer}>
+                <ArrowRightLeft className="h-4 w-4" />
+                Transfer Ownership
+              </DropdownMenuItem>
             </>
           )}
-          <DropdownMenuShortcut>d</DropdownMenuShortcut>
-        </DropdownMenuItem>
 
-        {/* Archive */}
-        {canArchive(draft.status) && (
-          <DropdownMenuItem onSelect={handleArchive}>
-            <Archive className="h-4 w-4" />
-            Archive
-            <DropdownMenuShortcut>a</DropdownMenuShortcut>
-          </DropdownMenuItem>
-        )}
+          {/* Delete (draft status only) */}
+          {canDelete(draft.status) && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={(e) => {
+                  // Prevent menu from closing on first click
+                  if (!deleteConfirm) {
+                    e.preventDefault();
+                  }
+                  handleDelete();
+                }}
+              >
+                <Trash2 className="h-4 w-4" />
+                {deleteConfirm ? 'Click again to delete' : 'Delete'}
+                {!deleteConfirm && <DropdownMenuShortcut>x</DropdownMenuShortcut>}
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-        {/* Unarchive */}
-        {canUnarchive(draft.status) && (
-          <DropdownMenuItem onSelect={handleUnarchive}>
-            <ArchiveRestore className="h-4 w-4" />
-            Unarchive
-          </DropdownMenuItem>
-        )}
-
-        {/* Export sub-menu */}
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <Download className="h-4 w-4" />
-            Export
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            <DropdownMenuItem onSelect={() => handleExport('markdown')}>
-              Markdown
-              <DropdownMenuShortcut>e</DropdownMenuShortcut>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => handleExport('cip108')}>
-              CIP-108 JSON
-            </DropdownMenuItem>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-
-        {/* Transfer */}
-        {canTransfer(draft.status) && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleTransfer}>
-              <ArrowRightLeft className="h-4 w-4" />
-              Transfer Ownership
-            </DropdownMenuItem>
-          </>
-        )}
-
-        {/* Delete (draft status only) */}
-        {canDelete(draft.status) && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              variant="destructive"
-              onSelect={(e) => {
-                // Prevent menu from closing on first click
-                if (!deleteConfirm) {
-                  e.preventDefault();
-                }
-                handleDelete();
-              }}
-            >
-              <Trash2 className="h-4 w-4" />
-              {deleteConfirm ? 'Click again to delete' : 'Delete'}
-              {!deleteConfirm && <DropdownMenuShortcut>x</DropdownMenuShortcut>}
-            </DropdownMenuItem>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      <TransferDialog
+        open={transferOpen}
+        onOpenChange={setTransferOpen}
+        draftId={draft.id}
+        draftTitle={draft.title}
+        ownerStakeAddress={draft.ownerStakeAddress}
+      />
+    </>
   );
 }

--- a/components/workspace/author/TeamProposalsSection.tsx
+++ b/components/workspace/author/TeamProposalsSection.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronRight, Users } from 'lucide-react';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import type { ProposalDraft, ProposalType } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TeamDraft extends ProposalDraft {
+  memberRole?: string;
+}
+
+interface TeamProposalsSectionProps {
+  drafts: TeamDraft[];
+  isLoading: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const date = new Date(dateStr).getTime();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 16) return address;
+  return `${address.slice(0, 8)}...${address.slice(-6)}`;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  lead: 'Lead',
+  editor: 'Editor',
+  viewer: 'Viewer',
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  lead: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+  editor: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  viewer: 'bg-muted text-muted-foreground',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TeamProposalsSection({ drafts, isLoading }: TeamProposalsSectionProps) {
+  const [expanded, setExpanded] = useState(drafts.length > 0);
+
+  // Don't render if loading and no previous data, or if there are no team drafts
+  if (isLoading && drafts.length === 0) return null;
+  if (!isLoading && drafts.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {/* Section header */}
+      <Button
+        variant="ghost"
+        className="flex items-center gap-2 px-1 h-auto py-1 hover:bg-transparent"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+        )}
+        <Users className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-muted-foreground">Team Proposals</span>
+        <Badge variant="secondary" className="text-xs tabular-nums">
+          {drafts.length}
+        </Badge>
+      </Button>
+
+      {/* Content */}
+      {expanded && (
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: 'var(--workspace-gap)' }}>
+          {drafts.map((draft) => (
+            <TeamDraftCard key={draft.id} draft={draft} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Team Draft Card
+// ---------------------------------------------------------------------------
+
+function TeamDraftCard({ draft }: { draft: TeamDraft }) {
+  const role = draft.memberRole ?? 'viewer';
+  const canEdit = role === 'lead' || role === 'editor';
+  const editorPath = canEdit
+    ? draft.proposalType === 'NewConstitution'
+      ? `/workspace/amendment/${draft.id}`
+      : `/workspace/author/${draft.id}`
+    : `/workspace/author/${draft.id}`;
+
+  return (
+    <Card className="h-full hover:bg-accent/50 transition-colors">
+      <Link href={editorPath} className="block cursor-pointer">
+        <CardContent className="space-y-3" style={{ padding: 'var(--workspace-card-padding)' }}>
+          {/* Title */}
+          <h3
+            className="font-medium line-clamp-2"
+            style={{
+              fontSize: 'var(--workspace-font-size)',
+              lineHeight: 'var(--workspace-line-height)',
+            }}
+          >
+            {draft.title || 'Untitled Draft'}
+          </h3>
+
+          {/* Badges row */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="outline" className="text-xs">
+              {PROPOSAL_TYPE_LABELS[draft.proposalType as ProposalType] ?? draft.proposalType}
+            </Badge>
+            <Badge className={`text-xs ${ROLE_COLORS[role] ?? ROLE_COLORS.viewer}`}>
+              {ROLE_LABELS[role] ?? role}
+            </Badge>
+          </div>
+
+          {/* Owner + updated time */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-muted-foreground font-mono">
+              {truncateAddress(draft.ownerStakeAddress)}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatRelativeTime(draft.updatedAt)}
+            </span>
+          </div>
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}

--- a/components/workspace/author/TransferDialog.tsx
+++ b/components/workspace/author/TransferDialog.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useTransferDraft } from '@/hooks/useDraftActions';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface TransferDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draftId: string;
+  draftTitle: string;
+  ownerStakeAddress: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TransferDialog({
+  open,
+  onOpenChange,
+  draftId,
+  draftTitle,
+  ownerStakeAddress,
+}: TransferDialogProps) {
+  const [newOwner, setNewOwner] = useState('');
+  const transferMutation = useTransferDraft(ownerStakeAddress);
+
+  const handleTransfer = () => {
+    if (!newOwner.trim()) return;
+    transferMutation.mutate(
+      { draftId, newOwnerStakeAddress: newOwner.trim() },
+      {
+        onSuccess: () => {
+          setNewOwner('');
+          onOpenChange(false);
+        },
+      },
+    );
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setNewOwner('');
+    }
+    onOpenChange(next);
+  };
+
+  const isValid = newOwner.trim().length > 0 && newOwner.trim() !== ownerStakeAddress;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Transfer Ownership</DialogTitle>
+          <DialogDescription>
+            Transfer &ldquo;{draftTitle || 'Untitled Draft'}&rdquo; to a new owner. This action
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          <Label htmlFor="new-owner-address">New owner stake address</Label>
+          <Input
+            id="new-owner-address"
+            placeholder="stake1..."
+            value={newOwner}
+            onChange={(e) => setNewOwner(e.target.value)}
+            className="font-mono text-sm"
+          />
+          {newOwner.trim() === ownerStakeAddress && (
+            <p className="text-xs text-destructive">Cannot transfer to the current owner.</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={transferMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleTransfer} disabled={!isValid || transferMutation.isPending}>
+            {transferMutation.isPending ? 'Transferring...' : 'Transfer'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hooks/useDraftActions.ts
+++ b/hooks/useDraftActions.ts
@@ -82,33 +82,36 @@ async function fetchBlobWithAuth(url: string): Promise<Blob> {
 
 export function useArchiveDraft(stakeAddress: string | null) {
   const queryClient = useQueryClient();
+  const queryFilter = { queryKey: ['author-drafts', stakeAddress] };
 
-  return useMutation<{ draft: ProposalDraft }, Error, { draftId: string }, { previous: unknown }>({
+  return useMutation<
+    { draft: ProposalDraft },
+    Error,
+    { draftId: string },
+    { snapshots: [readonly unknown[], unknown][] }
+  >({
     mutationFn: ({ draftId }) =>
       patchJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}/stage`, {
         targetStatus: 'archived',
       }),
 
     onMutate: async ({ draftId }) => {
-      const queryKey = ['author-drafts', stakeAddress];
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries(queryFilter);
+      const snapshots = queryClient.getQueriesData<{ drafts: ProposalDraft[] }>(queryFilter);
 
-      // Optimistically remove from the list (archived items are excluded by default)
-      queryClient.setQueryData(queryKey, (old: { drafts: ProposalDraft[] } | undefined) => {
+      // Optimistically remove from all matching draft lists
+      queryClient.setQueriesData<{ drafts: ProposalDraft[] }>(queryFilter, (old) => {
         if (!old) return old;
-        return {
-          drafts: old.drafts.filter((d) => d.id !== draftId),
-        };
+        return { drafts: old.drafts.filter((d) => d.id !== draftId) };
       });
 
-      return { previous };
+      return { snapshots };
     },
 
     onError: (_err, _vars, context) => {
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(['author-drafts', stakeAddress], context.previous);
-      }
+      context?.snapshots.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
       toastError('Failed to archive draft');
     },
 
@@ -117,7 +120,7 @@ export function useArchiveDraft(stakeAddress: string | null) {
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['author-drafts', stakeAddress] });
+      queryClient.invalidateQueries(queryFilter);
     },
   });
 }
@@ -128,20 +131,25 @@ export function useArchiveDraft(stakeAddress: string | null) {
 
 export function useUnarchiveDraft(stakeAddress: string | null) {
   const queryClient = useQueryClient();
+  const queryFilter = { queryKey: ['author-drafts', stakeAddress] };
 
-  return useMutation<{ draft: ProposalDraft }, Error, { draftId: string }, { previous: unknown }>({
+  return useMutation<
+    { draft: ProposalDraft },
+    Error,
+    { draftId: string },
+    { snapshots: [readonly unknown[], unknown][] }
+  >({
     mutationFn: ({ draftId }) =>
       patchJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}/stage`, {
         targetStatus: 'draft',
       }),
 
     onMutate: async ({ draftId }) => {
-      const queryKey = ['author-drafts', stakeAddress];
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries(queryFilter);
+      const snapshots = queryClient.getQueriesData<{ drafts: ProposalDraft[] }>(queryFilter);
 
       // Optimistically set status to draft
-      queryClient.setQueryData(queryKey, (old: { drafts: ProposalDraft[] } | undefined) => {
+      queryClient.setQueriesData<{ drafts: ProposalDraft[] }>(queryFilter, (old) => {
         if (!old) return old;
         return {
           drafts: old.drafts.map((d) =>
@@ -150,13 +158,13 @@ export function useUnarchiveDraft(stakeAddress: string | null) {
         };
       });
 
-      return { previous };
+      return { snapshots };
     },
 
     onError: (_err, _vars, context) => {
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(['author-drafts', stakeAddress], context.previous);
-      }
+      context?.snapshots.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
       toastError('Failed to unarchive draft');
     },
 
@@ -165,23 +173,26 @@ export function useUnarchiveDraft(stakeAddress: string | null) {
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['author-drafts', stakeAddress] });
+      queryClient.invalidateQueries(queryFilter);
     },
   });
 }
 
 // ---------------------------------------------------------------------------
 // Duplicate
-// TODO: Backend endpoint POST /api/workspace/drafts/[draftId]/duplicate
-// is being built in parallel. This mutation calls the expected shape.
+// POST /api/workspace/drafts/[draftId]/duplicate
+// Body: { stakeAddress, titlePrefix? }
 // ---------------------------------------------------------------------------
 
 export function useDuplicateDraft(stakeAddress: string | null) {
   const queryClient = useQueryClient();
 
-  return useMutation<{ draft: ProposalDraft }, Error, { draftId: string }>({
-    mutationFn: ({ draftId }) =>
-      postJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}/duplicate`, {}),
+  return useMutation<{ draft: ProposalDraft }, Error, { draftId: string; titlePrefix?: string }>({
+    mutationFn: ({ draftId, titlePrefix }) =>
+      postJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}/duplicate`, {
+        stakeAddress,
+        ...(titlePrefix && { titlePrefix }),
+      }),
 
     onSuccess: () => {
       toastSuccess('Draft duplicated');
@@ -196,37 +207,42 @@ export function useDuplicateDraft(stakeAddress: string | null) {
 
 // ---------------------------------------------------------------------------
 // Delete
-// TODO: Backend endpoint DELETE /api/workspace/drafts/[draftId]
-// is being built in parallel. Only allowed when status === 'draft'.
+// DELETE /api/workspace/drafts/[draftId]?stakeAddress=...
+// Only allowed when status === 'draft'.
 // ---------------------------------------------------------------------------
 
 export function useDeleteDraft(stakeAddress: string | null) {
   const queryClient = useQueryClient();
+  const queryFilter = { queryKey: ['author-drafts', stakeAddress] };
 
-  return useMutation<{ success: boolean }, Error, { draftId: string }, { previous: unknown }>({
+  return useMutation<
+    { success: boolean },
+    Error,
+    { draftId: string },
+    { snapshots: [readonly unknown[], unknown][] }
+  >({
     mutationFn: ({ draftId }) =>
-      deleteJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}`),
+      deleteJsonWithAuth(
+        `/api/workspace/drafts/${encodeURIComponent(draftId)}?stakeAddress=${encodeURIComponent(stakeAddress ?? '')}`,
+      ),
 
     onMutate: async ({ draftId }) => {
-      const queryKey = ['author-drafts', stakeAddress];
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries(queryFilter);
+      const snapshots = queryClient.getQueriesData<{ drafts: ProposalDraft[] }>(queryFilter);
 
-      // Optimistically remove from list
-      queryClient.setQueryData(queryKey, (old: { drafts: ProposalDraft[] } | undefined) => {
+      // Optimistically remove from all matching draft lists
+      queryClient.setQueriesData<{ drafts: ProposalDraft[] }>(queryFilter, (old) => {
         if (!old) return old;
-        return {
-          drafts: old.drafts.filter((d) => d.id !== draftId),
-        };
+        return { drafts: old.drafts.filter((d) => d.id !== draftId) };
       });
 
-      return { previous };
+      return { snapshots };
     },
 
     onError: (_err, _vars, context) => {
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(['author-drafts', stakeAddress], context.previous);
-      }
+      context?.snapshots.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
       toastError('Failed to delete draft');
     },
 
@@ -235,15 +251,15 @@ export function useDeleteDraft(stakeAddress: string | null) {
     },
 
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['author-drafts', stakeAddress] });
+      queryClient.invalidateQueries(queryFilter);
     },
   });
 }
 
 // ---------------------------------------------------------------------------
 // Export
-// TODO: Backend endpoint GET /api/workspace/drafts/[draftId]/export?format=markdown|cip108
-// is being built in parallel. Downloads the file via blob URL.
+// GET /api/workspace/drafts/[draftId]/export?format=markdown|cip108
+// Downloads the file via blob URL.
 // ---------------------------------------------------------------------------
 
 export function useExportDraft() {
@@ -271,6 +287,37 @@ export function useExportDraft() {
 
     onError: () => {
       toastError('Failed to export draft');
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Transfer Ownership
+// PATCH /api/workspace/drafts/[draftId]/transfer
+// Body: { currentOwnerStakeAddress, newOwnerStakeAddress }
+// ---------------------------------------------------------------------------
+
+export function useTransferDraft(stakeAddress: string | null) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { draft: ProposalDraft },
+    Error,
+    { draftId: string; newOwnerStakeAddress: string }
+  >({
+    mutationFn: ({ draftId, newOwnerStakeAddress }) =>
+      patchJsonWithAuth(`/api/workspace/drafts/${encodeURIComponent(draftId)}/transfer`, {
+        currentOwnerStakeAddress: stakeAddress,
+        newOwnerStakeAddress,
+      }),
+
+    onSuccess: () => {
+      toastSuccess('Ownership transferred');
+      queryClient.invalidateQueries({ queryKey: ['author-drafts', stakeAddress] });
+    },
+
+    onError: () => {
+      toastError('Failed to transfer ownership');
     },
   });
 }

--- a/hooks/useDrafts.ts
+++ b/hooks/useDrafts.ts
@@ -61,11 +61,31 @@ async function patchJson<T>(url: string, body: unknown): Promise<T> {
 // ---------------------------------------------------------------------------
 
 /** List all drafts for a user */
-export function useDrafts(stakeAddress: string | null) {
+export function useDrafts(stakeAddress: string | null, options?: { includeArchived?: boolean }) {
+  const includeArchived = options?.includeArchived ?? false;
   return useQuery<{ drafts: ProposalDraft[] }>({
-    queryKey: ['author-drafts', stakeAddress],
-    queryFn: () =>
-      fetchJson(`/api/workspace/drafts?stakeAddress=${encodeURIComponent(stakeAddress!)}`),
+    queryKey: ['author-drafts', stakeAddress, { includeArchived }],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.set('stakeAddress', stakeAddress!);
+      if (includeArchived) params.set('includeArchived', 'true');
+      return fetchJson(`/api/workspace/drafts?${params.toString()}`);
+    },
+    enabled: !!stakeAddress,
+    staleTime: 30_000,
+  });
+}
+
+/** Response type for team drafts (includes memberRole) */
+interface ProposalDraftWithRole extends ProposalDraft {
+  memberRole?: string;
+}
+
+/** List drafts where user is a team member (not owner) */
+export function useTeamDrafts(stakeAddress: string | null) {
+  return useQuery<{ drafts: ProposalDraftWithRole[] }>({
+    queryKey: ['team-drafts', stakeAddress],
+    queryFn: () => fetchJson(`/api/workspace/drafts?memberOf=${encodeURIComponent(stakeAddress!)}`),
     enabled: !!stakeAddress,
     staleTime: 30_000,
   });
@@ -101,14 +121,19 @@ interface CreateDraftVars {
 export function useCreateDraft() {
   const queryClient = useQueryClient();
 
-  return useMutation<{ draft: ProposalDraft }, Error, CreateDraftVars, { previous: unknown }>({
+  return useMutation<
+    { draft: ProposalDraft },
+    Error,
+    CreateDraftVars,
+    { snapshots: [readonly unknown[], unknown][] }
+  >({
     mutationFn: (body) => postJson<{ draft: ProposalDraft }>('/api/workspace/drafts', body),
 
     onMutate: async (vars) => {
-      const queryKey = ['author-drafts', vars.stakeAddress];
+      const queryFilter = { queryKey: ['author-drafts', vars.stakeAddress] };
 
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries(queryFilter);
+      const snapshots = queryClient.getQueriesData<{ drafts: ProposalDraft[] }>(queryFilter);
 
       const now = new Date().toISOString();
       const tempDraft: ProposalDraft = {
@@ -134,17 +159,17 @@ export function useCreateDraft() {
         updatedAt: now,
       };
 
-      queryClient.setQueryData(queryKey, (old: { drafts: ProposalDraft[] } | undefined) => ({
+      queryClient.setQueriesData<{ drafts: ProposalDraft[] }>(queryFilter, (old) => ({
         drafts: [tempDraft, ...(old?.drafts ?? [])],
       }));
 
-      return { previous };
+      return { snapshots };
     },
 
-    onError: (_err, vars, context) => {
-      if (context?.previous !== undefined) {
-        queryClient.setQueryData(['author-drafts', vars.stakeAddress], context.previous);
-      }
+    onError: (_err, _vars, context) => {
+      context?.snapshots.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
       toastError('Failed to create draft');
     },
 


### PR DESCRIPTION
## Summary
- Wire all draft quick action mutations (duplicate, delete, export, transfer) to their real API endpoints from PR #457
- Add `useTeamDrafts` hook and `TeamProposalsSection` component showing drafts where the user is a team member with role badges
- Add `LineageBanner` to the editor page showing source draft lineage when a draft supersedes another
- Create `TransferDialog` with address input for ownership transfer
- Update `useDrafts` to support `includeArchived` API parameter, fixing archive toggle integration
- Update all optimistic mutations to use `setQueriesData` for correct cache invalidation across query key variants

## Impact
- **What changed**: Frontend portfolio view (PR #458) is now fully integrated with backend APIs (PR #457). Team proposals section, lineage display, and transfer ownership dialog are wired end-to-end.
- **User-facing**: Yes — users can now duplicate/delete/export/transfer drafts via quick actions, see team proposals in the author dashboard, and see lineage banners in the editor for forked drafts.
- **Risk**: Low — frontend-only changes, no API or schema modifications. All existing tests pass.
- **Scope**: `hooks/useDraftActions.ts`, `hooks/useDrafts.ts`, `components/workspace/author/` (5 files), `app/workspace/editor/[draftId]/page.tsx`

## Test plan
- [ ] Verify duplicate action creates a copy with "Copy of" prefix
- [ ] Verify delete action shows confirmation, then removes draft
- [ ] Verify export downloads markdown and CIP-108 JSON files
- [ ] Verify transfer dialog opens from quick actions, validates input, transfers ownership
- [ ] Verify team proposals section appears when user has team memberships
- [ ] Verify lineage banner shows in editor for duplicated/forked drafts
- [ ] Verify archive toggle fetches archived drafts from API
- [ ] Verify optimistic updates work correctly for archive/unarchive/delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)