### PR TITLE
feat: add portfolio-to-editor view transition morph

### DIFF
--- a/app/workspace/amendment/[draftId]/page.tsx
+++ b/app/workspace/amendment/[draftId]/page.tsx
@@ -95,10 +95,12 @@ function AmendmentPanelWrapper({
 
 function AmendmentHeaderWrapper({
   title,
+  titleTransitionName,
   presence,
   onToggleDiff,
 }: {
   title: string;
+  titleTransitionName?: string;
   presence?: ReactNode;
   onToggleDiff?: () => void;
 }) {
@@ -109,6 +111,7 @@ function AmendmentHeaderWrapper({
       backLabel="governada"
       backHref="/workspace/author"
       title={title}
+      titleTransitionName={titleTransitionName}
       proposalType="Constitutional Amendment"
       panelOpen={panelOpen}
       activePanel={activePanel}
@@ -540,6 +543,7 @@ function AmendmentEditorPage() {
           toolbar={
             <AmendmentHeaderWrapper
               title={draft.title || 'Constitutional Amendment'}
+              titleTransitionName={draftId ? `draft-title-${draftId}` : undefined}
               presence={viewers.length > 0 ? <PresenceIndicator viewers={viewers} /> : undefined}
               onToggleDiff={changes.length > 0 ? () => setShowDiffView(true) : undefined}
             />

--- a/app/workspace/editor/[draftId]/page.tsx
+++ b/app/workspace/editor/[draftId]/page.tsx
@@ -495,6 +495,7 @@ function WorkspaceEditorPage() {
               backLabel="Back to drafts"
               backHref="/workspace/author"
               title={draft.title || 'Untitled proposal'}
+              titleTransitionName={draftId ? `draft-title-${draftId}` : undefined}
               proposalType={typeLabel}
               showModeSwitch={isOwner}
               mode={mode}

--- a/components/studio/StudioHeader.tsx
+++ b/components/studio/StudioHeader.tsx
@@ -28,6 +28,8 @@ interface StudioHeaderProps {
   onBack?: () => void;
   backLabel?: string;
   title?: string;
+  /** CSS view-transition-name for title morph animation */
+  titleTransitionName?: string;
   proposalType?: string;
   /** Compact readiness indicator in the header */
   readiness?: ReadinessBadgeData;
@@ -68,6 +70,7 @@ export function StudioHeader({
   onBack,
   backLabel = 'governada',
   title,
+  titleTransitionName,
   proposalType,
   queueProgress,
   onQueueJump,
@@ -139,7 +142,12 @@ export function StudioHeader({
       {/* Title + type badge */}
       {title && (
         <div className="hidden lg:flex items-center gap-2 min-w-0 flex-1">
-          <h1 className="text-sm font-semibold truncate min-w-0">{title}</h1>
+          <h1
+            className="text-sm font-semibold truncate min-w-0"
+            style={titleTransitionName ? { viewTransitionName: titleTransitionName } : undefined}
+          >
+            {title}
+          </h1>
           {proposalType && (
             <span className="text-[10px] font-medium text-muted-foreground bg-muted/50 rounded px-1.5 py-0.5 shrink-0">
               {proposalType}

--- a/components/workspace/author/DraftCard.tsx
+++ b/components/workspace/author/DraftCard.tsx
@@ -135,6 +135,7 @@ export function DraftCard({ draft, index, column, itemProps }: DraftCardProps) {
                 style={{
                   fontSize: 'var(--workspace-font-size)',
                   lineHeight: 'var(--workspace-line-height)',
+                  viewTransitionName: `draft-title-${draft.id}`,
                 }}
               >
                 {draft.title || 'Untitled proposal'}


### PR DESCRIPTION
## Summary
- Adds `view-transition-name` CSS property to DraftCard title and StudioHeader title with matching names (`draft-title-{id}`)
- Browser's native View Transitions API morphs the title text when navigating between portfolio and editor
- GPU-accelerated, zero JavaScript cost — graceful degradation in unsupported browsers
- Applied to both standard editor and amendment editor routes

## Impact
- **What changed**: 4 files, 15 lines added — pure CSS view transition wiring
- **User-facing**: Yes — title text smoothly morphs from card to editor header on navigation (Chrome/Edge)
- **Risk**: Low — CSS-only, no JS behavior changes, unsupported browsers see instant navigation as before
- **Scope**: DraftCard, StudioHeader, editor page, amendment page

## Test plan
- [ ] Click a draft card in portfolio — verify title morphs into editor header (Chrome/Edge)
- [ ] Navigate back — verify reverse morph animation
- [ ] Test in Firefox/Safari — verify graceful fallback (instant navigation, no errors)
- [ ] Verify amendment drafts also morph correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)