### PR TITLE
feat: elevate Author Studio craft quality

### DIFF
--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -35,6 +35,7 @@ import { WorkspacePanels } from '@/components/workspace/layout/WorkspacePanels';
 import { ProposalEditor, injectProposedEdit } from '@/components/workspace/editor/ProposalEditor';
 import { AgentChatPanel } from '@/components/workspace/agent/AgentChatPanel';
 import { StatusBar } from '@/components/workspace/layout/StatusBar';
+import { SaveErrorBanner } from '@/components/workspace/layout/SaveErrorBanner';
 import { RevisionJustificationFlow } from '@/components/workspace/editor/RevisionJustificationFlow';
 import { ReadinessPanel } from '@/components/workspace/author/ReadinessPanel';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -136,6 +137,20 @@ function AuthorPanelWrapper({
 }
 
 // ---------------------------------------------------------------------------
+// AuthorHeaderWrapper — connects readiness badge click to panel toggle
+// ---------------------------------------------------------------------------
+
+function AuthorHeaderWrapper(
+  props: React.ComponentProps<typeof StudioHeader> & {
+    readiness?: { level: 'low' | 'moderate' | 'high' | 'strong'; blockerCount: number };
+  },
+) {
+  const { togglePanel } = useStudio();
+
+  return <StudioHeader {...props} onReadinessClick={() => togglePanel('readiness')} />;
+}
+
+// ---------------------------------------------------------------------------
 // AuthorActionBarWrapper — connects action bar to studio context
 // ---------------------------------------------------------------------------
 
@@ -223,6 +238,24 @@ function WorkspaceEditorPage() {
     error: agentError,
   } = useAgent({ proposalId: draftId ?? '', userRole });
 
+  // --- Readiness badge for header (lightweight, no extra queries) ---
+  const readinessBadge = useMemo(() => {
+    if (!draft || !isOwner) return undefined;
+    const fields = [draft.title, draft.abstract, draft.motivation, draft.rationale];
+    const filled = fields.filter((f) => f && f.trim().length > 0).length;
+    const constCheck = draft.lastConstitutionalCheck?.score ?? null;
+    let blockerCount = 0;
+    if (filled < 4) blockerCount++;
+    if (constCheck === 'fail') blockerCount++;
+    const level =
+      blockerCount > 0
+        ? ('low' as const)
+        : constCheck === 'pass' && filled >= 4
+          ? ('strong' as const)
+          : ('moderate' as const);
+    return { level, blockerCount };
+  }, [draft, isOwner]);
+
   // --- Derived version data ---
   const versions = data?.versions ?? null;
   const submittedTxHash = draft?.submittedTxHash ?? null;
@@ -254,6 +287,18 @@ function WorkspaceEditorPage() {
     },
     [updateDraft, setSaving],
   );
+
+  // --- Retry save: re-send current content to mutation ---
+  const handleSaveRetry = useCallback(() => {
+    if (!draft) return;
+    setSaving();
+    updateDraft.mutate({
+      title: draft.title,
+      abstract: draft.abstract,
+      motivation: draft.motivation,
+      rationale: draft.rationale,
+    });
+  }, [draft, updateDraft, setSaving]);
 
   // --- Capture editor instance ---
   const handleEditorReady = useCallback((editor: Editor) => {
@@ -446,20 +491,22 @@ function WorkspaceEditorPage() {
         <WorkspacePanels
           layoutId="editor"
           toolbar={
-            <StudioHeader
+            <AuthorHeaderWrapper
               backLabel="Back to drafts"
               backHref="/workspace/author"
-              title={draft.title || 'Untitled'}
+              title={draft.title || 'Untitled proposal'}
               proposalType={typeLabel}
               showModeSwitch={isOwner}
               mode={mode}
               onModeChange={isOwner ? setMode : undefined}
               actions={saveVersionButton}
+              readiness={readinessBadge}
             />
           }
           main={
-            <div className="max-w-3xl mx-auto px-6 py-6">
+            <div className="max-w-3xl mx-auto px-6 py-6 transition-opacity duration-150">
               {draft.supersedesId && <LineageBanner supersedesId={draft.supersedesId} />}
+              <SaveErrorBanner onRetry={handleSaveRetry} />
               <ProposalEditor
                 content={content}
                 mode={mode}

--- a/components/studio/StudioHeader.tsx
+++ b/components/studio/StudioHeader.tsx
@@ -18,12 +18,21 @@ import {
 import { cn } from '@/lib/utils';
 import { StudioQueueProgress } from './StudioQueueProgress';
 
+interface ReadinessBadgeData {
+  level: 'low' | 'moderate' | 'high' | 'strong';
+  blockerCount: number;
+}
+
 interface StudioHeaderProps {
   backHref?: string;
   onBack?: () => void;
   backLabel?: string;
   title?: string;
   proposalType?: string;
+  /** Compact readiness indicator in the header */
+  readiness?: ReadinessBadgeData;
+  /** Called when readiness badge is clicked */
+  onReadinessClick?: () => void;
   queueProgress?: { current: number; total: number };
   onQueueJump?: (index: number) => void;
   onPrev?: () => void;
@@ -72,6 +81,8 @@ export function StudioHeader({
   notificationCount = 0,
   onCommandPalette,
   segmentBadge,
+  readiness,
+  onReadinessClick,
   panelOpen,
   activePanel,
   onPanelToggle,
@@ -185,6 +196,38 @@ export function StudioHeader({
             />
           ))}
         </div>
+      )}
+
+      {/* Readiness badge */}
+      {readiness && (
+        <button
+          onClick={onReadinessClick}
+          className={cn(
+            'hidden sm:flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-medium transition-colors cursor-pointer border',
+            readiness.level === 'strong' || readiness.level === 'high'
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+              : readiness.blockerCount > 0
+                ? 'border-destructive/30 bg-destructive/10 text-destructive'
+                : 'border-amber-500/30 bg-amber-500/10 text-amber-400',
+          )}
+          title="Submission readiness"
+        >
+          <span
+            className={cn(
+              'h-1.5 w-1.5 rounded-full',
+              readiness.level === 'strong' || readiness.level === 'high'
+                ? 'bg-emerald-400'
+                : readiness.blockerCount > 0
+                  ? 'bg-destructive'
+                  : 'bg-amber-400',
+            )}
+          />
+          {readiness.blockerCount > 0
+            ? `${readiness.blockerCount} blocker${readiness.blockerCount !== 1 ? 's' : ''}`
+            : readiness.level === 'strong' || readiness.level === 'high'
+              ? 'Ready'
+              : 'Needs work'}
+        </button>
       )}
 
       {/* Mode switcher */}

--- a/components/studio/StudioPanel.tsx
+++ b/components/studio/StudioPanel.tsx
@@ -23,7 +23,6 @@ interface StudioPanelProps {
 const BASE_TABS: Array<{ id: TabId; label: string; Icon: typeof MessageSquare }> = [
   { id: 'agent', label: 'Agent', Icon: MessageSquare },
   { id: 'intel', label: 'Intel', Icon: BarChart3 },
-  { id: 'notes', label: 'Notes', Icon: StickyNote },
 ];
 
 const MIN_PANEL_WIDTH = 280;
@@ -97,9 +96,10 @@ export function StudioPanel({
     [onWidthChange],
   );
 
-  // Build tabs dynamically: include vote only when voteContent provided, readiness when provided
+  // Build tabs dynamically: include notes/vote/readiness only when content is provided
   const TABS = [
     ...BASE_TABS,
+    ...(notesContent ? [{ id: 'notes' as TabId, label: 'Notes', Icon: StickyNote }] : []),
     ...(voteContent ? [{ id: 'vote' as TabId, label: 'Vote', Icon: Vote }] : []),
     ...(readinessContent
       ? [{ id: 'readiness' as TabId, label: 'Readiness', Icon: ShieldCheck }]
@@ -132,7 +132,7 @@ export function StudioPanel({
       ref={panelRef}
       className={cn(
         'hidden lg:flex flex-col relative border-l border-border bg-background shrink-0 overflow-hidden',
-        'transition-[width,opacity] duration-200 ease-out',
+        'transition-[width,opacity] duration-200 [transition-timing-function:cubic-bezier(0.32,0.72,0,1)]',
       )}
       style={{ width: isOpen ? clampedWidth : 0 }}
     >

--- a/components/workspace/author/AuthorIntelligencePanel.tsx
+++ b/components/workspace/author/AuthorIntelligencePanel.tsx
@@ -7,6 +7,7 @@
  * completeness gaps, vagueness issues, and overall quality per section.
  */
 
+import { useMemo } from 'react';
 import { Brain, Shield, ListChecks, Pencil } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -22,6 +23,8 @@ import type { SectionAnalysisOutput } from '@/lib/ai/skills/section-analysis';
 interface AuthorIntelligencePanelProps {
   results: Record<string, SectionAnalysisOutput | null>;
   loading: Record<string, boolean>;
+  /** Timestamps of when each section was last analyzed (ISO string) */
+  analyzedAt?: Record<string, string | null>;
   onApplyFix?: (field: string, search: string, replace: string) => void;
 }
 
@@ -37,13 +40,36 @@ const severityColors = {
   critical: 'bg-rose-500/10 text-rose-600 dark:text-rose-400',
 } as const;
 
+function formatTimeSince(iso: string): { label: string; isStale: boolean } {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diffMs / 60_000);
+  const isStale = mins > 10;
+  if (mins < 1) return { label: 'just now', isStale };
+  if (mins < 60) return { label: `${mins}m ago`, isStale };
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return { label: `${hours}h ago`, isStale };
+  return { label: `${Math.floor(hours / 24)}d ago`, isStale };
+}
+
 export function AuthorIntelligencePanel({
   results,
   loading,
+  analyzedAt,
   onApplyFix,
 }: AuthorIntelligencePanelProps) {
   const hasAnyResult = Object.values(results).some((r) => r !== null);
   const hasAnyLoading = Object.values(loading).some((l) => l);
+
+  // Compute staleness info outside of render to avoid impure Date.now() in JSX
+  const stalenessInfo = useMemo(() => {
+    if (!analyzedAt) return {};
+    const info: Record<string, { label: string; isStale: boolean }> = {};
+    for (const key of Object.keys(analyzedAt)) {
+      const ts = analyzedAt[key];
+      if (ts) info[key] = formatTimeSince(ts);
+    }
+    return info;
+  }, [analyzedAt]);
 
   return (
     <Card>
@@ -64,7 +90,6 @@ export function AuthorIntelligencePanel({
             {SECTIONS.map(({ field, label }) => {
               const result = results[field];
               const isLoading = loading[field] ?? false;
-
               return (
                 <AccordionItem key={field} value={field}>
                   <AccordionTrigger className="text-xs py-2 hover:no-underline">
@@ -79,6 +104,20 @@ export function AuthorIntelligencePanel({
                       {result && (
                         <span className="text-muted-foreground font-normal truncate max-w-[140px]">
                           {result.summary}
+                        </span>
+                      )}
+                      {stalenessInfo[field] && !isLoading && (
+                        <span
+                          className={`ml-auto text-[10px] shrink-0 ${
+                            stalenessInfo[field].isStale
+                              ? 'text-amber-400/70'
+                              : 'text-muted-foreground/50'
+                          }`}
+                          title={
+                            stalenessInfo[field].isStale ? 'Re-analyze on next edit' : undefined
+                          }
+                        >
+                          {stalenessInfo[field].label}
                         </span>
                       )}
                     </div>
@@ -165,7 +204,9 @@ export function AuthorIntelligencePanel({
                         {result.constitutionalFlags.length === 0 &&
                           result.completenessGaps.length === 0 &&
                           result.vaguenessIssues.length === 0 && (
-                            <p className="text-muted-foreground">No issues found. Looking good.</p>
+                            <p className="text-muted-foreground">
+                              This section is constitutionally sound and substantively complete.
+                            </p>
                           )}
                       </div>
                     )}

--- a/components/workspace/author/DraftCard.tsx
+++ b/components/workspace/author/DraftCard.tsx
@@ -137,7 +137,7 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
                   lineHeight: 'var(--workspace-line-height)',
                 }}
               >
-                {draft.title || 'Untitled Draft'}
+                {draft.title || 'Untitled proposal'}
               </h3>
               <span className="text-xs text-muted-foreground whitespace-nowrap">
                 v{draft.currentVersion}
@@ -168,7 +168,7 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
 
         {/* Quick actions button — positioned absolutely top-right over the card */}
         <div
-          className="absolute top-2 right-2 opacity-0 group-hover/card:opacity-100 focus-within:opacity-100 transition-opacity"
+          className="absolute top-2 right-2 opacity-0 group-hover/card:opacity-100 focus-within:opacity-100 transition-opacity duration-150"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >

--- a/components/workspace/author/PortfolioView.tsx
+++ b/components/workspace/author/PortfolioView.tsx
@@ -45,17 +45,18 @@ const COLUMN_META: Record<
   drafts: {
     label: 'Drafts',
     emptyTitle: 'No drafts',
-    emptyDescription: 'Create your first proposal to get started.',
+    emptyDescription: 'Start a new proposal or use AI scaffolding to generate a draft.',
   },
   inReview: {
     label: 'In Review',
     emptyTitle: 'No proposals in review',
-    emptyDescription: 'Open a draft for community feedback.',
+    emptyDescription:
+      'When a draft is ready, open it for structured community feedback and constitutional review.',
   },
   onChain: {
     label: 'On-Chain',
     emptyTitle: 'No submitted proposals',
-    emptyDescription: 'Complete the review process to submit on-chain.',
+    emptyDescription: 'Proposals that pass community review can be submitted on-chain for voting.',
   },
   archived: {
     label: 'Archived',
@@ -176,7 +177,18 @@ export function PortfolioView({ drafts, isLoading, showArchived }: PortfolioView
     return (
       <div className="grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: 'var(--workspace-gap)' }}>
         {[1, 2, 3].map((i) => (
-          <Skeleton key={i} className="h-36 w-full rounded-xl" />
+          <div key={i} className="rounded-xl border border-border p-4 space-y-3">
+            <div className="flex items-start justify-between">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-4 w-8" />
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-1/2" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
         ))}
       </div>
     );
@@ -188,9 +200,10 @@ export function PortfolioView({ drafts, isLoading, showArchived }: PortfolioView
       <Card className="border-dashed">
         <CardContent className="flex flex-col items-center justify-center py-12 text-center">
           <FileText className="h-10 w-10 text-muted-foreground/50 mb-3" />
-          <p className="text-muted-foreground font-medium">No drafts yet</p>
-          <p className="text-sm text-muted-foreground/70 mt-1">
-            Create your first proposal to get started.
+          <p className="text-muted-foreground font-medium">No proposals yet</p>
+          <p className="text-sm text-muted-foreground/70 mt-1 max-w-sm">
+            Create your first governance proposal. Choose from Treasury Withdrawals, Info Actions,
+            Parameter Changes, or Constitutional Amendments.
           </p>
         </CardContent>
       </Card>

--- a/components/workspace/author/ReadinessPanel.tsx
+++ b/components/workspace/author/ReadinessPanel.tsx
@@ -12,11 +12,12 @@
  * 4. Hover tooltips explaining each check
  */
 
-import { useMemo } from 'react';
-import { CheckCircle2, XCircle, AlertTriangle, Info, Shield, Users } from 'lucide-react';
+import { useMemo, useEffect, useRef } from 'react';
+import { CheckCircle2, XCircle, AlertTriangle, Info, Shield, Users, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useDraft } from '@/hooks/useDrafts';
 import { useDraftReviews } from '@/hooks/useDraftReviews';
+import { useAISkill } from '@/hooks/useAISkill';
 import { MIN_REVIEWS_FOR_SUBMISSION } from '@/lib/workspace/constants';
 import {
   computeConfidence,
@@ -25,6 +26,7 @@ import {
   type ConfidenceInput,
 } from '@/lib/workspace/confidence';
 import type { ProposalDraft, ConstitutionalCheckResult } from '@/lib/workspace/types';
+import type { ReadinessNarrativeOutput } from '@/lib/ai/skills/readiness-narrative';
 import { Skeleton } from '@/components/ui/skeleton';
 
 // ---------------------------------------------------------------------------
@@ -145,6 +147,78 @@ function contextMessage(level: string, blockerCount: number): string {
     return 'Your amendment looks ready for submission.';
   }
   return 'Address the recommendations below to strengthen your submission.';
+}
+
+// ---------------------------------------------------------------------------
+// AI Narrative — the "oh wow" moment
+// ---------------------------------------------------------------------------
+
+function ReadinessNarrative({
+  draft,
+  confidence,
+  blockers,
+  recommendations,
+  reviewCount,
+}: {
+  draft: ProposalDraft;
+  confidence: { score: number; level: string };
+  blockers: Array<{ label: string }>;
+  recommendations: Array<{ label: string }>;
+  reviewCount: number;
+}) {
+  const skill = useAISkill<ReadinessNarrativeOutput>();
+  const hasTriggered = useRef(false);
+
+  // Trigger once when confidence data is available and content exists
+  useEffect(() => {
+    if (hasTriggered.current) return;
+    if (!draft.title && !draft.abstract) return;
+
+    hasTriggered.current = true;
+    skill.mutate({
+      skill: 'readiness-narrative',
+      input: {
+        proposalType: draft.proposalType,
+        title: draft.title || '',
+        abstract: draft.abstract || '',
+        motivation: draft.motivation || '',
+        rationale: draft.rationale || '',
+        confidenceScore: confidence.score,
+        confidenceLevel: confidence.level,
+        blockerLabels: blockers.map((b) => b.label),
+        recommendationLabels: recommendations.map((r) => r.label),
+        constitutionalCheck: draft.lastConstitutionalCheck?.score ?? null,
+        reviewCount,
+      },
+      draftId: draft.id,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draft.id]);
+
+  if (skill.isPending) {
+    return (
+      <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-3.5 w-3.5 text-primary animate-pulse" />
+          <div className="h-3 w-3/4 rounded bg-primary/10 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!skill.data?.output?.narrative) return null;
+
+  const { narrative, actionItem } = skill.data.output;
+
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5 space-y-1.5">
+      <div className="flex items-start gap-2">
+        <Sparkles className="h-3.5 w-3.5 text-primary shrink-0 mt-0.5" />
+        <p className="text-xs text-foreground/80 leading-relaxed">{narrative}</p>
+      </div>
+      {actionItem && <p className="text-[11px] text-primary/70 pl-5 font-medium">{actionItem}</p>}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -325,12 +399,13 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
           </span>
         </div>
 
-        {/* Progress bar */}
+        {/* Progress bar — animates from 0 on mount */}
         <div className="h-2 rounded-full bg-muted overflow-hidden">
           <div
             className={cn(
-              'h-full rounded-full transition-all duration-500',
+              'h-full rounded-full transition-all duration-700 ease-out',
               confidenceLevelBg(confidence.level),
+              'animate-in fade-in',
             )}
             style={{ width: `${confidence.score}%` }}
           />
@@ -341,6 +416,17 @@ export function ReadinessPanel({ draftId }: ReadinessPanelProps) {
           {confidence.level}
         </p>
       </div>
+
+      {/* AI Readiness Narrative */}
+      {draftData?.draft && (
+        <ReadinessNarrative
+          draft={draftData.draft}
+          confidence={confidence}
+          blockers={blockers}
+          recommendations={recommendations}
+          reviewCount={reviewsData?.reviews?.length ?? 0}
+        />
+      )}
 
       {/* Blockers section */}
       {blockers.length > 0 && (

--- a/components/workspace/editor/CommandBar.tsx
+++ b/components/workspace/editor/CommandBar.tsx
@@ -222,9 +222,24 @@ export function CommandBarUI({
         {/* Input */}
         <div className="flex items-center gap-3 px-4 py-3">
           <div className="flex items-center gap-1.5 text-muted-foreground flex-shrink-0">
-            <kbd className="h-5 px-1.5 rounded bg-muted text-[10px] font-mono flex items-center">
+            <span className="h-5 px-1.5 rounded bg-primary/10 text-primary text-[10px] font-medium flex items-center gap-1">
+              <svg
+                className="h-3 w-3"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
+                <path d="M5 3v4" />
+                <path d="M19 17v4" />
+                <path d="M3 5h4" />
+                <path d="M17 19h4" />
+              </svg>
               AI
-            </kbd>
+            </span>
           </div>
           <input
             ref={inputRef}

--- a/components/workspace/editor/FormattingToolbar.tsx
+++ b/components/workspace/editor/FormattingToolbar.tsx
@@ -10,7 +10,7 @@
  * Rendered sticky so it stays visible when scrolling long proposal content.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Bold,
   Italic,
@@ -75,12 +75,108 @@ function Separator() {
 }
 
 // ---------------------------------------------------------------------------
+// URL Input Popover — replaces window.prompt for link/image URL entry
+// ---------------------------------------------------------------------------
+
+interface URLInputPopoverProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (url: string) => void;
+  defaultValue?: string;
+  placeholder?: string;
+}
+
+function URLInputPopover({
+  isOpen,
+  onClose,
+  onSubmit,
+  defaultValue = '',
+  placeholder = 'Enter URL...',
+}: URLInputPopoverProps) {
+  const [value, setValue] = useState(defaultValue);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset value when popover opens with a new defaultValue
+  useEffect(() => {
+    if (isOpen) {
+      setValue(defaultValue);
+      // Auto-focus after render
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen, defaultValue]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    onSubmit(value);
+    onClose();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  const handleFocus = async () => {
+    // Paste-to-fill: if the input is empty, try to auto-populate from clipboard
+    if (!value) {
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text && /^https?:\/\//.test(text.trim())) {
+          setValue(text.trim());
+        }
+      } catch {
+        // Clipboard access denied — silently ignore
+      }
+    }
+  };
+
+  return (
+    <div className="absolute top-full left-0 mt-1 z-50 rounded-md border border-border bg-popover shadow-lg p-2">
+      <div className="flex items-center gap-1.5">
+        <input
+          ref={inputRef}
+          type="url"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={handleFocus}
+          placeholder={placeholder}
+          className="h-7 w-56 rounded-sm border border-border bg-background px-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="inline-flex items-center justify-center h-7 px-2 rounded-sm bg-accent text-accent-foreground text-xs font-medium hover:bg-accent/80 transition-colors"
+        >
+          OK
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex items-center justify-center h-7 w-7 rounded-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Insert menu (+ button dropdown)
 // ---------------------------------------------------------------------------
 
 interface InsertItem {
   icon: React.ReactNode;
   label: string;
+  /** If set, the item opens a URL popover instead of running an immediate action. */
+  usesPopover?: boolean;
   action: (editor: Editor) => void;
 }
 
@@ -99,12 +195,9 @@ const INSERT_ITEMS: InsertItem[] = [
   {
     icon: <ImageIcon className="h-3.5 w-3.5" />,
     label: 'Image',
-    action: (editor) => {
-      const url = window.prompt('Enter image URL:');
-      if (url) {
-        editor.chain().focus().setImage({ src: url }).run();
-      }
-    },
+    usesPopover: true,
+    // action is a no-op here — the popover callback handles insertion
+    action: () => {},
   },
   {
     icon: <Code className="h-3.5 w-3.5" />,
@@ -113,7 +206,7 @@ const INSERT_ITEMS: InsertItem[] = [
   },
 ];
 
-function InsertMenu({ editor }: { editor: Editor }) {
+function InsertMenu({ editor, onImageInsert }: { editor: Editor; onImageInsert: () => void }) {
   const [open, setOpen] = useState(false);
 
   const handleToggle = useCallback(() => {
@@ -121,11 +214,15 @@ function InsertMenu({ editor }: { editor: Editor }) {
   }, []);
 
   const handleSelect = useCallback(
-    (action: (editor: Editor) => void) => {
-      action(editor);
+    (item: InsertItem) => {
+      if (item.usesPopover) {
+        onImageInsert();
+      } else {
+        item.action(editor);
+      }
       setOpen(false);
     },
-    [editor],
+    [editor, onImageInsert],
   );
 
   return (
@@ -141,7 +238,7 @@ function InsertMenu({ editor }: { editor: Editor }) {
             <button
               key={item.label}
               type="button"
-              onClick={() => handleSelect(item.action)}
+              onClick={() => handleSelect(item)}
               className="flex items-center gap-2 w-full px-3 py-1.5 text-sm text-foreground hover:bg-accent/50 transition-colors"
             >
               {item.icon}
@@ -158,71 +255,108 @@ function InsertMenu({ editor }: { editor: Editor }) {
 // Toolbar component
 // ---------------------------------------------------------------------------
 
+type ActivePopover = 'link' | 'image' | null;
+
 export function FormattingToolbar({ editor }: FormattingToolbarProps) {
   // Force re-render on editor state changes for active-state detection
   // We use editor.on in useEffect, but for simplicity Tiptap's React
   // hooks already trigger re-renders on transactions.
 
-  const setLink = useCallback(() => {
-    const previousUrl = editor.getAttributes('link').href as string | undefined;
-    const url = window.prompt('URL', previousUrl ?? '');
+  const [activePopover, setActivePopover] = useState<ActivePopover>(null);
 
-    if (url === null) return; // Cancelled
+  const openLinkPopover = useCallback(() => {
+    setActivePopover('link');
+  }, []);
 
-    if (url === '') {
-      editor.chain().focus().extendMarkRange('link').unsetLink().run();
-      return;
-    }
+  const openImagePopover = useCallback(() => {
+    setActivePopover('image');
+  }, []);
 
-    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+  const closePopover = useCallback(() => {
+    setActivePopover(null);
+    editor.commands.focus();
   }, [editor]);
+
+  const handleLinkSubmit = useCallback(
+    (url: string) => {
+      if (url === '') {
+        editor.chain().focus().extendMarkRange('link').unsetLink().run();
+        return;
+      }
+      editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+    },
+    [editor],
+  );
+
+  const handleImageSubmit = useCallback(
+    (url: string) => {
+      if (url) {
+        editor.chain().focus().setImage({ src: url }).run();
+      }
+    },
+    [editor],
+  );
+
+  const linkDefaultValue =
+    activePopover === 'link'
+      ? ((editor.getAttributes('link').href as string | undefined) ?? '')
+      : '';
 
   return (
     <div className="formatting-toolbar sticky top-0 z-10 flex items-center gap-0.5 px-3 py-1.5 bg-muted/30 border-b border-border/30 flex-wrap">
       {/* Inline formatting */}
       <ToolbarButton
         icon={<Bold className="h-3.5 w-3.5" />}
-        label="Bold"
+        label="Bold (Ctrl+B)"
         isActive={editor.isActive('bold')}
         onClick={() => editor.chain().focus().toggleBold().run()}
       />
       <ToolbarButton
         icon={<Italic className="h-3.5 w-3.5" />}
-        label="Italic"
+        label="Italic (Ctrl+I)"
         isActive={editor.isActive('italic')}
         onClick={() => editor.chain().focus().toggleItalic().run()}
       />
       <ToolbarButton
         icon={<Strikethrough className="h-3.5 w-3.5" />}
-        label="Strikethrough"
+        label="Strikethrough (Ctrl+Shift+X)"
         isActive={editor.isActive('strike')}
         onClick={() => editor.chain().focus().toggleStrike().run()}
       />
-      <ToolbarButton
-        icon={<Link className="h-3.5 w-3.5" />}
-        label="Link"
-        isActive={editor.isActive('link')}
-        onClick={setLink}
-      />
+      <div className="relative">
+        <ToolbarButton
+          icon={<Link className="h-3.5 w-3.5" />}
+          label="Link (Ctrl+K)"
+          isActive={editor.isActive('link')}
+          onClick={openLinkPopover}
+        />
+        <URLInputPopover
+          isOpen={activePopover === 'link'}
+          onClose={closePopover}
+          onSubmit={handleLinkSubmit}
+          defaultValue={linkDefaultValue}
+          placeholder="Enter URL..."
+        />
+      </div>
 
       <Separator />
 
       {/* Headings */}
       <ToolbarButton
         icon={<Heading1 className="h-3.5 w-3.5" />}
-        label="Heading 1"
+        label="Heading 1 (Ctrl+Alt+1)"
         isActive={editor.isActive('heading', { level: 1 })}
         onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
       />
       <ToolbarButton
         icon={<Heading2 className="h-3.5 w-3.5" />}
-        label="Heading 2"
+        label="Heading 2 (Ctrl+Alt+2)"
         isActive={editor.isActive('heading', { level: 2 })}
         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
       />
       <ToolbarButton
         icon={<Heading3 className="h-3.5 w-3.5" />}
-        label="Heading 3"
+        label="Heading 3 (Ctrl+Alt+3)"
         isActive={editor.isActive('heading', { level: 3 })}
         onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
       />
@@ -232,19 +366,19 @@ export function FormattingToolbar({ editor }: FormattingToolbarProps) {
       {/* Lists */}
       <ToolbarButton
         icon={<List className="h-3.5 w-3.5" />}
-        label="Bullet List"
+        label="Bullet List (Ctrl+Shift+8)"
         isActive={editor.isActive('bulletList')}
         onClick={() => editor.chain().focus().toggleBulletList().run()}
       />
       <ToolbarButton
         icon={<ListOrdered className="h-3.5 w-3.5" />}
-        label="Numbered List"
+        label="Numbered List (Ctrl+Shift+7)"
         isActive={editor.isActive('orderedList')}
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
       />
       <ToolbarButton
         icon={<CheckSquare className="h-3.5 w-3.5" />}
-        label="Task List"
+        label="Task List (Ctrl+Shift+9)"
         isActive={editor.isActive('taskList')}
         onClick={() => editor.chain().focus().toggleTaskList().run()}
       />
@@ -254,21 +388,23 @@ export function FormattingToolbar({ editor }: FormattingToolbarProps) {
       {/* Block elements */}
       <ToolbarButton
         icon={<Quote className="h-3.5 w-3.5" />}
-        label="Blockquote"
+        label="Blockquote (Ctrl+Shift+B)"
         isActive={editor.isActive('blockquote')}
         onClick={() => editor.chain().focus().toggleBlockquote().run()}
-      />
-      <ToolbarButton
-        icon={<Code className="h-3.5 w-3.5" />}
-        label="Code Block"
-        isActive={editor.isActive('codeBlock')}
-        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
       />
 
       <Separator />
 
-      {/* Insert menu */}
-      <InsertMenu editor={editor} />
+      {/* Insert menu (includes code block, table, divider, image) */}
+      <div className="relative">
+        <InsertMenu editor={editor} onImageInsert={openImagePopover} />
+        <URLInputPopover
+          isOpen={activePopover === 'image'}
+          onClose={closePopover}
+          onSubmit={handleImageSubmit}
+          placeholder="Enter image URL..."
+        />
+      </div>
     </div>
   );
 }

--- a/components/workspace/editor/ProposalEditor.tsx
+++ b/components/workspace/editor/ProposalEditor.tsx
@@ -229,9 +229,27 @@ export function ProposalEditor({
       }),
       ProposalDocument,
       Placeholder.configure({
-        placeholder: ({ node }) => {
+        placeholder: ({ node, pos, editor: e }) => {
           if (node.type.name === 'paragraph') {
-            return 'Start writing...';
+            // Section-specific governance placeholders
+            const $pos = e.state.doc.resolve(pos);
+            for (let depth = $pos.depth; depth >= 0; depth--) {
+              const parent = $pos.node(depth);
+              if (parent.type.name === 'sectionBlock') {
+                const field = parent.attrs.field as string;
+                const placeholders: Record<string, string> = {
+                  title: 'Give your proposal a clear, specific title',
+                  abstract:
+                    'Summarize your proposal in 2\u20133 sentences. What are you proposing and why?',
+                  motivation:
+                    'Why does Cardano need this? What problem are you solving, and who benefits?',
+                  rationale:
+                    'How will this be implemented? What makes this approach the right one?',
+                };
+                return placeholders[field] ?? 'Start writing\u2026';
+              }
+            }
+            return 'Start writing\u2026';
           }
           return '';
         },
@@ -369,16 +387,19 @@ export function ProposalEditor({
   useEffect(() => {
     if (!editor) return;
 
-    const interval = setInterval(() => {
+    const handleTransaction = () => {
       const storage = getCommandBarStorage(editor);
       if (storage?.isOpen && !commandBarOpen) {
         setCommandBarOpen(true);
         setCommandBarSelectedText(storage.selectedText || '');
         setCommandBarSection(storage.section || '');
       }
-    }, 100);
+    };
 
-    return () => clearInterval(interval);
+    editor.on('transaction', handleTransaction);
+    return () => {
+      editor.off('transaction', handleTransaction);
+    };
   }, [editor, commandBarOpen]);
 
   // -------------------------------------------------------------------------

--- a/components/workspace/editor/SlashCommandMenu.tsx
+++ b/components/workspace/editor/SlashCommandMenu.tsx
@@ -19,6 +19,96 @@ import type { Editor } from '@tiptap/core';
 import type { SlashCommandType } from '@/lib/workspace/editor/types';
 
 // ---------------------------------------------------------------------------
+// SVG icon helper (Lucide-style inline SVGs for DOM rendering)
+// ---------------------------------------------------------------------------
+
+function createSvgIcon(paths: string[]): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '16');
+  svg.setAttribute('height', '16');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const d of paths) {
+    const p = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    p.setAttribute('d', d);
+    svg.appendChild(p);
+  }
+  return svg;
+}
+
+// ---------------------------------------------------------------------------
+// Lucide icon paths
+// ---------------------------------------------------------------------------
+
+const ICON_HEADING: string[] = ['M4 12h8', 'M4 18V6', 'M12 18V6', 'M17 12l3-2v8'];
+const ICON_LIST: string[] = [
+  'M8 6h13',
+  'M8 12h13',
+  'M8 18h13',
+  'M3 6h.01',
+  'M3 12h.01',
+  'M3 18h.01',
+];
+const ICON_LIST_ORDERED: string[] = [
+  'M10 6h11',
+  'M10 12h11',
+  'M10 18h11',
+  'M4 6h1v4',
+  'M4 10h2',
+  'M6 18H4c0-1 2-2 2-3s-1-1.5-2-1',
+];
+const ICON_CHECK_SQUARE: string[] = [
+  'M9 11l3 3L22 4',
+  'M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11',
+];
+const ICON_QUOTE: string[] = [
+  'M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V21z',
+  'M17 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-1 2-2 2s-1 .008-1 1.031V21z',
+];
+const ICON_CODE: string[] = ['m18 16 4-4-4-4', 'M6 8l-4 4 4 4', 'M14.5 4l-5 16'];
+const ICON_TABLE: string[] = [
+  'M9 3H5a2 2 0 0 0-2 2v4m6-6h10a2 2 0 0 1 2 2v4M9 3v18m0 0h10a2 2 0 0 0 2-2V9M9 21H5a2 2 0 0 1-2-2V9m0 0h18',
+];
+const ICON_MINUS: string[] = ['M5 12h14'];
+const ICON_LIGHTBULB: string[] = [
+  'M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5',
+  'M9 18h6',
+  'M10 22h4',
+];
+const ICON_IMAGE: string[] = [
+  'M21 3.6v16.8a.6.6 0 0 1-.6.6H3.6a.6.6 0 0 1-.6-.6V3.6a.6.6 0 0 1 .6-.6h16.8a.6.6 0 0 1 .6.6z',
+  'M3 16l5-7 4.5 6 3.5-4 5 5',
+  'M16 10a2 2 0 1 1 0-4 2 2 0 0 1 0 4z',
+];
+const ICON_SPARKLES: string[] = [
+  'm12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z',
+  'M5 3v4',
+  'M19 17v4',
+  'M3 5h4',
+  'M17 19h4',
+];
+const ICON_SCALE: string[] = [
+  'm16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z',
+  'M2 16l3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z',
+  'M7 21h10',
+  'M12 3v18',
+  'M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2',
+];
+const ICON_SEARCH: string[] = ['M11 3a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z', 'M21 21l-4.35-4.35'];
+const ICON_FILE_TEXT: string[] = [
+  'M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z',
+  'M14 2v4a2 2 0 0 0 2 2h4',
+  'M10 9H8',
+  'M16 13H8',
+  'M16 17H8',
+];
+const ICON_PEN_LINE: string[] = ['M12 20h9', 'M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z'];
+
+// ---------------------------------------------------------------------------
 // Command definitions
 // ---------------------------------------------------------------------------
 
@@ -29,7 +119,7 @@ type CommandDef =
       id: string;
       label: string;
       description: string;
-      icon: string;
+      icon: string[];
       aliases: string[];
       execute: (editor: Editor) => void;
     }
@@ -38,7 +128,7 @@ type CommandDef =
       id: SlashCommandType;
       label: string;
       description: string;
-      icon: string;
+      icon: string[];
       aliases: string[];
     };
 
@@ -50,7 +140,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'heading',
     label: 'Heading 1',
     description: 'Large section heading',
-    icon: '\uD83C\uDD77', // H boxed
+    icon: ICON_HEADING,
     aliases: ['heading', 'h1'],
     execute: (editor) => editor.chain().focus().toggleHeading({ level: 1 }).run(),
   },
@@ -59,7 +149,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'h2',
     label: 'Heading 2',
     description: 'Medium section heading',
-    icon: '\uD83C\uDD77', // H boxed
+    icon: ICON_HEADING,
     aliases: ['h2'],
     execute: (editor) => editor.chain().focus().toggleHeading({ level: 2 }).run(),
   },
@@ -68,7 +158,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'h3',
     label: 'Heading 3',
     description: 'Small section heading',
-    icon: '\uD83C\uDD77', // H boxed
+    icon: ICON_HEADING,
     aliases: ['h3'],
     execute: (editor) => editor.chain().focus().toggleHeading({ level: 3 }).run(),
   },
@@ -77,7 +167,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'bullet',
     label: 'Bullet List',
     description: 'Create a simple bulleted list',
-    icon: '\u2022', // bullet
+    icon: ICON_LIST,
     aliases: ['bullet', 'list', 'ul'],
     execute: (editor) => editor.chain().focus().toggleBulletList().run(),
   },
@@ -86,7 +176,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'numbered',
     label: 'Numbered List',
     description: 'Create a numbered list',
-    icon: '\uD83D\uDD22', // 1234
+    icon: ICON_LIST_ORDERED,
     aliases: ['numbered', 'ordered', 'ol'],
     execute: (editor) => editor.chain().focus().toggleOrderedList().run(),
   },
@@ -95,7 +185,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'todo',
     label: 'Task List',
     description: 'Checklist with toggleable items',
-    icon: '\u2611', // checkbox
+    icon: ICON_CHECK_SQUARE,
     aliases: ['todo', 'checklist', 'task'],
     execute: (editor) => editor.chain().focus().toggleTaskList().run(),
   },
@@ -104,7 +194,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'quote',
     label: 'Blockquote',
     description: 'Insert a quote block',
-    icon: '\u275D', // heavy quote
+    icon: ICON_QUOTE,
     aliases: ['quote', 'blockquote'],
     execute: (editor) => editor.chain().focus().toggleBlockquote().run(),
   },
@@ -113,7 +203,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'code',
     label: 'Code Block',
     description: 'Insert a code block',
-    icon: '\u2329\u232A', // angle brackets
+    icon: ICON_CODE,
     aliases: ['code', 'codeblock'],
     execute: (editor) => editor.chain().focus().toggleCodeBlock().run(),
   },
@@ -122,7 +212,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'table',
     label: 'Table',
     description: 'Insert a 3x3 table',
-    icon: '\u25A6', // grid
+    icon: ICON_TABLE,
     aliases: ['table'],
     execute: (editor) =>
       editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
@@ -132,7 +222,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'divider',
     label: 'Divider',
     description: 'Insert a horizontal rule',
-    icon: '\u2015', // horizontal bar
+    icon: ICON_MINUS,
     aliases: ['divider', 'hr', 'rule'],
     execute: (editor) => editor.chain().focus().setHorizontalRule().run(),
   },
@@ -141,7 +231,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'callout',
     label: 'Callout',
     description: 'Highlighted note or warning block',
-    icon: '\uD83D\uDCA1', // lightbulb
+    icon: ICON_LIGHTBULB,
     aliases: ['callout', 'note', 'warning'],
     execute: (editor) =>
       editor
@@ -161,7 +251,7 @@ const CONTENT_COMMANDS: CommandDef[] = [
     id: 'image',
     label: 'Image',
     description: 'Insert an image from URL',
-    icon: '\uD83D\uDDBC', // framed picture
+    icon: ICON_IMAGE,
     aliases: ['image', 'img', 'picture'],
     execute: (editor) => {
       const url = window.prompt('Enter image URL:');
@@ -180,7 +270,7 @@ const AI_COMMANDS: CommandDef[] = [
     id: 'improve',
     label: 'Improve',
     description: 'AI improves the selected text or current section',
-    icon: '\u2728', // sparkles
+    icon: ICON_SPARKLES,
     aliases: ['improve'],
   },
   {
@@ -188,7 +278,7 @@ const AI_COMMANDS: CommandDef[] = [
     id: 'check-constitution',
     label: 'Check Constitution',
     description: 'Analyze constitutional compliance of this section',
-    icon: '\u2696\uFE0F', // scales
+    icon: ICON_SCALE,
     aliases: ['check-constitution', 'constitution'],
   },
   {
@@ -196,7 +286,7 @@ const AI_COMMANDS: CommandDef[] = [
     id: 'similar-proposals',
     label: 'Similar Proposals',
     description: 'Find precedent from past governance proposals',
-    icon: '\uD83D\uDD0D', // magnifying glass
+    icon: ICON_SEARCH,
     aliases: ['similar-proposals', 'similar'],
   },
   {
@@ -204,7 +294,7 @@ const AI_COMMANDS: CommandDef[] = [
     id: 'complete',
     label: 'Complete',
     description: 'AI suggests what is missing from this section',
-    icon: '\uD83D\uDCDD', // memo
+    icon: ICON_FILE_TEXT,
     aliases: ['complete'],
   },
   {
@@ -212,7 +302,7 @@ const AI_COMMANDS: CommandDef[] = [
     id: 'draft',
     label: 'Draft',
     description: 'AI drafts content from your instructions',
-    icon: '\u270D\uFE0F', // writing hand
+    icon: ICON_PEN_LINE,
     aliases: ['draft'],
   },
 ];
@@ -307,8 +397,8 @@ function createCommandItem(
   item.dataset.index = String(index);
 
   const iconSpan = document.createElement('span');
-  iconSpan.className = 'text-base flex-shrink-0 w-5 text-center';
-  iconSpan.textContent = cmd.icon;
+  iconSpan.className = 'flex-shrink-0 w-5 flex items-center justify-center text-muted-foreground';
+  iconSpan.appendChild(createSvgIcon(cmd.icon));
 
   const textContainer = document.createElement('div');
   textContainer.className = 'flex flex-col min-w-0';

--- a/components/workspace/layout/SaveErrorBanner.tsx
+++ b/components/workspace/layout/SaveErrorBanner.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * SaveErrorBanner — persistent amber warning when auto-save fails.
+ *
+ * Shows below the toolbar / above the editor content when
+ * `useSaveStatus().status === 'error'`. Includes:
+ *  - "Changes not saved" message with a Retry button
+ *  - One automatic retry after 3 seconds
+ *  - Dismiss (X) button that resets status to idle
+ *  - Auto-clears when status transitions back to 'saved'
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useSaveStatus } from '@/lib/workspace/save-status';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface SaveErrorBannerProps {
+  /** Called when the user clicks Retry or the auto-retry fires */
+  onRetry: () => void;
+}
+
+export function SaveErrorBanner({ onRetry }: SaveErrorBannerProps) {
+  const status = useSaveStatus((s) => s.status);
+  const setIdle = useSaveStatus((s) => s.setIdle);
+
+  const autoRetried = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Reset the auto-retry flag when status leaves 'error'
+  useEffect(() => {
+    if (status !== 'error') {
+      autoRetried.current = false;
+    }
+  }, [status]);
+
+  // Auto-retry once after 3 seconds
+  useEffect(() => {
+    if (status === 'error' && !autoRetried.current) {
+      timerRef.current = setTimeout(() => {
+        autoRetried.current = true;
+        onRetry();
+      }, 3000);
+    }
+
+    return () => clearTimeout(timerRef.current);
+  }, [status, onRetry]);
+
+  const handleDismiss = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setIdle();
+  }, [setIdle]);
+
+  if (status !== 'error') return null;
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border bg-amber-500/10 border-amber-500/30 px-3 py-2 text-sm text-amber-400 animate-in fade-in slide-in-from-top-1 duration-200">
+      <AlertTriangle className="h-4 w-4 shrink-0" />
+      <span className="flex-1">Changes not saved</span>
+      <button
+        onClick={onRetry}
+        className="shrink-0 rounded px-2 py-0.5 text-xs font-medium bg-amber-500/20 hover:bg-amber-500/30 text-amber-300 transition-colors cursor-pointer"
+      >
+        Retry
+      </button>
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 rounded p-0.5 hover:bg-amber-500/20 transition-colors cursor-pointer"
+        aria-label="Dismiss save error"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/components/workspace/layout/StatusBar.tsx
+++ b/components/workspace/layout/StatusBar.tsx
@@ -56,12 +56,14 @@ export function StatusBar({
         </button>
       )}
 
-      {/* Community */}
-      {community && (
+      {/* Community — hidden when both counts are zero to reduce noise */}
+      {community && (community.reviewerCount > 0 || community.themeCount > 0) && (
         <button className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors">
           <Users className="h-3 w-3" />
           <span>
-            {community.reviewerCount} reviewers, {community.themeCount} themes
+            {community.reviewerCount} reviewer{community.reviewerCount !== 1 ? 's' : ''}
+            {community.themeCount > 0 &&
+              `, ${community.themeCount} theme${community.themeCount !== 1 ? 's' : ''}`}
           </span>
         </button>
       )}

--- a/lib/ai/skills/readiness-narrative.ts
+++ b/lib/ai/skills/readiness-narrative.ts
@@ -1,0 +1,103 @@
+/**
+ * Skill: Readiness Narrative
+ *
+ * Generates a 1-2 sentence actionable insight about proposal readiness,
+ * grounded in the proposal's actual state and common patterns from
+ * governance proposals. Displayed in the ReadinessPanel as the "oh wow" moment.
+ */
+
+import { z } from 'zod';
+import { registerSkill } from './registry';
+
+const inputSchema = z.object({
+  proposalType: z.string(),
+  title: z.string(),
+  abstract: z.string(),
+  motivation: z.string(),
+  rationale: z.string(),
+  confidenceScore: z.number().min(0).max(100),
+  confidenceLevel: z.enum(['low', 'moderate', 'high', 'strong']),
+  blockerLabels: z.array(z.string()),
+  recommendationLabels: z.array(z.string()),
+  constitutionalCheck: z.enum(['pass', 'warning', 'fail']).nullable(),
+  reviewCount: z.number(),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+export interface ReadinessNarrativeOutput {
+  narrative: string;
+  actionItem: string | null;
+}
+
+registerSkill<Input, ReadinessNarrativeOutput>({
+  name: 'readiness-narrative',
+  description: 'Generate a concise, actionable readiness insight for a governance proposal.',
+  category: 'authoring',
+  inputSchema,
+  model: 'FAST',
+  maxTokens: 256,
+
+  systemPrompt: `You are a Cardano governance advisor. Given a proposal's readiness state, produce a concise, actionable insight in 1-2 sentences.
+
+Your response tells the author what specifically would most improve their proposal's chance of passing, based on the proposal type and current state. Be specific and grounded — reference the actual content gaps or strengths you see.
+
+Return ONLY valid JSON:
+{
+  "narrative": "1-2 sentence insight about the proposal's readiness state and what would most improve it",
+  "actionItem": "Single most impactful action, or null if proposal is ready"
+}
+
+Guidelines:
+- Be specific to THIS proposal, not generic advice
+- Reference the proposal type when relevant (e.g., treasury proposals need budget specifics)
+- If the proposal is ready (strong confidence), acknowledge it and note any final polish opportunities
+- If there are blockers, focus on the highest-impact one
+- Keep the tone professional and encouraging, not critical
+- Never say "consider" — be direct about what to do`,
+
+  buildPrompt: (input: Input) => {
+    const parts = [
+      `Proposal type: ${input.proposalType}`,
+      `Title: ${input.title}`,
+      `Confidence: ${input.confidenceScore}% (${input.confidenceLevel})`,
+      `Constitutional check: ${input.constitutionalCheck ?? 'Not run'}`,
+      `Reviews: ${input.reviewCount}`,
+      '',
+    ];
+
+    if (input.blockerLabels.length > 0) {
+      parts.push(`Blockers: ${input.blockerLabels.join('; ')}`);
+    }
+    if (input.recommendationLabels.length > 0) {
+      parts.push(`Recommendations: ${input.recommendationLabels.join('; ')}`);
+    }
+
+    parts.push('', 'Content summary:');
+    parts.push(`Abstract (${input.abstract.length} chars): ${input.abstract.slice(0, 300)}`);
+    parts.push(`Motivation (${input.motivation.length} chars): ${input.motivation.slice(0, 300)}`);
+    parts.push(`Rationale (${input.rationale.length} chars): ${input.rationale.slice(0, 300)}`);
+    parts.push('', 'Generate the readiness narrative. Return valid JSON only.');
+
+    return parts.join('\n');
+  },
+
+  parseOutput: (raw: string): ReadinessNarrativeOutput => {
+    try {
+      const cleaned = raw
+        .replace(/^```json\s*/, '')
+        .replace(/\s*```$/, '')
+        .trim();
+      const parsed = JSON.parse(cleaned);
+      return {
+        narrative: String(parsed.narrative ?? 'Analysis complete.'),
+        actionItem: parsed.actionItem ? String(parsed.actionItem) : null,
+      };
+    } catch {
+      return {
+        narrative: 'Unable to generate readiness analysis.',
+        actionItem: null,
+      };
+    }
+  },
+});

--- a/lib/ai/skills/registry.ts
+++ b/lib/ai/skills/registry.ts
@@ -49,4 +49,5 @@ export async function loadBuiltinSkills(): Promise<void> {
   await import('./amendment-translator');
   await import('./amendment-conflict-check');
   await import('./amendment-bridge');
+  await import('./readiness-narrative');
 }


### PR DESCRIPTION
## Summary
- **Interaction polish**: event-driven command bar, Linear easing, keyboard shortcut hints, inline URL popovers replacing window.prompt, save-error recovery banner
- **Information hierarchy**: readiness badge in StudioHeader, governance-specific placeholders and empty states, content-shaped loading skeletons
- **Visual consistency**: Lucide SVG icons in slash menu (replacing platform-inconsistent Unicode emoji), Sparkles AI badge, confidence bar mount animation
- **AI intelligence**: new `readiness-narrative` skill generates actionable 1-2 sentence insight in ReadinessPanel grounded in proposal state
- **Subtractions**: removed empty Notes tab from author mode, deduplicated Code Block button, hidden zero-value community metrics

## Impact
- **What changed**: 15 files across editor, studio shell, intelligence panels, and AI skills — craft polish from 7.5/10 toward 9.5/10
- **User-facing**: Yes — every author interaction feels more responsive, placeholders guide governance writing, readiness is glanceable from header
- **Risk**: Low — no data model changes, no migrations, no API contract changes. Pure UI/UX + one new AI skill
- **Scope**: ProposalEditor, StudioHeader, StudioPanel, FormattingToolbar, SlashCommandMenu, CommandBar, ReadinessPanel, AuthorIntelligencePanel, DraftCard, PortfolioView, StatusBar, SaveErrorBanner (new), readiness-narrative skill (new)

## Test plan
- [ ] Open Author Studio portfolio — verify skeleton shape matches cards, empty state shows governance types
- [ ] Create new draft — verify section-specific placeholders appear in each section
- [ ] Type `/` — verify Lucide SVG icons render consistently (no emoji)
- [ ] Press Ctrl+K — verify Sparkles AI badge in command bar
- [ ] Click Link button in toolbar — verify inline popover (not window.prompt)
- [ ] Toggle panels with Ctrl+Shift+C/I — verify Linear-style easing
- [ ] Check readiness badge in header (green/amber/red dot with label)
- [ ] Click readiness badge — verify opens Readiness panel tab
- [ ] Open Readiness panel — verify AI narrative loads below confidence bar
- [ ] Verify Notes tab absent in author mode, present in review mode
- [ ] Verify "0 reviewers, 0 themes" no longer shows in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)