### PR TITLE
feat: register global navigation keyboard shortcuts (G+key chords)

### DIFF
--- a/lib/workspace/default-commands.ts
+++ b/lib/workspace/default-commands.ts
@@ -7,6 +7,15 @@ import {
   PanelLeftOpen,
   Search,
   HelpCircle,
+  FileText,
+  Users,
+  Wallet,
+  Shield,
+  Activity,
+  User,
+  Wrench,
+  Settings,
+  PanelRight,
 } from 'lucide-react';
 import { commandRegistry } from './commands';
 
@@ -53,7 +62,7 @@ export function registerDefaultCommands(deps: {
     commandRegistry.register({
       id: 'navigate.review',
       label: 'Go to Review',
-      shortcut: 'g r',
+      shortcut: 'g v',
       icon: ClipboardCheck,
       section: 'navigation',
       execute: () => deps.push('/workspace/review'),
@@ -79,6 +88,105 @@ export function registerDefaultCommands(deps: {
       icon: Compass,
       section: 'navigation',
       execute: () => deps.push('/governance'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.proposals',
+      label: 'Go to Proposals',
+      shortcut: 'g p',
+      icon: FileText,
+      section: 'navigation',
+      execute: () => deps.push('/governance/proposals'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.representatives',
+      label: 'Go to Representatives',
+      shortcut: 'g r',
+      icon: Users,
+      section: 'navigation',
+      execute: () => deps.push('/governance/representatives'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.treasury',
+      label: 'Go to Treasury',
+      shortcut: 'g t',
+      icon: Wallet,
+      section: 'navigation',
+      execute: () => deps.push('/governance/treasury'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.committee',
+      label: 'Go to Committee',
+      shortcut: 'g c',
+      icon: Shield,
+      section: 'navigation',
+      execute: () => deps.push('/governance/committee'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.health',
+      label: 'Go to Governance Health',
+      shortcut: 'g e',
+      icon: Activity,
+      section: 'navigation',
+      execute: () => deps.push('/governance/health'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.you',
+      label: 'Go to You',
+      shortcut: 'g y',
+      icon: User,
+      section: 'navigation',
+      execute: () => deps.push('/you'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.match',
+      label: 'Go to Match',
+      shortcut: 'g m',
+      icon: Compass,
+      section: 'navigation',
+      execute: () => deps.push('/match'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.workspace',
+      label: 'Go to Workspace',
+      shortcut: 'g w',
+      icon: Wrench,
+      section: 'navigation',
+      execute: () => deps.push('/workspace'),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'navigate.settings',
+      label: 'Go to Settings',
+      shortcut: 'g s',
+      icon: Settings,
+      section: 'navigation',
+      execute: () => deps.push('/you/settings'),
     }),
   );
 
@@ -127,6 +235,17 @@ export function registerDefaultCommands(deps: {
       icon: HelpCircle,
       section: 'view',
       execute: () => deps.openKeyboardHelp(),
+    }),
+  );
+
+  unregisters.push(
+    commandRegistry.register({
+      id: 'view.toggle-intel-panel',
+      label: 'Toggle Intelligence Panel',
+      shortcut: ']',
+      icon: PanelRight,
+      section: 'view',
+      execute: () => window.dispatchEvent(new CustomEvent('toggleIntelPanel')),
     }),
   );
 


### PR DESCRIPTION
## Summary
- Register global keyboard chord shortcuts for all main navigation sections
- G H → Home, G P → Proposals, G R → Representatives, G T → Treasury
- G C → Committee, G E → Health, G Y → You, G M → Match
- G W → Workspace, G S → Settings, G A → Author, G V → Review
- G G → Governance (existing)
- ? → keyboard help overlay (existing)
- ] → dispatch toggleIntelPanel event (UI in Phase 5)
- Reassign Review shortcut from G R → G V to free G R for Representatives
- All shortcuts leverage existing keyboard engine + command registry

## Impact
- **What changed**: 10 new navigation chord shortcuts + 1 panel toggle shortcut added to the global command registry
- **User-facing**: Yes — power users can navigate with keyboard chords (G+P → Proposals, etc.)
- **Risk**: Low — additive commands in existing registry, no new components or hooks. Review shortcut changed from G R to G V.
- **Scope**: 1 modified file (`lib/workspace/default-commands.ts`)

## Test plan
- [ ] G then P navigates to Proposals
- [ ] G then R navigates to Representatives
- [ ] G then T navigates to Treasury
- [ ] G then C navigates to Committee
- [ ] G then E navigates to Governance Health
- [ ] G then Y navigates to You
- [ ] G then M navigates to Match
- [ ] G then W navigates to Workspace
- [ ] G then S navigates to Settings
- [ ] G then V navigates to Review (reassigned from G R)
- [ ] Shortcuts don't fire when typing in input fields
- [ ] Shortcuts don't fire when command palette is open
- [ ] ? key shows keyboard shortcuts overlay
- [ ] ] key dispatches toggleIntelPanel event
- [ ] All new shortcuts appear in keyboard help overlay (press ?)
- [ ] Works on both Mac and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)