### PR TITLE
feat: replace sidebar with 48px navigation rail

### DIFF
--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -9,6 +9,8 @@ import { TierThemeProvider } from '@/components/providers/TierThemeProvider';
 import { GovernadaHeader } from './GovernadaHeader';
 import { GovernadaBottomNav } from './GovernadaBottomNav';
 import { GovernadaSidebar } from './GovernadaSidebar';
+import { NavigationRail } from './NavigationRail';
+import { useFeatureFlag } from '@/components/FeatureGate';
 import { SyncFreshnessBanner } from '@/components/SyncFreshnessBanner';
 import { PreviewBanner } from '@/components/preview/PreviewBanner';
 import { FeedbackWidget } from '@/components/preview/FeedbackWidget';
@@ -87,9 +89,11 @@ function DeepLinkHandler() {
 function BackgroundGlobe({
   isHomepage,
   sidebarCollapsed,
+  useRail,
 }: {
   isHomepage: boolean;
   sidebarCollapsed: boolean;
+  useRail?: boolean;
 }) {
   const { segment } = useSegment();
   // Hide the background globe on homepage for anonymous/not-yet-loaded users
@@ -97,8 +101,10 @@ function BackgroundGlobe({
   return (
     <div
       className={cn(
-        'force-dark fixed inset-0 pointer-events-none z-0 transition-[left] duration-200',
-        sidebarCollapsed ? 'lg:left-16' : 'lg:left-60',
+        'force-dark fixed inset-0 pointer-events-none z-0',
+        useRail
+          ? 'lg:left-12'
+          : cn('transition-[left] duration-200', sidebarCollapsed ? 'lg:left-16' : 'lg:left-60'),
       )}
       aria-hidden="true"
     >
@@ -130,6 +136,8 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
     pathname === '/workspace/review' ||
     /^\/workspace\/(author|editor|amendment)\/[^/]+/.test(pathname);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const navigationRailFlag = useFeatureFlag('navigation_rail');
+  const navigationRail = navigationRailFlag === true;
 
   useEffect(() => {
     const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
@@ -154,13 +162,20 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
         <SyncFreshnessBanner />
         <PreviewBanner />
         {!isStudioMode && <GovernadaHeader />}
-        {!isStudioMode && (
-          <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
-        )}
+        {!isStudioMode &&
+          (navigationRail ? (
+            <NavigationRail />
+          ) : (
+            <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
+          ))}
 
         {/* Global constellation globe — subtle glassmorphic background */}
         {!isStudioMode && (
-          <BackgroundGlobe isHomepage={isHomepage} sidebarCollapsed={sidebarCollapsed} />
+          <BackgroundGlobe
+            isHomepage={isHomepage}
+            sidebarCollapsed={sidebarCollapsed}
+            useRail={navigationRail}
+          />
         )}
 
         {/* Discovery context wraps main so studio can access it */}
@@ -169,9 +184,16 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
             <main
               id="main-content"
               className={cn(
-                'relative z-0 min-h-screen transition-[padding-left] duration-200',
+                'relative z-0 min-h-screen',
                 isStudioMode ? '' : 'pb-16 lg:pb-0',
-                isStudioMode ? '' : sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+                isStudioMode
+                  ? ''
+                  : navigationRail
+                    ? 'lg:pl-12'
+                    : cn(
+                        'transition-[padding-left] duration-200',
+                        sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+                      ),
               )}
               tabIndex={-1}
             >
@@ -184,8 +206,13 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
         {!isStudioMode && (
           <footer
             className={cn(
-              'relative z-0 border-t border-border/40 py-4 px-4 text-center transition-[padding-left] duration-200',
-              sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+              'relative z-0 border-t border-border/40 py-4 px-4 text-center',
+              navigationRail
+                ? 'lg:pl-12'
+                : cn(
+                    'transition-[padding-left] duration-200',
+                    sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
+                  ),
             )}
           >
             <p className="text-xs text-muted-foreground/70">

--- a/components/governada/NavigationRail.tsx
+++ b/components/governada/NavigationRail.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+/**
+ * NavigationRail — 48px fixed-width icon rail replacing the 240px sidebar.
+ *
+ * Three Worlds: Home, Governance, You
+ * Feature-flagged behind `navigation_rail`.
+ *
+ * - Radix tooltips with keyboard shortcut hints
+ * - Spring-animated active indicator dot (with reduced-motion fallback)
+ * - Compact pinned entities section at bottom
+ * - Full accessibility: aria-labels, aria-current, keyboard nav via tab order
+ */
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { motion, LayoutGroup, useReducedMotion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { getSidebarSections, getCurrentSection } from '@/lib/nav/config';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
+import { usePinnedItems, type PinnedEntityType } from '@/hooks/usePinnedItems';
+import { useTranslation } from '@/lib/i18n/useTranslation';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { User, FileText, Building2, Shield } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Keyboard shortcut hints per section id */
+const SECTION_SHORTCUTS: Record<string, string> = {
+  home: 'G H',
+  governance: 'G G',
+  you: 'G Y',
+};
+
+/** Entity type icons for pinned items */
+const ENTITY_ICONS: Record<PinnedEntityType, LucideIcon> = {
+  drep: User,
+  proposal: FileText,
+  pool: Building2,
+  cc: Shield,
+};
+
+/** Build href for a pinned entity */
+function getEntityHref(type: PinnedEntityType, id: string): string {
+  switch (type) {
+    case 'drep':
+      return `/drep/${encodeURIComponent(id)}`;
+    case 'proposal':
+      return `/proposal/${id}`;
+    case 'pool':
+      return `/pool/${encodeURIComponent(id)}`;
+    case 'cc':
+      return `/governance/committee/${encodeURIComponent(id)}`;
+  }
+}
+
+/** Max pinned items shown in the rail */
+const MAX_RAIL_PINS = 4;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NavigationRail() {
+  const pathname = usePathname();
+  const { t } = useTranslation();
+  const { segment, stakeAddress, drepId, poolId } = useSegment();
+  const { depth } = useGovernanceDepth();
+  const unreadCount = useUnreadNotifications(stakeAddress ?? null);
+  const prefersReducedMotion = useReducedMotion();
+  const { pinnedItems } = usePinnedItems();
+
+  const sections = getSidebarSections({ segment, drepId, poolId, depth });
+  const currentSection = getCurrentSection(pathname);
+
+  const isDualRole = !!(drepId && poolId);
+
+  // Limit pinned items for compact display
+  const visiblePins = pinnedItems.slice(0, MAX_RAIL_PINS);
+  const overflowCount = pinnedItems.length - MAX_RAIL_PINS;
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <aside
+        className="hidden lg:flex flex-col items-center fixed left-0 top-10 bottom-0 w-12 z-30 border-r border-border/20 bg-background/60 backdrop-blur-xl"
+        aria-label={t('Main navigation')}
+      >
+        {/* Navigation icons */}
+        <nav
+          className="flex flex-col items-center gap-1 pt-3"
+          role="navigation"
+          aria-label={t('Main navigation')}
+        >
+          <LayoutGroup id="rail-nav">
+            {sections.map((section) => {
+              const isActive = currentSection === section.id;
+              const shortcut = SECTION_SHORTCUTS[section.id] ?? '';
+              const tooltipLabel = shortcut
+                ? `${t(section.label)} \u00B7 ${shortcut}`
+                : t(section.label);
+              const ariaLabel = shortcut ? `${t(section.label)} (${shortcut})` : t(section.label);
+
+              return (
+                <Tooltip key={section.id}>
+                  <TooltipTrigger asChild>
+                    <Link
+                      href={section.href}
+                      className={cn(
+                        'relative w-12 h-12 flex items-center justify-center rounded-lg transition-colors',
+                        'hover:bg-accent/50',
+                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                        isActive && 'text-foreground',
+                        !isActive && 'text-muted-foreground',
+                      )}
+                      aria-label={ariaLabel}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      <section.icon className="h-5 w-5" />
+
+                      {/* Active indicator dot */}
+                      {isActive &&
+                        (prefersReducedMotion ? (
+                          <span className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-primary" />
+                        ) : (
+                          <motion.span
+                            layoutId="rail-indicator"
+                            className="absolute bottom-1 left-1/2 -translate-x-1/2 w-1.5 h-1.5 rounded-full bg-primary"
+                            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                          />
+                        ))}
+
+                      {/* Notification badge on You */}
+                      {section.id === 'you' && unreadCount > 0 && (
+                        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
+                      )}
+
+                      {/* Dual-role badge on Home */}
+                      {section.id === 'home' && isDualRole && (
+                        <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-primary text-[9px] text-primary-foreground flex items-center justify-center font-bold">
+                          2
+                        </span>
+                      )}
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    {tooltipLabel}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </LayoutGroup>
+        </nav>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Pinned entities */}
+        {visiblePins.length > 0 && (
+          <div className="flex flex-col items-center gap-1.5 pb-3">
+            <div className="border-t border-border/30 w-8 mb-1" />
+            {visiblePins.map((item) => {
+              const href = getEntityHref(item.type, item.id);
+              const Icon = ENTITY_ICONS[item.type];
+              const firstLetter = item.label.charAt(0).toUpperCase();
+
+              return (
+                <Tooltip key={`${item.type}-${item.id}`}>
+                  <TooltipTrigger asChild>
+                    <Link
+                      href={href}
+                      className={cn(
+                        'w-8 h-8 rounded-full bg-muted/50 flex items-center justify-center transition-colors',
+                        'hover:bg-accent/50',
+                        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                      )}
+                      aria-label={`${t('Go to')} ${item.label}`}
+                    >
+                      {/* Show entity icon at small size as a visual type hint, overlaid with first letter */}
+                      <span className="relative">
+                        <Icon className="h-3 w-3 opacity-0 absolute" aria-hidden="true" />
+                        <span className="text-xs font-medium">{firstLetter}</span>
+                      </span>
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={8}>
+                    {item.label}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+
+            {/* Overflow indicator */}
+            {overflowCount > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="w-8 h-8 rounded-full bg-muted/30 flex items-center justify-center text-xs text-muted-foreground">
+                    +{overflowCount}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="right" sideOffset={8}>
+                  {`${overflowCount} ${t('more pinned')}`}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        )}
+      </aside>
+    </TooltipProvider>
+  );
+}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -28,6 +28,7 @@
  * state_of_governance_report     — Auto-generated epoch report with community intelligence
  * governance_temperature         — Governance Temperature gauge (0-100 aggregate sentiment)
  * research_assistant             — Conversational AI research assistant for proposal analysis
+ * navigation_rail                — 48px icon rail replacing 240px sidebar (Phase 2 nav renaissance)
  *
  * ---------------------------------------------------------------------------
  * RETIRED FLAGS (code checks removed or hardcoded)


### PR DESCRIPTION
## Summary
- New `NavigationRail` component: 48px fixed-width icon rail replacing 240px sidebar
- Feature-flagged behind `navigation_rail` (admin-only toggle)
- Shell layout updated: content gains ~192px width when rail active
- Sidebar preserved as fallback behind feature flag

## Impact
- **What changed**: Navigation paradigm shift from text sidebar to icon rail
- **User-facing**: Yes — significantly more content width, icon-only nav with tooltips
- **Risk**: Low — feature-flagged, sidebar fallback preserved, no data changes
- **Scope**: NavigationRail.tsx (new), GovernadaShell.tsx, featureFlags.ts

## Test plan
- [ ] Rail renders at lg: breakpoint with correct 48px width
- [ ] All 3 icons show with correct tooltips and shortcuts
- [ ] Active indicator animates between sections
- [ ] Pinned entities display as circles with first letter
- [ ] Content area uses full width (lg:pl-12)
- [ ] BackgroundGlobe and footer offset correctly
- [ ] Feature flag OFF shows original sidebar
- [ ] No CLS on page load
- [ ] Keyboard navigation works (Tab through icons)
- [ ] Screen reader announces icon labels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)