### PR TITLE
feat: stale review tracking, minimum threshold gate, reviewer status

### DIFF
--- a/app/api/workspace/drafts/[draftId]/reviews/route.ts
+++ b/app/api/workspace/drafts/[draftId]/reviews/route.ts
@@ -23,7 +23,11 @@ function extractDraftId(pathname: string): string | null {
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-function mapReviewRow(row: any): DraftReview {
+function mapReviewRow(row: any, currentVersion: number): DraftReview {
+  const reviewedAtVersion: number | null = row.reviewed_at_version ?? null;
+  // Stale if reviewed_at_version is known and is less than current version.
+  // Reviews with null reviewed_at_version (pre-migration) are NOT considered stale.
+  const isStale = reviewedAtVersion !== null && currentVersion > reviewedAtVersion;
   return {
     id: row.id,
     draftId: row.draft_id,
@@ -34,6 +38,8 @@ function mapReviewRow(row: any): DraftReview {
     valueScore: row.value_score,
     feedbackText: row.feedback_text,
     feedbackThemes: row.feedback_themes ?? [],
+    reviewedAtVersion,
+    isStale,
     createdAt: row.created_at,
   };
 }
@@ -52,23 +58,23 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
   const admin = getSupabaseAdmin();
   const sandboxCohortId = request.headers.get('x-sandbox-cohort') || null;
 
-  // If sandbox header present, verify the draft is visible to this sandbox
-  if (sandboxCohortId) {
-    const { data: draft } = await admin
-      .from('proposal_drafts')
-      .select('id, preview_cohort_id')
-      .eq('id', draftId)
-      .maybeSingle();
+  // Fetch draft to get current_version for stale detection (and sandbox scoping)
+  const { data: draft } = await admin
+    .from('proposal_drafts')
+    .select('id, preview_cohort_id, current_version')
+    .eq('id', draftId)
+    .maybeSingle();
 
-    if (!draft) {
-      return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
-    }
-
-    // Sandbox users can see reviews on sandbox-scoped drafts or real drafts
-    if (draft.preview_cohort_id && draft.preview_cohort_id !== sandboxCohortId) {
-      return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
-    }
+  if (!draft) {
+    return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
   }
+
+  // Sandbox users can see reviews on sandbox-scoped drafts or real drafts
+  if (sandboxCohortId && draft.preview_cohort_id && draft.preview_cohort_id !== sandboxCohortId) {
+    return NextResponse.json({ error: 'Draft not found' }, { status: 404 });
+  }
+
+  const currentVersion: number = draft.current_version ?? 1;
 
   const { data, error } = await admin
     .from('draft_reviews')
@@ -80,13 +86,14 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     return NextResponse.json({ error: 'Failed to fetch reviews' }, { status: 500 });
   }
 
-  const reviews: DraftReview[] = (data ?? []).map(mapReviewRow);
+  const reviews: DraftReview[] = (data ?? []).map((row) => mapReviewRow(row, currentVersion));
 
-  // Compute aggregate scores
+  // Compute aggregate scores (EXCLUDE stale reviews)
+  const nonStaleReviews = reviews.filter((r) => !r.isStale);
   const scores = { impact: 0, feasibility: 0, constitutional: 0, value: 0 };
   const counts = { impact: 0, feasibility: 0, constitutional: 0, value: 0 };
 
-  for (const r of reviews) {
+  for (const r of nonStaleReviews) {
     if (r.impactScore != null) {
       scores.impact += r.impactScore;
       counts.impact++;
@@ -150,6 +157,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     aggregateScores,
     responsesByReview,
     total: reviews.length,
+    nonStaleReviewCount: nonStaleReviews.length,
   });
 });
 
@@ -196,7 +204,7 @@ export const POST = withRouteHandler(
     // Verify draft exists and is in community_review stage
     const { data: draft } = await admin
       .from('proposal_drafts')
-      .select('id, owner_stake_address, status, preview_cohort_id')
+      .select('id, owner_stake_address, status, preview_cohort_id, current_version')
       .eq('id', draftId)
       .single();
 
@@ -236,7 +244,7 @@ export const POST = withRouteHandler(
       );
     }
 
-    // Insert review
+    // Insert review with version tracking for stale detection
     const { data: review, error: insertError } = await admin
       .from('draft_reviews')
       .insert({
@@ -248,6 +256,7 @@ export const POST = withRouteHandler(
         value_score: body.valueScore ?? null,
         feedback_text: body.feedbackText,
         feedback_themes: body.feedbackThemes ?? [],
+        reviewed_at_version: draft.current_version ?? null,
       })
       .select()
       .single();
@@ -272,7 +281,10 @@ export const POST = withRouteHandler(
       ctx.wallet ?? body.reviewerStakeAddress,
     );
 
-    return NextResponse.json({ review: mapReviewRow(review) }, { status: 201 });
+    return NextResponse.json(
+      { review: mapReviewRow(review, draft.current_version ?? 1) },
+      { status: 201 },
+    );
   },
   { auth: 'required', rateLimit: { max: 10, window: 60 } },
 );

--- a/app/api/workspace/drafts/[draftId]/stage/route.ts
+++ b/app/api/workspace/drafts/[draftId]/stage/route.ts
@@ -7,6 +7,7 @@ import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { StageTransitionSchema } from '@/lib/api/schemas/workspace';
 import { captureServerEvent } from '@/lib/posthog-server';
+import { MIN_REVIEWS_FOR_SUBMISSION } from '@/lib/workspace/constants';
 import type { DraftStatus } from '@/lib/workspace/types';
 
 export const dynamic = 'force-dynamic';
@@ -52,6 +53,7 @@ function validateTransition(
   },
   reviewCount: number,
   unrespondedCount: number,
+  nonStaleReviewCount: number,
 ): ValidationResult {
   const errors: string[] = [];
 
@@ -110,6 +112,12 @@ function validateTransition(
         `Minimum ${FCP_MIN_HOURS}h at Final Comment Period not met (${remaining}h remaining)`,
       );
     }
+    // Enforce minimum non-stale review threshold
+    if (nonStaleReviewCount < MIN_REVIEWS_FOR_SUBMISSION) {
+      errors.push(
+        `Minimum ${MIN_REVIEWS_FOR_SUBMISSION} non-stale reviews required before submission. Currently has ${nonStaleReviewCount}.`,
+      );
+    }
     return { valid: errors.length === 0, errors };
   }
 
@@ -153,17 +161,31 @@ export const POST = withRouteHandler(
     const currentStage = draft.status as DraftStatus;
     const targetStage = body.targetStage as DraftStatus;
 
-    // Count reviews and unresponded reviews for validation
+    // Count reviews, unresponded reviews, and non-stale reviews for validation
     let reviewCount = 0;
     let unrespondedCount = 0;
+    let nonStaleReviewCount = 0;
+    const currentVersion: number = draft.current_version ?? 1;
 
-    if (currentStage === 'community_review' || currentStage === 'response_revision') {
+    const needsReviewCounts =
+      currentStage === 'community_review' ||
+      currentStage === 'response_revision' ||
+      currentStage === 'final_comment';
+
+    if (needsReviewCounts) {
       const { data: reviews } = await admin
         .from('draft_reviews')
-        .select('id')
+        .select('id, reviewed_at_version')
         .eq('draft_id', draftId);
 
       reviewCount = reviews?.length ?? 0;
+
+      // Count non-stale reviews: reviewed_at_version is null (pre-migration, benefit of doubt)
+      // or reviewed_at_version >= current_version
+      nonStaleReviewCount = (reviews ?? []).filter((r) => {
+        const version = r.reviewed_at_version as number | null;
+        return version === null || version >= currentVersion;
+      }).length;
 
       if (reviewCount > 0) {
         const reviewIds = (reviews ?? []).map((r) => r.id);
@@ -184,6 +206,7 @@ export const POST = withRouteHandler(
       draft,
       reviewCount,
       unrespondedCount,
+      nonStaleReviewCount,
     );
 
     if (!validation.valid) {

--- a/app/api/workspace/drafts/route.ts
+++ b/app/api/workspace/drafts/route.ts
@@ -152,7 +152,43 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
       return NextResponse.json({ error: 'Failed to fetch drafts' }, { status: 500 });
     }
 
-    const drafts: ProposalDraft[] = (data ?? []).map(mapDraftRow);
+    // Check if a reviewer stake address was provided for "your review status"
+    const reviewerStakeAddress = request.nextUrl.searchParams.get('reviewerStakeAddress');
+
+    let drafts: ProposalDraft[] = (data ?? []).map(mapDraftRow);
+
+    // If reviewer address provided, enrich each draft with the reviewer's review status
+    if (reviewerStakeAddress && drafts.length > 0) {
+      const draftIds = drafts.map((d) => d.id);
+      const { data: reviewerReviews } = await admin
+        .from('draft_reviews')
+        .select('draft_id, reviewed_at_version')
+        .eq('reviewer_stake_address', reviewerStakeAddress)
+        .in('draft_id', draftIds);
+
+      // Build a map of draft_id -> reviewer's review
+      const reviewMap = new Map<string, { reviewedAtVersion: number | null }>();
+      for (const r of reviewerReviews ?? []) {
+        reviewMap.set(r.draft_id, {
+          reviewedAtVersion: (r.reviewed_at_version as number | null) ?? null,
+        });
+      }
+
+      drafts = drafts.map((draft) => {
+        const review = reviewMap.get(draft.id);
+        if (!review) {
+          return { ...draft, yourReviewStatus: 'none' as const };
+        }
+        // Stale if reviewed_at_version is known and less than current version
+        const isStale =
+          review.reviewedAtVersion !== null && review.reviewedAtVersion < draft.currentVersion;
+        return {
+          ...draft,
+          yourReviewStatus: isStale ? ('stale' as const) : ('reviewed' as const),
+        };
+      });
+    }
+
     return NextResponse.json({ drafts });
   }
 

--- a/lib/workspace/constants.ts
+++ b/lib/workspace/constants.ts
@@ -1,0 +1,2 @@
+/** Minimum non-stale reviews required before a proposal can be submitted on-chain. */
+export const MIN_REVIEWS_FOR_SUBMISSION = 3;

--- a/lib/workspace/types.ts
+++ b/lib/workspace/types.ts
@@ -223,6 +223,8 @@ export interface ProposalDraft {
   submittedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Review status for the current user — only populated on community-reviewable draft lists. */
+  yourReviewStatus?: 'reviewed' | 'stale' | 'none';
 }
 
 export interface DraftVersion {
@@ -362,6 +364,8 @@ export interface DraftReview {
   valueScore: number | null;
   feedbackText: string;
   feedbackThemes: string[];
+  reviewedAtVersion: number | null;
+  isStale: boolean;
   createdAt: string;
 }
 

--- a/supabase/migrations/061_add_reviewed_at_version.sql
+++ b/supabase/migrations/061_add_reviewed_at_version.sql
@@ -1,0 +1,5 @@
+ALTER TABLE draft_reviews
+ADD COLUMN reviewed_at_version INTEGER;
+
+COMMENT ON COLUMN draft_reviews.reviewed_at_version IS
+  'The draft version number at the time this review was submitted. Used for stale review detection.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -2091,6 +2091,7 @@ export type Database = {
           feedback_themes: string[];
           id: string;
           impact_score: number | null;
+          reviewed_at_version: number | null;
           reviewer_stake_address: string;
           reviewer_user_id: string | null;
           value_score: number | null;
@@ -2104,6 +2105,7 @@ export type Database = {
           feedback_themes?: string[];
           id?: string;
           impact_score?: number | null;
+          reviewed_at_version?: number | null;
           reviewer_stake_address: string;
           reviewer_user_id?: string | null;
           value_score?: number | null;
@@ -2117,6 +2119,7 @@ export type Database = {
           feedback_themes?: string[];
           id?: string;
           impact_score?: number | null;
+          reviewed_at_version?: number | null;
           reviewer_stake_address?: string;
           reviewer_user_id?: string | null;
           value_score?: number | null;


### PR DESCRIPTION
## Summary
- **Stale review tracking** — `reviewed_at_version` column on `draft_reviews`. Reviews submitted against older versions are flagged `isStale: true`. Stale reviews excluded from aggregate scores and non-stale count.
- **Minimum review threshold** — `MIN_REVIEWS_FOR_SUBMISSION = 3` constant. Stage transition to `submitted` blocked if non-stale review count is below threshold.
- **Your review status** — `GET /api/workspace/drafts?status=...&reviewerStakeAddress=...` now returns `yourReviewStatus` per draft ('reviewed' | 'stale' | 'none') for the reviewer portfolio.
- **Migration** — `061_add_reviewed_at_version.sql` adds nullable integer column.

## Impact
- **What changed**: Review data model gains version awareness. Stage transitions enforce engagement depth.
- **User-facing**: Not directly (APIs only). Frontend PRs will consume stale flags + threshold.
- **Risk**: Low — additive column, backwards-compatible (null = not stale). Threshold only gates final submission.
- **Scope**: 1 migration, 7 modified files, 1 new constants file

## Test plan
- [ ] New reviews get `reviewed_at_version` set to draft's `current_version`
- [ ] Review list returns `isStale` correctly (stale when version < current)
- [ ] Aggregate scores exclude stale reviews
- [ ] Stage transition to submitted returns 400 if < 3 non-stale reviews
- [ ] Community drafts response includes `yourReviewStatus` when `reviewerStakeAddress` provided
- [ ] All 825 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)