### PR TITLE
feat: submission ceremony — full-page route, journey summary, financial simulation

### DIFF
--- a/app/workspace/author/[draftId]/submit/page.tsx
+++ b/app/workspace/author/[draftId]/submit/page.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Submission Ceremony Page — full-page multi-step governance action submission.
+ *
+ * Replaces the compact modal with a deliberate, ceremony-grade experience
+ * proportional to the 100,000 ADA commitment. Left panel shows the journey
+ * summary; right panel progresses through submission steps.
+ *
+ * Wrapped in <FeatureGate flag="governance_action_submission">.
+ */
+
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, Shield } from 'lucide-react';
+import Link from 'next/link';
+import { FeatureGate } from '@/components/FeatureGate';
+import { useDraft } from '@/hooks/useDrafts';
+import { useDraftReviews } from '@/hooks/useDraftReviews';
+import { useTeam } from '@/hooks/useTeam';
+import { useGovernanceAction } from '@/hooks/useGovernanceAction';
+import { computeConfidence } from '@/lib/workspace/confidence';
+import type { GovernanceActionTarget } from '@/lib/workspace/types';
+import { JourneySummary } from '@/components/workspace/author/submission/JourneySummary';
+import { FinancialSimulation } from '@/components/workspace/author/submission/FinancialSimulation';
+import { MetadataPreview } from '@/components/workspace/author/submission/MetadataPreview';
+
+// ---------------------------------------------------------------------------
+// Step indicator
+// ---------------------------------------------------------------------------
+
+function StepIndicator({
+  current,
+  total,
+  labels,
+}: {
+  current: number;
+  total: number;
+  labels: string[];
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-muted-foreground mb-6">
+      <Shield className="h-4 w-4 text-[var(--compass-teal)]" />
+      <span className="font-medium text-foreground">
+        Step {current + 1} of {total}
+      </span>
+      <span className="mx-1">—</span>
+      <span>{labels[current]}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inner component (inside FeatureGate)
+// ---------------------------------------------------------------------------
+
+function SubmissionPageInner() {
+  const params = useParams();
+  const router = useRouter();
+  const draftId = typeof params.draftId === 'string' ? params.draftId : null;
+
+  // Data fetching
+  const { data: draftData, isLoading: draftLoading } = useDraft(draftId);
+  const { data: reviewsData } = useDraftReviews(draftId);
+  const { data: teamData } = useTeam(draftId);
+
+  // Governance action hook
+  const { phase, startSubmission } = useGovernanceAction();
+
+  // Step wizard state
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const draft = draftData?.draft ?? null;
+  const versions = draftData?.versions ?? [];
+
+  // Redirect if draft not in final_comment status
+  useEffect(() => {
+    if (
+      !draftLoading &&
+      draft &&
+      draft.status !== 'final_comment' &&
+      draft.status !== 'submitted'
+    ) {
+      router.replace(`/workspace/author/${draftId}`);
+    }
+  }, [draft, draftLoading, draftId, router]);
+
+  // Trigger preflight on mount
+  useEffect(() => {
+    if (!draft || phase.status !== 'idle') return;
+    const target: GovernanceActionTarget = {
+      type: draft.proposalType,
+      anchorUrl: '',
+      anchorHash: '',
+    };
+    startSubmission(target);
+  }, [draft, phase.status, startSubmission]);
+
+  // Compute review summary
+  const reviewSummary = useMemo(() => {
+    if (!reviewsData) return { total: 0, nonStale: 0, averageScore: null, allAddressed: false };
+
+    const { reviews, responsesByReview, nonStaleReviewCount } = reviewsData;
+    const total = reviews.length;
+    const nonStale = nonStaleReviewCount;
+
+    // Average across all review dimensions
+    const scores = reviews
+      .map((r) => {
+        const dims = [
+          r.impactScore,
+          r.feasibilityScore,
+          r.constitutionalScore,
+          r.valueScore,
+        ].filter((s): s is number => s !== null);
+        return dims.length > 0 ? dims.reduce((a, b) => a + b, 0) / dims.length : null;
+      })
+      .filter((s): s is number => s !== null);
+
+    const averageScore =
+      scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+
+    // Check if all reviews have responses
+    const allAddressed = reviews.every((r) => {
+      const responses = responsesByReview[r.id] ?? [];
+      return responses.length > 0;
+    });
+
+    return { total, nonStale, averageScore, allAddressed };
+  }, [reviewsData]);
+
+  // Compute confidence
+  const confidence = useMemo(() => {
+    if (!draft) {
+      return computeConfidence({
+        totalReviews: 0,
+        nonStaleReviews: 0,
+        averageScore: null,
+        respondedCount: 0,
+        totalReviewsToRespond: 0,
+        constitutionalCheck: null,
+        fieldsComplete: 0,
+      });
+    }
+
+    const fieldsComplete = [draft.title, draft.abstract, draft.motivation, draft.rationale].filter(
+      (f) => f && f.trim().length > 0,
+    ).length;
+
+    const respondedCount = reviewsData
+      ? reviewsData.reviews.filter((r) => (reviewsData.responsesByReview[r.id] ?? []).length > 0)
+          .length
+      : 0;
+
+    return computeConfidence({
+      totalReviews: reviewSummary.total,
+      nonStaleReviews: reviewSummary.nonStale,
+      averageScore: reviewSummary.averageScore,
+      respondedCount,
+      totalReviewsToRespond: reviewSummary.total,
+      constitutionalCheck: draft.lastConstitutionalCheck?.score ?? null,
+      fieldsComplete,
+    });
+  }, [draft, reviewsData, reviewSummary]);
+
+  // Team members
+  const teamMembers = useMemo(() => {
+    if (!teamData?.members) return undefined;
+    return teamData.members.map((m) => ({
+      stakeAddress: m.stakeAddress,
+      role: m.role,
+    }));
+  }, [teamData]);
+
+  // Has team?
+  const hasTeam = teamMembers && teamMembers.length > 1;
+
+  // Step configuration
+  // Steps: financial, metadata, (team if exists - not built yet), confirm (not built yet)
+  // For Session 1A we build steps 1 and 2 only
+  const stepLabels = useMemo(() => {
+    const labels = ['Financial Impact', 'Metadata Preview'];
+    if (hasTeam) labels.push('Team Sign-Off');
+    labels.push('Final Confirmation');
+    return labels;
+  }, [hasTeam]);
+
+  const totalSteps = stepLabels.length;
+
+  // Navigation
+  const handleNext = useCallback(() => {
+    setCurrentStep((s) => Math.min(s + 1, totalSteps - 1));
+  }, [totalSteps]);
+
+  const handleBack = useCallback(() => {
+    setCurrentStep((s) => Math.max(s - 1, 0));
+  }, []);
+
+  // Loading state
+  if (draftLoading || !draft) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="animate-spin h-8 w-8 border-2 border-[var(--compass-teal)] border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  // Preflight data
+  const preflight = phase.status === 'confirming' ? phase.preflight : null;
+  const preflightLoading = phase.status === 'idle' || phase.status === 'preflight';
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ── Header ── */}
+      <div className="border-b border-border bg-card/50">
+        <div className="max-w-7xl mx-auto px-4 py-4">
+          <Link
+            href={`/workspace/author/${draftId}`}
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to editor
+          </Link>
+          <h1 className="text-xl font-display font-semibold text-foreground">
+            Submit: {draft.title || 'Untitled Proposal'}
+          </h1>
+        </div>
+      </div>
+
+      {/* ── Two-panel layout ── */}
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="flex flex-col lg:flex-row gap-6">
+          {/* Left panel: Journey Summary (~35%) */}
+          <div className="lg:w-[35%] shrink-0">
+            <div className="lg:sticky lg:top-6">
+              <JourneySummary
+                draft={draft}
+                reviews={reviewSummary}
+                confidence={confidence}
+                versionCount={versions.length}
+                teamMembers={teamMembers}
+              />
+            </div>
+          </div>
+
+          {/* Right panel: Submission Steps (~65%) */}
+          <div className="flex-1 min-w-0">
+            <StepIndicator current={currentStep} total={totalSteps} labels={stepLabels} />
+
+            {currentStep === 0 && (
+              <FinancialSimulation
+                preflight={preflight}
+                proposalType={draft.proposalType}
+                isLoading={preflightLoading}
+                onContinue={handleNext}
+                onBack={() => router.push(`/workspace/author/${draftId}`)}
+              />
+            )}
+
+            {currentStep === 1 && (
+              <MetadataPreview draft={draft} onContinue={handleNext} onBack={handleBack} />
+            )}
+
+            {/* Steps 2+ (Team Sign-Off, Final Confirmation) — built in Session 1B */}
+            {currentStep >= 2 && (
+              <div className="rounded-lg border border-border bg-card p-8 text-center space-y-4">
+                <Shield className="h-12 w-12 text-muted-foreground mx-auto" />
+                <h2 className="text-lg font-display font-semibold text-foreground">
+                  {stepLabels[currentStep]}
+                </h2>
+                <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                  This step will be available in the next update. Use the back button to return.
+                </p>
+                <button
+                  onClick={handleBack}
+                  className="text-sm text-[var(--compass-teal)] hover:underline"
+                >
+                  Go back
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exported page (wrapped in FeatureGate)
+// ---------------------------------------------------------------------------
+
+export default function SubmissionCeremonyPage() {
+  return (
+    <FeatureGate flag="governance_action_submission">
+      <SubmissionPageInner />
+    </FeatureGate>
+  );
+}

--- a/components/workspace/author/submission/FinancialSimulation.tsx
+++ b/components/workspace/author/submission/FinancialSimulation.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+/**
+ * Financial Simulation — Step 1 of the submission ceremony.
+ *
+ * Shows the financial impact of submitting a governance action:
+ * deposit, fee, balance, deposit return conditions, and voting mechanics.
+ */
+
+import { AlertTriangle, Check, ArrowRight, ArrowLeft, Loader2, Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import type { GovernanceActionPreflight, ProposalType } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FinancialSimulationProps {
+  preflight: GovernanceActionPreflight | null;
+  proposalType: ProposalType;
+  isLoading: boolean;
+  onContinue: () => void;
+  onBack: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Voting mechanics data (constitutional/protocol-level, hardcoded per type)
+// ---------------------------------------------------------------------------
+
+interface VotingMechanics {
+  bodies: string[];
+  threshold: string;
+}
+
+const VOTING_MECHANICS: Record<ProposalType, VotingMechanics> = {
+  InfoAction: {
+    bodies: ['DRep'],
+    threshold: 'Simple majority (>50%)',
+  },
+  TreasuryWithdrawals: {
+    bodies: ['DRep', 'Constitutional Committee'],
+    threshold: '67% DRep voting power + CC majority',
+  },
+  ParameterChange: {
+    bodies: ['DRep', 'Constitutional Committee'],
+    threshold: '67% DRep voting power + CC majority',
+  },
+  HardForkInitiation: {
+    bodies: ['DRep', 'SPO', 'Constitutional Committee'],
+    threshold: '75% DRep + SPO + CC majority',
+  },
+  NoConfidence: {
+    bodies: ['DRep', 'SPO'],
+    threshold: '67% DRep + SPO voting power',
+  },
+  NewCommittee: {
+    bodies: ['DRep', 'SPO'],
+    threshold: '67% DRep + SPO voting power',
+  },
+  NewConstitution: {
+    bodies: ['DRep', 'Constitutional Committee'],
+    threshold: '75% DRep voting power + CC majority',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAda(lovelaceStr: string): string {
+  const ada = Number(lovelaceStr) / 1_000_000;
+  return `${ada.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ADA`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function FinancialSimulation({
+  preflight,
+  proposalType,
+  isLoading,
+  onContinue,
+  onBack,
+}: FinancialSimulationProps) {
+  const mechanics = VOTING_MECHANICS[proposalType];
+
+  if (isLoading || !preflight) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--compass-teal)]" />
+        <p className="text-sm text-muted-foreground">Running preflight checks...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-display font-semibold text-foreground mb-1">
+          Financial Impact
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Review the financial commitment required for this governance action.
+        </p>
+      </div>
+
+      {/* ── Deposit & Balance ── */}
+      <div className="rounded-lg border border-border bg-card p-5 space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">Deposit Required</span>
+          <span className="text-sm font-mono font-semibold text-[var(--wayfinder-amber)]">
+            {formatAda(preflight.depositLovelace)}
+          </span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">Estimated Fee</span>
+          <span className="text-sm font-mono text-foreground">{preflight.estimatedFee}</span>
+        </div>
+        <div className="border-t border-border pt-3 flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">Your Wallet Balance</span>
+          <span className="text-sm font-mono text-foreground">{preflight.currentBalance}</span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">Balance After</span>
+          <span
+            className={`text-sm font-mono ${
+              preflight.canAfford ? 'text-foreground' : 'text-destructive font-semibold'
+            }`}
+          >
+            {preflight.canAfford ? preflight.balanceAfter : 'Insufficient funds'}
+          </span>
+        </div>
+      </div>
+
+      {/* ── Insufficient balance warning ── */}
+      {!preflight.canAfford && (
+        <Alert className="border-destructive/30 bg-destructive/5">
+          <AlertTriangle className="h-4 w-4 text-destructive" />
+          <AlertDescription className="text-destructive text-sm">
+            Your wallet does not have sufficient funds for the deposit plus transaction fees.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* ── Deposit Return Conditions ── */}
+      <div className="rounded-lg border border-border bg-card p-5 space-y-3">
+        <h3 className="text-sm font-medium text-foreground mb-2">Deposit Return Conditions</h3>
+        <div className="space-y-2">
+          <div className="flex items-start gap-2 text-sm">
+            <Check className="h-4 w-4 text-emerald-400 mt-0.5 shrink-0" />
+            <span className="text-foreground">Returned if proposal is ratified</span>
+          </div>
+          <div className="flex items-start gap-2 text-sm">
+            <Check className="h-4 w-4 text-emerald-400 mt-0.5 shrink-0" />
+            <span className="text-foreground">
+              Returned if proposal expires after the voting period
+            </span>
+          </div>
+          <div className="flex items-start gap-2 text-sm">
+            <AlertTriangle className="h-4 w-4 text-[var(--wayfinder-amber)] mt-0.5 shrink-0" />
+            <span className="text-foreground">
+              May not be returned if dropped as unconstitutional
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Voting Mechanics ── */}
+      <div className="rounded-lg border border-border bg-card p-5 space-y-3">
+        <h3 className="text-sm font-medium text-foreground mb-2">Voting Mechanics</h3>
+        <div className="space-y-2 text-sm">
+          <div className="flex items-start gap-2">
+            <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <div>
+              <span className="text-muted-foreground">Bodies that vote: </span>
+              <span className="text-foreground">{mechanics.bodies.join(' + ')}</span>
+            </div>
+          </div>
+          <div className="flex items-start gap-2">
+            <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <div>
+              <span className="text-muted-foreground">Threshold: </span>
+              <span className="text-foreground">{mechanics.threshold}</span>
+            </div>
+          </div>
+          <div className="flex items-start gap-2">
+            <Info className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
+            <div>
+              <span className="text-muted-foreground">Voting period: </span>
+              <span className="text-foreground">~6 epochs (~30 days)</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Navigation ── */}
+      <div className="flex gap-3 pt-2">
+        <Button variant="outline" onClick={onBack} className="flex-1">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onContinue} disabled={!preflight.canAfford} className="flex-1">
+          Continue
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/JourneySummary.tsx
+++ b/components/workspace/author/submission/JourneySummary.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+/**
+ * Journey Summary Panel — shows the proposal's path to submission.
+ *
+ * Displays the approval chain at a glance: confidence score, timeline
+ * milestones, review status, constitutional check, and team members.
+ * Used as the left panel in the submission ceremony page.
+ */
+
+import { Check, X, Clock, Users, Shield, FileText } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { ProposalDraft } from '@/lib/workspace/types';
+import type { ConfidenceResult } from '@/lib/workspace/confidence';
+import { confidenceLevelColor, confidenceLevelBg } from '@/lib/workspace/confidence';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface JourneySummaryProps {
+  draft: ProposalDraft;
+  reviews: {
+    total: number;
+    nonStale: number;
+    averageScore: number | null;
+    allAddressed: boolean;
+  };
+  confidence: ConfidenceResult;
+  versionCount: number;
+  teamMembers?: { stakeAddress: string; role: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function has48hInReview(draft: ProposalDraft): boolean {
+  if (!draft.communityReviewStartedAt) return false;
+  const start = new Date(draft.communityReviewStartedAt).getTime();
+  const now = Date.now();
+  return now - start >= 48 * 60 * 60 * 1000;
+}
+
+function constitutionalLabel(check: ProposalDraft['lastConstitutionalCheck']): {
+  label: string;
+  passed: boolean | null;
+} {
+  if (!check) return { label: 'Not run', passed: null };
+  switch (check.score) {
+    case 'pass':
+      return { label: 'Pass', passed: true };
+    case 'warning':
+      return { label: 'Warning', passed: null };
+    case 'fail':
+      return { label: 'Fail', passed: false };
+    default:
+      return { label: 'Unknown', passed: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checklist item
+// ---------------------------------------------------------------------------
+
+function ChecklistItem({
+  label,
+  passed,
+  detail,
+}: {
+  label: string;
+  passed: boolean | null;
+  detail?: string;
+}) {
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <div className="mt-0.5 shrink-0">
+        {passed === true && <Check className="h-3.5 w-3.5 text-emerald-400" />}
+        {passed === false && <X className="h-3.5 w-3.5 text-destructive" />}
+        {passed === null && <Clock className="h-3.5 w-3.5 text-muted-foreground" />}
+      </div>
+      <div className="min-w-0">
+        <span className="text-foreground">{label}</span>
+        {detail && <span className="ml-1 text-muted-foreground">{detail}</span>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function JourneySummary({
+  draft,
+  reviews,
+  confidence,
+  versionCount,
+  teamMembers,
+}: JourneySummaryProps) {
+  const constCheck = constitutionalLabel(draft.lastConstitutionalCheck);
+  const reviewed48h = has48hInReview(draft);
+
+  return (
+    <div className="space-y-6">
+      {/* ── Confidence Score ── */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-muted-foreground">Community Confidence</span>
+          <Badge variant="outline" className={confidenceLevelColor(confidence.level)}>
+            {confidence.level.charAt(0).toUpperCase() + confidence.level.slice(1)}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-3">
+          <span
+            className={`text-2xl font-display font-bold ${confidenceLevelColor(confidence.level)}`}
+          >
+            {confidence.score}%
+          </span>
+          <div className="flex-1">
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${confidenceLevelBg(confidence.level)}`}
+                style={{ width: `${confidence.score}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Journey Checklist ── */}
+      <div className="rounded-lg border-l-2 border-l-[var(--compass-teal)] border border-border bg-card p-4 space-y-3">
+        <div className="flex items-center gap-2 mb-1">
+          <FileText className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">Journey</span>
+        </div>
+
+        <div className="space-y-2.5">
+          <ChecklistItem
+            label="Draft created"
+            passed={true}
+            detail={formatRelativeTime(draft.createdAt)}
+          />
+
+          <ChecklistItem
+            label={`${versionCount} version${versionCount !== 1 ? 's' : ''}`}
+            passed={versionCount >= 1}
+            detail={versionCount > 1 ? '(iterated)' : undefined}
+          />
+
+          <ChecklistItem
+            label={`${reviews.nonStale} review${reviews.nonStale !== 1 ? 's' : ''} received`}
+            passed={reviews.nonStale > 0}
+            detail={
+              reviews.averageScore !== null ? `avg ${reviews.averageScore.toFixed(1)}/5` : undefined
+            }
+          />
+
+          <ChecklistItem
+            label="All reviews addressed"
+            passed={reviews.total > 0 ? reviews.allAddressed : null}
+            detail={reviews.total === 0 ? 'No reviews yet' : undefined}
+          />
+
+          <ChecklistItem
+            label={`Constitutional check: ${constCheck.label}`}
+            passed={constCheck.passed}
+          />
+
+          <ChecklistItem
+            label="48h in community review"
+            passed={reviewed48h}
+            detail={!reviewed48h && draft.communityReviewStartedAt ? 'In progress' : undefined}
+          />
+        </div>
+      </div>
+
+      {/* ── Team Section ── */}
+      {teamMembers && teamMembers.length > 0 && (
+        <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+          <div className="flex items-center gap-2 mb-1">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium text-foreground">Team</span>
+          </div>
+          <div className="space-y-2">
+            {teamMembers.map((m) => (
+              <div key={m.stakeAddress} className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground font-mono text-xs truncate max-w-[160px]">
+                  {m.stakeAddress.slice(0, 12)}...{m.stakeAddress.slice(-6)}
+                </span>
+                <Badge variant="outline" className="text-xs capitalize">
+                  {m.role}
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── Confidence Factors ── */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <div className="flex items-center gap-2 mb-1">
+          <Shield className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium text-foreground">Score Breakdown</span>
+        </div>
+        {confidence.factors.map((f) => (
+          <div key={f.name} className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">{f.name}</span>
+            <span className="text-foreground">{f.detail}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/MetadataPreview.tsx
+++ b/components/workspace/author/submission/MetadataPreview.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+/**
+ * Metadata Preview — Step 2 of the submission ceremony.
+ *
+ * Shows the exact CIP-108 JSON-LD document that will be published permanently.
+ * Uses the useCip108Preview() hook to generate the preview from draft content.
+ */
+
+import { useEffect } from 'react';
+import { ArrowRight, ArrowLeft, Loader2, FileCode, Hash, Link2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCip108Preview } from '@/hooks/useDrafts';
+import { BASE_URL } from '@/lib/constants';
+import type { ProposalDraft } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface MetadataPreviewProps {
+  draft: ProposalDraft;
+  onContinue: () => void;
+  onBack: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MetadataPreview({ draft, onContinue, onBack }: MetadataPreviewProps) {
+  const { mutate: generatePreview, data, isPending } = useCip108Preview();
+
+  // Generate preview on mount
+  useEffect(() => {
+    generatePreview({
+      title: draft.title,
+      abstract: draft.abstract || undefined,
+      motivation: draft.motivation || undefined,
+      rationale: draft.rationale || undefined,
+    });
+  }, [draft.title, draft.abstract, draft.motivation, draft.rationale, generatePreview]);
+
+  const anchorUrl = `${BASE_URL}/api/workspace/cip108/${draft.id}`;
+
+  if (isPending || !data) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 space-y-4">
+        <Loader2 className="h-8 w-8 animate-spin text-[var(--compass-teal)]" />
+        <p className="text-sm text-muted-foreground">Generating metadata preview...</p>
+      </div>
+    );
+  }
+
+  const jsonString = JSON.stringify(data.document, null, 2);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-display font-semibold text-foreground mb-1">
+          Metadata Preview
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          This is the governance metadata that will be published permanently. Review it carefully.
+        </p>
+      </div>
+
+      {/* ── JSON Viewer ── */}
+      <div className="rounded-lg border border-border bg-card overflow-hidden">
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-muted/50">
+          <FileCode className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">CIP-108 JSON-LD</span>
+        </div>
+        <div className="max-h-[400px] overflow-auto">
+          <pre className="p-4 text-xs font-mono text-foreground whitespace-pre-wrap break-words leading-relaxed">
+            {jsonString}
+          </pre>
+        </div>
+      </div>
+
+      {/* ── Anchor URL & Hash ── */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Link2 className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-medium text-muted-foreground">Anchor URL</span>
+          </div>
+          <code className="text-xs text-foreground break-all">{anchorUrl}</code>
+        </div>
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Hash className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-medium text-muted-foreground">
+              Content Hash (blake2b-256)
+            </span>
+          </div>
+          <code className="text-xs text-foreground break-all font-mono">{data.contentHash}</code>
+        </div>
+      </div>
+
+      {/* ── Navigation ── */}
+      <div className="flex gap-3 pt-2">
+        <Button variant="outline" onClick={onBack} className="flex-1">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onContinue} className="flex-1">
+          Continue
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Full-page submission route** (`/workspace/author/[draftId]/submit`) — two-panel layout with step wizard. Replaces modal-based flow. FeatureGate wrapped, redirect guard for non-final_comment drafts.
- **JourneySummary** — left panel showing approval chain: confidence score + progress bar, journey checklist (versions, reviews, constitutional check, time in review), team members, factor breakdown.
- **FinancialSimulation** (Step 1) — deposit amount, wallet balance, balance after, deposit return conditions, voting mechanics per proposal type (bodies, thresholds, period).
- **MetadataPreview** (Step 2) — CIP-108 JSON-LD preview with formatted JSON, anchor URL, content hash.

## Impact
- **What changed**: Submission UX upgraded from compact modal to full-page ceremony with proportional gravity.
- **User-facing**: Yes — new submission page with financial simulation, journey context, and metadata preview.
- **Risk**: Low — new route, existing modal preserved as fallback. No hook/API changes.
- **Scope**: 4 new files (route + 3 components), 0 modified

## Test plan
- [ ] `/workspace/author/[draftId]/submit` renders with two-panel layout
- [ ] Redirects if draft not in `final_comment` status
- [ ] Journey summary shows correct confidence, review count, version count
- [ ] Financial simulation shows deposit, balance, return conditions
- [ ] Voting mechanics correct per proposal type
- [ ] Metadata preview shows valid CIP-108 JSON
- [ ] Step progression (1 → 2) works with Back/Continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)