### PR TITLE
feat: proposer monitoring dashboard — voting progress, deposit tracking, vote activity

### DIFF
--- a/app/api/workspace/proposals/monitor/route.ts
+++ b/app/api/workspace/proposals/monitor/route.ts
@@ -1,0 +1,216 @@
+/**
+ * Proposal Monitoring API — returns voting progress, deposit status,
+ * and recent vote activity for a submitted governance action.
+ *
+ * GET /api/workspace/proposals/monitor?txHash=...&proposalIndex=...
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { logger } from '@/lib/logger';
+import type { ProposalMonitorData } from '@/lib/workspace/monitor-types';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Thresholds per proposal type (constitutional / protocol-level)
+// Percentage thresholds for passing a governance action.
+// ---------------------------------------------------------------------------
+
+interface BodyThresholds {
+  drep: number;
+  spo?: number;
+  cc?: number;
+}
+
+const THRESHOLDS: Record<string, BodyThresholds> = {
+  TreasuryWithdrawals: { drep: 0.67, cc: 0.51 },
+  ParameterChange: { drep: 0.67, cc: 0.51 },
+  HardForkInitiation: { drep: 0.75, spo: 0.51, cc: 0.51 },
+  NoConfidence: { drep: 0.67, spo: 0.51 },
+  NewCommittee: { drep: 0.67, spo: 0.51 },
+  NewConstitution: { drep: 0.75, cc: 0.51 },
+  InfoAction: { drep: 0.51 },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deriveStatus(proposal: {
+  ratified_epoch: number | null;
+  enacted_epoch: number | null;
+  expired_epoch: number | null;
+  dropped_epoch: number | null;
+}): ProposalMonitorData['status'] {
+  if (proposal.enacted_epoch != null) return 'enacted';
+  if (proposal.ratified_epoch != null) return 'ratified';
+  if (proposal.expired_epoch != null) return 'expired';
+  if (proposal.dropped_epoch != null) return 'dropped';
+  return 'voting';
+}
+
+function deriveDepositStatus(
+  status: ProposalMonitorData['status'],
+): ProposalMonitorData['deposit']['status'] {
+  if (status === 'voting') return 'locked';
+  if (status === 'dropped') return 'at_risk';
+  return 'returned';
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const txHash = request.nextUrl.searchParams.get('txHash');
+  const proposalIndexStr = request.nextUrl.searchParams.get('proposalIndex');
+
+  if (!txHash || proposalIndexStr == null) {
+    return NextResponse.json(
+      { error: 'Missing txHash or proposalIndex query parameter' },
+      { status: 400 },
+    );
+  }
+
+  const proposalIndex = parseInt(proposalIndexStr, 10);
+  if (isNaN(proposalIndex)) {
+    return NextResponse.json({ error: 'Invalid proposalIndex' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+
+  // ── 1. Fetch proposal lifecycle data ─────────────────────────────────
+  const { data: proposal, error: pError } = await supabase
+    .from('proposals')
+    .select('*')
+    .eq('tx_hash', txHash)
+    .eq('proposal_index', proposalIndex)
+    .maybeSingle();
+
+  if (pError) {
+    logger.error('[monitor] Failed to fetch proposal', { error: pError });
+    return NextResponse.json({ error: 'Failed to fetch proposal' }, { status: 500 });
+  }
+
+  if (!proposal) {
+    return NextResponse.json({ error: 'Proposal not found' }, { status: 404 });
+  }
+
+  const status = deriveStatus(proposal);
+  const thresholds = THRESHOLDS[proposal.proposal_type] ?? THRESHOLDS.InfoAction;
+
+  // ── 2. Fetch latest voting summary ───────────────────────────────────
+  const { data: summaryRows } = await supabase
+    .from('proposal_voting_summary')
+    .select('*')
+    .eq('proposal_tx_hash', txHash)
+    .eq('proposal_index', proposalIndex)
+    .order('epoch_no', { ascending: false })
+    .limit(1);
+
+  const summary = summaryRows?.[0] ?? null;
+
+  // Build voting tallies
+  const drepYesPower = summary?.drep_yes_vote_power ?? 0;
+  const drepNoPower = summary?.drep_no_vote_power ?? 0;
+  const drepAbstainPower = summary?.drep_abstain_vote_power ?? 0;
+
+  const voting: ProposalMonitorData['voting'] = {
+    drep: {
+      yesCount: summary?.drep_yes_votes_cast ?? 0,
+      yesVotePower: drepYesPower,
+      noCount: summary?.drep_no_votes_cast ?? 0,
+      noVotePower: drepNoPower,
+      abstainCount: summary?.drep_abstain_votes_cast ?? 0,
+      abstainVotePower: drepAbstainPower,
+      threshold: thresholds.drep,
+    },
+  };
+
+  if (thresholds.spo != null) {
+    voting.spo = {
+      yesCount: summary?.pool_yes_votes_cast ?? 0,
+      yesVotePower: summary?.pool_yes_vote_power ?? 0,
+      noCount: summary?.pool_no_votes_cast ?? 0,
+      noVotePower: summary?.pool_no_vote_power ?? 0,
+      abstainCount: summary?.pool_abstain_votes_cast ?? 0,
+      abstainVotePower: summary?.pool_abstain_vote_power ?? 0,
+      threshold: thresholds.spo,
+    };
+  }
+
+  if (thresholds.cc != null) {
+    voting.cc = {
+      yesCount: summary?.committee_yes_votes_cast ?? 0,
+      noCount: summary?.committee_no_votes_cast ?? 0,
+      abstainCount: summary?.committee_abstain_votes_cast ?? 0,
+      threshold: thresholds.cc,
+    };
+  }
+
+  // ── 3. Fetch recent vote activity ────────────────────────────────────
+  const { data: recentVoteRows } = await supabase
+    .from('drep_votes')
+    .select('drep_id, vote, epoch_no, block_time, meta_url')
+    .eq('proposal_tx_hash', txHash)
+    .eq('proposal_index', proposalIndex)
+    .order('block_time', { ascending: false })
+    .limit(10);
+
+  const recentVotes: ProposalMonitorData['recentVotes'] =
+    recentVoteRows?.map((v) => ({
+      voterId: v.drep_id,
+      voterType: 'drep' as const,
+      vote: v.vote as 'Yes' | 'No' | 'Abstain',
+      epochNo: v.epoch_no ?? blockTimeToEpoch(v.block_time),
+      hasRationale: !!v.meta_url,
+    })) ?? [];
+
+  // ── 4. Compute deposit info ──────────────────────────────────────────
+  // The governance action deposit is fixed at 100,000 ADA (100_000_000_000 lovelace)
+  // per CIP-1694. The proposals table doesn't store deposit directly,
+  // so we use the known constant.
+  const GOVERNANCE_ACTION_DEPOSIT_LOVELACE = 100_000_000_000;
+  const depositStatus = deriveDepositStatus(status);
+
+  // ── 5. Compute epochs remaining ──────────────────────────────────────
+  const expirationEpoch = proposal.expiration_epoch;
+  const epochsRemaining =
+    status === 'voting' && expirationEpoch != null
+      ? Math.max(0, expirationEpoch - currentEpoch)
+      : null;
+
+  // ── 6. Assemble response ─────────────────────────────────────────────
+  const monitorData: ProposalMonitorData = {
+    txHash: proposal.tx_hash,
+    proposalIndex: proposal.proposal_index,
+    title: proposal.title ?? 'Untitled Proposal',
+    proposalType: proposal.proposal_type,
+
+    status,
+    proposedEpoch: proposal.proposed_epoch,
+    ratifiedEpoch: proposal.ratified_epoch,
+    enactedEpoch: proposal.enacted_epoch,
+    expiredEpoch: proposal.expired_epoch,
+    droppedEpoch: proposal.dropped_epoch,
+    expirationEpoch: proposal.expiration_epoch,
+
+    voting,
+    recentVotes,
+
+    deposit: {
+      amount: GOVERNANCE_ACTION_DEPOSIT_LOVELACE,
+      status: depositStatus,
+      returnAddress: null, // Not stored in proposals table; safe to omit
+    },
+
+    currentEpoch,
+    epochsRemaining,
+  };
+
+  return NextResponse.json(monitorData);
+});

--- a/app/workspace/author/[draftId]/monitor/page.tsx
+++ b/app/workspace/author/[draftId]/monitor/page.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Proposal Monitoring Dashboard — voting progress, vote activity,
+ * deposit tracking, and lifecycle status for a submitted governance action.
+ *
+ * Route: /workspace/author/[draftId]/monitor
+ */
+
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, ExternalLink, Loader2, Clock, Share2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useDraft } from '@/hooks/useDrafts';
+import { useProposalMonitor } from '@/hooks/useProposalMonitor';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import { VotingProgress } from '@/components/workspace/author/monitor/VotingProgress';
+import { VoteActivity } from '@/components/workspace/author/monitor/VoteActivity';
+import { DepositStatus } from '@/components/workspace/author/monitor/DepositStatus';
+import type { ProposalMonitorData } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Status badge colors
+// ---------------------------------------------------------------------------
+
+const STATUS_BADGE: Record<ProposalMonitorData['status'], { label: string; className: string }> = {
+  voting: {
+    label: 'In Voting',
+    className: 'bg-blue-500/15 text-blue-400',
+  },
+  ratified: {
+    label: 'Ratified',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  enacted: {
+    label: 'Enacted',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  expired: {
+    label: 'Expired',
+    className: 'bg-muted text-muted-foreground',
+  },
+  dropped: {
+    label: 'Dropped',
+    className: 'bg-destructive/15 text-destructive',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function MonitorPage() {
+  const params = useParams();
+  const router = useRouter();
+  const draftId = params.draftId as string;
+
+  // Load the draft to get submittedTxHash
+  const { data: draftData, isLoading: draftLoading } = useDraft(draftId);
+  const draft = draftData?.draft ?? null;
+
+  // Derive proposalIndex — defaults to 0 since most governance actions
+  // submitted through the platform are the first action in their tx
+  const proposalIndex = 0;
+
+  // Fetch monitoring data
+  const {
+    data: monitor,
+    isLoading: monitorLoading,
+    error: monitorError,
+  } = useProposalMonitor(draft?.submittedTxHash ?? null, proposalIndex);
+
+  // Guard: redirect if not submitted
+  if (draft && draft.status !== 'submitted') {
+    router.replace(`/workspace/author/${draftId}`);
+    return null;
+  }
+
+  // Loading state
+  if (draftLoading || (!monitor && monitorLoading)) {
+    return <MonitorSkeleton />;
+  }
+
+  // No draft found
+  if (!draft) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <p className="text-muted-foreground">Draft not found.</p>
+      </div>
+    );
+  }
+
+  // Monitor data not available yet (proposal may not be synced)
+  if (!monitor) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <BackLink />
+        <Card>
+          <CardContent className="py-8 text-center space-y-3">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />
+            <h2 className="font-medium">Waiting for on-chain data</h2>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              {monitorError
+                ? 'Unable to load monitoring data. The proposal may not have been indexed yet. Data syncs every hour.'
+                : 'Your proposal has been submitted. Monitoring data will appear once the next sync cycle completes (up to 1 hour).'}
+            </p>
+            {draft.submittedTxHash && (
+              <a
+                href={`https://cardanoscan.io/transaction/${draft.submittedTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300"
+              >
+                View transaction on Cardanoscan
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const statusBadge = STATUS_BADGE[monitor.status];
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      {/* Back link */}
+      <BackLink />
+
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-xl font-display font-semibold">{monitor.title}</h1>
+          <Badge variant="outline" className="text-xs">
+            {PROPOSAL_TYPE_LABELS[monitor.proposalType as keyof typeof PROPOSAL_TYPE_LABELS] ??
+              monitor.proposalType}
+          </Badge>
+          <Badge className={statusBadge.className}>{statusBadge.label}</Badge>
+        </div>
+
+        {/* Epochs remaining */}
+        {monitor.epochsRemaining != null && monitor.status === 'voting' && (
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Clock className="h-3.5 w-3.5" />
+            <span>
+              {monitor.epochsRemaining === 0
+                ? 'Expiring this epoch'
+                : `${monitor.epochsRemaining} epoch${monitor.epochsRemaining === 1 ? '' : 's'} remaining`}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Voting Progress */}
+      <Card>
+        <CardContent className="pt-6 pb-5">
+          <VotingProgress voting={monitor.voting} />
+        </CardContent>
+      </Card>
+
+      {/* Recent Votes */}
+      <Card>
+        <CardContent className="pt-6 pb-5">
+          <VoteActivity votes={monitor.recentVotes} currentEpoch={monitor.currentEpoch} />
+        </CardContent>
+      </Card>
+
+      {/* Deposit Status */}
+      <Card>
+        <CardContent className="pt-6 pb-5">
+          <DepositStatus
+            deposit={monitor.deposit}
+            expirationEpoch={monitor.expirationEpoch}
+            status={monitor.status}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <Card>
+        <CardContent className="pt-6 pb-5">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider mb-3">
+            Actions
+          </h3>
+          <div className="flex items-center gap-3 flex-wrap">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                const url = `${window.location.origin}/proposals/${monitor.txHash}/${monitor.proposalIndex}`;
+                navigator.clipboard.writeText(url).catch(() => {});
+              }}
+            >
+              <Share2 className="h-3.5 w-3.5 mr-1.5" />
+              Share Proposal
+            </Button>
+            <Button variant="outline" size="sm" asChild>
+              <a
+                href={`https://cardanoscan.io/transaction/${monitor.txHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+                View on Cardanoscan
+              </a>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function BackLink() {
+  return (
+    <Link
+      href="/workspace/author"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <ArrowLeft className="h-3.5 w-3.5" />
+      Back to portfolio
+    </Link>
+  );
+}
+
+function MonitorSkeleton() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-48 w-full rounded-xl" />
+      <Skeleton className="h-36 w-full rounded-xl" />
+      <Skeleton className="h-28 w-full rounded-xl" />
+    </div>
+  );
+}

--- a/components/workspace/author/DraftCard.tsx
+++ b/components/workspace/author/DraftCard.tsx
@@ -5,12 +5,15 @@ import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { motion, useReducedMotion } from 'framer-motion';
-import { ExternalLink, CheckCircle2, ShieldCheck, XCircle } from 'lucide-react';
+import { ExternalLink, CheckCircle2, ShieldCheck, XCircle, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
 import { useFocusStore } from '@/lib/workspace/focus';
+import { useProposalMonitor } from '@/hooks/useProposalMonitor';
+import { VotingProgress } from './monitor/VotingProgress';
 import { DraftQuickActions } from './DraftQuickActions';
 import type { ProposalDraft, DraftStatus } from '@/lib/workspace/types';
+import type { ProposalMonitorData } from '@/lib/workspace/monitor-types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,10 +94,13 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
   const setInputMethod = useFocusStore((s) => s.setInputMethod);
   const prefersReducedMotion = useReducedMotion();
 
+  // Submitted drafts go to the monitoring dashboard; others to the editor
   const editorPath =
-    draft.proposalType === 'NewConstitution'
-      ? `/workspace/amendment/${draft.id}`
-      : `/workspace/author/${draft.id}`;
+    draft.status === 'submitted'
+      ? `/workspace/author/${draft.id}/monitor`
+      : draft.proposalType === 'NewConstitution'
+        ? `/workspace/amendment/${draft.id}`
+        : `/workspace/author/${draft.id}`;
 
   return (
     <motion.div
@@ -232,25 +238,68 @@ function InReviewColumnInfo({ draft }: { draft: ProposalDraft }) {
   );
 }
 
+const ON_CHAIN_STATUS_LABELS: Record<
+  ProposalMonitorData['status'],
+  { label: string; className: string }
+> = {
+  voting: { label: 'In Voting', className: 'bg-blue-500/15 text-blue-400' },
+  ratified: {
+    label: 'Ratified',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  enacted: {
+    label: 'Enacted',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  expired: { label: 'Expired', className: 'bg-muted text-muted-foreground' },
+  dropped: { label: 'Dropped', className: 'bg-destructive/15 text-destructive' },
+};
+
 function OnChainColumnInfo({ draft }: { draft: ProposalDraft }) {
+  const { data: monitor } = useProposalMonitor(draft.submittedTxHash, 0);
+
   return (
-    <div className="flex flex-col gap-1">
-      {draft.submittedAt && (
-        <span className="text-xs text-muted-foreground">
-          Submitted {formatRelativeTime(draft.submittedAt)}
-        </span>
-      )}
-      {draft.submittedTxHash && (
-        <a
-          href={`https://cardanoscan.io/transaction/${draft.submittedTxHash}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {truncateHash(draft.submittedTxHash)}
-          <ExternalLink className="h-3 w-3" />
-        </a>
+    <div className="flex flex-col gap-1.5">
+      {/* Monitor-enriched info when available */}
+      {monitor ? (
+        <>
+          {/* Status badge override */}
+          <div className="flex items-center gap-2">
+            <Badge className={cn('text-xs', ON_CHAIN_STATUS_LABELS[monitor.status].className)}>
+              {ON_CHAIN_STATUS_LABELS[monitor.status].label}
+            </Badge>
+            {monitor.epochsRemaining != null && monitor.status === 'voting' && (
+              <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                <Clock className="h-3 w-3" />
+                {monitor.epochsRemaining}e left
+              </span>
+            )}
+          </div>
+
+          {/* Compact voting progress */}
+          <VotingProgress voting={monitor.voting} compact />
+        </>
+      ) : (
+        <>
+          {/* Fallback: basic info while monitor data loads */}
+          {draft.submittedAt && (
+            <span className="text-xs text-muted-foreground">
+              Submitted {formatRelativeTime(draft.submittedAt)}
+            </span>
+          )}
+          {draft.submittedTxHash && (
+            <a
+              href={`https://cardanoscan.io/transaction/${draft.submittedTxHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {truncateHash(draft.submittedTxHash)}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/workspace/author/monitor/DepositStatus.tsx
+++ b/components/workspace/author/monitor/DepositStatus.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * DepositStatus — displays the deposit tracking info for a submitted proposal.
+ *
+ * Shows deposit amount, lock/return status, and conditions for return.
+ */
+
+import { Lock, Unlock, AlertTriangle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { DepositInfo, ProposalMonitorData } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DepositStatusProps {
+  deposit: DepositInfo;
+  expirationEpoch: number | null;
+  status: ProposalMonitorData['status'];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAda(lovelace: number): string {
+  const ada = lovelace / 1_000_000;
+  return ada.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  });
+}
+
+const STATUS_CONFIG = {
+  locked: {
+    icon: Lock,
+    label: 'Locked',
+    color: 'text-[var(--wayfinder-amber)]',
+    bgColor: 'bg-[var(--wayfinder-amber)]/10',
+  },
+  returned: {
+    icon: Unlock,
+    label: 'Returned',
+    color: 'text-[var(--compass-teal)]',
+    bgColor: 'bg-[var(--compass-teal)]/10',
+  },
+  at_risk: {
+    icon: AlertTriangle,
+    label: 'At Risk',
+    color: 'text-destructive',
+    bgColor: 'bg-destructive/10',
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DepositStatus({ deposit, expirationEpoch, status }: DepositStatusProps) {
+  const config = STATUS_CONFIG[deposit.status];
+  const Icon = config.icon;
+
+  // Determine return condition text
+  let returnCondition: string;
+  if (deposit.status === 'returned') {
+    if (status === 'ratified' || status === 'enacted') {
+      returnCondition = 'Returned upon ratification';
+    } else if (status === 'expired') {
+      returnCondition = 'Returned upon expiration';
+    } else {
+      returnCondition = 'Deposit has been returned';
+    }
+  } else if (deposit.status === 'at_risk') {
+    returnCondition =
+      'Proposal was dropped (unconstitutional). Deposit may be at risk depending on protocol rules.';
+  } else {
+    // locked
+    if (expirationEpoch != null) {
+      returnCondition = `Returns on ratification or epoch ${expirationEpoch} (expiry)`;
+    } else {
+      returnCondition = 'Returns on ratification or expiry';
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+        Deposit
+      </h3>
+
+      <div className="flex items-start gap-3">
+        {/* Status icon */}
+        <div className={cn('p-2 rounded-lg', config.bgColor)}>
+          <Icon className={cn('h-4 w-4', config.color)} />
+        </div>
+
+        <div className="flex-1 space-y-1">
+          {/* Status + amount */}
+          <div className="flex items-center gap-2">
+            <span className={cn('text-sm font-medium', config.color)}>{config.label}</span>
+          </div>
+
+          <p className="text-sm">
+            <span className="font-mono tabular-nums">{formatAda(deposit.amount)}</span>
+            <span className="text-muted-foreground ml-1">ADA</span>
+          </p>
+
+          {/* Return condition */}
+          <p className="text-xs text-muted-foreground">{returnCondition}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/monitor/VoteActivity.tsx
+++ b/components/workspace/author/monitor/VoteActivity.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * VoteActivity — shows recent votes on a submitted governance action.
+ *
+ * Displays the last 10 votes with voter ID, vote direction, epoch,
+ * and whether a rationale was published.
+ */
+
+import { FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { RecentVote } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface VoteActivityProps {
+  votes: RecentVote[];
+  currentEpoch: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateId(id: string): string {
+  if (id.length <= 16) return id;
+  return `${id.slice(0, 8)}...${id.slice(-6)}`;
+}
+
+function epochLabel(voteEpoch: number, currentEpoch: number): string {
+  const diff = currentEpoch - voteEpoch;
+  if (diff === 0) return 'This epoch';
+  if (diff === 1) return '1 epoch ago';
+  return `${diff} epochs ago`;
+}
+
+const VOTE_COLORS: Record<string, string> = {
+  Yes: 'text-[var(--compass-teal)]',
+  No: 'text-destructive',
+  Abstain: 'text-muted-foreground',
+};
+
+const VOTER_TYPE_LABELS: Record<string, string> = {
+  drep: 'DRep',
+  spo: 'SPO',
+  cc: 'CC',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function VoteActivity({ votes, currentEpoch }: VoteActivityProps) {
+  if (votes.length === 0) {
+    return (
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+          Recent Votes
+        </h3>
+        <p className="text-sm text-muted-foreground">No votes recorded yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+        Recent Votes
+      </h3>
+
+      <div className="space-y-1">
+        {votes.map((v, i) => (
+          <div
+            key={`${v.voterId}-${v.epochNo}-${i}`}
+            className="flex items-center gap-3 py-1.5 text-sm"
+          >
+            {/* Voter type + ID */}
+            <span className="text-muted-foreground shrink-0 w-10">
+              {VOTER_TYPE_LABELS[v.voterType] ?? v.voterType}
+            </span>
+            <span className="font-mono text-xs truncate min-w-0 flex-1">
+              {truncateId(v.voterId)}
+            </span>
+
+            {/* Vote direction */}
+            <span className={cn('font-medium w-14 text-right shrink-0', VOTE_COLORS[v.vote])}>
+              {v.vote}
+            </span>
+
+            {/* Epoch */}
+            <span className="text-xs text-muted-foreground w-24 text-right shrink-0 tabular-nums">
+              {epochLabel(v.epochNo, currentEpoch)}
+            </span>
+
+            {/* Rationale indicator */}
+            <span
+              className="w-5 shrink-0 flex justify-center"
+              title={v.hasRationale ? 'Has rationale' : undefined}
+            >
+              {v.hasRationale && <FileText className="h-3.5 w-3.5 text-[var(--wayfinder-amber)]" />}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/monitor/VotingProgress.tsx
+++ b/components/workspace/author/monitor/VotingProgress.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+/**
+ * VotingProgress — per-body progress bars with threshold markers.
+ *
+ * Shows DRep, SPO, and CC voting progress as horizontal bars with a
+ * threshold line indicating the required percentage for ratification.
+ */
+
+import { cn } from '@/lib/utils';
+import type { VotingBodyTally, CCTally } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface VotingProgressProps {
+  voting: {
+    drep: VotingBodyTally;
+    spo?: VotingBodyTally;
+    cc?: CCTally;
+  };
+  /** Compact mode for portfolio cards — single bar, no labels */
+  compact?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Compute yes percentage from vote power (DRep/SPO) */
+function yesPercentFromPower(body: VotingBodyTally): number {
+  const total = body.yesVotePower + body.noVotePower + body.abstainVotePower;
+  if (total === 0) return 0;
+  // Threshold is measured against yes / (yes + no) — abstain excluded from denominator
+  const effective = body.yesVotePower + body.noVotePower;
+  if (effective === 0) return 0;
+  return body.yesVotePower / effective;
+}
+
+/** Compute yes percentage from CC vote counts */
+function yesPercentFromCounts(cc: CCTally): number {
+  const total = cc.yesCount + cc.noCount + cc.abstainCount;
+  if (total === 0) return 0;
+  const effective = cc.yesCount + cc.noCount;
+  if (effective === 0) return 0;
+  return cc.yesCount / effective;
+}
+
+function formatPercent(ratio: number): string {
+  return `${(ratio * 100).toFixed(0)}%`;
+}
+
+// ---------------------------------------------------------------------------
+// Single bar component
+// ---------------------------------------------------------------------------
+
+function ProgressBar({
+  label,
+  yesPercent,
+  threshold,
+  compact,
+}: {
+  label: string;
+  yesPercent: number;
+  threshold: number;
+  compact?: boolean;
+}) {
+  const barPercent = Math.min(yesPercent * 100, 100);
+  const thresholdPercent = threshold * 100;
+  const meetingThreshold = yesPercent >= threshold;
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2 w-full">
+        <span className="text-xs text-muted-foreground w-10 shrink-0">{label}</span>
+        <div className="relative flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+          <div
+            className={cn(
+              'h-full rounded-full transition-all duration-500',
+              meetingThreshold ? 'bg-[var(--compass-teal)]' : 'bg-[var(--compass-teal)]/70',
+            )}
+            style={{ width: `${barPercent}%` }}
+          />
+          {/* Threshold marker */}
+          <div
+            className="absolute top-0 h-full w-0.5 bg-foreground/40"
+            style={{ left: `${thresholdPercent}%` }}
+          />
+        </div>
+        <span className="text-xs tabular-nums text-muted-foreground w-9 text-right shrink-0">
+          {formatPercent(yesPercent)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground tabular-nums">
+          {formatPercent(yesPercent)} / {formatPercent(threshold)} threshold
+        </span>
+      </div>
+      <div className="relative h-3 bg-muted rounded-full overflow-hidden">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500',
+            meetingThreshold ? 'bg-[var(--compass-teal)]' : 'bg-[var(--compass-teal)]/70',
+          )}
+          style={{ width: `${barPercent}%` }}
+        />
+        {/* Threshold line */}
+        <div
+          className="absolute top-0 h-full w-0.5 bg-foreground/50"
+          style={{ left: `${thresholdPercent}%` }}
+          title={`Threshold: ${formatPercent(threshold)}`}
+        />
+      </div>
+      {meetingThreshold && <p className="text-xs text-[var(--compass-teal)]">Threshold met</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function VotingProgress({ voting, compact }: VotingProgressProps) {
+  const drepPercent = yesPercentFromPower(voting.drep);
+
+  if (compact) {
+    return (
+      <div className="flex flex-col gap-1 w-full">
+        <ProgressBar
+          label="DRep"
+          yesPercent={drepPercent}
+          threshold={voting.drep.threshold}
+          compact
+        />
+        {voting.spo && (
+          <ProgressBar
+            label="SPO"
+            yesPercent={yesPercentFromPower(voting.spo)}
+            threshold={voting.spo.threshold}
+            compact
+          />
+        )}
+        {voting.cc && (
+          <ProgressBar
+            label="CC"
+            yesPercent={yesPercentFromCounts(voting.cc)}
+            threshold={voting.cc.threshold}
+            compact
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+        Voting Progress
+      </h3>
+
+      <ProgressBar label="DRep" yesPercent={drepPercent} threshold={voting.drep.threshold} />
+
+      {voting.spo && (
+        <ProgressBar
+          label="SPO"
+          yesPercent={yesPercentFromPower(voting.spo)}
+          threshold={voting.spo.threshold}
+        />
+      )}
+
+      {voting.cc && (
+        <ProgressBar
+          label="Constitutional Committee"
+          yesPercent={yesPercentFromCounts(voting.cc)}
+          threshold={voting.cc.threshold}
+        />
+      )}
+    </div>
+  );
+}

--- a/hooks/useProposalMonitor.ts
+++ b/hooks/useProposalMonitor.ts
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * Hook to fetch monitoring data for a submitted governance action.
+ *
+ * Uses TanStack Query with a 1-minute stale time and 5-minute auto-refetch
+ * since voting data changes slowly (epoch-based).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import type { ProposalMonitorData } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Fetch helper (same pattern as useDrafts.ts)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const headers: Record<string, string> = {};
+  try {
+    const { getStoredSession } = await import('@/lib/supabaseAuth');
+    const token = getStoredSession();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {
+    // No session available
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useProposalMonitor(txHash: string | null, proposalIndex: number | null) {
+  return useQuery<ProposalMonitorData>({
+    queryKey: ['proposal-monitor', txHash, proposalIndex],
+    queryFn: () =>
+      fetchJson<ProposalMonitorData>(
+        `/api/workspace/proposals/monitor?txHash=${encodeURIComponent(txHash!)}&proposalIndex=${proposalIndex}`,
+      ),
+    enabled: !!txHash && proposalIndex != null,
+    staleTime: 60_000, // 1 minute
+    refetchInterval: 300_000, // refetch every 5 minutes
+  });
+}

--- a/lib/workspace/monitor-types.ts
+++ b/lib/workspace/monitor-types.ts
@@ -1,0 +1,89 @@
+/**
+ * Types for the Proposal Monitoring Dashboard.
+ *
+ * Shared between the API route and frontend components.
+ */
+
+// ---------------------------------------------------------------------------
+// Voting tally per governance body
+// ---------------------------------------------------------------------------
+
+export interface VotingBodyTally {
+  yesCount: number;
+  yesVotePower: number;
+  noCount: number;
+  noVotePower: number;
+  abstainCount: number;
+  abstainVotePower: number;
+  /** Threshold ratio (0-1) required for this body to pass */
+  threshold: number;
+}
+
+export interface CCTally {
+  yesCount: number;
+  noCount: number;
+  abstainCount: number;
+  /** Threshold ratio (0-1) required for CC to pass */
+  threshold: number;
+}
+
+// ---------------------------------------------------------------------------
+// Recent vote activity
+// ---------------------------------------------------------------------------
+
+export interface RecentVote {
+  voterId: string;
+  voterType: 'drep' | 'spo' | 'cc';
+  vote: 'Yes' | 'No' | 'Abstain';
+  epochNo: number;
+  hasRationale: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Deposit tracking
+// ---------------------------------------------------------------------------
+
+export interface DepositInfo {
+  /** Deposit amount in lovelace */
+  amount: number;
+  status: 'locked' | 'returned' | 'at_risk';
+  returnAddress: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Full monitoring response
+// ---------------------------------------------------------------------------
+
+export interface ProposalMonitorData {
+  // Identity
+  txHash: string;
+  proposalIndex: number;
+  title: string;
+  proposalType: string;
+
+  // Lifecycle status
+  status: 'voting' | 'ratified' | 'enacted' | 'expired' | 'dropped';
+  proposedEpoch: number | null;
+  ratifiedEpoch: number | null;
+  enactedEpoch: number | null;
+  expiredEpoch: number | null;
+  droppedEpoch: number | null;
+  expirationEpoch: number | null;
+
+  // Voting tallies
+  voting: {
+    drep: VotingBodyTally;
+    spo?: VotingBodyTally;
+    cc?: CCTally;
+  };
+
+  // Recent vote activity
+  recentVotes: RecentVote[];
+
+  // Deposit
+  deposit: DepositInfo;
+
+  // Epochs
+  currentEpoch: number;
+  epochsRemaining: number | null;
+}


### PR DESCRIPTION
## Summary
- **Monitoring API** (`GET /api/workspace/proposals/monitor`) — assembles voting tallies, recent votes, deposit status, thresholds from existing synced tables. No new migrations.
- **Dashboard page** (`/workspace/author/[draftId]/monitor`) — voting progress bars per body with threshold markers, recent vote activity feed, deposit status card, epochs remaining.
- **VotingProgress** — per-body bars with threshold lines, compact mode for portfolio cards.
- **VoteActivity** — recent votes list with voter type, vote direction, epoch delta, rationale indicator.
- **DepositStatus** — locked/returned/at-risk display with ADA formatting.
- **Enhanced On-Chain cards** — portfolio cards show compact voting progress, status badge, epochs remaining. Click navigates to monitoring dashboard.

## Impact
- **What changed**: Proposers can monitor their submitted proposals with real-time voting data.
- **User-facing**: Yes — new monitoring dashboard, enhanced portfolio cards for submitted proposals.
- **Risk**: Low — new route + components, existing data tables. No schema changes.
- **Scope**: 7 new files, 1 modified (DraftCard.tsx)

## Test plan
- [ ] Monitor page shows voting progress bars with correct thresholds per type
- [ ] Recent votes display with voter type and direction
- [ ] Deposit status shows locked/returned/at-risk correctly
- [ ] On-Chain portfolio cards show compact voting progress
- [ ] Click On-Chain card navigates to /monitor
- [ ] Redirect to editor if draft not submitted
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)