### PR TITLE
feat: team approval gate + outcome debrief (Phase 4 Session 1B)

### DIFF
--- a/app/api/workspace/drafts/[draftId]/approvals/route.ts
+++ b/app/api/workspace/drafts/[draftId]/approvals/route.ts
@@ -1,0 +1,199 @@
+/**
+ * Team Approvals API — manage team member approvals for proposal submission.
+ *
+ * GET  /api/workspace/drafts/[draftId]/approvals
+ *   Returns approval status for all editor-role team members.
+ *
+ * POST /api/workspace/drafts/[draftId]/approvals
+ *   Records the current user's approval. Idempotent (re-approval is no-op).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractDraftId(pathname: string): string | null {
+  const match = pathname.match(/\/drafts\/([^/]+)\/approvals/);
+  return match?.[1] ?? null;
+}
+
+interface TeamApproval {
+  memberId: string;
+  stakeAddress: string;
+  role: string;
+  approvedAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// GET — list approvals for a draft
+// ---------------------------------------------------------------------------
+
+export const GET = withRouteHandler(
+  async (request: NextRequest) => {
+    const draftId = extractDraftId(request.nextUrl.pathname);
+    if (!draftId) {
+      return NextResponse.json({ error: 'Missing draftId' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+
+    // Fetch team for this draft
+    const { data: teamRow } = await admin
+      .from('proposal_teams')
+      .select('id')
+      .eq('draft_id', draftId)
+      .maybeSingle();
+
+    // No team — solo proposer, all approved by default
+    if (!teamRow) {
+      return NextResponse.json({
+        approvals: [] as TeamApproval[],
+        allApproved: true,
+        pendingCount: 0,
+      });
+    }
+
+    // Fetch team members (only editors need to approve)
+    const { data: members } = await admin
+      .from('proposal_team_members')
+      .select('id, stake_address, role')
+      .eq('team_id', teamRow.id);
+
+    const editors = (members ?? []).filter((m) => m.role === 'editor');
+
+    // No editors — only lead/viewers, all approved
+    if (editors.length === 0) {
+      return NextResponse.json({
+        approvals: [] as TeamApproval[],
+        allApproved: true,
+        pendingCount: 0,
+      });
+    }
+
+    // Fetch existing approvals
+    const editorIds = editors.map((e) => e.id);
+    const { data: approvalRows } = await admin
+      .from('proposal_team_approvals')
+      .select('team_member_id, approved_at')
+      .eq('draft_id', draftId)
+      .in('team_member_id', editorIds);
+
+    const approvalMap = new Map<string, string>();
+    for (const row of approvalRows ?? []) {
+      approvalMap.set(row.team_member_id, row.approved_at);
+    }
+
+    const approvals: TeamApproval[] = editors.map((e) => ({
+      memberId: e.id,
+      stakeAddress: e.stake_address,
+      role: e.role,
+      approvedAt: approvalMap.get(e.id) ?? null,
+    }));
+
+    const pendingCount = approvals.filter((a) => !a.approvedAt).length;
+
+    return NextResponse.json({
+      approvals,
+      allApproved: pendingCount === 0,
+      pendingCount,
+    });
+  },
+  { auth: 'optional' },
+);
+
+// ---------------------------------------------------------------------------
+// POST — record approval for the current user
+// ---------------------------------------------------------------------------
+
+export const POST = withRouteHandler(
+  async (request: NextRequest, ctx) => {
+    const draftId = extractDraftId(request.nextUrl.pathname);
+    if (!draftId) {
+      return NextResponse.json({ error: 'Missing draftId' }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const stakeAddress: string | undefined = body?.stakeAddress;
+    if (!stakeAddress) {
+      return NextResponse.json({ error: 'Missing stakeAddress' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+
+    // Find the team for this draft
+    const { data: teamRow } = await admin
+      .from('proposal_teams')
+      .select('id')
+      .eq('draft_id', draftId)
+      .maybeSingle();
+
+    if (!teamRow) {
+      return NextResponse.json({ error: 'No team exists for this draft' }, { status: 404 });
+    }
+
+    // Find the team member by stake address
+    const { data: member } = await admin
+      .from('proposal_team_members')
+      .select('id, role')
+      .eq('team_id', teamRow.id)
+      .eq('stake_address', stakeAddress)
+      .maybeSingle();
+
+    if (!member) {
+      return NextResponse.json({ error: 'Not a member of this team' }, { status: 403 });
+    }
+
+    if (member.role !== 'editor') {
+      return NextResponse.json(
+        { error: 'Only editors need to approve. Leads have implicit approval.' },
+        { status: 400 },
+      );
+    }
+
+    // Idempotent upsert — if already approved, just return existing
+    const { data: existing } = await admin
+      .from('proposal_team_approvals')
+      .select('approved_at')
+      .eq('draft_id', draftId)
+      .eq('team_member_id', member.id)
+      .maybeSingle();
+
+    if (existing) {
+      return NextResponse.json({ success: true, approvedAt: existing.approved_at });
+    }
+
+    // Insert new approval
+    const { data: approval, error: insertError } = await admin
+      .from('proposal_team_approvals')
+      .insert({
+        draft_id: draftId,
+        team_member_id: member.id,
+      })
+      .select('approved_at')
+      .single();
+
+    if (insertError || !approval) {
+      return NextResponse.json({ error: 'Failed to record approval' }, { status: 500 });
+    }
+
+    captureServerEvent(
+      'team_approval_recorded',
+      {
+        draft_id: draftId,
+        team_member_id: member.id,
+        stake_address: stakeAddress,
+      },
+      ctx.wallet ?? stakeAddress,
+    );
+
+    return NextResponse.json({ success: true, approvedAt: approval.approved_at });
+  },
+  { auth: 'required', rateLimit: { max: 20, window: 60 } },
+);

--- a/app/api/workspace/proposals/[txHash]/[index]/voting-summary/route.ts
+++ b/app/api/workspace/proposals/[txHash]/[index]/voting-summary/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Voting Summary API — fetch the latest voting tallies for a proposal.
+ *
+ * GET /api/workspace/proposals/[txHash]/[index]/voting-summary
+ * Returns aggregated vote counts and power by body (DRep, CC, SPO).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+function extractParams(pathname: string): { txHash: string; index: number } | null {
+  const match = pathname.match(/\/proposals\/([^/]+)\/(\d+)\/voting-summary/);
+  if (!match) return null;
+  return { txHash: match[1], index: parseInt(match[2], 10) };
+}
+
+export const GET = withRouteHandler(
+  async (request: NextRequest) => {
+    const params = extractParams(request.nextUrl.pathname);
+    if (!params) {
+      return NextResponse.json({ error: 'Missing txHash or index' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+
+    // Fetch the most recent voting summary for this proposal
+    const { data: row, error } = await admin
+      .from('proposal_voting_summary')
+      .select('*')
+      .eq('proposal_tx_hash', params.txHash)
+      .eq('proposal_index', params.index)
+      .order('epoch_no', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: 'Failed to fetch voting summary' }, { status: 500 });
+    }
+
+    if (!row) {
+      return NextResponse.json({ summary: null });
+    }
+
+    return NextResponse.json({
+      summary: {
+        drepYesPower: row.drep_yes_vote_power ?? 0,
+        drepNoPower: row.drep_no_vote_power ?? 0,
+        drepAbstainPower: row.drep_abstain_vote_power ?? 0,
+        drepYesCount: row.drep_yes_votes_cast ?? 0,
+        drepNoCount: row.drep_no_votes_cast ?? 0,
+        drepAbstainCount: row.drep_abstain_votes_cast ?? 0,
+        ccYesCount: row.committee_yes_votes_cast ?? 0,
+        ccNoCount: row.committee_no_votes_cast ?? 0,
+        ccAbstainCount: row.committee_abstain_votes_cast ?? 0,
+        spoYesCount: row.pool_yes_votes_cast ?? 0,
+        spoNoCount: row.pool_no_votes_cast ?? 0,
+        spoAbstainCount: row.pool_abstain_votes_cast ?? 0,
+      },
+    });
+  },
+  { auth: 'optional' },
+);

--- a/app/api/workspace/proposals/[txHash]/debrief/route.ts
+++ b/app/api/workspace/proposals/[txHash]/debrief/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Proposal Debrief API — fetch on-chain proposal lifecycle data for debrief view.
+ *
+ * GET /api/workspace/proposals/[txHash]/debrief
+ * Returns the proposal's terminal status (ratified/expired/dropped) and epoch info.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+
+export const dynamic = 'force-dynamic';
+
+function extractTxHash(pathname: string): string | null {
+  const match = pathname.match(/\/proposals\/([^/]+)\/debrief/);
+  return match?.[1] ?? null;
+}
+
+export const GET = withRouteHandler(
+  async (request: NextRequest) => {
+    const txHash = extractTxHash(request.nextUrl.pathname);
+    if (!txHash) {
+      return NextResponse.json({ error: 'Missing txHash' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+
+    const { data: row, error } = await admin
+      .from('proposals')
+      .select(
+        'tx_hash, proposal_index, proposal_type, ratified_epoch, expired_epoch, dropped_epoch, enacted_epoch',
+      )
+      .eq('tx_hash', txHash)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: 'Failed to fetch proposal' }, { status: 500 });
+    }
+
+    if (!row) {
+      return NextResponse.json({ proposal: null });
+    }
+
+    return NextResponse.json({
+      proposal: {
+        txHash: row.tx_hash,
+        proposalIndex: row.proposal_index,
+        proposalType: row.proposal_type,
+        ratifiedEpoch: row.ratified_epoch,
+        expiredEpoch: row.expired_epoch,
+        droppedEpoch: row.dropped_epoch,
+        enactedEpoch: row.enacted_epoch,
+      },
+    });
+  },
+  { auth: 'optional' },
+);

--- a/app/workspace/author/[draftId]/debrief/page.tsx
+++ b/app/workspace/author/[draftId]/debrief/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Outcome Debrief Page — post-mortem for proposals with a terminal status.
+ *
+ * Accessible only when the proposal is ratified, expired, or dropped.
+ * Shows final voting breakdown, where it fell short, review feedback summary,
+ * and a "Fork & Revise" action to iterate on the proposal.
+ */
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { FeatureGate } from '@/components/FeatureGate';
+import { useDraft } from '@/hooks/useDrafts';
+import { OutcomeDebrief } from '@/components/workspace/author/debrief/OutcomeDebrief';
+
+// ---------------------------------------------------------------------------
+// Inner component
+// ---------------------------------------------------------------------------
+
+function DebriefPageInner() {
+  const params = useParams();
+  const router = useRouter();
+  const draftId = typeof params.draftId === 'string' ? params.draftId : null;
+
+  const { data: draftData, isLoading } = useDraft(draftId);
+  const draft = draftData?.draft ?? null;
+
+  // Only accessible for submitted proposals — redirect others back to portfolio
+  useEffect(() => {
+    if (!isLoading && draft && draft.status !== 'submitted') {
+      router.replace(`/workspace/author/${draftId}`);
+    }
+  }, [draft, isLoading, draftId, router]);
+
+  if (isLoading || !draft) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="animate-spin h-8 w-8 border-2 border-[var(--compass-teal)] border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="border-b border-border bg-card/50">
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          <Link
+            href="/workspace/author"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to portfolio
+          </Link>
+          <h1 className="text-xl font-display font-semibold text-foreground">Outcome Debrief</h1>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <OutcomeDebrief draft={draft} draftId={draftId!} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exported page
+// ---------------------------------------------------------------------------
+
+export default function DebriefPage() {
+  return (
+    <FeatureGate flag="governance_action_submission">
+      <DebriefPageInner />
+    </FeatureGate>
+  );
+}

--- a/app/workspace/author/[draftId]/submit/page.tsx
+++ b/app/workspace/author/[draftId]/submit/page.tsx
@@ -26,6 +26,9 @@ import type { GovernanceActionTarget } from '@/lib/workspace/types';
 import { JourneySummary } from '@/components/workspace/author/submission/JourneySummary';
 import { FinancialSimulation } from '@/components/workspace/author/submission/FinancialSimulation';
 import { MetadataPreview } from '@/components/workspace/author/submission/MetadataPreview';
+import { TeamSignOff } from '@/components/workspace/author/submission/TeamSignOff';
+import { FinalConfirmation } from '@/components/workspace/author/submission/FinalConfirmation';
+import { SubmissionSuccess } from '@/components/workspace/author/submission/SubmissionSuccess';
 
 // ---------------------------------------------------------------------------
 // Step indicator
@@ -67,7 +70,7 @@ function SubmissionPageInner() {
   const { data: teamData } = useTeam(draftId);
 
   // Governance action hook
-  const { phase, startSubmission } = useGovernanceAction();
+  const { phase, startSubmission, confirmSubmission, isProcessing } = useGovernanceAction();
 
   // Step wizard state
   const [currentStep, setCurrentStep] = useState(0);
@@ -178,14 +181,16 @@ function SubmissionPageInner() {
   const hasTeam = teamMembers && teamMembers.length > 1;
 
   // Step configuration
-  // Steps: financial, metadata, (team if exists - not built yet), confirm (not built yet)
-  // For Session 1A we build steps 1 and 2 only
   const stepLabels = useMemo(() => {
     const labels = ['Financial Impact', 'Metadata Preview'];
     if (hasTeam) labels.push('Team Sign-Off');
     labels.push('Final Confirmation');
     return labels;
   }, [hasTeam]);
+
+  // Compute which step index is the team sign-off and final confirmation
+  const teamSignOffStep = hasTeam ? 2 : -1;
+  const finalConfirmStep = hasTeam ? 3 : 2;
 
   const totalSteps = stepLabels.length;
 
@@ -198,6 +203,34 @@ function SubmissionPageInner() {
     setCurrentStep((s) => Math.max(s - 1, 0));
   }, []);
 
+  // Handle confirm & sign from FinalConfirmation step
+  const handleConfirmSubmit = useCallback(async () => {
+    if (!draftId) return;
+
+    const publishFn = async () => {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      try {
+        const { getStoredSession } = await import('@/lib/supabaseAuth');
+        const token = getStoredSession();
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+      } catch {
+        // No session
+      }
+      const res = await fetch(`/api/workspace/drafts/${encodeURIComponent(draftId)}/publish`, {
+        method: 'POST',
+        headers,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Failed to publish metadata: ${res.status} ${text}`);
+      }
+      const data = await res.json();
+      return { anchorUrl: data.anchorUrl as string, anchorHash: data.anchorHash as string };
+    };
+
+    await confirmSubmission(publishFn);
+  }, [draftId, confirmSubmission]);
+
   // Loading state
   if (draftLoading || !draft) {
     return (
@@ -207,9 +240,28 @@ function SubmissionPageInner() {
     );
   }
 
+  // Success state — show after successful submission
+  if (phase.status === 'success') {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="max-w-xl mx-auto px-4 py-12">
+          <SubmissionSuccess
+            txHash={phase.txHash}
+            anchorUrl={phase.anchorUrl}
+            proposalTitle={draft.title || 'Untitled Proposal'}
+            proposalType={draft.proposalType}
+          />
+        </div>
+      </div>
+    );
+  }
+
   // Preflight data
   const preflight = phase.status === 'confirming' ? phase.preflight : null;
   const preflightLoading = phase.status === 'idle' || phase.status === 'preflight';
+
+  // Deposit amount for the final confirmation step
+  const depositAda = preflight ? Number(preflight.depositLovelace) / 1_000_000 : 100_000;
 
   return (
     <div className="min-h-screen bg-background">
@@ -263,23 +315,20 @@ function SubmissionPageInner() {
               <MetadataPreview draft={draft} onContinue={handleNext} onBack={handleBack} />
             )}
 
-            {/* Steps 2+ (Team Sign-Off, Final Confirmation) — built in Session 1B */}
-            {currentStep >= 2 && (
-              <div className="rounded-lg border border-border bg-card p-8 text-center space-y-4">
-                <Shield className="h-12 w-12 text-muted-foreground mx-auto" />
-                <h2 className="text-lg font-display font-semibold text-foreground">
-                  {stepLabels[currentStep]}
-                </h2>
-                <p className="text-sm text-muted-foreground max-w-md mx-auto">
-                  This step will be available in the next update. Use the back button to return.
-                </p>
-                <button
-                  onClick={handleBack}
-                  className="text-sm text-[var(--compass-teal)] hover:underline"
-                >
-                  Go back
-                </button>
-              </div>
+            {/* Team Sign-Off (only if team exists) */}
+            {currentStep === teamSignOffStep && draftId && (
+              <TeamSignOff draftId={draftId} onContinue={handleNext} onBack={handleBack} />
+            )}
+
+            {/* Final Confirmation */}
+            {currentStep === finalConfirmStep && (
+              <FinalConfirmation
+                depositAda={depositAda}
+                onSubmit={handleConfirmSubmit}
+                onBack={handleBack}
+                isProcessing={isProcessing}
+                phase={phase}
+              />
             )}
           </div>
         </div>

--- a/components/workspace/author/DraftCard.tsx
+++ b/components/workspace/author/DraftCard.tsx
@@ -102,6 +102,12 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
         ? `/workspace/amendment/${draft.id}`
         : `/workspace/author/${draft.id}`;
 
+  // On-chain submitted proposals link to the debrief page
+  const cardHref =
+    column === 'onChain' && draft.status === 'submitted'
+      ? `/workspace/author/${draft.id}/debrief`
+      : editorPath;
+
   return (
     <motion.div
       initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
@@ -117,7 +123,7 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
         {...(itemProps ?? {})}
       >
         <Link
-          href={editorPath}
+          href={cardHref}
           onClick={() => setInputMethod('pointer')}
           className="block cursor-pointer"
         >

--- a/components/workspace/author/debrief/OutcomeDebrief.tsx
+++ b/components/workspace/author/debrief/OutcomeDebrief.tsx
@@ -1,0 +1,542 @@
+'use client';
+
+/**
+ * OutcomeDebrief — post-mortem view for proposals with terminal on-chain status.
+ *
+ * Shows final voting breakdown, where the proposal fell short (if applicable),
+ * review feedback summary, and a "Fork & Revise" CTA to iterate.
+ */
+
+import { useMemo, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ArrowRight,
+  Copy,
+  AlertTriangle,
+  MessageSquare,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useDraftReviews } from '@/hooks/useDraftReviews';
+import { useDuplicateDraft } from '@/hooks/useDraftActions';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import type { ProposalDraft } from '@/lib/workspace/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface OnChainProposal {
+  txHash: string;
+  proposalIndex: number;
+  proposalType: string;
+  ratifiedEpoch: number | null;
+  expiredEpoch: number | null;
+  droppedEpoch: number | null;
+  enactedEpoch: number | null;
+}
+
+interface VotingSummary {
+  drepYesPower: number;
+  drepNoPower: number;
+  drepAbstainPower: number;
+  drepYesCount: number;
+  drepNoCount: number;
+  drepAbstainCount: number;
+  ccYesCount: number;
+  ccNoCount: number;
+  ccAbstainCount: number;
+  spoYesCount: number;
+  spoNoCount: number;
+  spoAbstainCount: number;
+}
+
+type TerminalStatus = 'ratified' | 'expired' | 'dropped' | 'active';
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const headers: Record<string, string> = {};
+  try {
+    const { getStoredSession } = await import('@/lib/supabaseAuth');
+    const token = getStoredSession();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {
+    // No session available
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+function useOnChainProposal(txHash: string | null) {
+  return useQuery<{ proposal: OnChainProposal | null }>({
+    queryKey: ['debrief-proposal', txHash],
+    queryFn: () => fetchJson(`/api/workspace/proposals/${encodeURIComponent(txHash!)}/debrief`),
+    enabled: !!txHash,
+    staleTime: 60_000,
+  });
+}
+
+function useVotingSummary(txHash: string | null, proposalIndex: number | null) {
+  return useQuery<{ summary: VotingSummary | null }>({
+    queryKey: ['debrief-voting', txHash, proposalIndex],
+    queryFn: () =>
+      fetchJson(
+        `/api/workspace/proposals/${encodeURIComponent(txHash!)}/${proposalIndex}/voting-summary`,
+      ),
+    enabled: !!txHash && proposalIndex != null,
+    staleTime: 60_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getTerminalStatus(proposal: OnChainProposal | null): TerminalStatus {
+  if (!proposal) return 'active';
+  if (proposal.ratifiedEpoch != null) return 'ratified';
+  if (proposal.expiredEpoch != null) return 'expired';
+  if (proposal.droppedEpoch != null) return 'dropped';
+  return 'active';
+}
+
+const STATUS_CONFIG: Record<
+  TerminalStatus,
+  { label: string; color: string; bgColor: string; icon: typeof CheckCircle2 }
+> = {
+  ratified: {
+    label: 'Ratified',
+    color: 'text-emerald-400',
+    bgColor: 'bg-emerald-500/10',
+    icon: CheckCircle2,
+  },
+  expired: {
+    label: 'Expired',
+    color: 'text-[var(--wayfinder-amber)]',
+    bgColor: 'bg-[var(--wayfinder-amber)]/10',
+    icon: Clock,
+  },
+  dropped: {
+    label: 'Dropped',
+    color: 'text-destructive',
+    bgColor: 'bg-destructive/10',
+    icon: XCircle,
+  },
+  active: {
+    label: 'Active',
+    color: 'text-blue-400',
+    bgColor: 'bg-blue-500/10',
+    icon: Clock,
+  },
+};
+
+function computeBodyPercentages(yes: number, no: number, abstain: number) {
+  const total = yes + no + abstain;
+  if (total === 0) return { yes: 0, no: 0, abstain: 0 };
+  return {
+    yes: Math.round((yes / total) * 100),
+    no: Math.round((no / total) * 100),
+    abstain: Math.round((abstain / total) * 100),
+  };
+}
+
+// Thresholds by proposal type per CIP-1694
+function getThresholds(proposalType: string) {
+  switch (proposalType) {
+    case 'TreasuryWithdrawals':
+      return { drep: 67, cc: 51, spo: null };
+    case 'ParameterChange':
+      return { drep: 67, cc: 51, spo: null };
+    case 'HardForkInitiation':
+      return { drep: 67, cc: 51, spo: 51 };
+    case 'NoConfidence':
+      return { drep: 67, cc: null, spo: 51 };
+    case 'NewCommittee':
+      return { drep: 67, cc: null, spo: 51 };
+    case 'NewConstitution':
+      return { drep: 75, cc: 67, spo: null };
+    case 'InfoAction':
+    default:
+      return { drep: null, cc: null, spo: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function VotingBodyRow({
+  label,
+  yesPercent,
+  noPercent,
+  abstainPercent,
+  threshold,
+  yesCount,
+  noCount,
+}: {
+  label: string;
+  yesPercent: number;
+  noPercent: number;
+  abstainPercent: number;
+  threshold: number | null;
+  yesCount: number;
+  noCount: number;
+}) {
+  const passed = threshold != null ? yesPercent >= threshold : null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Yes {yesPercent}% / No {noPercent}% / Abstain {abstainPercent}%
+          </span>
+          {passed != null && (
+            <Badge
+              variant="outline"
+              className={
+                passed
+                  ? 'border-emerald-500/40 text-emerald-400'
+                  : 'border-destructive/40 text-destructive'
+              }
+            >
+              {passed ? 'Passed' : `Missed (${threshold}%)`}
+            </Badge>
+          )}
+        </div>
+      </div>
+      {/* Progress bar */}
+      <div className="h-3 rounded-full bg-muted overflow-hidden flex relative">
+        {yesPercent > 0 && (
+          <div
+            className="h-full bg-emerald-500 transition-all"
+            style={{ width: `${yesPercent}%` }}
+          />
+        )}
+        {noPercent > 0 && (
+          <div
+            className="h-full bg-destructive transition-all"
+            style={{ width: `${noPercent}%` }}
+          />
+        )}
+        {abstainPercent > 0 && (
+          <div
+            className="h-full bg-muted-foreground/30 transition-all"
+            style={{ width: `${abstainPercent}%` }}
+          />
+        )}
+        {/* Threshold marker */}
+        {threshold != null && (
+          <div
+            className="absolute top-0 bottom-0 w-0.5 bg-foreground/60"
+            style={{ left: `${threshold}%` }}
+          />
+        )}
+      </div>
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>
+          {yesCount} yes / {noCount} no
+        </span>
+        {threshold != null && <span>{threshold}% threshold</span>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+interface OutcomeDebriefProps {
+  draft: ProposalDraft;
+  draftId: string;
+}
+
+export function OutcomeDebrief({ draft, draftId }: OutcomeDebriefProps) {
+  const router = useRouter();
+  const { stakeAddress } = useSegment();
+
+  // Fetch on-chain proposal data
+  const { data: proposalData, isLoading: proposalLoading } = useOnChainProposal(
+    draft.submittedTxHash,
+  );
+  const proposal = proposalData?.proposal ?? null;
+
+  // Fetch voting summary
+  const { data: votingData, isLoading: votingLoading } = useVotingSummary(
+    draft.submittedTxHash,
+    proposal?.proposalIndex ?? null,
+  );
+  const voting = votingData?.summary ?? null;
+
+  // Fetch reviews
+  const { data: reviewsData } = useDraftReviews(draftId);
+  const reviews = useMemo(() => reviewsData?.reviews ?? [], [reviewsData]);
+  const responsesByReview = useMemo(() => reviewsData?.responsesByReview ?? {}, [reviewsData]);
+
+  // Fork & Revise
+  const duplicateMutation = useDuplicateDraft(stakeAddress);
+
+  const handleForkAndRevise = useCallback(() => {
+    duplicateMutation.mutate(
+      { draftId, titlePrefix: 'Revision of:' },
+      {
+        onSuccess: (data) => {
+          router.push(`/workspace/author/${data.draft.id}`);
+        },
+      },
+    );
+  }, [draftId, duplicateMutation, router]);
+
+  // Compute terminal status
+  const status = getTerminalStatus(proposal);
+  const config = STATUS_CONFIG[status];
+  const StatusIcon = config.icon;
+
+  // Voting percentages
+  const drepPct = voting
+    ? computeBodyPercentages(voting.drepYesPower, voting.drepNoPower, voting.drepAbstainPower)
+    : null;
+  const ccPct = voting
+    ? computeBodyPercentages(voting.ccYesCount, voting.ccNoCount, voting.ccAbstainCount)
+    : null;
+  const spoPct = voting
+    ? computeBodyPercentages(voting.spoYesCount, voting.spoNoCount, voting.spoAbstainCount)
+    : null;
+
+  const thresholds = getThresholds(draft.proposalType);
+
+  // Declined review feedback
+  const declinedReviews = useMemo(() => {
+    return reviews.filter((r) => {
+      const responses = responsesByReview[r.id] ?? [];
+      return responses.some((resp) => resp.responseType === 'decline');
+    });
+  }, [reviews, responsesByReview]);
+
+  // Average review score
+  const avgReviewScore = useMemo(() => {
+    const scores = reviews
+      .map((r) => {
+        const dims = [
+          r.impactScore,
+          r.feasibilityScore,
+          r.constitutionalScore,
+          r.valueScore,
+        ].filter((s): s is number => s != null);
+        return dims.length > 0 ? dims.reduce((a, b) => a + b, 0) / dims.length : null;
+      })
+      .filter((s): s is number => s != null);
+    return scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+  }, [reviews]);
+
+  // Where it fell short
+  const shortfalls = useMemo(() => {
+    if (!voting || status === 'ratified') return [];
+    const items: string[] = [];
+    if (thresholds.drep != null && drepPct && drepPct.yes < thresholds.drep) {
+      items.push(
+        `DRep voting power reached ${drepPct.yes}% but needed ${thresholds.drep}% (missed by ${thresholds.drep - drepPct.yes}%)`,
+      );
+    }
+    if (thresholds.cc != null && ccPct && ccPct.yes < thresholds.cc) {
+      items.push(`Constitutional Committee reached ${ccPct.yes}% but needed ${thresholds.cc}%`);
+    }
+    if (thresholds.spo != null && spoPct && spoPct.yes < thresholds.spo) {
+      items.push(`SPO pool vote reached ${spoPct.yes}% but needed ${thresholds.spo}%`);
+    }
+    if (voting.drepNoCount > 0) {
+      items.push(`${voting.drepNoCount} DRep${voting.drepNoCount !== 1 ? 's' : ''} voted No`);
+    }
+    return items;
+  }, [voting, status, thresholds, drepPct, ccPct, spoPct]);
+
+  const isDataLoading = proposalLoading || votingLoading;
+
+  return (
+    <div className="space-y-8">
+      {/* Status Header */}
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex items-start gap-4">
+          <div
+            className={`w-12 h-12 rounded-full ${config.bgColor} flex items-center justify-center shrink-0`}
+          >
+            <StatusIcon className={`h-6 w-6 ${config.color}`} />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-lg font-display font-bold text-foreground mb-1">
+              {draft.title || 'Untitled Proposal'}
+            </h2>
+            <div className="flex items-center gap-3 flex-wrap">
+              <Badge variant="outline" className={config.color}>
+                {config.label}
+              </Badge>
+              {!isDataLoading && proposal && status === 'active' && (
+                <span className="text-sm text-muted-foreground">
+                  Voting is still active. Debrief will be available once voting concludes.
+                </span>
+              )}
+              {!isDataLoading && !proposal && (
+                <span className="text-sm text-muted-foreground">
+                  On-chain proposal data not yet available. It may take a few epochs to sync.
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Final Voting Breakdown */}
+      {voting && (
+        <div className="rounded-lg border border-border bg-card p-6 space-y-6">
+          <h3 className="text-base font-semibold text-foreground">Final Voting Breakdown</h3>
+
+          {thresholds.drep != null && drepPct && (
+            <VotingBodyRow
+              label="DRep"
+              yesPercent={drepPct.yes}
+              noPercent={drepPct.no}
+              abstainPercent={drepPct.abstain}
+              threshold={thresholds.drep}
+              yesCount={voting.drepYesCount}
+              noCount={voting.drepNoCount}
+            />
+          )}
+
+          {thresholds.cc != null && ccPct && (
+            <VotingBodyRow
+              label="Constitutional Committee"
+              yesPercent={ccPct.yes}
+              noPercent={ccPct.no}
+              abstainPercent={ccPct.abstain}
+              threshold={thresholds.cc}
+              yesCount={voting.ccYesCount}
+              noCount={voting.ccNoCount}
+            />
+          )}
+
+          {thresholds.spo != null && spoPct && (
+            <VotingBodyRow
+              label="SPO"
+              yesPercent={spoPct.yes}
+              noPercent={spoPct.no}
+              abstainPercent={spoPct.abstain}
+              threshold={thresholds.spo}
+              yesCount={voting.spoYesCount}
+              noCount={voting.spoNoCount}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Where It Fell Short */}
+      {shortfalls.length > 0 && (
+        <div className="rounded-lg border border-[var(--wayfinder-amber)]/30 bg-[var(--wayfinder-amber)]/5 p-6 space-y-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-[var(--wayfinder-amber)]" />
+            <h3 className="text-base font-semibold text-foreground">Where It Fell Short</h3>
+          </div>
+          <ul className="space-y-2">
+            {shortfalls.map((item, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-[var(--wayfinder-amber)] shrink-0" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Review Feedback Summary */}
+      {reviews.length > 0 && (
+        <div className="rounded-lg border border-border bg-card p-6 space-y-4">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-5 w-5 text-muted-foreground" />
+            <h3 className="text-base font-semibold text-foreground">
+              Review Feedback ({reviews.length} review{reviews.length !== 1 ? 's' : ''})
+            </h3>
+          </div>
+
+          {avgReviewScore != null && (
+            <p className="text-sm text-muted-foreground">
+              Average review score:{' '}
+              <span className="text-foreground font-medium">{avgReviewScore.toFixed(1)}/5</span>
+            </p>
+          )}
+
+          {declinedReviews.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                {declinedReviews.length} concern{declinedReviews.length !== 1 ? 's' : ''} were
+                declined:
+              </p>
+              <ul className="space-y-1.5">
+                {declinedReviews.slice(0, 5).map((r) => (
+                  <li key={r.id} className="text-sm text-muted-foreground flex items-start gap-2">
+                    <XCircle className="h-3.5 w-3.5 mt-0.5 text-destructive shrink-0" />
+                    <span className="line-clamp-2">
+                      {r.feedbackThemes.length > 0
+                        ? r.feedbackThemes.join(', ')
+                        : r.feedbackText.slice(0, 120)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Loading placeholder for on-chain data */}
+      {isDataLoading && (
+        <div className="rounded-lg border border-border bg-card p-8 text-center">
+          <div className="mx-auto w-8 h-8 rounded-full border-2 border-muted-foreground/30 border-t-foreground animate-spin mb-4" />
+          <p className="text-sm text-muted-foreground">Loading on-chain voting data...</p>
+        </div>
+      )}
+
+      {/* Next Steps */}
+      <div className="rounded-lg border border-border bg-card p-6 space-y-4">
+        <h3 className="text-base font-semibold text-foreground">Next Steps</h3>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Button
+            onClick={handleForkAndRevise}
+            disabled={duplicateMutation.isPending}
+            className="flex-1"
+            style={{ backgroundColor: 'var(--compass-teal)', color: 'var(--primary-foreground)' }}
+          >
+            {duplicateMutation.isPending ? (
+              'Creating revision...'
+            ) : (
+              <>
+                <Copy className="h-4 w-4 mr-2" />
+                Fork &amp; Revise
+              </>
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => router.push('/workspace/author')}
+            className="flex-1"
+          >
+            Return to Portfolio
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Fork &amp; Revise creates a new draft based on this proposal with all content preserved.
+          Improve based on feedback and re-submit.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/author/submission/SubmissionSuccess.tsx
+++ b/components/workspace/author/submission/SubmissionSuccess.tsx
@@ -157,6 +157,11 @@ export function SubmissionSuccess({
         </ul>
       </div>
 
+      {/* Portfolio note */}
+      <p className="text-xs text-muted-foreground text-center">
+        Track voting progress and view the outcome debrief in your portfolio.
+      </p>
+
       {/* Action buttons */}
       <div className="flex gap-3">
         <Button variant="outline" onClick={handleCopyLink} className="flex-1">

--- a/components/workspace/author/submission/TeamSignOff.tsx
+++ b/components/workspace/author/submission/TeamSignOff.tsx
@@ -3,15 +3,17 @@
 /**
  * TeamSignOff — Step 3 of the submission ceremony.
  *
- * INFORMATIONAL ONLY — displays team composition and roles but does not
- * block submission. The lead can always proceed. A blocking approval gate
- * will be added in Phase 4 when team collaboration is more mature.
+ * BLOCKING GATE — the "Continue" button is disabled until all editors
+ * have recorded their approval. The lead has implicit approval and can
+ * always proceed. Solo proposers (no team) skip through automatically.
  */
 
-import { Users, UserCircle, ArrowLeft, ArrowRight } from 'lucide-react';
+import { Users, UserCircle, ArrowLeft, ArrowRight, Check, Clock, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useTeam } from '@/hooks/useTeam';
+import { useTeamApprovals, useApproveSubmission } from '@/hooks/useTeamApprovals';
+import { useSegment } from '@/components/providers/SegmentProvider';
 import type { TeamRole } from '@/lib/workspace/types';
 
 // ---------------------------------------------------------------------------
@@ -50,10 +52,46 @@ function truncateAddress(addr: string): string {
 // ---------------------------------------------------------------------------
 
 export function TeamSignOff({ draftId, onContinue, onBack }: TeamSignOffProps) {
-  const { data, isLoading } = useTeam(draftId);
+  const { stakeAddress } = useSegment();
+  const { data: teamData, isLoading: teamLoading } = useTeam(draftId);
+  const { data: approvalsData, isLoading: approvalsLoading } = useTeamApprovals(draftId);
+  const approveMutation = useApproveSubmission(draftId);
 
-  const team = data?.team ?? null;
-  const members = data?.members ?? [];
+  const team = teamData?.team ?? null;
+  const members = teamData?.members ?? [];
+
+  const isLoading = teamLoading || approvalsLoading;
+
+  // Determine if the current user is the lead
+  const currentMember = members.find((m) => m.stakeAddress === stakeAddress);
+  const isLead = currentMember?.role === 'lead';
+  const isEditor = currentMember?.role === 'editor';
+
+  // Approval state
+  const allApproved = approvalsData?.allApproved ?? true;
+  const pendingCount = approvalsData?.pendingCount ?? 0;
+  const approvals = approvalsData?.approvals ?? [];
+
+  // Build a lookup: memberId -> approvedAt
+  const approvalMap = new Map<string, string | null>();
+  for (const a of approvals) {
+    approvalMap.set(a.memberId, a.approvedAt);
+  }
+
+  // Can the current user approve?
+  const currentMemberApproval = isEditor
+    ? approvals.find((a) => a.stakeAddress === stakeAddress)
+    : null;
+  const hasApproved = currentMemberApproval?.approvedAt != null;
+  const canApprove = isEditor && !hasApproved;
+
+  // Continue is enabled if: solo proposer, all approved, or lead (implicit approval)
+  const canContinue = !team || allApproved || isLead;
+
+  const handleApprove = () => {
+    if (!stakeAddress) return;
+    approveMutation.mutate({ stakeAddress });
+  };
 
   // No team — solo proposer
   if (!isLoading && !team) {
@@ -95,7 +133,7 @@ export function TeamSignOff({ draftId, onContinue, onBack }: TeamSignOffProps) {
     );
   }
 
-  // Team exists — show members
+  // Team exists — show members with approval status
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -110,32 +148,97 @@ export function TeamSignOff({ draftId, onContinue, onBack }: TeamSignOffProps) {
         </p>
       </div>
 
-      {/* Member list */}
+      {/* Member list with approval status */}
       <div className="space-y-2">
-        {members.map((member) => (
-          <div
-            key={member.id}
-            className="flex items-center justify-between px-4 py-3 rounded-lg border border-border bg-card"
-          >
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0">
-                <UserCircle className="h-4 w-4 text-muted-foreground" />
+        {members.map((member) => {
+          const memberApproved = approvalMap.get(member.id) != null;
+          const isLeadMember = member.role === 'lead';
+          const isViewerMember = member.role === 'viewer';
+
+          return (
+            <div
+              key={member.id}
+              className="flex items-center justify-between px-4 py-3 rounded-lg border border-border bg-card"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0">
+                  <UserCircle className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <span className="text-sm font-mono text-foreground truncate">
+                  {truncateAddress(member.stakeAddress)}
+                </span>
               </div>
-              <span className="text-sm font-mono text-foreground truncate">
-                {truncateAddress(member.stakeAddress)}
-              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                {/* Approval status indicator */}
+                {isLeadMember && (
+                  <span className="flex items-center gap-1 text-xs text-emerald-400">
+                    <Check className="h-3.5 w-3.5" />
+                    Implicit
+                  </span>
+                )}
+                {!isLeadMember &&
+                  !isViewerMember &&
+                  (memberApproved ? (
+                    <span className="flex items-center gap-1 text-xs text-emerald-400">
+                      <Check className="h-3.5 w-3.5" />
+                      Approved
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Clock className="h-3.5 w-3.5" />
+                      Pending
+                    </span>
+                  ))}
+                <Badge variant="outline" className={ROLE_COLORS[member.role]}>
+                  {ROLE_LABELS[member.role]}
+                </Badge>
+              </div>
             </div>
-            <Badge variant="outline" className={ROLE_COLORS[member.role]}>
-              {ROLE_LABELS[member.role]}
-            </Badge>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
-      {/* Informational note */}
-      <p className="text-xs text-muted-foreground text-center px-4">
-        Team sign-off is informational. The lead can proceed with submission.
-      </p>
+      {/* Approve button for the current editor */}
+      {canApprove && (
+        <Button
+          onClick={handleApprove}
+          disabled={approveMutation.isPending}
+          className="w-full"
+          style={{ backgroundColor: 'var(--compass-teal)', color: 'var(--primary-foreground)' }}
+        >
+          {approveMutation.isPending ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              Recording approval...
+            </>
+          ) : (
+            <>
+              <Check className="h-4 w-4 mr-2" />
+              Approve Submission
+            </>
+          )}
+        </Button>
+      )}
+
+      {/* Status note */}
+      {allApproved ? (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-center">
+          <p className="text-sm text-emerald-400 font-medium flex items-center justify-center gap-2">
+            <Check className="h-4 w-4" />
+            All team members have approved
+          </p>
+        </div>
+      ) : isLead ? (
+        <p className="text-xs text-muted-foreground text-center px-4">
+          {pendingCount} editor{pendingCount !== 1 ? 's' : ''} still pending. As lead, you may
+          proceed without waiting, but we recommend waiting for all approvals.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground text-center px-4">
+          Waiting for {pendingCount} editor{pendingCount !== 1 ? 's' : ''} to approve before
+          submission can proceed.
+        </p>
+      )}
 
       {/* Navigation */}
       <div className="flex gap-3">
@@ -143,7 +246,7 @@ export function TeamSignOff({ draftId, onContinue, onBack }: TeamSignOffProps) {
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back
         </Button>
-        <Button onClick={onContinue} className="flex-1">
+        <Button onClick={onContinue} disabled={!canContinue} className="flex-1">
           Continue
           <ArrowRight className="h-4 w-4 ml-2" />
         </Button>

--- a/hooks/useTeamApprovals.ts
+++ b/hooks/useTeamApprovals.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TeamApproval {
+  memberId: string;
+  stakeAddress: string;
+  role: string;
+  approvedAt: string | null;
+}
+
+export interface ApprovalsResponse {
+  approvals: TeamApproval[];
+  allApproved: boolean;
+  pendingCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers (same pattern as useTeam.ts)
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const headers: Record<string, string> = {};
+  try {
+    const { getStoredSession } = await import('@/lib/supabaseAuth');
+    const token = getStoredSession();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {
+    // No session available
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  try {
+    const { getStoredSession } = await import('@/lib/supabaseAuth');
+    const token = getStoredSession();
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+  } catch {
+    // No session available
+  }
+  const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/** Fetch team approval status for a draft */
+export function useTeamApprovals(draftId: string | null) {
+  return useQuery<ApprovalsResponse>({
+    queryKey: ['team-approvals', draftId],
+    queryFn: () => fetchJson(`/api/workspace/drafts/${encodeURIComponent(draftId!)}/approvals`),
+    enabled: !!draftId,
+    staleTime: 15_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/** Record approval for the current user */
+export function useApproveSubmission(draftId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<{ success: boolean; approvedAt: string }, Error, { stakeAddress: string }>({
+    mutationFn: ({ stakeAddress }) =>
+      postJson(`/api/workspace/drafts/${encodeURIComponent(draftId)}/approvals`, {
+        stakeAddress,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['team-approvals', draftId] });
+    },
+  });
+}

--- a/supabase/migrations/062_add_team_approvals.sql
+++ b/supabase/migrations/062_add_team_approvals.sql
@@ -1,0 +1,15 @@
+-- Team approval records for proposal submission.
+-- The lead can always submit; editors must approve before the lead can proceed.
+
+CREATE TABLE proposal_team_approvals (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  draft_id UUID NOT NULL REFERENCES proposal_drafts(id) ON DELETE CASCADE,
+  team_member_id UUID NOT NULL REFERENCES proposal_team_members(id) ON DELETE CASCADE,
+  approved_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(draft_id, team_member_id)
+);
+
+CREATE INDEX idx_team_approvals_draft ON proposal_team_approvals(draft_id);
+
+COMMENT ON TABLE proposal_team_approvals IS
+  'Records team member approvals for proposal submission. The lead can always submit; editors must approve.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -4625,6 +4625,42 @@ export type Database = {
           },
         ];
       };
+      proposal_team_approvals: {
+        Row: {
+          id: string;
+          draft_id: string;
+          team_member_id: string;
+          approved_at: string;
+        };
+        Insert: {
+          id?: string;
+          draft_id: string;
+          team_member_id: string;
+          approved_at?: string;
+        };
+        Update: {
+          id?: string;
+          draft_id?: string;
+          team_member_id?: string;
+          approved_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'proposal_team_approvals_draft_id_fkey';
+            columns: ['draft_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposal_drafts';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'proposal_team_approvals_team_member_id_fkey';
+            columns: ['team_member_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposal_team_members';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       proposal_team_members: {
         Row: {
           id: string;


### PR DESCRIPTION
## Summary
- **Team Approval Gate**: Upgraded TeamSignOff from informational to blocking — editors must approve before submission proceeds. Lead has implicit approval. Solo proposers skip through. New `proposal_team_approvals` table, API endpoints, and TanStack Query hooks.
- **Outcome Debrief View**: New `/workspace/author/[draftId]/debrief` page for terminal proposals (ratified/expired/dropped). Shows final voting breakdown per body with threshold comparison, "where it fell short" analysis, review feedback summary with declined concerns, and Fork & Revise CTA.
- **Submission Ceremony Completion**: All 4 steps now wired — Financial Impact, Metadata Preview, Team Sign-Off, and Final Confirmation with 15-second cooldown and Sign & Submit.
- **Navigation Updates**: On-chain DraftCard links to debrief page. SubmissionSuccess adds portfolio tracking note.

## Impact
- **What changed**: Team approval is now a blocking submission gate, and proposers can see a post-mortem debrief after their proposal reaches a terminal on-chain status.
- **User-facing**: Yes — editors must now approve before submission; proposers see voting breakdown + improvement suggestions after proposals conclude
- **Risk**: Low — new tables/endpoints/pages with no changes to existing data flows. Migration is additive only.
- **Scope**: 12 files (3 new API routes, 2 new pages/components, 1 new hook, 1 migration, 5 modified files)

## Test plan
- [ ] Verify solo proposer (no team) can proceed through submission ceremony without blocking
- [ ] Verify team with editors blocks Continue until all editors approve
- [ ] Verify lead can always proceed (implicit approval)
- [ ] Verify re-approval is idempotent (no error)
- [ ] Verify debrief page loads for submitted proposals with on-chain data
- [ ] Verify debrief page shows "data not yet available" gracefully when proposal not synced
- [ ] Verify Fork & Revise creates a new draft with "Revision of:" prefix
- [ ] Verify DraftCard in on-chain column links to debrief page
- [ ] Apply migration: `062_add_team_approvals.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)