### PR TITLE
feat: header compression with epoch strip, governance pulse, breadcrumbs

### DIFF
--- a/components/governada/EpochStrip.tsx
+++ b/components/governada/EpochStrip.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEpochContext } from '@/hooks/useEpochContext';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+
+/**
+ * Inline epoch display for the compressed header.
+ * Shows epoch number, time remaining, and active proposal count.
+ * Hidden on screens < 640px.
+ */
+export function EpochStrip() {
+  const { epoch, day, totalDays, activeProposalCount } = useEpochContext();
+  const { t } = useTranslation();
+
+  // Compute hours remaining in the epoch
+  // Each epoch = 5 days. Remaining days = totalDays - day, plus rest of current day (~24h approximation)
+  const remainingDays = totalDays - day;
+  const hoursRemaining = remainingDays * 24;
+
+  const timeLabel =
+    hoursRemaining >= 24
+      ? `${remainingDays}d ${t('left')}`
+      : hoursRemaining > 0
+        ? `${hoursRemaining}h ${t('left')}`
+        : t('ending');
+
+  const proposalLabel =
+    activeProposalCount !== null ? `${activeProposalCount} ${t('active')}` : null;
+
+  const ariaDescription = [
+    `${t('Epoch')} ${epoch}`,
+    `${t('Day')} ${day} ${t('of')} ${totalDays}`,
+    proposalLabel ? `${activeProposalCount} ${t('active proposals')}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <div
+      className="hidden sm:flex items-center gap-1 text-[11px] text-muted-foreground font-mono tabular-nums"
+      aria-label={ariaDescription}
+      role="status"
+    >
+      <span>
+        {t('Ep')} {epoch}
+      </span>
+      <span className="text-muted-foreground/40">&middot;</span>
+      <span>{timeLabel}</span>
+      {proposalLabel && (
+        <>
+          <span className="text-muted-foreground/40">&middot;</span>
+          <span>{proposalLabel}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -15,7 +15,7 @@ import {
   ShieldCheck,
   Scale,
   Layers,
-  HelpCircle,
+  Globe,
   CheckCheck,
   FlaskConical,
   RotateCcw,
@@ -25,13 +25,15 @@ import {
   UserCog,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
-import { DepthPickerDropdown } from './DepthPickerDropdown';
 import { DepthPromptModal } from './DepthPromptModal';
-import { LanguagePicker } from './LanguagePicker';
+import { EpochStrip } from './EpochStrip';
+import { GovernancePulse } from './GovernancePulse';
+import { HeaderBreadcrumbs } from './HeaderBreadcrumbs';
 import { cn } from '@/lib/utils';
 import { getStoredSession } from '@/lib/supabaseAuth';
-import { HELP_ITEMS } from '@/lib/nav/config';
 import { useTranslation } from '@/lib/i18n/useTranslation';
+import { useLocale } from '@/components/providers/LocaleProvider';
+import { SUPPORTED_LOCALES, LOCALE_NAMES, type SupportedLocale } from '@/lib/i18n/config';
 import { useWallet } from '@/utils/wallet-context';
 import { useSegment, type UserSegment } from '@/components/providers/SegmentProvider';
 import { TIER_SCORE_COLOR, type TierKey } from '@/components/governada/cards/tierStyles';
@@ -201,6 +203,7 @@ export function GovernadaHeader() {
     enterSandbox,
     exitSandbox,
   } = useSegment();
+  const { locale, setLocale } = useLocale();
   const { data: adminData } = useAdminCheck(isAuthenticated);
   const isAdmin = adminData?.isAdmin === true;
   const hasOverride = segment !== realSegment;
@@ -401,7 +404,7 @@ export function GovernadaHeader() {
 
   const [scrolled, setScrolled] = useState(false);
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 32);
+    const onScroll = () => setScrolled(window.scrollY > 16);
     onScroll();
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
@@ -418,66 +421,43 @@ export function GovernadaHeader() {
           : 'border-b border-border/20 bg-background/60 backdrop-blur-xl',
       )}
     >
-      <div className="mx-auto max-w-7xl flex items-center justify-between h-14 px-6">
-        {/* Logo — sidebar handles navigation on desktop */}
-        <Link
-          href="/"
-          className={cn(
-            'font-display text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded',
-            headerTransparent && 'nav-text-shadow',
-          )}
-        >
-          governada
-        </Link>
+      <div className="mx-auto max-w-7xl flex items-center justify-between h-10 px-4">
+        {/* Logo + breadcrumbs */}
+        <div className="flex items-center min-w-0">
+          <Link
+            href="/"
+            className={cn(
+              'font-display text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded shrink-0',
+              headerTransparent && 'nav-text-shadow',
+            )}
+          >
+            governada
+          </Link>
+          <HeaderBreadcrumbs />
+        </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
+          {/* Epoch strip */}
+          <EpochStrip />
+
+          {/* Search / command palette */}
           <Button
             variant="ghost"
-            size="sm"
-            className="text-muted-foreground"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground hover:text-foreground"
             onClick={() =>
               document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }))
             }
-            aria-label="Open command palette"
+            aria-label={t('Search')}
           >
-            <Search className="h-4 w-4 mr-1.5" />
-            <kbd className="text-xs text-muted-foreground/80 bg-muted px-1.5 py-0.5 rounded">
-              ⌘K
-            </kbd>
+            <Search className="h-4 w-4" />
           </Button>
 
-          {/* Governance depth picker (desktop only) */}
-          {connected && isAuthenticated && <DepthPickerDropdown />}
+          {/* Governance pulse */}
+          <GovernancePulse />
 
           {/* Notification bell dropdown */}
           {connected && isAuthenticated && <NotificationBell unreadCount={unreadCount} />}
-
-          {/* Help dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                aria-label={t('Help')}
-              >
-                <HelpCircle className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              {HELP_ITEMS.map(({ href, label, icon: Icon }) => (
-                <DropdownMenuItem key={href} asChild>
-                  <Link href={href}>
-                    <Icon className="h-4 w-4" />
-                    {t(label)}
-                  </Link>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Language picker */}
-          <LanguagePicker />
 
           {connected && isAuthenticated ? (
             <DropdownMenu>
@@ -513,6 +493,24 @@ export function GovernadaHeader() {
                   <User className="h-4 w-4" />
                   {t('Profile & Settings')}
                 </DropdownMenuItem>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Globe className="h-4 w-4" />
+                    {t('Language')}
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {SUPPORTED_LOCALES.map((loc: SupportedLocale) => (
+                      <DropdownMenuItem
+                        key={loc}
+                        onClick={() => setLocale(loc)}
+                        className="justify-between"
+                      >
+                        <span>{LOCALE_NAMES[loc]}</span>
+                        {locale === loc && <span className="text-primary">&#10003;</span>}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
                 {isAdmin && (
                   <>
                     <DropdownMenuSeparator />
@@ -769,6 +767,31 @@ export function GovernadaHeader() {
             </DropdownMenu>
           ) : (
             <>
+              {/* Language picker for unauthenticated users */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                    aria-label={t('Change language')}
+                  >
+                    <Globe className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-44">
+                  {SUPPORTED_LOCALES.map((loc: SupportedLocale) => (
+                    <DropdownMenuItem
+                      key={loc}
+                      onClick={() => setLocale(loc)}
+                      className="justify-between"
+                    >
+                      <span>{LOCALE_NAMES[loc]}</span>
+                      {locale === loc && <span className="text-primary">&#10003;</span>}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
               <Button
                 variant="outline"
                 size="sm"

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -9,7 +9,6 @@ import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { GovernadaHeader } from './GovernadaHeader';
 import { GovernadaBottomNav } from './GovernadaBottomNav';
 import { GovernadaSidebar } from './GovernadaSidebar';
-import { EpochContextBar } from './EpochContextBar';
 import { SyncFreshnessBanner } from '@/components/SyncFreshnessBanner';
 import { PreviewBanner } from '@/components/preview/PreviewBanner';
 import { FeedbackWidget } from '@/components/preview/FeedbackWidget';
@@ -158,7 +157,6 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
         {!isStudioMode && (
           <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
         )}
-        {!isStudioMode && <EpochContextBar sidebarCollapsed={sidebarCollapsed} />}
 
         {/* Global constellation globe — subtle glassmorphic background */}
         {!isStudioMode && (

--- a/components/governada/GovernadaSidebar.tsx
+++ b/components/governada/GovernadaSidebar.tsx
@@ -133,7 +133,7 @@ export function GovernadaSidebar({ collapsed, onToggle }: GovernadaSidebarProps)
   return (
     <aside
       className={cn(
-        'hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-30 border-r border-border/20 bg-background/60 backdrop-blur-xl transition-[width] duration-200',
+        'hidden lg:flex flex-col fixed left-0 top-10 bottom-0 z-30 border-r border-border/20 bg-background/60 backdrop-blur-xl transition-[width] duration-200',
         collapsed ? 'w-16' : 'w-60',
       )}
     >

--- a/components/governada/GovernancePulse.tsx
+++ b/components/governada/GovernancePulse.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEpochContext } from '@/hooks/useEpochContext';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type PulseStatus = 'calm' | 'active' | 'urgent';
+
+const PULSE_COLORS: Record<PulseStatus, string> = {
+  calm: 'oklch(0.68 0.16 162)', // compass teal
+  active: 'oklch(0.75 0.15 85)', // amber
+  urgent: 'oklch(0.65 0.2 25)', // red
+};
+
+const PULSE_LABELS: Record<PulseStatus, string> = {
+  calm: 'Calm',
+  active: 'Active',
+  urgent: 'Urgent',
+};
+
+function getPulseStatus(day: number, activeProposalCount: number | null): PulseStatus {
+  const hasActive = (activeProposalCount ?? 0) > 0;
+
+  if (day >= 5 && hasActive) return 'urgent';
+  if (day >= 4 && hasActive) return 'active';
+  return 'calm';
+}
+
+/**
+ * Governance pulse dot — colored indicator encoding governance urgency.
+ * Green (calm): epoch days 1-3 or no active proposals.
+ * Amber (active): day 4 with active proposals.
+ * Red (urgent): day 5 with active proposals.
+ * Pulses gently on amber/red states.
+ */
+export function GovernancePulse() {
+  const { day, activeProposalCount } = useEpochContext();
+  const { t } = useTranslation();
+
+  const status = getPulseStatus(day, activeProposalCount);
+  const color = PULSE_COLORS[status];
+  const label = PULSE_LABELS[status];
+  const shouldPulse = status !== 'calm';
+
+  const tooltipText =
+    status === 'calm'
+      ? t('Governance is calm — no urgent deadlines')
+      : status === 'active'
+        ? t('Voting deadline approaching — proposals need attention')
+        : t('Final day to vote — urgent action needed');
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="relative flex items-center justify-center w-5 h-5 cursor-default"
+            aria-label={`${t('Governance status')}: ${t(label)}`}
+            role="status"
+          >
+            {/* Glow ring — visible on amber/red, pulses */}
+            {shouldPulse && (
+              <span
+                className="absolute inset-0 rounded-full animate-pulse"
+                style={{
+                  backgroundColor: color,
+                  opacity: 0.2,
+                  animationDuration: '2s',
+                }}
+                aria-hidden="true"
+              />
+            )}
+            {/* Core dot */}
+            <span
+              className={cn('relative block rounded-full', shouldPulse ? 'w-2.5 h-2.5' : 'w-2 h-2')}
+              style={{
+                backgroundColor: color,
+                boxShadow: shouldPulse ? `0 0 6px 1px ${color}` : 'none',
+              }}
+              aria-hidden="true"
+            />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>{tooltipText}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/governada/HeaderBreadcrumbs.tsx
+++ b/components/governada/HeaderBreadcrumbs.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ArrowLeft, ChevronRight } from 'lucide-react';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+import { cn } from '@/lib/utils';
+
+const ROUTE_LABELS: Record<string, string> = {
+  governance: 'Governance',
+  proposals: 'Proposals',
+  representatives: 'Representatives',
+  pools: 'Pools',
+  committee: 'Committee',
+  treasury: 'Treasury',
+  health: 'Health',
+  you: 'You',
+  workspace: 'Workspace',
+  match: 'Match',
+  help: 'Help',
+  settings: 'Settings',
+  admin: 'Admin',
+  review: 'Review',
+  author: 'Author',
+  votes: 'Votes',
+  delegators: 'Delegators',
+  delegation: 'Delegation',
+  identity: 'Identity',
+  drep: 'DRep',
+  spo: 'SPO',
+  proposal: 'Proposal',
+};
+
+interface BreadcrumbSegment {
+  label: string;
+  href: string;
+}
+
+function buildBreadcrumbs(pathname: string): BreadcrumbSegment[] {
+  if (pathname === '/') return [];
+
+  const parts = pathname.split('/').filter(Boolean);
+  const segments: BreadcrumbSegment[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const href = '/' + parts.slice(0, i + 1).join('/');
+
+    // Skip dynamic segments (entity IDs) — they'd show a hash/ID which isn't readable
+    const label = ROUTE_LABELS[part];
+    if (!label) continue;
+
+    segments.push({ label, href });
+  }
+
+  // Limit to 3 segments max
+  return segments.slice(0, 3);
+}
+
+/**
+ * Route-based breadcrumbs for the header.
+ * Desktop: full path with separators.
+ * Mobile: "Back to {parent}" link.
+ */
+export function HeaderBreadcrumbs() {
+  const pathname = usePathname();
+  const { t } = useTranslation();
+
+  const segments = buildBreadcrumbs(pathname);
+
+  if (segments.length === 0) return null;
+
+  const parentSegment = segments.length >= 2 ? segments[segments.length - 2] : null;
+
+  return (
+    <>
+      {/* Desktop breadcrumbs */}
+      <nav aria-label={t('Breadcrumb')} className="hidden md:block ml-4">
+        <ol className="flex items-center gap-1 text-xs text-muted-foreground">
+          {segments.map((segment, index) => {
+            const isLast = index === segments.length - 1;
+            return (
+              <li key={segment.href} className="flex items-center gap-1">
+                {index > 0 && (
+                  <ChevronRight
+                    className="h-3 w-3 shrink-0 text-muted-foreground/40"
+                    aria-hidden="true"
+                  />
+                )}
+                {isLast ? (
+                  <span className={cn('text-foreground/80 font-medium')} aria-current="page">
+                    {t(segment.label)}
+                  </span>
+                ) : (
+                  <Link href={segment.href} className="hover:text-foreground transition-colors">
+                    {t(segment.label)}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      {/* Mobile back link — shown below md breakpoint but only when header is visible (md:block on header) */}
+      {parentSegment && (
+        <nav aria-label={t('Breadcrumb')} className="md:hidden ml-3">
+          <Link
+            href={parentSegment.href}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+            <span>
+              {t('Back to')} {t(parentSegment.label)}
+            </span>
+          </Link>
+        </nav>
+      )}
+    </>
+  );
+}

--- a/components/governada/SectionPillBar.tsx
+++ b/components/governada/SectionPillBar.tsx
@@ -24,7 +24,7 @@ export function SectionPillBar({ section: _section }: SectionPillBarProps) {
   if (!items || items.length < 2) return null;
 
   return (
-    <div className="sticky top-0 md:top-14 z-20 lg:hidden border-b border-border/50 bg-background/95 backdrop-blur-xl pt-[env(safe-area-inset-top)] md:pt-0">
+    <div className="sticky top-0 md:top-10 z-20 lg:hidden border-b border-border/50 bg-background/95 backdrop-blur-xl pt-[env(safe-area-inset-top)] md:pt-0">
       <nav
         className="flex items-center gap-1.5 px-4 py-2 overflow-x-auto scrollbar-none"
         aria-label="Section navigation"

--- a/components/governada/discover/GovernadaDRepBrowse.tsx
+++ b/components/governada/discover/GovernadaDRepBrowse.tsx
@@ -547,7 +547,7 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
 
       {/* ── Sticky filter bar — Engaged+ ─────────────────────────── */}
       <DepthGate minDepth="engaged">
-        <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+        <div className="sticky top-10 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
           <DiscoverFilterBar
             search={filters.search}
             onSearchChange={(v) => setFilter('search', v)}

--- a/components/governada/discover/GovernadaDiscover.tsx
+++ b/components/governada/discover/GovernadaDiscover.tsx
@@ -122,7 +122,7 @@ export function GovernadaDiscover({
         message="Browse and compare governance participants. Scores reflect actual voting behavior, not popularity."
       />
       {/* ── Tab bar ──────────────────────────────────────────── */}
-      <div className="border-b border-border/30 sticky top-14 z-30 bg-card/60 backdrop-blur-xl -mx-4 px-4 sm:-mx-6 sm:px-6">
+      <div className="border-b border-border/30 sticky top-10 z-30 bg-card/60 backdrop-blur-xl -mx-4 px-4 sm:-mx-6 sm:px-6">
         <div
           className="flex gap-0 overflow-x-auto scrollbar-none max-w-4xl"
           role="tablist"

--- a/components/governada/discover/GovernadaSPOBrowse.tsx
+++ b/components/governada/discover/GovernadaSPOBrowse.tsx
@@ -327,7 +327,7 @@ export function GovernadaSPOBrowse() {
       </div>
 
       {/* ── Sticky filter bar ────────────────────────────────────── */}
-      <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+      <div className="sticky top-10 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
         <DiscoverFilterBar
           search={filters.search}
           onSearchChange={(v) => setFilter('search', v)}

--- a/components/governada/discover/ProposalsBrowse.tsx
+++ b/components/governada/discover/ProposalsBrowse.tsx
@@ -298,7 +298,7 @@ export function ProposalsBrowse() {
 
       {/* Filters — Engaged+ get search/filter bar */}
       <DepthGate minDepth="engaged">
-        <div className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
+        <div className="sticky top-10 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 py-2 bg-card/60 backdrop-blur-xl border-b border-border/30">
           <DiscoverFilterBar
             search={search}
             onSearchChange={setFilter(setSearch)}

--- a/components/governada/match/CuratedVoteFlow.tsx
+++ b/components/governada/match/CuratedVoteFlow.tsx
@@ -433,7 +433,7 @@ export function CuratedVoteFlow() {
   return (
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Top bar: progress + confidence */}
-      <div className="sticky top-14 z-10 bg-background/80 backdrop-blur-sm border-b border-border/30">
+      <div className="sticky top-10 z-10 bg-background/80 backdrop-blur-sm border-b border-border/30">
         <div className="mx-auto max-w-2xl px-4 py-3 space-y-2">
           <div className="flex items-center justify-between text-xs">
             <Link

--- a/components/governada/match/QuickMatchFlow.tsx
+++ b/components/governada/match/QuickMatchFlow.tsx
@@ -296,7 +296,7 @@ export function QuickMatchFlow() {
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Progress bar */}
       {typeof step === 'number' && (
-        <div className="sticky top-14 z-10 bg-background border-b border-border/50">
+        <div className="sticky top-10 z-10 bg-background border-b border-border/50">
           <div className="mx-auto max-w-2xl px-4 py-3">
             <div className="flex items-center gap-3">
               <button

--- a/components/governada/pulse/GovernadaPulseOverview.tsx
+++ b/components/governada/pulse/GovernadaPulseOverview.tsx
@@ -428,7 +428,7 @@ export function GovernadaPulseOverview() {
       <AnonymousNudge variant="health" />
       {/* ── Tab bar ───────────── */}
       <div
-        className="sticky top-14 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 flex gap-1 border-b border-border/30 -mb-2 overflow-x-auto bg-card/60 backdrop-blur-xl"
+        className="sticky top-10 lg:top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 flex gap-1 border-b border-border/30 -mb-2 overflow-x-auto bg-card/60 backdrop-blur-xl"
         role="tablist"
         aria-label="Pulse view"
       >


### PR DESCRIPTION
## Summary
- Compress header from 56px to 40px, reclaiming vertical space
- Add inline epoch strip showing epoch number, time remaining, active proposals
- Add governance pulse dot (green/amber/red) encoding governance urgency at a glance
- Add route-based breadcrumbs for spatial context
- Absorb EpochContextBar data into header (remove separate bar from shell)
- Remove Help dropdown, Depth picker, standalone Language picker from header (moving to command palette in follow-up PR)
- Move Language picker into user dropdown menu as sub-menu
- Fix CSS cascade: update all top-14 references to top-10

## Impact
- **What changed**: Header is 16px shorter with 3 new intelligence elements (epoch strip, pulse dot, breadcrumbs). EpochContextBar removed from shell.
- **User-facing**: Yes — header shows governance state at a glance, breadcrumbs provide navigation context, scroll-linked glassmorphism responds faster
- **Risk**: Low — visual/layout change only, no data model changes
- **Scope**: Header, shell, sidebar, pill bar, discover browse pages, match flows, pulse overview (CSS cascade fix)

## Test plan
- [ ] Header renders at 40px on all screen sizes
- [ ] Epoch strip shows correct epoch data, hidden on small screens
- [ ] Pulse dot colors correctly based on epoch day + active proposals
- [ ] Breadcrumbs show on desktop, collapse to Back link on mobile
- [ ] Sidebar, pill bar, browse filter bars position correctly below new header
- [ ] Language picker accessible in user menu (authenticated) and globe button (unauthenticated)
- [ ] No visual regression on any page
- [ ] Accessibility: pulse dot has aria-label, breadcrumbs use semantic nav/ol

🤖 Generated with [Claude Code](https://claude.com/claude-code)