### PR TITLE
feat: submission ceremony — team sign-off, cooldown timer, success view

### DIFF
--- a/components/workspace/author/DraftActions.tsx
+++ b/components/workspace/author/DraftActions.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   Shield,
   ExternalLink,
@@ -151,8 +152,10 @@ function SubmitOnChainButton({
   draft: ProposalDraft;
   onDraftUpdate?: (updates: Partial<ProposalDraft>) => void;
 }) {
+  const router = useRouter();
   const [showFlow, setShowFlow] = useState(false);
   const flagEnabled = useFeatureFlag('governance_action_submission');
+  const submissionCeremony = useFeatureFlag('submission_ceremony');
 
   // Fetch review data for threshold gate
   const { data: reviewsData } = useDraftReviews(draft.status === 'final_comment' ? draft.id : null);
@@ -162,7 +165,8 @@ function SubmitOnChainButton({
   if (draft.status !== 'final_comment') return null;
   if (flagEnabled === null || !flagEnabled) return null;
 
-  if (showFlow) {
+  // Old modal fallback — only used when submission_ceremony flag is off
+  if (showFlow && !submissionCeremony) {
     return (
       <SubmissionFlow
         draft={draft}
@@ -209,9 +213,19 @@ function SubmitOnChainButton({
     );
   }
 
+  const handleSubmitClick = () => {
+    if (submissionCeremony) {
+      // Navigate to the full-page submission ceremony
+      router.push(`/workspace/author/${draft.id}/submit`);
+    } else {
+      // Fallback: open the old modal flow
+      setShowFlow(true);
+    }
+  };
+
   return (
     <Button
-      onClick={() => setShowFlow(true)}
+      onClick={handleSubmitClick}
       className="w-full bg-amber-600 hover:bg-amber-700 text-white"
       size="lg"
     >

--- a/components/workspace/author/submission/FinalConfirmation.tsx
+++ b/components/workspace/author/submission/FinalConfirmation.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+/**
+ * FinalConfirmation — Step 4 of the submission ceremony.
+ *
+ * Shows the deposit amount prominently and enforces a 15-second cooldown
+ * before the "Sign & Submit" button becomes active. This forced pause
+ * prevents impulse submissions of a 100,000 ADA commitment.
+ *
+ * When isProcessing is true, shows a processing overlay with phase-aware
+ * status messages from the useGovernanceAction hook.
+ */
+
+import { useState, useEffect } from 'react';
+import { Shield, ArrowLeft, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { GovernanceActionPhase } from '@/hooks/useGovernanceAction';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface FinalConfirmationProps {
+  depositAda: number;
+  onSubmit: () => void;
+  onBack: () => void;
+  isProcessing: boolean;
+  /** Current phase from useGovernanceAction — drives processing status text */
+  phase?: GovernanceActionPhase;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const COOLDOWN_SECONDS = 15;
+
+const PHASE_STATUS_MESSAGES: Record<string, string> = {
+  publishing: 'Publishing metadata...',
+  building: 'Building transaction...',
+  signing: 'Waiting for wallet signature...',
+  submitting: 'Submitting to network...',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function FinalConfirmation({
+  depositAda,
+  onSubmit,
+  onBack,
+  isProcessing,
+  phase,
+}: FinalConfirmationProps) {
+  const [secondsLeft, setSecondsLeft] = useState(COOLDOWN_SECONDS);
+  const [cooldownDone, setCooldownDone] = useState(false);
+
+  // Cooldown timer — starts when the component mounts (user arrives at this step)
+  useEffect(() => {
+    if (secondsLeft <= 0) {
+      setCooldownDone(true);
+      return;
+    }
+    const timer = setTimeout(() => setSecondsLeft((s) => s - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [secondsLeft]);
+
+  // Progress percentage for the cooldown bar (0% at start, 100% when done)
+  const progressPercent = ((COOLDOWN_SECONDS - secondsLeft) / COOLDOWN_SECONDS) * 100;
+
+  // Processing overlay
+  if (isProcessing) {
+    const statusMessage =
+      phase?.status && phase.status in PHASE_STATUS_MESSAGES
+        ? PHASE_STATUS_MESSAGES[phase.status]
+        : 'Processing...';
+
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col items-center justify-center py-12 space-y-6">
+          <Loader2 className="h-10 w-10 animate-spin text-[var(--compass-teal)]" />
+          <div className="text-center">
+            <p className="text-lg font-semibold text-foreground mb-1">{statusMessage}</p>
+            {phase?.status === 'signing' && (
+              <p className="text-sm text-muted-foreground">
+                Check your wallet extension for the signature request
+              </p>
+            )}
+          </div>
+        </div>
+        <Button variant="outline" disabled className="w-full opacity-50">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+      </div>
+    );
+  }
+
+  // Format deposit with commas
+  const formattedDeposit = depositAda.toLocaleString();
+
+  return (
+    <div className="space-y-6">
+      {/* Deposit amount — large and prominent */}
+      <div className="text-center py-6">
+        <p className="text-4xl font-display font-bold text-foreground tracking-tight">
+          {formattedDeposit} ADA
+        </p>
+        <p className="text-sm font-semibold uppercase tracking-widest text-muted-foreground mt-2">
+          Refundable Deposit
+        </p>
+      </div>
+
+      {/* Warning */}
+      <div className="rounded-lg border border-[var(--wayfinder-amber)]/30 bg-[var(--wayfinder-amber)]/5 px-4 py-3">
+        <p className="text-sm text-foreground">
+          This action is irreversible once confirmed. The deposit will be locked until the proposal
+          is ratified or expires.
+        </p>
+      </div>
+
+      {/* Cooldown timer bar */}
+      <div className="space-y-2">
+        <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-1000 ease-linear"
+            style={{
+              width: `${progressPercent}%`,
+              backgroundColor: cooldownDone ? 'var(--compass-teal)' : 'var(--wayfinder-amber)',
+            }}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground text-center">
+          {cooldownDone ? 'Ready to submit' : `${secondsLeft}s remaining`}
+        </p>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack} className="flex-1" disabled={isProcessing}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={!cooldownDone || isProcessing}
+          className="flex-1 transition-colors"
+          style={
+            cooldownDone
+              ? { backgroundColor: 'var(--compass-teal)', color: 'var(--primary-foreground)' }
+              : undefined
+          }
+        >
+          <Shield className="h-4 w-4 mr-2" />
+          Sign &amp; Submit
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/SubmissionSuccess.tsx
+++ b/components/workspace/author/submission/SubmissionSuccess.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+/**
+ * SubmissionSuccess — shown after a successful governance action submission.
+ *
+ * Displays the transaction hash, anchor URL, "what happens next" guidance,
+ * and action buttons to return to portfolio or share the result.
+ */
+
+import { useState, useCallback } from 'react';
+import { Check, ExternalLink, ArrowRight, Share2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { ProposalType } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface SubmissionSuccessProps {
+  txHash: string;
+  anchorUrl: string;
+  proposalTitle: string;
+  proposalType: ProposalType;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateHash(hash: string): string {
+  if (hash.length <= 20) return hash;
+  return `${hash.slice(0, 10)}...${hash.slice(-10)}`;
+}
+
+/**
+ * Determine which governance bodies vote on this type.
+ * Based on CIP-1694 voting thresholds.
+ */
+function votingBodies(type: ProposalType): string {
+  switch (type) {
+    case 'TreasuryWithdrawals':
+      return 'DReps and the Constitutional Committee';
+    case 'ParameterChange':
+      return 'DReps and the Constitutional Committee';
+    case 'HardForkInitiation':
+      return 'DReps, SPOs, and the Constitutional Committee';
+    case 'NoConfidence':
+      return 'DReps and SPOs';
+    case 'NewCommittee':
+      return 'DReps and SPOs';
+    case 'NewConstitution':
+      return 'DReps and the Constitutional Committee';
+    case 'InfoAction':
+    default:
+      return 'DReps (non-binding signal)';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SubmissionSuccess({
+  txHash,
+  anchorUrl,
+  proposalTitle,
+  proposalType,
+}: SubmissionSuccessProps) {
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+
+  const cardanoscanUrl = `https://cardanoscan.io/transaction/${txHash}`;
+
+  const handleCopyLink = useCallback(() => {
+    const shareText = `I just submitted "${proposalTitle}" as a governance action on Cardano!\n\n${cardanoscanUrl}`;
+    navigator.clipboard.writeText(shareText).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    });
+  }, [proposalTitle, cardanoscanUrl]);
+
+  const handleReturnToPortfolio = useCallback(() => {
+    router.push('/workspace/author');
+  }, [router]);
+
+  return (
+    <div className="space-y-6">
+      {/* Celebration header */}
+      <div className="text-center py-6">
+        <div className="mx-auto w-14 h-14 rounded-full bg-[var(--compass-teal)]/15 flex items-center justify-center mb-4">
+          <Check className="h-7 w-7 text-[var(--compass-teal)]" />
+        </div>
+        <h2 className="text-xl font-display font-bold text-foreground mb-2">
+          Your proposal is now on-chain!
+        </h2>
+        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+          &ldquo;{proposalTitle}&rdquo; has been submitted as a governance action.
+        </p>
+      </div>
+
+      {/* Transaction details */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Transaction Hash</p>
+          <div className="flex items-center gap-2">
+            <code className="text-sm font-mono text-foreground">{truncateHash(txHash)}</code>
+            <a
+              href={cardanoscanUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 text-muted-foreground hover:text-[var(--compass-teal)] transition-colors"
+              aria-label="View on CardanoScan"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </div>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Anchor URL</p>
+          <a
+            href={anchorUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-mono text-[var(--compass-teal)] hover:underline break-all"
+          >
+            {anchorUrl}
+          </a>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Type</p>
+          <Badge variant="outline">{proposalType}</Badge>
+        </div>
+      </div>
+
+      {/* What happens next */}
+      <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">What Happens Next</h3>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li className="flex items-start gap-2">
+            <span className="mt-1 w-1.5 h-1.5 rounded-full bg-[var(--compass-teal)] shrink-0" />
+            <span>{votingBodies(proposalType)} will review and vote on your proposal</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1 w-1.5 h-1.5 rounded-full bg-[var(--compass-teal)] shrink-0" />
+            <span>Voting period: ~6 epochs (~30 days)</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1 w-1.5 h-1.5 rounded-full bg-[var(--compass-teal)] shrink-0" />
+            <span>You&apos;ll see voting progress in your portfolio</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1 w-1.5 h-1.5 rounded-full bg-[var(--compass-teal)] shrink-0" />
+            <span>Deposit returned on ratification or expiry</span>
+          </li>
+        </ul>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={handleCopyLink} className="flex-1">
+          {copied ? (
+            <>
+              <Check className="h-4 w-4 mr-2" />
+              Copied!
+            </>
+          ) : (
+            <>
+              <Share2 className="h-4 w-4 mr-2" />
+              Share
+            </>
+          )}
+        </Button>
+        <Button onClick={handleReturnToPortfolio} className="flex-1">
+          Return to Portfolio
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/TeamSignOff.tsx
+++ b/components/workspace/author/submission/TeamSignOff.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+/**
+ * TeamSignOff — Step 3 of the submission ceremony.
+ *
+ * INFORMATIONAL ONLY — displays team composition and roles but does not
+ * block submission. The lead can always proceed. A blocking approval gate
+ * will be added in Phase 4 when team collaboration is more mature.
+ */
+
+import { Users, UserCircle, ArrowLeft, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useTeam } from '@/hooks/useTeam';
+import type { TeamRole } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface TeamSignOffProps {
+  draftId: string;
+  onContinue: () => void;
+  onBack: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROLE_LABELS: Record<TeamRole, string> = {
+  lead: 'Lead',
+  editor: 'Editor',
+  viewer: 'Viewer',
+};
+
+const ROLE_COLORS: Record<TeamRole, string> = {
+  lead: 'border-[var(--compass-teal)]/40 text-[var(--compass-teal)]',
+  editor: 'border-[var(--wayfinder-amber)]/40 text-[var(--wayfinder-amber)]',
+  viewer: 'border-border text-muted-foreground',
+};
+
+function truncateAddress(addr: string): string {
+  if (addr.length <= 16) return addr;
+  return `${addr.slice(0, 8)}...${addr.slice(-8)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TeamSignOff({ draftId, onContinue, onBack }: TeamSignOffProps) {
+  const { data, isLoading } = useTeam(draftId);
+
+  const team = data?.team ?? null;
+  const members = data?.members ?? [];
+
+  // No team — solo proposer
+  if (!isLoading && !team) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center py-8">
+          <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
+            <UserCircle className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <h3 className="text-lg font-semibold text-foreground mb-2">Solo Proposer</h3>
+          <p className="text-sm text-muted-foreground max-w-sm mx-auto">
+            No team has been created for this proposal. You are submitting as a solo proposer.
+          </p>
+        </div>
+
+        <div className="flex gap-3">
+          <Button variant="outline" onClick={onBack} className="flex-1">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+          <Button onClick={onContinue} className="flex-1">
+            Continue
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center py-8">
+          <div className="mx-auto w-8 h-8 rounded-full border-2 border-muted-foreground/30 border-t-foreground animate-spin mb-4" />
+          <p className="text-sm text-muted-foreground">Loading team information...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Team exists — show members
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="text-center">
+        <div className="mx-auto w-12 h-12 rounded-full bg-[var(--compass-teal)]/10 flex items-center justify-center mb-4">
+          <Users className="h-6 w-6 text-[var(--compass-teal)]" />
+        </div>
+        <h3 className="text-lg font-semibold text-foreground mb-1">Team Authorization</h3>
+        <p className="text-sm text-muted-foreground">
+          {team?.name ?? 'Proposal Team'} — {members.length} member
+          {members.length !== 1 ? 's' : ''}
+        </p>
+      </div>
+
+      {/* Member list */}
+      <div className="space-y-2">
+        {members.map((member) => (
+          <div
+            key={member.id}
+            className="flex items-center justify-between px-4 py-3 rounded-lg border border-border bg-card"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0">
+                <UserCircle className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <span className="text-sm font-mono text-foreground truncate">
+                {truncateAddress(member.stakeAddress)}
+              </span>
+            </div>
+            <Badge variant="outline" className={ROLE_COLORS[member.role]}>
+              {ROLE_LABELS[member.role]}
+            </Badge>
+          </div>
+        ))}
+      </div>
+
+      {/* Informational note */}
+      <p className="text-xs text-muted-foreground text-center px-4">
+        Team sign-off is informational. The lead can proceed with submission.
+      </p>
+
+      {/* Navigation */}
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={onBack} className="flex-1">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back
+        </Button>
+        <Button onClick={onContinue} className="flex-1">
+          Continue
+          <ArrowRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/index.ts
+++ b/components/workspace/author/submission/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Submission ceremony components — Phase 3 of the Proposal Lifecycle.
+ *
+ * These components form the steps of the full-page submission wizard
+ * at /workspace/author/[draftId]/submit.
+ */
+
+export { TeamSignOff } from './TeamSignOff';
+export { FinalConfirmation } from './FinalConfirmation';
+export { SubmissionSuccess } from './SubmissionSuccess';


### PR DESCRIPTION
## Summary
- **TeamSignOff** (Step 3) — informational display of team members with role badges. Non-blocking — lead can always proceed. Solo proposer state when no team.
- **FinalConfirmation** (Step 4) — 15-second cooldown timer with progress bar. Large deposit display. "Sign & Submit" disabled during countdown. Processing overlay with phase-aware status messages.
- **SubmissionSuccess** — celebration view with tx hash (CardanoScan link), anchor URL, type-specific "What Happens Next" guidance, share-to-clipboard, return to portfolio.
- **DraftActions update** — Submit button navigates to new ceremony page (behind `submission_ceremony` flag) or falls back to old modal.
- **Barrel export** for all submission components.

## Impact
- **What changed**: Submission steps 3-4 + success view complete the ceremony. DraftActions wired to new route.
- **User-facing**: Yes — cooldown timer prevents impulse submissions, success view celebrates + guides.
- **Risk**: Low — new components, DraftActions gated behind feature flag for safe rollout.
- **Scope**: 4 new files + 1 modified (DraftActions.tsx)

## Test plan
- [ ] TeamSignOff shows team members or solo state
- [ ] Cooldown timer counts down from 15s, enables button at 0
- [ ] "Sign & Submit" disabled during cooldown — no bypass
- [ ] Processing overlay shows correct phase messages
- [ ] Success view shows tx hash link + anchor URL
- [ ] Share button copies formatted text to clipboard
- [ ] DraftActions navigates to /submit when ceremony flag enabled
- [ ] Falls back to old modal when flag disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)