### PR TITLE
feat: author studio — block handles, focus mode, minimap, shortcuts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -355,6 +355,16 @@
    Base layer
    ============================================================ */
 
+/* Constitution editor focus mode — dims non-active sections */
+.constitution-focus-mode [data-section-field] {
+  opacity: 0.25;
+  transition: opacity 0.3s ease;
+}
+.constitution-focus-mode [data-section-field].active-section,
+.constitution-focus-mode [data-section-field]:hover {
+  opacity: 1;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/workspace/amendment/[draftId]/page.tsx
+++ b/app/workspace/amendment/[draftId]/page.tsx
@@ -41,6 +41,7 @@ import { IntentInputPanel } from '@/components/workspace/author/IntentInputPanel
 import { Skeleton } from '@/components/ui/skeleton';
 import { ReadinessPanel } from '@/components/workspace/author/ReadinessPanel';
 import { AmendmentGenealogyTimeline } from '@/components/workspace/review/AmendmentGenealogyTimeline';
+import { KeyboardShortcutsOverlay } from '@/components/workspace/editor/KeyboardShortcutsOverlay';
 import { CONSTITUTION_NODES, CONSTITUTION_VERSION } from '@/lib/constitution/fullText';
 import { extractAmendmentChanges, serializeAmendmentChanges } from '@/lib/constitution/utils';
 import { proposeChange } from '@/components/workspace/editor/SuggestModePlugin';
@@ -513,6 +514,7 @@ function AmendmentEditorPage() {
           }
           statusBar={<AmendmentActionBarWrapper statusInfo={statusInfo} />}
         />
+        <KeyboardShortcutsOverlay />
       </StudioProvider>
     </>
   );

--- a/components/workspace/editor/BlockHandleExtension.ts
+++ b/components/workspace/editor/BlockHandleExtension.ts
@@ -1,0 +1,266 @@
+/**
+ * BlockHandleExtension — Notion-style "+" gutter button and drag handle.
+ *
+ * Renders two UI elements on block hover:
+ * 1. A "+" button that opens the slash command menu at that position
+ * 2. A 6-dot drag handle for block reordering (within a section)
+ *
+ * Uses a ProseMirror plugin view that tracks cursor/hover position and
+ * renders a floating UI element alongside the hovered block.
+ */
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+const blockHandlePluginKey = new PluginKey('blockHandle');
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+function createHandleElement(): HTMLElement {
+  const container = document.createElement('div');
+  container.className =
+    'block-handle-container fixed z-40 flex items-center gap-0.5 opacity-0 transition-opacity pointer-events-none';
+  container.style.userSelect = 'none';
+
+  // Drag handle (6-dot grip)
+  const drag = document.createElement('div');
+  drag.className =
+    'block-drag-handle w-4 h-6 flex items-center justify-center rounded cursor-grab text-muted-foreground/30 hover:text-muted-foreground/60 hover:bg-muted/50 transition-colors pointer-events-auto';
+  drag.setAttribute('draggable', 'true');
+  drag.setAttribute('aria-label', 'Drag to reorder');
+  drag.innerHTML = `<svg width="10" height="14" viewBox="0 0 10 14" fill="currentColor">
+    <circle cx="3" cy="2" r="1.2"/><circle cx="7" cy="2" r="1.2"/>
+    <circle cx="3" cy="7" r="1.2"/><circle cx="7" cy="7" r="1.2"/>
+    <circle cx="3" cy="12" r="1.2"/><circle cx="7" cy="12" r="1.2"/>
+  </svg>`;
+
+  // Plus button
+  const plus = document.createElement('button');
+  plus.className =
+    'block-plus-button w-5 h-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground/80 hover:bg-primary/10 transition-colors pointer-events-auto cursor-pointer';
+  plus.setAttribute('aria-label', 'Add block');
+  plus.innerHTML = `<svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5">
+    <line x1="6" y1="1" x2="6" y2="11"/><line x1="1" y1="6" x2="11" y2="6"/>
+  </svg>`;
+
+  container.appendChild(drag);
+  container.appendChild(plus);
+
+  return container;
+}
+
+// ---------------------------------------------------------------------------
+// Find the top-level block node at a given screen position
+// ---------------------------------------------------------------------------
+
+function findBlockAtCoords(
+  view: EditorView,
+  coords: { left: number; top: number },
+): { pos: number; dom: HTMLElement } | null {
+  const posInfo = view.posAtCoords(coords);
+  if (!posInfo) return null;
+
+  // Walk up to find the top-level block within the content section
+  const $pos = view.state.doc.resolve(posInfo.pos);
+
+  // Find depth 2 (section > block) or depth 1 (doc > block)
+  for (let depth = $pos.depth; depth >= 1; depth--) {
+    const node = $pos.node(depth);
+    const nodeType = node.type.name;
+
+    // Stop at section boundaries
+    if (nodeType === 'constitutionSection' || nodeType === 'sectionBlock') break;
+
+    // This is a block-level node (paragraph, heading, list, etc.)
+    if (
+      nodeType === 'paragraph' ||
+      nodeType === 'heading' ||
+      nodeType === 'bulletList' ||
+      nodeType === 'orderedList' ||
+      nodeType === 'taskList' ||
+      nodeType === 'blockquote' ||
+      nodeType === 'codeBlock' ||
+      nodeType === 'table' ||
+      nodeType === 'horizontalRule'
+    ) {
+      const pos = $pos.before(depth);
+      const dom = view.nodeDOM(pos) as HTMLElement | null;
+      if (dom) {
+        return { pos, dom };
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export interface BlockHandleOptions {
+  /** Called when the "+" button is clicked. Receives the position to insert at. */
+  onPlusClick?: (pos: number) => void;
+}
+
+export const BlockHandleExtension = Extension.create<BlockHandleOptions>({
+  name: 'blockHandle',
+
+  addOptions() {
+    return {
+      onPlusClick: undefined,
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const editorRef = this.editor;
+    let handleEl: HTMLElement | null = null;
+    let currentBlockPos: number | null = null;
+    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    return [
+      new Plugin({
+        key: blockHandlePluginKey,
+
+        view() {
+          // Create the floating handle element
+          handleEl = createHandleElement();
+
+          document.body.appendChild(handleEl);
+
+          return {
+            update(view: EditorView) {
+              if (!handleEl) return;
+
+              // Only show when editor is editable
+              if (!view.editable) {
+                handleEl.style.opacity = '0';
+                handleEl.style.pointerEvents = 'none';
+                return;
+              }
+            },
+
+            destroy() {
+              if (handleEl) {
+                handleEl.remove();
+                handleEl = null;
+              }
+              if (hideTimeout) clearTimeout(hideTimeout);
+            },
+          };
+        },
+
+        props: {
+          handleDOMEvents: {
+            mousemove(view: EditorView, event: MouseEvent) {
+              if (!handleEl || !view.editable) return false;
+
+              // Clear any pending hide
+              if (hideTimeout) {
+                clearTimeout(hideTimeout);
+                hideTimeout = undefined;
+              }
+
+              const coords = { left: event.clientX, top: event.clientY };
+              const block = findBlockAtCoords(view, coords);
+
+              if (!block) {
+                // Delay hiding to avoid flicker when moving between blocks
+                hideTimeout = setTimeout(() => {
+                  if (handleEl) {
+                    handleEl.style.opacity = '0';
+                    handleEl.style.pointerEvents = 'none';
+                  }
+                  currentBlockPos = null;
+                }, 200);
+                return false;
+              }
+
+              // Same block, no update needed
+              if (currentBlockPos === block.pos) return false;
+              currentBlockPos = block.pos;
+
+              // Position the handle to the left of the block
+              const blockRect = block.dom.getBoundingClientRect();
+              handleEl.style.top = `${blockRect.top + 2}px`;
+              handleEl.style.left = `${Math.max(4, blockRect.left - 48)}px`;
+              handleEl.style.opacity = '1';
+              handleEl.style.pointerEvents = 'auto';
+
+              // Wire the plus button click for this specific position
+              const plusBtn = handleEl.querySelector('.block-plus-button');
+              if (plusBtn) {
+                const newPlusBtn = plusBtn.cloneNode(true) as HTMLElement;
+                plusBtn.parentNode?.replaceChild(newPlusBtn, plusBtn);
+                newPlusBtn.addEventListener('mousedown', (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const { tr } = editorRef.state;
+                  const $blockPos = editorRef.state.doc.resolve(block.pos);
+                  const after = block.pos + $blockPos.parent.child($blockPos.index()).nodeSize;
+                  const paragraph = editorRef.state.schema.nodes.paragraph.create();
+                  editorRef.view.dispatch(tr.insert(after, paragraph));
+                  editorRef.commands.focus(after + 1);
+                  setTimeout(() => {
+                    editorRef.commands.insertContent('/');
+                  }, 10);
+                });
+              }
+
+              // Wire drag handle for this block
+              const dragHandle = handleEl.querySelector('.block-drag-handle');
+              if (dragHandle) {
+                const newDrag = dragHandle.cloneNode(true) as HTMLElement;
+                dragHandle.parentNode?.replaceChild(newDrag, dragHandle);
+                newDrag.setAttribute('draggable', 'true');
+                newDrag.addEventListener('dragstart', (e) => {
+                  if (e.dataTransfer) {
+                    e.dataTransfer.effectAllowed = 'move';
+                    // Use ProseMirror's selection-based drag
+                    const $pos = editorRef.state.doc.resolve(block.pos);
+                    const nodeAtPos = $pos.parent.child($pos.index());
+                    const from = block.pos;
+                    const to = from + nodeAtPos.nodeSize;
+                    editorRef.commands.setNodeSelection(from);
+
+                    // Create a drag image from the block
+                    const ghost = block.dom.cloneNode(true) as HTMLElement;
+                    ghost.style.opacity = '0.5';
+                    ghost.style.position = 'absolute';
+                    ghost.style.top = '-1000px';
+                    document.body.appendChild(ghost);
+                    e.dataTransfer.setDragImage(ghost, 0, 0);
+                    setTimeout(() => ghost.remove(), 0);
+
+                    e.dataTransfer.setData(
+                      'application/prosemirror-block',
+                      JSON.stringify({ from, to }),
+                    );
+                  }
+                });
+              }
+
+              return false;
+            },
+
+            mouseleave(_view: EditorView) {
+              if (!handleEl) return false;
+              // Delay hiding so user can move to the handle itself
+              hideTimeout = setTimeout(() => {
+                if (handleEl) {
+                  handleEl.style.opacity = '0';
+                  handleEl.style.pointerEvents = 'none';
+                }
+                currentBlockPos = null;
+              }, 300);
+              return false;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/components/workspace/editor/ChangeMinimap.tsx
+++ b/components/workspace/editor/ChangeMinimap.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * ChangeMinimap — VS Code-style vertical strip showing where changes exist in the document.
+ *
+ * Renders a thin vertical bar in the TOC sidebar with colored dots/bars indicating
+ * where amendments have been made. Click to scroll to that section.
+ */
+
+import { useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import type { AmendmentChange } from '@/lib/constitution/types';
+import type { ConstitutionNode } from '@/lib/constitution/fullText';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ChangeMinimapProps {
+  nodes: ConstitutionNode[];
+  changes: AmendmentChange[];
+  activeSection?: string;
+  onNavigate: (sectionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ChangeMinimap({ nodes, changes, activeSection, onNavigate }: ChangeMinimapProps) {
+  // Group changes by section and count status
+  const sectionStats = useMemo(() => {
+    const map = new Map<
+      string,
+      { total: number; pending: number; accepted: number; rejected: number }
+    >();
+    for (const c of changes) {
+      const stats = map.get(c.articleId) ?? { total: 0, pending: 0, accepted: 0, rejected: 0 };
+      stats.total++;
+      if (c.status === 'pending') stats.pending++;
+      else if (c.status === 'accepted') stats.accepted++;
+      else if (c.status === 'rejected') stats.rejected++;
+      map.set(c.articleId, stats);
+    }
+    return map;
+  }, [changes]);
+
+  if (changes.length === 0) return null;
+
+  return (
+    <div className="hidden lg:flex flex-col items-center gap-0.5 py-2 px-1">
+      {nodes.map((node) => {
+        const stats = sectionStats.get(node.id);
+        const isActive = activeSection === node.id;
+
+        if (!stats) {
+          // No changes in this section — thin muted line
+          return (
+            <button
+              key={node.id}
+              onClick={() => onNavigate(node.id)}
+              className="w-1.5 h-2 rounded-full bg-muted/20 hover:bg-muted/40 transition-colors cursor-pointer"
+              title={node.title}
+            />
+          );
+        }
+
+        // Determine color based on most significant status
+        const color =
+          stats.rejected > 0
+            ? 'bg-rose-500'
+            : stats.pending > 0
+              ? 'bg-amber-400'
+              : 'bg-emerald-500';
+
+        return (
+          <button
+            key={node.id}
+            onClick={() => onNavigate(node.id)}
+            className={cn(
+              'w-2 rounded-full transition-all cursor-pointer',
+              color,
+              isActive ? 'h-4 ring-1 ring-primary/50' : 'h-2.5 hover:h-3',
+            )}
+            title={`${node.title}: ${stats.total} change${stats.total !== 1 ? 's' : ''}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/components/workspace/editor/ConstitutionEditor.tsx
+++ b/components/workspace/editor/ConstitutionEditor.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import { cn } from '@/lib/utils';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -43,6 +44,7 @@ import { FormattingToolbar } from './FormattingToolbar';
 import { ConstitutionTOC } from './ConstitutionTOC';
 import { scanDiffMarks } from './SuggestModePlugin';
 import { createConstitutionSlashMenu } from './ConstitutionSlashMenuExtension';
+import { BlockHandleExtension } from './BlockHandleExtension';
 
 import type { ReactNode } from 'react';
 import type { ConstitutionNode } from '@/lib/constitution/fullText';
@@ -93,6 +95,8 @@ export interface ConstitutionEditorProps {
   sentimentSlots?: Record<string, ReactNode>;
   /** Current user's ID (for comment ownership styling) */
   currentUserId?: string;
+  /** Focus mode: dims non-active sections */
+  focusMode?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -134,6 +138,7 @@ export function ConstitutionEditor({
   onDiffReject,
   marginIndicators,
   currentUserId,
+  focusMode = false,
 }: ConstitutionEditorProps) {
   const isReadOnly = readOnly || mode === 'review';
 
@@ -248,6 +253,7 @@ export function ConstitutionEditor({
         TableHeader,
         TaskList,
         TaskItem.configure({ nested: true }),
+        BlockHandleExtension.configure({}),
       ];
 
       return baseExtensions;
@@ -485,7 +491,9 @@ export function ConstitutionEditor({
   // -------------------------------------------------------------------------
 
   return (
-    <div className="constitution-editor-wrapper relative">
+    <div
+      className={cn('constitution-editor-wrapper relative', focusMode && 'constitution-focus-mode')}
+    >
       {/* Table of contents sidebar */}
       <ConstitutionTOC
         nodes={constitutionNodes}

--- a/components/workspace/editor/KeyboardShortcutsOverlay.tsx
+++ b/components/workspace/editor/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+/**
+ * KeyboardShortcutsOverlay — Press "?" to see all available keyboard shortcuts.
+ *
+ * Inspired by Cursor and Linear's keyboard shortcut help overlays.
+ * Shows all registered shortcuts grouped by category.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { X, Keyboard } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Shortcut data
+// ---------------------------------------------------------------------------
+
+interface ShortcutGroup {
+  label: string;
+  shortcuts: Array<{ keys: string; description: string }>;
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    label: 'Navigation',
+    shortcuts: [
+      { keys: '/', description: 'Open slash command menu' },
+      { keys: 'Ctrl+K', description: 'Command palette (AI instruction)' },
+      { keys: 'Ctrl+Shift+C', description: 'Toggle Agent panel' },
+      { keys: 'Ctrl+Shift+I', description: 'Toggle Intel panel' },
+      { keys: 'Ctrl+Shift+N', description: 'Toggle Notes panel' },
+      { keys: 'Esc', description: 'Close panel / dismiss menu' },
+    ],
+  },
+  {
+    label: 'Formatting',
+    shortcuts: [
+      { keys: 'Ctrl+B', description: 'Bold' },
+      { keys: 'Ctrl+I', description: 'Italic' },
+      { keys: 'Ctrl+Shift+S', description: 'Strikethrough' },
+      { keys: 'Ctrl+Shift+X', description: 'Code' },
+    ],
+  },
+  {
+    label: 'Editing',
+    shortcuts: [
+      { keys: 'Tab', description: 'Accept AI suggestion / indent' },
+      { keys: 'Ctrl+Z', description: 'Undo' },
+      { keys: 'Ctrl+Shift+Z', description: 'Redo' },
+      { keys: 'Ctrl+Enter', description: 'Send agent message' },
+    ],
+  },
+  {
+    label: 'Amendment',
+    shortcuts: [
+      { keys: '/amend', description: 'Propose amendment to section' },
+      { keys: '/check-conflicts', description: 'Check for constitutional conflicts' },
+      { keys: '/explain-impact', description: 'Explain governance impact' },
+      { keys: '/compare-original', description: 'Show original text' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function KeyboardShortcutsOverlay() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Don't trigger when typing in inputs
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.getAttribute('contenteditable') === 'true' ||
+        target.closest('[role="textbox"]')
+      ) {
+        return;
+      }
+
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        e.preventDefault();
+        setIsOpen((prev) => !prev);
+      }
+
+      if (e.key === 'Escape' && isOpen) {
+        setIsOpen(false);
+      }
+    },
+    [isOpen],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => setIsOpen(false)}
+      />
+
+      {/* Modal */}
+      <div className="relative z-10 w-full max-w-lg mx-4 rounded-xl border border-border bg-background shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Keyboard className="h-4 w-4 text-primary" />
+            <h2 className="text-sm font-semibold">Keyboard Shortcuts</h2>
+          </div>
+          <button
+            onClick={() => setIsOpen(false)}
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-5 py-4 max-h-[60vh] overflow-y-auto space-y-5">
+          {SHORTCUT_GROUPS.map((group) => (
+            <div key={group.label}>
+              <h3 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 mb-2">
+                {group.label}
+              </h3>
+              <div className="space-y-1.5">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={shortcut.keys}
+                    className="flex items-center justify-between text-xs py-1"
+                  >
+                    <span className="text-muted-foreground">{shortcut.description}</span>
+                    <kbd className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-muted border border-border/50 text-[10px] font-mono text-muted-foreground">
+                      {shortcut.keys}
+                    </kbd>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-2.5 border-t border-border/50 text-center">
+          <span className="text-[10px] text-muted-foreground/50">
+            Press{' '}
+            <kbd className="px-1 py-0.5 rounded bg-muted border border-border/50 text-[9px] font-mono">
+              ?
+            </kbd>{' '}
+            to toggle
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Block handle extension** — Notion-style "+" gutter button (inserts paragraph + triggers `/` slash menu) and 6-dot drag handle for block reordering, both appear on block hover
- **Keyboard shortcuts overlay** — Press `?` to see all available shortcuts grouped by category (navigation, formatting, editing, amendment)
- **Change minimap** — VS Code-style vertical strip component showing where amendments exist, color-coded by status (amber/green/red), click to navigate
- **Focus mode** — CSS-based section dimming that reduces non-active sections to 0.25 opacity, hover to restore. `focusMode` prop on ConstitutionEditor

## Impact
- **What changed**: Four new Cursor/Linear/Notion-inspired features for the Author Studio editor
- **User-facing**: Yes — block handles on hover, `?` shortcut overlay, minimap and focus mode ready for wiring
- **Risk**: Low — all additive (new extension + 3 new components), no existing behavior changed
- **Scope**: 3 new files, 2 modified files (ConstitutionEditor, globals.css, page.tsx)

## Test plan
- [ ] Hover over a paragraph in the editor — verify "+" and drag grip appear to the left
- [ ] Click "+" — verify new paragraph created with `/` slash menu triggered
- [ ] Press `?` outside of inputs — verify shortcuts overlay modal appears
- [ ] Press `Esc` — verify overlay closes
- [ ] Verify ChangeMinimap component renders correctly (requires parent wiring)
- [ ] Verify focus mode CSS dims non-active sections when class applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)