### PR TITLE
feat: community confidence, readiness panel, stale review treatment

### DIFF
--- a/app/api/workspace/drafts/[draftId]/duplicate/route.ts
+++ b/app/api/workspace/drafts/[draftId]/duplicate/route.ts
@@ -132,6 +132,7 @@ function mapDraftRow(row: any): ProposalDraft {
     submittedAnchorUrl: row.submitted_anchor_url ?? null,
     submittedAnchorHash: row.submitted_anchor_hash ?? null,
     submittedAt: row.submitted_at ?? null,
+    lastConstitutionalCheck: row.last_constitutional_check ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/app/api/workspace/drafts/[draftId]/route.ts
+++ b/app/api/workspace/drafts/[draftId]/route.ts
@@ -253,6 +253,7 @@ function mapDraftRow(row: any): ProposalDraft {
     submittedAnchorUrl: row.submitted_anchor_url ?? null,
     submittedAnchorHash: row.submitted_anchor_hash ?? null,
     submittedAt: row.submitted_at ?? null,
+    lastConstitutionalCheck: row.last_constitutional_check ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/app/api/workspace/drafts/[draftId]/transfer/route.ts
+++ b/app/api/workspace/drafts/[draftId]/transfer/route.ts
@@ -168,6 +168,7 @@ function mapDraftRow(row: any): ProposalDraft {
     submittedAnchorUrl: row.submitted_anchor_url ?? null,
     submittedAnchorHash: row.submitted_anchor_hash ?? null,
     submittedAt: row.submitted_at ?? null,
+    lastConstitutionalCheck: row.last_constitutional_check ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/app/api/workspace/drafts/route.ts
+++ b/app/api/workspace/drafts/route.ts
@@ -363,6 +363,7 @@ function mapDraftRow(row: any): ProposalDraft {
     submittedAnchorUrl: row.submitted_anchor_url ?? null,
     submittedAnchorHash: row.submitted_anchor_hash ?? null,
     submittedAt: row.submitted_at ?? null,
+    lastConstitutionalCheck: row.last_constitutional_check ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/app/workspace/amendment/[draftId]/page.tsx
+++ b/app/workspace/amendment/[draftId]/page.tsx
@@ -40,6 +40,7 @@ import { AmendmentIntelPanel } from '@/components/workspace/author/AmendmentInte
 import { SaveStatusIndicator } from '@/components/workspace/layout/SaveStatusIndicator';
 import { IntentInputPanel } from '@/components/workspace/author/IntentInputPanel';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ReadinessPanel } from '@/components/workspace/author/ReadinessPanel';
 import { CONSTITUTION_NODES, CONSTITUTION_VERSION } from '@/lib/constitution/fullText';
 import { extractAmendmentChanges, serializeAmendmentChanges } from '@/lib/constitution/utils';
 import { proposeChange } from '@/components/workspace/editor/SuggestModePlugin';
@@ -56,9 +57,11 @@ import type { ConstitutionSlashCommandType } from '@/components/workspace/editor
 function AmendmentPanelWrapper({
   agentContent,
   intelContent,
+  readinessContent,
 }: {
   agentContent: ReactNode;
   intelContent: ReactNode;
+  readinessContent?: ReactNode;
 }) {
   const { panelOpen, activePanel, panelWidth, closePanel, togglePanel, setPanelWidth } =
     useStudio();
@@ -73,6 +76,7 @@ function AmendmentPanelWrapper({
       onWidthChange={setPanelWidth}
       agentContent={agentContent}
       intelContent={intelContent}
+      readinessContent={readinessContent}
     />
   );
 }
@@ -532,7 +536,13 @@ function AmendmentEditorPage() {
               currentUserId={stakeAddress ?? 'anonymous'}
             />
           }
-          context={<AmendmentPanelWrapper agentContent={agentChatNode} intelContent={intelNode} />}
+          context={
+            <AmendmentPanelWrapper
+              agentContent={agentChatNode}
+              intelContent={intelNode}
+              readinessContent={draftId ? <ReadinessPanel draftId={draftId} /> : undefined}
+            />
+          }
           statusBar={<AmendmentActionBarWrapper statusInfo={statusInfo} />}
         />
       </StudioProvider>

--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -36,6 +36,7 @@ import { ProposalEditor, injectProposedEdit } from '@/components/workspace/edito
 import { AgentChatPanel } from '@/components/workspace/agent/AgentChatPanel';
 import { StatusBar } from '@/components/workspace/layout/StatusBar';
 import { RevisionJustificationFlow } from '@/components/workspace/editor/RevisionJustificationFlow';
+import { ReadinessPanel } from '@/components/workspace/author/ReadinessPanel';
 import { Skeleton } from '@/components/ui/skeleton';
 import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
 import type { ProposalType } from '@/lib/workspace/types';
@@ -110,7 +111,13 @@ function LineageBanner({ supersedesId }: { supersedesId: string }) {
 // AuthorPanelWrapper — thin wrapper that connects StudioPanel to StudioProvider
 // ---------------------------------------------------------------------------
 
-function AuthorPanelWrapper({ agentContent }: { agentContent: ReactNode }) {
+function AuthorPanelWrapper({
+  agentContent,
+  readinessContent,
+}: {
+  agentContent: ReactNode;
+  readinessContent?: ReactNode;
+}) {
   const { panelOpen, activePanel, panelWidth, closePanel, togglePanel, setPanelWidth } =
     useStudio();
 
@@ -123,6 +130,7 @@ function AuthorPanelWrapper({ agentContent }: { agentContent: ReactNode }) {
       width={panelWidth}
       onWidthChange={setPanelWidth}
       agentContent={agentContent}
+      readinessContent={readinessContent}
     />
   );
 }
@@ -476,7 +484,12 @@ function WorkspaceEditorPage() {
               />
             </div>
           }
-          context={<AuthorPanelWrapper agentContent={agentChatNode} />}
+          context={
+            <AuthorPanelWrapper
+              agentContent={agentChatNode}
+              readinessContent={draftId ? <ReadinessPanel draftId={draftId} /> : undefined}
+            />
+          }
           statusBar={<AuthorActionBarWrapper statusInfo={statusBarNode} />}
         />
       </StudioProvider>

--- a/components/studio/StudioActionBar.tsx
+++ b/components/studio/StudioActionBar.tsx
@@ -13,7 +13,7 @@ import {
 import { cn } from '@/lib/utils';
 import { useDiscoveryHub } from '@/components/discovery/DiscoveryHubContext';
 
-type PanelId = 'agent' | 'intel' | 'notes' | 'vote';
+type PanelId = 'agent' | 'intel' | 'notes' | 'vote' | 'readiness';
 
 interface StudioActionBarProps {
   mode?: 'review' | 'author';

--- a/components/studio/StudioHeader.tsx
+++ b/components/studio/StudioHeader.tsx
@@ -40,8 +40,8 @@ interface StudioHeaderProps {
   /** User segment badge label */
   segmentBadge?: { label: string; color: string };
   panelOpen?: boolean;
-  activePanel?: 'agent' | 'intel' | 'notes' | 'vote' | null;
-  onPanelToggle?: (panel: 'agent' | 'intel' | 'notes' | 'vote') => void;
+  activePanel?: 'agent' | 'intel' | 'notes' | 'vote' | 'readiness' | null;
+  onPanelToggle?: (panel: 'agent' | 'intel' | 'notes' | 'vote' | 'readiness') => void;
   isFullWidth?: boolean;
   onFullWidthToggle?: () => void;
   onSearchToggle?: () => void;

--- a/components/studio/StudioPanel.tsx
+++ b/components/studio/StudioPanel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
-import { X, MessageSquare, BarChart3, StickyNote, Vote } from 'lucide-react';
+import { X, MessageSquare, BarChart3, StickyNote, Vote, ShieldCheck } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-type TabId = 'agent' | 'intel' | 'notes' | 'vote';
+type TabId = 'agent' | 'intel' | 'notes' | 'vote' | 'readiness';
 
 interface StudioPanelProps {
   isOpen: boolean;
@@ -17,9 +17,10 @@ interface StudioPanelProps {
   intelContent?: ReactNode;
   notesContent?: ReactNode;
   voteContent?: ReactNode;
+  readinessContent?: ReactNode;
 }
 
-const TABS: Array<{ id: TabId; label: string; Icon: typeof MessageSquare }> = [
+const BASE_TABS: Array<{ id: TabId; label: string; Icon: typeof MessageSquare }> = [
   { id: 'agent', label: 'Agent', Icon: MessageSquare },
   { id: 'intel', label: 'Intel', Icon: BarChart3 },
   { id: 'notes', label: 'Notes', Icon: StickyNote },
@@ -39,6 +40,7 @@ export function StudioPanel({
   intelContent,
   notesContent,
   voteContent,
+  readinessContent,
 }: StudioPanelProps) {
   const isDragging = useRef(false);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -96,6 +98,11 @@ export function StudioPanel({
     [onWidthChange],
   );
 
+  // Build tabs: include readiness tab only when readinessContent is provided
+  const TABS = readinessContent
+    ? [...BASE_TABS, { id: 'readiness' as TabId, label: 'Readiness', Icon: ShieldCheck }]
+    : BASE_TABS;
+
   const tabContent: Record<TabId, ReactNode> = {
     agent: agentContent,
     intel: intelContent ?? (
@@ -113,6 +120,7 @@ export function StudioPanel({
         Vote panel coming soon
       </div>
     ),
+    readiness: readinessContent ?? null,
   };
 
   // ---- Desktop panel (lg+) ----

--- a/components/studio/StudioProvider.tsx
+++ b/components/studio/StudioProvider.tsx
@@ -15,7 +15,7 @@ import type { PanelId } from '@/lib/workspace/store';
 
 interface StudioState {
   panelOpen: boolean;
-  activePanel: 'agent' | 'intel' | 'notes' | 'vote';
+  activePanel: PanelId;
   panelWidth: number;
   focusLevel: 0 | 1 | 2;
   isFullWidth: boolean;
@@ -23,7 +23,7 @@ interface StudioState {
 }
 
 interface StudioContextValue extends StudioState {
-  togglePanel: (panel: 'agent' | 'intel' | 'notes' | 'vote') => void;
+  togglePanel: (panel: PanelId) => void;
   closePanel: () => void;
   setPanelWidth: (width: number) => void;
   setFocusLevel: (level: 0 | 1 | 2) => void;
@@ -64,7 +64,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   // Legacy toggle: same panel toggles off; different panel switches to it
   const togglePanel = useCallback(
-    (panel: 'agent' | 'intel' | 'notes' | 'vote') => {
+    (panel: PanelId) => {
       storeTogglePanel(panel);
     },
     [storeTogglePanel],

--- a/components/workspace/author/DraftCard.tsx
+++ b/components/workspace/author/DraftCard.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { motion, useReducedMotion } from 'framer-motion';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, CheckCircle2, ShieldCheck, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
 import { useFocusStore } from '@/lib/workspace/focus';
 import { DraftQuickActions } from './DraftQuickActions';
@@ -193,9 +194,40 @@ function DraftColumnInfo({ draft }: { draft: ProposalDraft }) {
 
 function InReviewColumnInfo({ draft }: { draft: ProposalDraft }) {
   const days = daysAgo(draft.communityReviewStartedAt);
+  const { filled } = completenessCount(draft);
+  const fieldsOk = filled >= 4;
+  const constCheck = draft.lastConstitutionalCheck?.score ?? null;
+  const constOk = constCheck === 'pass';
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-col gap-1.5">
       {days !== null && <span className="text-xs text-muted-foreground">{days}d in review</span>}
+      <div className="flex items-center gap-2 flex-wrap">
+        <span
+          className={cn(
+            'flex items-center gap-0.5 text-xs',
+            fieldsOk ? 'text-emerald-400' : 'text-muted-foreground',
+          )}
+        >
+          {fieldsOk ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
+          {filled}/4
+        </span>
+        {constCheck && (
+          <span
+            className={cn(
+              'flex items-center gap-0.5 text-xs',
+              constOk
+                ? 'text-emerald-400'
+                : constCheck === 'warning'
+                  ? 'text-amber-400'
+                  : 'text-destructive',
+            )}
+          >
+            <ShieldCheck className="h-3 w-3" />
+            {constCheck === 'pass' ? 'Pass' : constCheck === 'warning' ? 'Warn' : 'Fail'}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/workspace/author/DraftEditor.tsx
+++ b/components/workspace/author/DraftEditor.tsx
@@ -14,6 +14,7 @@ import { DraftActions } from './DraftActions';
 import { LifecycleStatus } from './LifecycleStatus';
 import { ReviewsList } from './ReviewsList';
 import { ReviewRubric } from './ReviewRubric';
+import { ReReviewBanner } from './ReReviewBanner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -150,6 +151,14 @@ export function DraftEditor({ viewerStakeAddress }: DraftEditorProps = {}) {
       {/* Two-column layout on desktop, stacked on mobile */}
       <div className="flex flex-col lg:flex-row gap-6">
         <div className="flex-1 min-w-0 space-y-4">
+          {/* Re-review banner for reviewers with stale reviews */}
+          {!isOwner &&
+            !isTeamMember &&
+            viewerStakeAddress &&
+            draft.status === 'community_review' && (
+              <ReReviewBanner draft={draft} viewerStakeAddress={viewerStakeAddress} />
+            )}
+
           {/* Show review form for non-owners during community review */}
           {showReviewForm && draftId && viewerStakeAddress && (
             <ReviewRubric

--- a/components/workspace/author/ReReviewBanner.tsx
+++ b/components/workspace/author/ReReviewBanner.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * ReReviewBanner — shown to reviewers who previously reviewed a draft that
+ * has since been updated. Prompts them to re-review the new version.
+ */
+
+import { useMemo } from 'react';
+import { AlertTriangle, ArrowRight } from 'lucide-react';
+import { useDraftReviews } from '@/hooks/useDraftReviews';
+import type { ProposalDraft } from '@/lib/workspace/types';
+
+interface ReReviewBannerProps {
+  draft: ProposalDraft;
+  viewerStakeAddress: string;
+}
+
+export function ReReviewBanner({ draft, viewerStakeAddress }: ReReviewBannerProps) {
+  const { data } = useDraftReviews(draft.id);
+
+  const staleReview = useMemo(() => {
+    if (!data) return null;
+    return (
+      data.reviews.find((r) => r.reviewerStakeAddress === viewerStakeAddress && r.isStale) ?? null
+    );
+  }, [data, viewerStakeAddress]);
+
+  if (!staleReview) return null;
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+      <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+      <div className="flex-1 space-y-1">
+        <p className="text-sm">
+          You reviewed version {staleReview.reviewedAtVersion ?? '?'}. The proposal has been updated
+          to version {draft.currentVersion}.
+        </p>
+        <a
+          href={`/workspace/author/${draft.id}`}
+          className="inline-flex items-center gap-1 text-xs text-amber-400 hover:text-amber-300 transition-colors"
+        >
+          Re-review
+          <ArrowRight className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/ReadinessPanel.tsx
+++ b/components/workspace/author/ReadinessPanel.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+/**
+ * ReadinessPanel — Submission readiness sidebar for the proposal authoring workspace.
+ *
+ * Displays:
+ * 1. Community Confidence composite score (bar + level badge)
+ * 2. Readiness checks (pass/fail/warning list)
+ * 3. Factor breakdown (per-dimension mini bars)
+ *
+ * All confidence computation is delegated to the pure `computeConfidence()` function.
+ */
+
+import { useMemo } from 'react';
+import { CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useDraft } from '@/hooks/useDrafts';
+import { useDraftReviews } from '@/hooks/useDraftReviews';
+import { MIN_REVIEWS_FOR_SUBMISSION } from '@/lib/workspace/constants';
+import {
+  computeConfidence,
+  confidenceLevelColor,
+  confidenceLevelBg,
+  type ConfidenceInput,
+} from '@/lib/workspace/confidence';
+import type { ProposalDraft, ConstitutionalCheckResult } from '@/lib/workspace/types';
+import { Skeleton } from '@/components/ui/skeleton';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fieldsCompleteCount(draft: ProposalDraft): number {
+  return [draft.title, draft.abstract, draft.motivation, draft.rationale].filter(
+    (f) => f && f.trim().length > 0,
+  ).length;
+}
+
+function extractCheckScore(
+  check: ConstitutionalCheckResult | null,
+): 'pass' | 'warning' | 'fail' | null {
+  if (!check) return null;
+  return check.score;
+}
+
+function hoursInReview(communityReviewStartedAt: string | null): number | null {
+  if (!communityReviewStartedAt) return null;
+  const diffMs = Date.now() - new Date(communityReviewStartedAt).getTime();
+  return Math.max(0, diffMs / (1000 * 60 * 60));
+}
+
+// ---------------------------------------------------------------------------
+// Check item component
+// ---------------------------------------------------------------------------
+
+type CheckStatus = 'pass' | 'fail' | 'warning';
+
+function CheckItem({ status, label }: { status: CheckStatus; label: string }) {
+  const icon =
+    status === 'pass' ? (
+      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+    ) : status === 'fail' ? (
+      <XCircle className="h-3.5 w-3.5 text-destructive shrink-0" />
+    ) : (
+      <AlertTriangle className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+    );
+
+  return (
+    <div className="flex items-start gap-2 text-xs">
+      {icon}
+      <span className="text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Factor bar component
+// ---------------------------------------------------------------------------
+
+function FactorBar({ name, value }: { name: string; value: number }) {
+  const color = value >= 80 ? 'bg-emerald-500' : value >= 50 ? 'bg-amber-500' : 'bg-destructive';
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="w-24 text-muted-foreground truncate">{name}</span>
+      <div className="flex-1 h-1.5 rounded-full bg-muted">
+        <div
+          className={cn('h-full rounded-full transition-all', color)}
+          style={{ width: `${Math.max(2, value)}%` }}
+        />
+      </div>
+      <span className="w-8 text-right text-muted-foreground tabular-nums">{value}%</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface ReadinessPanelProps {
+  draftId: string;
+}
+
+export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
+  const { data: draftData, isLoading: draftLoading } = useDraft(draftId);
+  const { data: reviewsData, isLoading: reviewsLoading } = useDraftReviews(draftId);
+
+  const isLoading = draftLoading || reviewsLoading;
+
+  const { confidence, checks } = useMemo(() => {
+    if (!draftData?.draft) {
+      return { confidence: null, checks: [] };
+    }
+
+    const draft = draftData.draft;
+    const reviews = reviewsData?.reviews ?? [];
+    const responsesByReview = reviewsData?.responsesByReview ?? {};
+    const nonStaleReviewCount = reviewsData?.nonStaleReviewCount ?? 0;
+    const aggregateScores = reviewsData?.aggregateScores;
+
+    // Count reviews that have at least one response
+    const respondedCount = reviews.filter((r) => (responsesByReview[r.id]?.length ?? 0) > 0).length;
+
+    // Compute average score from aggregate scores (non-stale only from API)
+    const scoreValues = aggregateScores
+      ? [
+          aggregateScores.impact,
+          aggregateScores.feasibility,
+          aggregateScores.constitutional,
+          aggregateScores.value,
+        ].filter((s): s is number => s !== null)
+      : [];
+    const averageScore =
+      scoreValues.length > 0 ? scoreValues.reduce((a, b) => a + b, 0) / scoreValues.length : null;
+
+    const fieldsComplete = fieldsCompleteCount(draft);
+    const constitutionalCheck = extractCheckScore(draft.lastConstitutionalCheck);
+
+    const input: ConfidenceInput = {
+      totalReviews: reviews.length,
+      nonStaleReviews: nonStaleReviewCount,
+      averageScore,
+      respondedCount,
+      totalReviewsToRespond: reviews.length,
+      constitutionalCheck,
+      fieldsComplete,
+    };
+
+    const result = computeConfidence(input);
+
+    // Build checks list
+    const staleCount = reviews.length - nonStaleReviewCount;
+    const unaddressedCount = reviews.filter(
+      (r) => (responsesByReview[r.id]?.length ?? 0) === 0,
+    ).length;
+    const hours = hoursInReview(draft.communityReviewStartedAt);
+
+    type Check = { status: CheckStatus; label: string };
+    const checksList: Check[] = [
+      {
+        status: fieldsComplete >= 4 ? 'pass' : 'fail',
+        label: `Content complete (${fieldsComplete}/4 fields)`,
+      },
+      {
+        status:
+          constitutionalCheck === 'pass'
+            ? 'pass'
+            : constitutionalCheck === 'warning'
+              ? 'warning'
+              : constitutionalCheck === 'fail'
+                ? 'fail'
+                : 'fail',
+        label: `Constitutional check: ${constitutionalCheck === 'pass' ? 'Pass' : constitutionalCheck === 'warning' ? 'Warning' : constitutionalCheck === 'fail' ? 'Fail' : 'Not run'}`,
+      },
+      {
+        status: nonStaleReviewCount >= MIN_REVIEWS_FOR_SUBMISSION ? 'pass' : 'fail',
+        label: `${nonStaleReviewCount} review${nonStaleReviewCount !== 1 ? 's' : ''} (min ${MIN_REVIEWS_FOR_SUBMISSION} required)`,
+      },
+    ];
+
+    if (unaddressedCount > 0) {
+      checksList.push({
+        status: 'fail',
+        label: `${unaddressedCount} review${unaddressedCount !== 1 ? 's' : ''} unaddressed`,
+      });
+    } else if (reviews.length > 0) {
+      checksList.push({
+        status: 'pass',
+        label: 'All reviews addressed',
+      });
+    }
+
+    if (hours !== null) {
+      checksList.push({
+        status: hours >= 48 ? 'pass' : 'warning',
+        label:
+          hours >= 48
+            ? `${Math.floor(hours / 24)}d in community review`
+            : `${Math.floor(hours)}h in review (48h recommended)`,
+      });
+    }
+
+    if (staleCount > 0) {
+      checksList.push({
+        status: 'warning',
+        label: `${staleCount} stale review${staleCount !== 1 ? 's' : ''}`,
+      });
+    }
+
+    return { confidence: result, checks: checksList };
+  }, [draftData, reviewsData]);
+
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-4">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-full rounded-full" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (!confidence) {
+    return <div className="p-4 text-sm text-muted-foreground">No draft data available.</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-5">
+      {/* Confidence score header */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium">Community Confidence</h3>
+          <span
+            className={cn('text-sm font-bold tabular-nums', confidenceLevelColor(confidence.level))}
+          >
+            {confidence.score}%
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all duration-500',
+              confidenceLevelBg(confidence.level),
+            )}
+            style={{ width: `${confidence.score}%` }}
+          />
+        </div>
+
+        {/* Level label */}
+        <p className={cn('text-xs capitalize', confidenceLevelColor(confidence.level))}>
+          {confidence.level}
+        </p>
+      </div>
+
+      {/* Checks section */}
+      <div className="space-y-2">
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Checks
+        </h4>
+        <div className="space-y-1.5">
+          {checks.map((check, i) => (
+            <CheckItem key={i} status={check.status} label={check.label} />
+          ))}
+        </div>
+      </div>
+
+      {/* Factor breakdown */}
+      <div className="space-y-2">
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Factor Breakdown
+        </h4>
+        <div className="space-y-1.5">
+          {confidence.factors.map((factor) => (
+            <FactorBar key={factor.name} name={factor.name} value={factor.value} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/ReviewsList.tsx
+++ b/components/workspace/author/ReviewsList.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { MessageSquare, Star } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { MessageSquare, Star, ChevronDown, ChevronRight, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { useDraftReviews } from '@/hooks/useDraftReviews';
 import { ResponseEditor } from './ResponseEditor';
 import type { DraftReview } from '@/lib/workspace/types';
@@ -34,6 +37,7 @@ function ScoreBar({ label, score }: { label: string; score: number | null }) {
 
 function AggregateScores({
   scores,
+  hasStaleReviews,
 }: {
   scores: {
     impact: number | null;
@@ -41,6 +45,7 @@ function AggregateScores({
     constitutional: number | null;
     value: number | null;
   };
+  hasStaleReviews: boolean;
 }) {
   const items = [
     { label: 'Impact', score: scores.impact },
@@ -52,16 +57,21 @@ function AggregateScores({
   if (items.length === 0) return null;
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 p-3 rounded-lg bg-muted/30">
-      {items.map((item) => (
-        <div key={item.label} className="text-center">
-          <div className="flex items-center justify-center gap-1">
-            <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
-            <span className="text-lg font-bold">{item.score}</span>
+    <div className="space-y-1">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 p-3 rounded-lg bg-muted/30">
+        {items.map((item) => (
+          <div key={item.label} className="text-center">
+            <div className="flex items-center justify-center gap-1">
+              <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+              <span className="text-lg font-bold">{item.score}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">{item.label}</p>
           </div>
-          <p className="text-xs text-muted-foreground">{item.label}</p>
-        </div>
-      ))}
+        ))}
+      </div>
+      {hasStaleReviews && (
+        <p className="text-xs text-muted-foreground italic">Averages exclude stale reviews</p>
+      )}
     </div>
   );
 }
@@ -91,7 +101,12 @@ function ReviewCard({
   const hasResponse = responses.length > 0;
 
   return (
-    <div className="space-y-3 border-b last:border-0 pb-4 last:pb-0">
+    <div
+      className={cn(
+        'space-y-3 border-b last:border-0 pb-4 last:pb-0',
+        review.isStale && 'opacity-50',
+      )}
+    >
       {/* Review header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -99,6 +114,25 @@ function ReviewCard({
           <span className="text-xs text-muted-foreground">
             {new Date(review.createdAt).toLocaleDateString()}
           </span>
+          {review.isStale && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="text-xs border-amber-500/30 text-amber-600 dark:text-amber-400 gap-1"
+                  >
+                    <AlertTriangle className="h-3 w-3" />
+                    Stale
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  This review was submitted for version {review.reviewedAtVersion ?? '?'}. The
+                  proposal has been updated since.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
         {hasResponse && (
           <Badge
@@ -189,6 +223,22 @@ interface ReviewsListProps {
 
 export function ReviewsList({ draftId, isOwner }: ReviewsListProps) {
   const { data, isLoading } = useDraftReviews(draftId);
+  const [staleExpanded, setStaleExpanded] = useState(false);
+
+  // Separate current and stale reviews
+  const { currentReviews, staleReviews } = useMemo(() => {
+    if (!data) return { currentReviews: [], staleReviews: [] };
+    const current: DraftReview[] = [];
+    const stale: DraftReview[] = [];
+    for (const review of data.reviews) {
+      if (review.isStale) {
+        stale.push(review);
+      } else {
+        current.push(review);
+      }
+    }
+    return { currentReviews: current, staleReviews: stale };
+  }, [data]);
 
   if (isLoading) {
     return (
@@ -229,10 +279,11 @@ export function ReviewsList({ draftId, isOwner }: ReviewsListProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <AggregateScores scores={data.aggregateScores} />
+        <AggregateScores scores={data.aggregateScores} hasStaleReviews={staleReviews.length > 0} />
 
+        {/* Current reviews */}
         <div className="space-y-4">
-          {data.reviews.map((review) => (
+          {currentReviews.map((review) => (
             <ReviewCard
               key={review.id}
               review={review}
@@ -242,6 +293,37 @@ export function ReviewsList({ draftId, isOwner }: ReviewsListProps) {
             />
           ))}
         </div>
+
+        {/* Stale reviews — collapsible section */}
+        {staleReviews.length > 0 && (
+          <div className="border-t pt-3">
+            <button
+              onClick={() => setStaleExpanded(!staleExpanded)}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors w-full cursor-pointer"
+            >
+              {staleExpanded ? (
+                <ChevronDown className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5" />
+              )}
+              <AlertTriangle className="h-3 w-3 text-amber-400" />
+              Stale Reviews ({staleReviews.length})
+            </button>
+            {staleExpanded && (
+              <div className="space-y-4 mt-3">
+                {staleReviews.map((review) => (
+                  <ReviewCard
+                    key={review.id}
+                    review={review}
+                    responses={data.responsesByReview[review.id] ?? []}
+                    isOwner={isOwner}
+                    draftId={draftId}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/hooks/useDraftReviews.ts
+++ b/hooks/useDraftReviews.ts
@@ -42,7 +42,7 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
 // Types
 // ---------------------------------------------------------------------------
 
-interface ReviewsResponse {
+export interface ReviewsResponse {
   reviews: DraftReview[];
   aggregateScores: {
     impact: number | null;
@@ -60,6 +60,7 @@ interface ReviewsResponse {
     }>
   >;
   total: number;
+  nonStaleReviewCount: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/hooks/useDrafts.ts
+++ b/hooks/useDrafts.ts
@@ -155,6 +155,7 @@ export function useCreateDraft() {
         submittedAnchorUrl: null,
         submittedAnchorHash: null,
         submittedAt: null,
+        lastConstitutionalCheck: null,
         createdAt: now,
         updatedAt: now,
       };

--- a/lib/workspace/confidence.ts
+++ b/lib/workspace/confidence.ts
@@ -1,0 +1,200 @@
+/**
+ * Community Confidence Composite — pure computation of proposal readiness.
+ *
+ * Computes a 0-100 confidence score from review, constitutional, and content
+ * signals. Used by ReadinessPanel in the author workspace sidebar.
+ *
+ * All inputs are plain values (no hooks, no side effects) so this module is
+ * fully testable in isolation.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ConfidenceFactor {
+  name: string;
+  /** Normalized value 0-100 */
+  value: number;
+  /** Weight 0-1 */
+  weight: number;
+  /** Human-readable detail, e.g. "5 reviews (3 required)" */
+  detail: string;
+}
+
+export interface ConfidenceResult {
+  /** Composite score 0-100 */
+  score: number;
+  level: 'low' | 'moderate' | 'high' | 'strong';
+  factors: ConfidenceFactor[];
+}
+
+export interface ConfidenceInput {
+  totalReviews: number;
+  nonStaleReviews: number;
+  /** Average review score on 1-5 scale, null if no reviews scored */
+  averageScore: number | null;
+  respondedCount: number;
+  totalReviewsToRespond: number;
+  constitutionalCheck: 'pass' | 'warning' | 'fail' | null;
+  /** Count of non-empty fields among title, abstract, motivation, rationale (0-4) */
+  fieldsComplete: number;
+}
+
+// ---------------------------------------------------------------------------
+// Factor computation helpers
+// ---------------------------------------------------------------------------
+
+/** Linear interpolation: maps `value` in [lo, hi] to [0, 100], clamped. */
+function lerp(value: number, lo: number, hi: number): number {
+  if (hi <= lo) return value >= hi ? 100 : 0;
+  const t = (value - lo) / (hi - lo);
+  return Math.round(Math.max(0, Math.min(1, t)) * 100);
+}
+
+// ---------------------------------------------------------------------------
+// Main computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the Community Confidence Composite score.
+ *
+ * Factor weights and scaling:
+ *
+ * | Factor                | Weight | 0%     | 50%    | 100%    |
+ * |-----------------------|--------|--------|--------|---------|
+ * | Review count (fresh)  | 0.30   | 0      | 2      | 5+      |
+ * | Average score         | 0.30   | < 2.0  | 3.0    | >= 4.0  |
+ * | Response completeness | 0.20   | 0%     | 50%    | 100%    |
+ * | Constitutional check  | 0.10   | fail   | warn   | pass    |
+ * | Content completeness  | 0.10   | <2     | 3      | 4       |
+ */
+export function computeConfidence(input: ConfidenceInput): ConfidenceResult {
+  // 1. Review count (non-stale)
+  const reviewCountValue = lerp(input.nonStaleReviews, 0, 5);
+  const reviewCountFactor: ConfidenceFactor = {
+    name: 'Review Count',
+    value: reviewCountValue,
+    weight: 0.3,
+    detail:
+      input.nonStaleReviews === input.totalReviews
+        ? `${input.nonStaleReviews} review${input.nonStaleReviews !== 1 ? 's' : ''}`
+        : `${input.nonStaleReviews} current (${input.totalReviews} total)`,
+  };
+
+  // 2. Average score (1-5 scale -> 0-100 with 2.0 = 0%, 4.0 = 100%)
+  const avgScoreValue = input.averageScore !== null ? lerp(input.averageScore, 2.0, 4.0) : 0;
+  const avgScoreFactor: ConfidenceFactor = {
+    name: 'Average Score',
+    value: avgScoreValue,
+    weight: 0.3,
+    detail:
+      input.averageScore !== null ? `${input.averageScore.toFixed(1)} / 5.0` : 'No scores yet',
+  };
+
+  // 3. Response completeness
+  const responsePct =
+    input.totalReviewsToRespond > 0
+      ? (input.respondedCount / input.totalReviewsToRespond) * 100
+      : input.totalReviews > 0
+        ? 0
+        : 100; // No reviews = nothing to respond to, treat as complete
+  const responseValue = Math.round(Math.max(0, Math.min(100, responsePct)));
+  const responseFactor: ConfidenceFactor = {
+    name: 'Responses',
+    value: responseValue,
+    weight: 0.2,
+    detail:
+      input.totalReviewsToRespond > 0
+        ? `${input.respondedCount}/${input.totalReviewsToRespond} addressed`
+        : 'No reviews to address',
+  };
+
+  // 4. Constitutional check
+  let constitutionalValue: number;
+  let constitutionalDetail: string;
+  switch (input.constitutionalCheck) {
+    case 'pass':
+      constitutionalValue = 100;
+      constitutionalDetail = 'Pass';
+      break;
+    case 'warning':
+      constitutionalValue = 50;
+      constitutionalDetail = 'Warning';
+      break;
+    case 'fail':
+      constitutionalValue = 0;
+      constitutionalDetail = 'Fail';
+      break;
+    default:
+      constitutionalValue = 0;
+      constitutionalDetail = 'Not run';
+  }
+  const constitutionalFactor: ConfidenceFactor = {
+    name: 'Constitutional',
+    value: constitutionalValue,
+    weight: 0.1,
+    detail: constitutionalDetail,
+  };
+
+  // 5. Content completeness (0-4 fields)
+  const completenessValue = lerp(input.fieldsComplete, 1, 4);
+  const completenessFactor: ConfidenceFactor = {
+    name: 'Completeness',
+    value: completenessValue,
+    weight: 0.1,
+    detail: `${input.fieldsComplete}/4 fields`,
+  };
+
+  const factors = [
+    reviewCountFactor,
+    avgScoreFactor,
+    responseFactor,
+    constitutionalFactor,
+    completenessFactor,
+  ];
+
+  // Weighted sum
+  const score = Math.round(factors.reduce((sum, f) => sum + f.value * f.weight, 0));
+
+  // Level mapping
+  let level: ConfidenceResult['level'];
+  if (score <= 30) level = 'low';
+  else if (score <= 60) level = 'moderate';
+  else if (score <= 80) level = 'high';
+  else level = 'strong';
+
+  return { score, level, factors };
+}
+
+// ---------------------------------------------------------------------------
+// Level color helpers (for UI components)
+// ---------------------------------------------------------------------------
+
+/** Returns a Tailwind text color class for the given confidence level. */
+export function confidenceLevelColor(level: ConfidenceResult['level']): string {
+  switch (level) {
+    case 'strong':
+      return 'text-emerald-400';
+    case 'high':
+      return 'text-teal-400';
+    case 'moderate':
+      return 'text-amber-400';
+    case 'low':
+      return 'text-destructive';
+  }
+}
+
+/** Returns a Tailwind background color class for the progress bar fill. */
+export function confidenceLevelBg(level: ConfidenceResult['level']): string {
+  switch (level) {
+    case 'strong':
+      return 'bg-emerald-500';
+    case 'high':
+      return 'bg-teal-500';
+    case 'moderate':
+      return 'bg-amber-500';
+    case 'low':
+      return 'bg-destructive';
+  }
+}

--- a/lib/workspace/default-commands.ts
+++ b/lib/workspace/default-commands.ts
@@ -24,7 +24,7 @@ export function registerDefaultCommands(deps: {
   /** Next.js router.push */
   push: (url: string) => void;
   /** Toggle a panel by ID */
-  togglePanel: (panel: 'agent' | 'intel' | 'notes' | 'vote') => void;
+  togglePanel: (panel: 'agent' | 'intel' | 'notes' | 'vote' | 'readiness') => void;
   /** Toggle the sidebar */
   toggleSidebar: () => void;
   /** Open the command palette */

--- a/lib/workspace/store.ts
+++ b/lib/workspace/store.ts
@@ -7,7 +7,7 @@ import { persist } from 'zustand/middleware';
 // Types
 // ---------------------------------------------------------------------------
 
-export type PanelId = 'agent' | 'intel' | 'notes' | 'vote';
+export type PanelId = 'agent' | 'intel' | 'notes' | 'vote' | 'readiness';
 
 export interface WorkspaceState {
   // Entity selection (NOT persisted — driven by URL)

--- a/lib/workspace/types.ts
+++ b/lib/workspace/types.ts
@@ -221,6 +221,8 @@ export interface ProposalDraft {
   submittedAnchorUrl: string | null;
   submittedAnchorHash: string | null;
   submittedAt: string | null;
+  /** Last constitutional check result (stored as JSON in DB). */
+  lastConstitutionalCheck: ConstitutionalCheckResult | null;
   createdAt: string;
   updatedAt: string;
   /** Review status for the current user — only populated on community-reviewable draft lists. */


### PR DESCRIPTION
## Summary
- **`computeConfidence()`** — pure function computing 0-100 weighted score from 5 factors: review count (0.30), average score (0.30), response completeness (0.20), constitutional check (0.10), content completeness (0.10). Level mapping: low/moderate/high/strong.
- **ReadinessPanel** — new StudioPanel tab showing confidence score, readiness checks list (content, constitutional, review count, responses, time in review, stale reviews), and per-factor breakdown bars.
- **Stale review treatment** — ReviewsList shows stale reviews with reduced opacity + amber badge, grouped below current reviews. Aggregate scores note excludes stale.
- **Re-review banner** — shown to reviewers whose previous review is stale, with version mismatch info.
- **Readiness indicators on portfolio cards** — In Review cards show field completeness + constitutional check status.
- **`lastConstitutionalCheck`** added to ProposalDraft type and all mapDraftRow helpers.

## Impact
- **What changed**: Review intelligence layer — proposers see confidence score + readiness checklist, reviewers see stale flags + re-review prompts.
- **User-facing**: Yes — ReadinessPanel tab in editor sidebar, stale badges on reviews, re-review banner, readiness indicators on portfolio cards.
- **Risk**: Low — additive UI, no data model changes. Pure confidence function is testable.
- **Scope**: 3 new files, 18 modified across API routes, types, components, store

## Test plan
- [ ] ReadinessPanel shows correct confidence score with factor breakdown
- [ ] Checks list shows ✓/✗ for each gate correctly
- [ ] Stale reviews appear muted with amber badge in ReviewsList
- [ ] Re-review banner shows for reviewers with stale reviews
- [ ] Portfolio In Review cards show readiness indicators
- [ ] All 825 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)