### PR TITLE
feat: author studio overhaul — Cursor + Linear + Notion (Phases 1-5)

### DIFF
--- a/app/workspace/amendment/[draftId]/page.tsx
+++ b/app/workspace/amendment/[draftId]/page.tsx
@@ -17,11 +17,10 @@ import { useState, useCallback, useMemo, useEffect, useRef, type ReactNode } fro
 import { useSaveStatus } from '@/lib/workspace/save-status';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useSyncEntityToURL } from '@/hooks/useSyncEntityToURL';
-import { cn } from '@/lib/utils';
 import { useDraft, useUpdateDraft } from '@/hooks/useDrafts';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useAgent } from '@/hooks/useAgent';
-import { useRecordGenealogy } from '@/hooks/useAmendmentGenealogy';
+import { useRecordGenealogy, useAmendmentGenealogy } from '@/hooks/useAmendmentGenealogy';
 import { posthog } from '@/lib/posthog';
 import { StudioProvider, useStudio } from '@/components/studio/StudioProvider';
 import { StudioHeader } from '@/components/studio/StudioHeader';
@@ -41,6 +40,7 @@ import { SaveStatusIndicator } from '@/components/workspace/layout/SaveStatusInd
 import { IntentInputPanel } from '@/components/workspace/author/IntentInputPanel';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ReadinessPanel } from '@/components/workspace/author/ReadinessPanel';
+import { AmendmentGenealogyTimeline } from '@/components/workspace/review/AmendmentGenealogyTimeline';
 import { CONSTITUTION_NODES, CONSTITUTION_VERSION } from '@/lib/constitution/fullText';
 import { extractAmendmentChanges, serializeAmendmentChanges } from '@/lib/constitution/utils';
 import { proposeChange } from '@/components/workspace/editor/SuggestModePlugin';
@@ -57,10 +57,12 @@ import type { ConstitutionSlashCommandType } from '@/components/workspace/editor
 function AmendmentPanelWrapper({
   agentContent,
   intelContent,
+  notesContent,
   readinessContent,
 }: {
   agentContent: ReactNode;
   intelContent: ReactNode;
+  notesContent?: ReactNode;
   readinessContent?: ReactNode;
 }) {
   const { panelOpen, activePanel, panelWidth, closePanel, togglePanel, setPanelWidth } =
@@ -76,6 +78,7 @@ function AmendmentPanelWrapper({
       onWidthChange={setPanelWidth}
       agentContent={agentContent}
       intelContent={intelContent}
+      notesContent={notesContent}
       readinessContent={readinessContent}
     />
   );
@@ -85,17 +88,7 @@ function AmendmentPanelWrapper({
 // AmendmentHeaderWrapper — connects StudioHeader to StudioProvider
 // ---------------------------------------------------------------------------
 
-function AmendmentHeaderWrapper({
-  title,
-  mode,
-  onModeChange,
-  isOwner,
-}: {
-  title: string;
-  mode: AmendmentEditorMode;
-  onModeChange: (mode: AmendmentEditorMode) => void;
-  isOwner: boolean;
-}) {
+function AmendmentHeaderWrapper({ title }: { title: string }) {
   const { panelOpen, activePanel, togglePanel, isFullWidth, toggleFullWidth } = useStudio();
 
   return (
@@ -109,34 +102,6 @@ function AmendmentHeaderWrapper({
       onPanelToggle={togglePanel}
       isFullWidth={isFullWidth}
       onFullWidthToggle={toggleFullWidth}
-      actions={
-        isOwner ? (
-          <div className="flex items-center rounded-md border border-border bg-muted/30 p-0.5">
-            <button
-              onClick={() => onModeChange('suggest')}
-              className={cn(
-                'px-3 py-1 text-[11px] font-medium rounded-sm transition-colors cursor-pointer',
-                mode === 'suggest'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              Edit
-            </button>
-            <button
-              onClick={() => onModeChange('review')}
-              className={cn(
-                'px-3 py-1 text-[11px] font-medium rounded-sm transition-colors cursor-pointer',
-                mode === 'review'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              Preview
-            </button>
-          </div>
-        ) : undefined
-      }
     />
   );
 }
@@ -176,7 +141,8 @@ function AmendmentEditorPage() {
   useSyncEntityToURL();
   const { data, isLoading, error } = useDraft(draftId);
 
-  const [mode, setMode] = useState<AmendmentEditorMode>('suggest');
+  // Always suggest mode — WYSIWYG editing, no Edit/Preview toggle
+  const mode: AmendmentEditorMode = 'suggest';
   const [changes, setChanges] = useState<AmendmentChange[]>([]);
   const [showIntentPanel, setShowIntentPanel] = useState(searchParams.get('mode') === 'intent');
   const [intentGenerating, setIntentGenerating] = useState(false);
@@ -186,6 +152,7 @@ function AmendmentEditorPage() {
   const updateDraft = useUpdateDraft(draftId ?? '');
   const { setSaving } = useSaveStatus();
   const recordGenealogy = useRecordGenealogy();
+  const { data: genealogyData } = useAmendmentGenealogy(draftId);
 
   // --- Debounced auto-save for changes ---
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -199,16 +166,7 @@ function AmendmentEditorPage() {
     : segment === 'cc'
       ? ('cc_member' as const)
       : ('reviewer' as const);
-  const readOnly = !isOwner || mode === 'review';
-
-  // --- Mode change with analytics ---
-  const handleModeChange = useCallback(
-    (next: AmendmentEditorMode) => {
-      posthog.capture('amendment_mode_changed', { proposal_id: draftId, mode: next });
-      setMode(next);
-    },
-    [draftId],
-  );
+  const readOnly = !isOwner;
 
   // --- Agent hook ---
   const {
@@ -448,11 +406,27 @@ function AmendmentEditorPage() {
       activeToolCall={agentActiveToolCall}
       error={agentError}
       onApplyComment={readOnly ? undefined : handleApplyComment}
+      starterPrompts={[
+        'Help me draft amendment language for this section',
+        'Check my changes for constitutional conflicts',
+        'Explain the governance impact of these amendments',
+        'What counterarguments should I anticipate?',
+      ]}
     />
   );
 
   // --- Intel panel ---
   const intelNode = draftId ? <AmendmentIntelPanel draftId={draftId} changes={changes} /> : null;
+
+  // --- Notes panel (edit history timeline) ---
+  const notesNode = (
+    <div className="p-4 space-y-3">
+      <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        Edit History
+      </h3>
+      <AmendmentGenealogyTimeline entries={genealogyData?.entries ?? []} />
+    </div>
+  );
 
   // --- Loading state ---
   if (isLoading) {
@@ -513,14 +487,7 @@ function AmendmentEditorPage() {
       <StudioProvider>
         <WorkspacePanels
           layoutId="amendment"
-          toolbar={
-            <AmendmentHeaderWrapper
-              title={draft.title || 'Constitutional Amendment'}
-              mode={mode}
-              onModeChange={handleModeChange}
-              isOwner={isOwner}
-            />
-          }
+          toolbar={<AmendmentHeaderWrapper title={draft.title || 'Constitutional Amendment'} />}
           main={
             <ConstitutionEditor
               constitutionNodes={CONSTITUTION_NODES}
@@ -540,6 +507,7 @@ function AmendmentEditorPage() {
             <AmendmentPanelWrapper
               agentContent={agentChatNode}
               intelContent={intelNode}
+              notesContent={notesNode}
               readinessContent={draftId ? <ReadinessPanel draftId={draftId} /> : undefined}
             />
           }

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -128,7 +128,8 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation();
   const isHomepage = pathname === '/';
   const isStudioMode =
-    pathname === '/workspace/review' || /^\/workspace\/(author|editor)\/[^/]+/.test(pathname);
+    pathname === '/workspace/review' ||
+    /^\/workspace\/(author|editor|amendment)\/[^/]+/.test(pathname);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   useEffect(() => {

--- a/components/studio/StudioActionBar.tsx
+++ b/components/studio/StudioActionBar.tsx
@@ -198,8 +198,11 @@ export function StudioActionBar({
       {/* Spacer when no status */}
       {!statusInfo && <div className="flex-1" />}
 
-      {/* Right: context actions */}
-      {contextActions && <div className="flex items-center gap-2 shrink-0">{contextActions}</div>}
+      {/* Right: context actions + Explorer */}
+      <div className="flex items-center gap-2 shrink-0">
+        {contextActions}
+        <ExplorerButton />
+      </div>
     </div>
   );
 }

--- a/components/studio/StudioPanel.tsx
+++ b/components/studio/StudioPanel.tsx
@@ -24,7 +24,6 @@ const BASE_TABS: Array<{ id: TabId; label: string; Icon: typeof MessageSquare }>
   { id: 'agent', label: 'Agent', Icon: MessageSquare },
   { id: 'intel', label: 'Intel', Icon: BarChart3 },
   { id: 'notes', label: 'Notes', Icon: StickyNote },
-  { id: 'vote', label: 'Vote', Icon: Vote },
 ];
 
 const MIN_PANEL_WIDTH = 280;
@@ -98,10 +97,14 @@ export function StudioPanel({
     [onWidthChange],
   );
 
-  // Build tabs: include readiness tab only when readinessContent is provided
-  const TABS = readinessContent
-    ? [...BASE_TABS, { id: 'readiness' as TabId, label: 'Readiness', Icon: ShieldCheck }]
-    : BASE_TABS;
+  // Build tabs dynamically: include vote only when voteContent provided, readiness when provided
+  const TABS = [
+    ...BASE_TABS,
+    ...(voteContent ? [{ id: 'vote' as TabId, label: 'Vote', Icon: Vote }] : []),
+    ...(readinessContent
+      ? [{ id: 'readiness' as TabId, label: 'Readiness', Icon: ShieldCheck }]
+      : []),
+  ];
 
   const tabContent: Record<TabId, ReactNode> = {
     agent: agentContent,

--- a/components/workspace/agent/AgentChatPanel.tsx
+++ b/components/workspace/agent/AgentChatPanel.tsx
@@ -60,6 +60,13 @@ function toolLabel(toolName: string): string {
 // Types
 // ---------------------------------------------------------------------------
 
+const DEFAULT_STARTER_PROMPTS = [
+  'What are the key risks of this proposal?',
+  'Summarize the main arguments for and against',
+  'Draft a rationale for voting Yes',
+  'What questions should I ask the proposer?',
+];
+
 interface AgentChatPanelProps {
   /** Send message function from useAgent */
   sendMessage: (message: string) => Promise<void>;
@@ -75,6 +82,8 @@ interface AgentChatPanelProps {
   onApplyEdit?: (edit: ProposedEdit) => void;
   /** Callback when user wants to add a proposed comment */
   onApplyComment?: (comment: ProposedComment) => void;
+  /** Context-specific starter prompts (defaults to review-oriented) */
+  starterPrompts?: string[];
   /** Additional class names */
   className?: string;
 }
@@ -278,8 +287,10 @@ export function AgentChatPanel({
   error,
   onApplyEdit,
   onApplyComment,
+  starterPrompts,
   className,
 }: AgentChatPanelProps) {
+  const prompts = starterPrompts ?? DEFAULT_STARTER_PROMPTS;
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -343,12 +354,7 @@ export function AgentChatPanel({
               </p>
             </div>
             <div className="flex flex-wrap gap-1.5 justify-center max-w-[280px]">
-              {[
-                'What are the key risks of this proposal?',
-                'Summarize the main arguments for and against',
-                'Draft a rationale for voting Yes',
-                'What questions should I ask the proposer?',
-              ].map((suggestion) => (
+              {prompts.map((suggestion) => (
                 <button
                   key={suggestion}
                   onClick={() => sendMessage(suggestion)}

--- a/components/workspace/author/AmendmentIntelPanel.tsx
+++ b/components/workspace/author/AmendmentIntelPanel.tsx
@@ -194,11 +194,33 @@ export function AmendmentIntelPanel({ draftId, changes }: AmendmentIntelPanelPro
         </CardContent>
       </Card>
 
-      {/* Section 2: Conflict Check */}
+      {/* Milestone nudge — show when 3+ sections amended and check not yet run */}
+      {changes.length >= 3 && conflicts === null && !conflictLoading && (
+        <div className="flex items-start gap-2 rounded-md bg-primary/5 border border-primary/20 px-3 py-2.5">
+          <Info className="h-3.5 w-3.5 text-primary shrink-0 mt-0.5" />
+          <div className="space-y-1.5">
+            <p className="text-[11px] text-foreground">
+              You&apos;ve amended {byArticle.size} section{byArticle.size !== 1 ? 's' : ''}. Run a
+              constitutional check to catch conflicts early.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleConflictCheck}
+              className="h-6 text-[10px] px-2"
+            >
+              <Shield className="mr-1 h-3 w-3" />
+              Run Check
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Section 2: Constitutional Check */}
       <Card className="border-border/50">
         <CardHeader className="pb-2 pt-3 px-3">
           <CardTitle className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Conflict Check
+            Constitutional Check
           </CardTitle>
         </CardHeader>
         <CardContent className="px-3 pb-3 space-y-2">
@@ -218,7 +240,7 @@ export function AmendmentIntelPanel({ draftId, changes }: AmendmentIntelPanelPro
               ) : (
                 <>
                   <Shield className="mr-1.5 h-3 w-3" />
-                  Run Conflict Check
+                  Run Constitutional Check
                 </>
               )}
             </Button>

--- a/components/workspace/author/ReadinessPanel.tsx
+++ b/components/workspace/author/ReadinessPanel.tsx
@@ -3,16 +3,17 @@
 /**
  * ReadinessPanel — Submission readiness sidebar for the proposal authoring workspace.
  *
+ * JTBD: "What do I need to do to get this ready for submission?"
+ *
  * Displays:
  * 1. Community Confidence composite score (bar + level badge)
- * 2. Readiness checks (pass/fail/warning list)
+ * 2. Blockers (fail checks) separated from Recommendations (warnings)
  * 3. Factor breakdown (per-dimension mini bars)
- *
- * All confidence computation is delegated to the pure `computeConfidence()` function.
+ * 4. Hover tooltips explaining each check
  */
 
 import { useMemo } from 'react';
-import { CheckCircle2, XCircle, AlertTriangle } from 'lucide-react';
+import { CheckCircle2, XCircle, AlertTriangle, Info, Shield, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useDraft } from '@/hooks/useDrafts';
 import { useDraftReviews } from '@/hooks/useDraftReviews';
@@ -50,12 +51,40 @@ function hoursInReview(communityReviewStartedAt: string | null): number | null {
 }
 
 // ---------------------------------------------------------------------------
-// Check item component
+// Tooltip descriptions for each check type
+// ---------------------------------------------------------------------------
+
+const CHECK_TOOLTIPS: Record<string, string> = {
+  content:
+    'All four proposal fields (title, abstract, motivation, rationale) must be filled before submission. Reviewers need this context to evaluate your amendment.',
+  constitutional:
+    'AI analysis of your amendment against existing constitutional articles. Checks for conflicts, alignment issues, and legal consistency. Run from the Intel tab.',
+  reviews:
+    'Community reviews provide feedback and build confidence. More non-stale reviews signal stronger community engagement.',
+  unaddressed:
+    'Reviews waiting for your response. Address each review to show the community you are incorporating feedback.',
+  addressed: 'All community reviews have been responded to.',
+  duration:
+    '48 hours of community review gives enough time for diverse perspectives. Rushing through this period may result in less thorough feedback.',
+  stale:
+    'Reviews made against an older version of your proposal. Consider asking these reviewers to update their feedback.',
+};
+
+// ---------------------------------------------------------------------------
+// Check item component with tooltip
 // ---------------------------------------------------------------------------
 
 type CheckStatus = 'pass' | 'fail' | 'warning';
 
-function CheckItem({ status, label }: { status: CheckStatus; label: string }) {
+function CheckItem({
+  status,
+  label,
+  tooltip,
+}: {
+  status: CheckStatus;
+  label: string;
+  tooltip?: string;
+}) {
   const icon =
     status === 'pass' ? (
       <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
@@ -66,9 +95,19 @@ function CheckItem({ status, label }: { status: CheckStatus; label: string }) {
     );
 
   return (
-    <div className="flex items-start gap-2 text-xs">
+    <div className="group flex items-start gap-2 text-xs">
       {icon}
-      <span className="text-muted-foreground">{label}</span>
+      <div className="flex-1 min-w-0">
+        <span className="text-muted-foreground">{label}</span>
+        {tooltip && (
+          <div className="hidden group-hover:block mt-1 text-[10px] text-muted-foreground/60 leading-relaxed">
+            {tooltip}
+          </div>
+        )}
+      </div>
+      {tooltip && (
+        <Info className="h-3 w-3 text-muted-foreground/30 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+      )}
     </div>
   );
 }
@@ -95,6 +134,20 @@ function FactorBar({ name, value }: { name: string; value: number }) {
 }
 
 // ---------------------------------------------------------------------------
+// JTBD context message
+// ---------------------------------------------------------------------------
+
+function contextMessage(level: string, blockerCount: number): string {
+  if (blockerCount > 0) {
+    return `${blockerCount} blocker${blockerCount !== 1 ? 's' : ''} must be resolved before submission.`;
+  }
+  if (level === 'excellent' || level === 'ready') {
+    return 'Your amendment looks ready for submission.';
+  }
+  return 'Address the recommendations below to strengthen your submission.';
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -108,9 +161,9 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
 
   const isLoading = draftLoading || reviewsLoading;
 
-  const { confidence, checks } = useMemo(() => {
+  const { confidence, blockers, recommendations } = useMemo(() => {
     if (!draftData?.draft) {
-      return { confidence: null, checks: [] };
+      return { confidence: null, blockers: [], recommendations: [] };
     }
 
     const draft = draftData.draft;
@@ -149,66 +202,88 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
 
     const result = computeConfidence(input);
 
-    // Build checks list
+    // Build checks list with tooltips, split into blockers and recommendations
     const staleCount = reviews.length - nonStaleReviewCount;
     const unaddressedCount = reviews.filter(
       (r) => (responsesByReview[r.id]?.length ?? 0) === 0,
     ).length;
     const hours = hoursInReview(draft.communityReviewStartedAt);
 
-    type Check = { status: CheckStatus; label: string };
-    const checksList: Check[] = [
-      {
-        status: fieldsComplete >= 4 ? 'pass' : 'fail',
-        label: `Content complete (${fieldsComplete}/4 fields)`,
-      },
-      {
-        status:
-          constitutionalCheck === 'pass'
-            ? 'pass'
-            : constitutionalCheck === 'warning'
-              ? 'warning'
-              : constitutionalCheck === 'fail'
-                ? 'fail'
-                : 'fail',
-        label: `Constitutional check: ${constitutionalCheck === 'pass' ? 'Pass' : constitutionalCheck === 'warning' ? 'Warning' : constitutionalCheck === 'fail' ? 'Fail' : 'Not run'}`,
-      },
-      {
-        status: nonStaleReviewCount >= MIN_REVIEWS_FOR_SUBMISSION ? 'pass' : 'fail',
-        label: `${nonStaleReviewCount} review${nonStaleReviewCount !== 1 ? 's' : ''} (min ${MIN_REVIEWS_FOR_SUBMISSION} required)`,
-      },
-    ];
+    type Check = { status: CheckStatus; label: string; tooltip?: string };
+    const blockersList: Check[] = [];
+    const recommendationsList: Check[] = [];
 
+    // Content completeness
+    const contentCheck: Check = {
+      status: fieldsComplete >= 4 ? 'pass' : 'fail',
+      label: `Content complete (${fieldsComplete}/4 fields)`,
+      tooltip: CHECK_TOOLTIPS.content,
+    };
+    if (contentCheck.status === 'fail') blockersList.push(contentCheck);
+    else recommendationsList.push(contentCheck);
+
+    // Constitutional check
+    const constCheck: Check = {
+      status:
+        constitutionalCheck === 'pass'
+          ? 'pass'
+          : constitutionalCheck === 'warning'
+            ? 'warning'
+            : 'fail',
+      label: `Constitutional check: ${constitutionalCheck === 'pass' ? 'Pass' : constitutionalCheck === 'warning' ? 'Warning' : constitutionalCheck === 'fail' ? 'Fail' : 'Not run'}`,
+      tooltip: CHECK_TOOLTIPS.constitutional,
+    };
+    if (constCheck.status === 'fail') blockersList.push(constCheck);
+    else recommendationsList.push(constCheck);
+
+    // Reviews count
+    const reviewCheck: Check = {
+      status: nonStaleReviewCount >= MIN_REVIEWS_FOR_SUBMISSION ? 'pass' : 'fail',
+      label: `${nonStaleReviewCount} review${nonStaleReviewCount !== 1 ? 's' : ''} (min ${MIN_REVIEWS_FOR_SUBMISSION} required)`,
+      tooltip: CHECK_TOOLTIPS.reviews,
+    };
+    if (reviewCheck.status === 'fail') blockersList.push(reviewCheck);
+    else recommendationsList.push(reviewCheck);
+
+    // Unaddressed reviews
     if (unaddressedCount > 0) {
-      checksList.push({
+      blockersList.push({
         status: 'fail',
         label: `${unaddressedCount} review${unaddressedCount !== 1 ? 's' : ''} unaddressed`,
+        tooltip: CHECK_TOOLTIPS.unaddressed,
       });
     } else if (reviews.length > 0) {
-      checksList.push({
+      recommendationsList.push({
         status: 'pass',
         label: 'All reviews addressed',
+        tooltip: CHECK_TOOLTIPS.addressed,
       });
     }
 
+    // Review duration
     if (hours !== null) {
-      checksList.push({
+      const durationCheck: Check = {
         status: hours >= 48 ? 'pass' : 'warning',
         label:
           hours >= 48
             ? `${Math.floor(hours / 24)}d in community review`
             : `${Math.floor(hours)}h in review (48h recommended)`,
-      });
+        tooltip: CHECK_TOOLTIPS.duration,
+      };
+      if (durationCheck.status === 'warning') recommendationsList.push(durationCheck);
+      else recommendationsList.push(durationCheck);
     }
 
+    // Stale reviews
     if (staleCount > 0) {
-      checksList.push({
+      recommendationsList.push({
         status: 'warning',
         label: `${staleCount} stale review${staleCount !== 1 ? 's' : ''}`,
+        tooltip: CHECK_TOOLTIPS.stale,
       });
     }
 
-    return { confidence: result, checks: checksList };
+    return { confidence: result, blockers: blockersList, recommendations: recommendationsList };
   }, [draftData, reviewsData]);
 
   if (isLoading) {
@@ -228,10 +303,21 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
 
   return (
     <div className="p-4 space-y-5">
-      {/* Confidence score header */}
+      {/* JTBD header */}
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium flex items-center gap-1.5">
+          <Shield className="h-3.5 w-3.5 text-primary" />
+          Submission Readiness
+        </h3>
+        <p className="text-[11px] text-muted-foreground/70">
+          {contextMessage(confidence.level, blockers.length)}
+        </p>
+      </div>
+
+      {/* Confidence score */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium">Community Confidence</h3>
+          <span className="text-xs text-muted-foreground">Community Confidence</span>
           <span
             className={cn('text-sm font-bold tabular-nums', confidenceLevelColor(confidence.level))}
           >
@@ -251,22 +337,50 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
         </div>
 
         {/* Level label */}
-        <p className={cn('text-xs capitalize', confidenceLevelColor(confidence.level))}>
+        <p className={cn('text-[11px] capitalize', confidenceLevelColor(confidence.level))}>
           {confidence.level}
         </p>
       </div>
 
-      {/* Checks section */}
-      <div className="space-y-2">
-        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-          Checks
-        </h4>
-        <div className="space-y-1.5">
-          {checks.map((check, i) => (
-            <CheckItem key={i} status={check.status} label={check.label} />
-          ))}
+      {/* Blockers section */}
+      {blockers.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-[10px] font-semibold text-destructive uppercase tracking-wider flex items-center gap-1.5">
+            <XCircle className="h-3 w-3" />
+            Blockers
+          </h4>
+          <div className="space-y-2 pl-0.5">
+            {blockers.map((check, i) => (
+              <CheckItem
+                key={`b-${i}`}
+                status={check.status}
+                label={check.label}
+                tooltip={check.tooltip}
+              />
+            ))}
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* Recommendations section */}
+      {recommendations.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+            <Users className="h-3 w-3" />
+            {blockers.length > 0 ? 'Other Checks' : 'Checks'}
+          </h4>
+          <div className="space-y-2 pl-0.5">
+            {recommendations.map((check, i) => (
+              <CheckItem
+                key={`r-${i}`}
+                status={check.status}
+                label={check.label}
+                tooltip={check.tooltip}
+              />
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Factor breakdown */}
       <div className="space-y-2">

--- a/components/workspace/editor/ConstitutionEditor.tsx
+++ b/components/workspace/editor/ConstitutionEditor.tsx
@@ -19,6 +19,13 @@ import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import CharacterCount from '@tiptap/extension-character-count';
 import Link from '@tiptap/extension-link';
+import Image from '@tiptap/extension-image';
+import { Table } from '@tiptap/extension-table';
+import TableRow from '@tiptap/extension-table-row';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
 import Document from '@tiptap/extension-document';
 
 import {
@@ -32,6 +39,7 @@ import { CommandBarExtension, CommandBarUI } from './CommandBar';
 import { InlineComment, CommentPopover } from './InlineComment';
 import { MarginDecorations, setMarginIndicators } from './MarginDecorations';
 import { SelectionToolbar } from './SelectionToolbar';
+import { FormattingToolbar } from './FormattingToolbar';
 import { ConstitutionTOC } from './ConstitutionTOC';
 import { scanDiffMarks } from './SuggestModePlugin';
 import { createConstitutionSlashMenu } from './ConstitutionSlashMenuExtension';
@@ -230,6 +238,16 @@ export function ConstitutionEditor({
             class: 'text-primary underline hover:opacity-80',
           },
         }),
+        Image.configure({
+          inline: false,
+          allowBase64: false,
+        }),
+        Table.configure({ resizable: true }),
+        TableRow,
+        TableCell,
+        TableHeader,
+        TaskList,
+        TaskItem.configure({ nested: true }),
       ];
 
       return baseExtensions;
@@ -478,6 +496,9 @@ export function ConstitutionEditor({
 
       {/* Main editor area — offset for desktop TOC */}
       <div className="lg:ml-56 p-6 max-w-3xl mx-auto">
+        {/* Formatting toolbar (edit mode only) */}
+        {!isReadOnly && editor && <FormattingToolbar editor={editor} />}
+
         {/* Tiptap editor */}
         <EditorContent editor={editor} />
 

--- a/components/workspace/editor/ConstitutionSlashMenuExtension.ts
+++ b/components/workspace/editor/ConstitutionSlashMenuExtension.ts
@@ -1,18 +1,240 @@
 /**
- * ConstitutionSlashMenuExtension — Tiptap Extension for constitution-specific slash commands.
+ * ConstitutionSlashMenuExtension — Unified slash command menu for the constitution editor.
  *
- * Follows the same ProseMirror plugin pattern as SlashCommandMenu.tsx but uses
- * CONSTITUTION_COMMANDS instead of the proposal-specific COMMANDS array.
+ * Combines:
+ * 1. Content block commands (headings, lists, tables, etc.) — execute directly on editor
+ * 2. AI commands (improve, complete, draft, etc.) — fire onSlashCommand callback
+ * 3. Constitution-specific commands (amend, check-conflicts, etc.) — fire onSlashCommand callback
  *
- * The extension detects `/` typed at the start of a line, shows a dropdown
- * with constitution-specific commands, and fires onSlashCommand when selected.
+ * Type `/` at the start of a line to trigger. Arrow keys to navigate, Enter to select.
  */
 
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { DecorationSet } from '@tiptap/pm/view';
 import type { EditorView } from '@tiptap/pm/view';
-import { CONSTITUTION_COMMANDS, type ConstitutionCommandDef } from './ConstitutionSlashCommands';
+import type { Editor } from '@tiptap/core';
+
+// ---------------------------------------------------------------------------
+// Command definitions — discriminated union (content vs ai)
+// ---------------------------------------------------------------------------
+
+type CommandDef =
+  | {
+      kind: 'content';
+      id: string;
+      label: string;
+      description: string;
+      icon: string;
+      aliases: string[];
+      section: 'content';
+      execute: (editor: Editor) => void;
+    }
+  | {
+      kind: 'ai';
+      id: string;
+      label: string;
+      description: string;
+      icon: string;
+      aliases: string[];
+      section: 'ai' | 'constitution';
+    };
+
+// --- Content block commands ---
+
+const CONTENT_COMMANDS: CommandDef[] = [
+  {
+    kind: 'content',
+    id: 'heading',
+    label: 'Heading 1',
+    description: 'Large section heading',
+    icon: '\uD83C\uDD77',
+    aliases: ['heading', 'h1'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'h2',
+    label: 'Heading 2',
+    description: 'Medium section heading',
+    icon: '\uD83C\uDD77',
+    aliases: ['h2'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'h3',
+    label: 'Heading 3',
+    description: 'Small section heading',
+    icon: '\uD83C\uDD77',
+    aliases: ['h3'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'bullet',
+    label: 'Bullet List',
+    description: 'Create a simple bulleted list',
+    icon: '\u2022',
+    aliases: ['bullet', 'list', 'ul'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleBulletList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'numbered',
+    label: 'Numbered List',
+    description: 'Create a numbered list',
+    icon: '\uD83D\uDD22',
+    aliases: ['numbered', 'ordered', 'ol'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'todo',
+    label: 'Task List',
+    description: 'Checklist with toggleable items',
+    icon: '\u2611',
+    aliases: ['todo', 'checklist', 'task'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleTaskList().run(),
+  },
+  {
+    kind: 'content',
+    id: 'quote',
+    label: 'Blockquote',
+    description: 'Insert a quote block',
+    icon: '\u275D',
+    aliases: ['quote', 'blockquote'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleBlockquote().run(),
+  },
+  {
+    kind: 'content',
+    id: 'code',
+    label: 'Code Block',
+    description: 'Insert a code block',
+    icon: '\u2329\u232A',
+    aliases: ['code', 'codeblock'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+  },
+  {
+    kind: 'content',
+    id: 'table',
+    label: 'Table',
+    description: 'Insert a 3x3 table',
+    icon: '\u25A6',
+    aliases: ['table'],
+    section: 'content',
+    execute: (editor) =>
+      editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
+  },
+  {
+    kind: 'content',
+    id: 'divider',
+    label: 'Divider',
+    description: 'Insert a horizontal rule',
+    icon: '\u2015',
+    aliases: ['divider', 'hr', 'rule'],
+    section: 'content',
+    execute: (editor) => editor.chain().focus().setHorizontalRule().run(),
+  },
+  {
+    kind: 'content',
+    id: 'image',
+    label: 'Image',
+    description: 'Insert an image from URL',
+    icon: '\uD83D\uDDBC',
+    aliases: ['image', 'img', 'picture'],
+    section: 'content',
+    execute: (editor) => {
+      const url = window.prompt('Enter image URL:');
+      if (url) {
+        editor.chain().focus().setImage({ src: url }).run();
+      }
+    },
+  },
+];
+
+// --- AI commands ---
+
+const AI_COMMANDS: CommandDef[] = [
+  {
+    kind: 'ai',
+    id: 'improve',
+    label: 'Improve',
+    description: 'AI improves the selected text or current section',
+    icon: '\u2728',
+    aliases: ['improve'],
+    section: 'ai',
+  },
+  {
+    kind: 'ai',
+    id: 'complete',
+    label: 'Complete',
+    description: 'AI suggests what is missing from this section',
+    icon: '\uD83D\uDCDD',
+    aliases: ['complete'],
+    section: 'ai',
+  },
+  {
+    kind: 'ai',
+    id: 'draft',
+    label: 'Draft',
+    description: 'AI drafts content from your instructions',
+    icon: '\u270D\uFE0F',
+    aliases: ['draft'],
+    section: 'ai',
+  },
+];
+
+// --- Constitution-specific AI commands ---
+
+const CONSTITUTION_COMMANDS: CommandDef[] = [
+  {
+    kind: 'ai',
+    id: 'amend',
+    label: 'Propose Amendment',
+    description: 'Suggest changes to this article',
+    icon: '\u270F\uFE0F',
+    aliases: ['amend', 'amendment'],
+    section: 'constitution',
+  },
+  {
+    kind: 'ai',
+    id: 'check-conflicts',
+    label: 'Check Conflicts',
+    description: 'Check for conflicts with other articles',
+    icon: '\u26A0\uFE0F',
+    aliases: ['check-conflicts', 'conflicts'],
+    section: 'constitution',
+  },
+  {
+    kind: 'ai',
+    id: 'explain-impact',
+    label: 'Explain Impact',
+    description: 'Explain governance impact of this change',
+    icon: '\uD83D\uDCCA',
+    aliases: ['explain-impact', 'impact'],
+    section: 'constitution',
+  },
+  {
+    kind: 'ai',
+    id: 'compare-original',
+    label: 'Compare Original',
+    description: 'Show the original text',
+    icon: '\uD83D\uDD0D',
+    aliases: ['compare-original', 'compare'],
+    section: 'constitution',
+  },
+];
+
+const ALL_COMMANDS: CommandDef[] = [...CONTENT_COMMANDS, ...AI_COMMANDS, ...CONSTITUTION_COMMANDS];
 
 // ---------------------------------------------------------------------------
 // Plugin state
@@ -33,53 +255,82 @@ const constitutionSlashMenuPluginKey = new PluginKey<SlashMenuState>('constituti
 // ---------------------------------------------------------------------------
 
 function createMenuElement(
-  commands: ConstitutionCommandDef[],
+  commands: CommandDef[],
   selectedIndex: number,
-  onSelect: (commandId: string) => void,
+  onSelect: (command: CommandDef) => void,
 ): HTMLElement {
   const container = document.createElement('div');
   container.className =
-    'slash-command-menu fixed z-50 w-64 rounded-lg border border-border bg-popover shadow-lg overflow-hidden py-1';
+    'slash-command-menu fixed z-50 w-72 rounded-lg border border-border bg-popover shadow-lg overflow-hidden py-1 max-h-80 overflow-y-auto';
   container.setAttribute('role', 'listbox');
 
-  commands.forEach((cmd, index) => {
-    const item = document.createElement('div');
-    item.className = `slash-command-item flex items-center gap-3 px-3 py-2 cursor-pointer text-sm transition-colors ${
-      index === selectedIndex
-        ? 'bg-accent text-accent-foreground'
-        : 'text-foreground hover:bg-accent/50'
-    }`;
-    item.setAttribute('role', 'option');
-    item.setAttribute('aria-selected', String(index === selectedIndex));
+  // Group by section
+  const contentItems = commands.filter((c) => c.section === 'content');
+  const aiItems = commands.filter((c) => c.section === 'ai');
+  const constItems = commands.filter((c) => c.section === 'constitution');
 
-    const iconSpan = document.createElement('span');
-    iconSpan.className = 'text-base flex-shrink-0';
-    iconSpan.textContent = cmd.icon;
+  let globalIndex = 0;
 
-    const textContainer = document.createElement('div');
-    textContainer.className = 'flex flex-col min-w-0';
+  const addSection = (label: string, items: CommandDef[]) => {
+    if (items.length === 0) return;
 
-    const label = document.createElement('span');
-    label.className = 'font-medium text-[13px] leading-tight';
-    label.textContent = `/${cmd.id}`;
+    if (globalIndex > 0) {
+      const separator = document.createElement('div');
+      separator.className = 'mx-2 my-1 border-t border-border/50';
+      container.appendChild(separator);
+    }
 
-    const desc = document.createElement('span');
-    desc.className = 'text-[11px] text-muted-foreground leading-tight truncate';
-    desc.textContent = cmd.description;
+    const header = document.createElement('div');
+    header.className =
+      'px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground select-none';
+    header.textContent = label;
+    container.appendChild(header);
 
-    textContainer.appendChild(label);
-    textContainer.appendChild(desc);
-    item.appendChild(iconSpan);
-    item.appendChild(textContainer);
+    for (const cmd of items) {
+      const item = document.createElement('div');
+      item.className = `slash-command-item flex items-center gap-3 px-3 py-2 cursor-pointer text-sm transition-colors ${
+        globalIndex === selectedIndex
+          ? 'bg-accent text-accent-foreground'
+          : 'text-foreground hover:bg-accent/50'
+      }`;
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', String(globalIndex === selectedIndex));
 
-    item.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      onSelect(cmd.id);
-    });
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'text-base flex-shrink-0';
+      iconSpan.textContent = cmd.icon;
 
-    container.appendChild(item);
-  });
+      const textContainer = document.createElement('div');
+      textContainer.className = 'flex flex-col min-w-0';
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'font-medium text-[13px] leading-tight';
+      nameEl.textContent = cmd.label;
+
+      const desc = document.createElement('span');
+      desc.className = 'text-[11px] text-muted-foreground leading-tight truncate';
+      desc.textContent = cmd.description;
+
+      textContainer.appendChild(nameEl);
+      textContainer.appendChild(desc);
+      item.appendChild(iconSpan);
+      item.appendChild(textContainer);
+
+      const cmdRef = cmd;
+      item.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onSelect(cmdRef);
+      });
+
+      container.appendChild(item);
+      globalIndex++;
+    }
+  };
+
+  addSection('Content', contentItems);
+  addSection('AI', aiItems);
+  addSection('Constitution', constItems);
 
   return container;
 }
@@ -94,7 +345,7 @@ function getSectionContext(view: EditorView): string {
 
   for (let depth = $from.depth; depth >= 0; depth--) {
     const node = $from.node(depth);
-    if (node.type.name === 'constitutionSection') {
+    if (node.type.name === 'constitutionSection' || node.type.name === 'sectionBlock') {
       return node.attrs.field as string;
     }
   }
@@ -106,11 +357,14 @@ function getSectionContext(view: EditorView): string {
 // Filter commands by query
 // ---------------------------------------------------------------------------
 
-function filterCommands(query: string): ConstitutionCommandDef[] {
-  if (!query) return CONSTITUTION_COMMANDS;
+function filterCommands(query: string): CommandDef[] {
+  if (!query) return ALL_COMMANDS;
   const lower = query.toLowerCase();
-  return CONSTITUTION_COMMANDS.filter(
-    (cmd) => cmd.id.includes(lower) || cmd.label.toLowerCase().includes(lower),
+  return ALL_COMMANDS.filter(
+    (cmd) =>
+      cmd.id.includes(lower) ||
+      cmd.label.toLowerCase().includes(lower) ||
+      cmd.aliases.some((a) => a.includes(lower)),
   );
 }
 
@@ -193,9 +447,14 @@ export function createConstitutionSlashMenu(
             this.editor.state.tr.setMeta(constitutionSlashMenuPluginKey, { type: 'close' }),
           );
 
-          // Fire the callback
-          const section = getSectionContext(this.editor.view);
-          this.options.onSlashCommand?.(selected.id, section);
+          // Execute: content commands run on editor, AI commands fire callback
+          if (selected.kind === 'content') {
+            selected.execute(this.editor);
+          } else {
+            const section = getSectionContext(this.editor.view);
+            this.options.onSlashCommand?.(selected.id, section);
+          }
+
           return true;
         },
         Escape: () => {
@@ -211,6 +470,7 @@ export function createConstitutionSlashMenu(
 
     addProseMirrorPlugins() {
       const extensionOptions = this.options;
+      const editorRef = this.editor;
       let menuElement: HTMLElement | null = null;
 
       return [
@@ -250,7 +510,7 @@ export function createConstitutionSlashMenu(
               if (tr.docChanged || tr.selectionSet) {
                 const { $from } = newState.selection;
                 const textBefore = $from.parent.textContent.slice(0, $from.parentOffset);
-                const slashMatch = textBefore.match(/(?:^|\s)\/([a-z-]*)$/);
+                const slashMatch = textBefore.match(/(?:^|\s)\/([a-z0-9-]*)$/);
 
                 if (slashMatch) {
                   const query = slashMatch[1];
@@ -311,7 +571,7 @@ export function createConstitutionSlashMenu(
                   menuElement.remove();
                 }
 
-                menuElement = createMenuElement(filtered, state.selectedIndex, (commandId) => {
+                menuElement = createMenuElement(filtered, state.selectedIndex, (cmd) => {
                   if (state.triggerPos !== null) {
                     const from = state.triggerPos;
                     const to = view.state.selection.from;
@@ -321,8 +581,12 @@ export function createConstitutionSlashMenu(
                     view.dispatch(tr);
                   }
 
-                  const section = getSectionContext(view);
-                  extensionOptions.onSlashCommand?.(commandId, section);
+                  if (cmd.kind === 'content') {
+                    cmd.execute(editorRef);
+                  } else {
+                    const section = getSectionContext(view);
+                    extensionOptions.onSlashCommand?.(cmd.id, section);
+                  }
                 });
 
                 const coords = view.coordsAtPos(view.state.selection.from);

--- a/components/workspace/editor/ConstitutionTOC.tsx
+++ b/components/workspace/editor/ConstitutionTOC.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 /**
- * ConstitutionTOC — Table of contents sidebar for the constitution editor.
+ * ConstitutionTOC — Notion-style table of contents sidebar for the constitution editor.
  *
- * Renders a floating sidebar (desktop) or horizontal scroll (mobile) showing
- * all constitution sections with article number badges, amendment status dots,
- * and click-to-navigate functionality.
- *
- * Groups sections by: preamble/defined-terms at top, then articles, then appendices.
+ * Features:
+ * - Collapsible groups (Preamble, Articles, Appendices) with chevron toggles
+ * - Active section highlighting and amendment dot indicators
+ * - Change count on hover per section
+ * - Click to navigate
  */
 
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ConstitutionNode } from '@/lib/constitution/fullText';
+import type { AmendmentChange } from '@/lib/constitution/types';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -23,6 +25,8 @@ export interface ConstitutionTOCProps {
   amendedIds: Set<string>;
   activeSection?: string;
   onNavigate: (sectionId: string) => void;
+  /** Amendment changes for hover summaries */
+  changes?: AmendmentChange[];
 }
 
 // ---------------------------------------------------------------------------
@@ -41,7 +45,6 @@ function groupNodes(nodes: ConstitutionNode[]): GroupedSection[] {
 
   for (const node of nodes) {
     if (node.articleNumber === null) {
-      // Preamble, defined terms, or appendix-like content
       if (node.id.startsWith('appendix')) {
         appendices.push(node);
       } else {
@@ -69,34 +72,76 @@ export function ConstitutionTOC({
   amendedIds,
   activeSection,
   onNavigate,
+  changes = [],
 }: ConstitutionTOCProps) {
   const groups = useMemo(() => groupNodes(nodes), [nodes]);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const changeCountBySection = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const c of changes) {
+      map.set(c.articleId, (map.get(c.articleId) ?? 0) + 1);
+    }
+    return map;
+  }, [changes]);
+
+  const toggleGroup = (label: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) {
+        next.delete(label);
+      } else {
+        next.add(label);
+      }
+      return next;
+    });
+  };
 
   return (
     <>
-      {/* Desktop: fixed left sidebar */}
-      <nav className="hidden lg:block fixed left-0 top-20 bottom-0 w-56 overflow-y-auto border-r border-border/30 bg-background/80 backdrop-blur-sm z-30 py-4 px-3">
+      {/* Desktop: sidebar panel */}
+      <nav className="hidden lg:block w-full h-full overflow-y-auto py-4 px-3">
         <h3 className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-semibold px-2 mb-3">
           Constitution
         </h3>
-        {groups.map((group) => (
-          <div key={group.label} className="mb-4">
-            <span className="text-[9px] uppercase tracking-wide text-muted-foreground/40 font-medium px-2">
-              {group.label}
-            </span>
-            <ul className="mt-1 space-y-0.5">
-              {group.nodes.map((node) => (
-                <TOCItem
-                  key={node.id}
-                  node={node}
-                  isActive={activeSection === node.id}
-                  isAmended={amendedIds.has(node.id)}
-                  onNavigate={onNavigate}
-                />
-              ))}
-            </ul>
-          </div>
-        ))}
+        {groups.map((group) => {
+          const isCollapsed = collapsed.has(group.label);
+          return (
+            <div key={group.label} className="mb-3">
+              <button
+                onClick={() => toggleGroup(group.label)}
+                className="flex items-center gap-1 px-2 py-1 w-full text-left group cursor-pointer"
+              >
+                {isCollapsed ? (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground/40 shrink-0" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-muted-foreground/40 shrink-0" />
+                )}
+                <span className="text-[9px] uppercase tracking-wide text-muted-foreground/50 font-medium group-hover:text-muted-foreground transition-colors">
+                  {group.label}
+                </span>
+                <span className="text-[9px] text-muted-foreground/30 ml-auto tabular-nums">
+                  {group.nodes.length}
+                </span>
+              </button>
+
+              {!isCollapsed && (
+                <ul className="mt-0.5 space-y-0.5">
+                  {group.nodes.map((node) => (
+                    <TOCItem
+                      key={node.id}
+                      node={node}
+                      isActive={activeSection === node.id}
+                      isAmended={amendedIds.has(node.id)}
+                      changeCount={changeCountBySection.get(node.id)}
+                      onNavigate={onNavigate}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
       </nav>
 
       {/* Mobile: horizontal scroll strip */}
@@ -138,10 +183,11 @@ interface TOCItemProps {
   node: ConstitutionNode;
   isActive: boolean;
   isAmended: boolean;
+  changeCount?: number;
   onNavigate: (sectionId: string) => void;
 }
 
-function TOCItem({ node, isActive, isAmended, onNavigate }: TOCItemProps) {
+function TOCItem({ node, isActive, isAmended, changeCount, onNavigate }: TOCItemProps) {
   return (
     <li>
       <button
@@ -152,8 +198,12 @@ function TOCItem({ node, isActive, isAmended, onNavigate }: TOCItemProps) {
             ? 'bg-primary/10 text-primary'
             : 'text-muted-foreground hover:text-foreground hover:bg-muted/30',
         )}
+        title={
+          changeCount
+            ? `${changeCount} change${changeCount !== 1 ? 's' : ''} in this section`
+            : undefined
+        }
       >
-        {/* Article number badge */}
         {node.articleNumber !== null ? (
           <span
             className={cn(
@@ -167,11 +217,22 @@ function TOCItem({ node, isActive, isAmended, onNavigate }: TOCItemProps) {
           <span className="w-4 flex-shrink-0" />
         )}
 
-        {/* Title */}
         <span className="text-[11px] leading-tight truncate flex-1">{node.title}</span>
 
-        {/* Amendment dot */}
-        {isAmended && <span className="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />}
+        {isAmended && changeCount && changeCount > 0 && (
+          <span className="hidden group-hover:inline-flex items-center justify-center h-4 min-w-[16px] px-1 rounded bg-amber-500/15 text-[9px] font-medium text-amber-400 tabular-nums">
+            {changeCount}
+          </span>
+        )}
+
+        {isAmended && (
+          <span
+            className={cn(
+              'w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0',
+              changeCount && changeCount > 0 ? 'group-hover:hidden' : '',
+            )}
+          />
+        )}
       </button>
     </li>
   );

--- a/components/workspace/editor/SelectionToolbar.tsx
+++ b/components/workspace/editor/SelectionToolbar.tsx
@@ -23,6 +23,9 @@ import {
   Flag,
   ShieldAlert,
   Scale,
+  Bold,
+  Italic,
+  Link as LinkIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -276,6 +279,56 @@ export function SelectionToolbar({
       <div className="flex items-center gap-1 rounded-lg border border-border bg-background shadow-lg p-1">
         {!showCommentInput ? (
           <>
+            {/* Inline formatting buttons (edit mode only) */}
+            {editor.isEditable && (
+              <>
+                <button
+                  onClick={() => editor.chain().focus().toggleBold().run()}
+                  className={cn(
+                    'p-1.5 rounded-md transition-colors cursor-pointer',
+                    editor.isActive('bold')
+                      ? 'text-foreground bg-muted'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  )}
+                  title="Bold"
+                >
+                  <Bold className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  onClick={() => editor.chain().focus().toggleItalic().run()}
+                  className={cn(
+                    'p-1.5 rounded-md transition-colors cursor-pointer',
+                    editor.isActive('italic')
+                      ? 'text-foreground bg-muted'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  )}
+                  title="Italic"
+                >
+                  <Italic className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  onClick={() => {
+                    const url = window.prompt('URL', editor.getAttributes('link').href ?? '');
+                    if (url === null) return;
+                    if (url === '') {
+                      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+                    } else {
+                      editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+                    }
+                  }}
+                  className={cn(
+                    'p-1.5 rounded-md transition-colors cursor-pointer',
+                    editor.isActive('link')
+                      ? 'text-foreground bg-muted'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  )}
+                  title="Link"
+                >
+                  <LinkIcon className="h-3.5 w-3.5" />
+                </button>
+                <div className="w-px h-4 bg-border" />
+              </>
+            )}
             <button
               onClick={() => setShowCommentInput(true)}
               className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground rounded-md hover:bg-muted/50 transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary
- **Fix studio mode detection** — `/workspace/amendment/` now recognized as studio mode, hiding default Governada chrome
- **Remove Vote tab** for authors, add Explorer icon to bottom bar, wire author-specific agent prompts
- **Notes tab** shows edit history timeline via AmendmentGenealogyTimeline
- **Readiness tab** redesigned with JTBD framing, hover tooltips, blocker/recommendation split
- **Intel tab** renamed to Constitutional Check with milestone nudge when 3+ sections amended
- **Unified slash command menu** — 11 content commands + AI + constitution commands in one `/` menu
- **FormattingToolbar** added to ConstitutionEditor (bold, italic, link, headings, lists, tables, images)
- **SelectionToolbar** enhanced with inline formatting (Bold/Italic/Link) in edit mode
- **TOC overhauled** with collapsible groups and change count on hover
- **Edit/Preview toggle removed** — always WYSIWYG suggest mode

## Impact
- **What changed**: Author Studio now matches Review Studio shell UX, adds Notion-style editing tools, removes unnecessary Vote tab and Edit/Preview toggle
- **User-facing**: Yes — authors get formatting toolbar, unified slash commands, edit history, improved readiness checks, constitutional check nudges
- **Risk**: Medium — extensive editor changes, but all additive (new extensions, toolbar). No data model changes. No migrations.
- **Scope**: 11 files across studio shell, editor, panels, and page orchestrator

## Test plan
- [ ] Visit `/workspace/amendment/[draftId]` — verify studio header, no default Governada chrome
- [ ] Verify Vote tab is NOT shown, Notes/Agent/Intel/Readiness tabs are
- [ ] Click Notes tab — verify edit history timeline renders
- [ ] Click Readiness tab — verify JTBD header, hover tooltips on checks, blocker/recommendation sections
- [ ] Type `/` in editor — verify full content + AI + constitution command menu appears
- [ ] Verify FormattingToolbar appears above editor with bold/italic/link/headings/lists/table/insert
- [ ] Select text — verify Bold/Italic/Link buttons appear in floating toolbar
- [ ] Verify TOC groups are collapsible with chevron toggles
- [ ] Verify no Edit/Preview toggle in header
- [ ] Verify Explorer compass icon in bottom action bar
- [ ] Verify agent starter prompts are author-specific
- [ ] Mobile responsive check

🤖 Generated with [Claude Code](https://claude.com/claude-code)