### PR TITLE
feat: restore Workspace as top-level nav section (Four Worlds)

### DIFF
--- a/components/governada/GovernadaBottomNav.tsx
+++ b/components/governada/GovernadaBottomNav.tsx
@@ -22,6 +22,9 @@ export function GovernadaBottomNav() {
 
   const isActive = (href: string) => {
     if (href === '/') return pathname === '/';
+    // All /workspace/* routes highlight the Workspace bottom bar item,
+    // regardless of whether the item's href is /workspace or /workspace/author.
+    if (href.startsWith('/workspace') && pathname.startsWith('/workspace')) return true;
     return pathname === href || pathname.startsWith(href + '/');
   };
 

--- a/components/governada/GovernadaSidebar.tsx
+++ b/components/governada/GovernadaSidebar.tsx
@@ -27,12 +27,13 @@ interface GovernadaSidebarProps {
 export function GovernadaSidebar({ collapsed, onToggle }: GovernadaSidebarProps) {
   const pathname = usePathname();
   const { t } = useTranslation();
-  const { segment, stakeAddress, drepId, poolId } = useSegment();
+  const { segment, stakeAddress, drepId, poolId, delegatedDrep, delegatedPool } = useSegment();
   const { depth } = useGovernanceDepth();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
   const prefersReducedMotion = useReducedMotion();
 
-  const sections = getSidebarSections({ segment, drepId, poolId, depth });
+  const isDelegated = !!(delegatedDrep || delegatedPool);
+  const sections = getSidebarSections({ segment, drepId, poolId, depth, isDelegated });
   const sidebarMetrics = useSidebarMetrics();
 
   const isActive = (href: string) => {

--- a/components/governada/NavigationRail.tsx
+++ b/components/governada/NavigationRail.tsx
@@ -3,7 +3,7 @@
 /**
  * NavigationRail — 48px fixed-width icon rail replacing the 240px sidebar.
  *
- * Three Worlds: Home, Governance, You
+ * Four Worlds: Home, Workspace, Governance, You
  * Feature-flagged behind `navigation_rail`.
  *
  * - Radix tooltips with keyboard shortcut hints
@@ -33,6 +33,7 @@ import type { LucideIcon } from 'lucide-react';
 /** Keyboard shortcut hints per section id */
 const SECTION_SHORTCUTS: Record<string, string> = {
   home: 'G H',
+  workspace: 'G W',
   governance: 'G G',
   you: 'G Y',
 };
@@ -69,13 +70,14 @@ const MAX_RAIL_PINS = 4;
 export function NavigationRail() {
   const pathname = usePathname();
   const { t } = useTranslation();
-  const { segment, stakeAddress, drepId, poolId } = useSegment();
+  const { segment, stakeAddress, drepId, poolId, delegatedDrep, delegatedPool } = useSegment();
   const { depth } = useGovernanceDepth();
   const unreadCount = useUnreadNotifications(stakeAddress ?? null);
   const prefersReducedMotion = useReducedMotion();
   const { pinnedItems } = usePinnedItems();
 
-  const sections = getSidebarSections({ segment, drepId, poolId, depth });
+  const isDelegated = !!(delegatedDrep || delegatedPool);
+  const sections = getSidebarSections({ segment, drepId, poolId, depth, isDelegated });
   const currentSection = getCurrentSection(pathname);
 
   const isDualRole = !!(drepId && poolId);
@@ -139,8 +141,8 @@ export function NavigationRail() {
                         <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
                       )}
 
-                      {/* Dual-role badge on Home */}
-                      {section.id === 'home' && isDualRole && (
+                      {/* Dual-role badge on Workspace */}
+                      {section.id === 'workspace' && isDualRole && (
                         <span className="absolute -top-0.5 -right-0.5 h-4 w-4 rounded-full bg-primary text-[9px] text-primary-foreground flex items-center justify-center font-bold">
                           2
                         </span>

--- a/docs/strategy/context/navigation-architecture.md
+++ b/docs/strategy/context/navigation-architecture.md
@@ -1,7 +1,7 @@
 # Navigation Architecture Spec
 
 > **Purpose:** Definitive reference for all navigation, routing, and information architecture decisions. Every page, section, and nav element must conform to this spec. Agents MUST read this before building any page, layout, or navigation component.
-> **Status:** Approved architecture. Implementation pending.
+> **Status:** Approved architecture. Four Worlds model implemented (Home, Workspace, Governance, You).
 > **Companion docs:** `ux-constraints.md` (page-level JTBD), `persona-quick-ref.md` (persona JTBDs)
 
 ---
@@ -44,44 +44,42 @@ See `ux-constraints.md` for per-persona Hub constraints.
 
 ### Workspace
 
-| Attribute        | Value                                    |
-| ---------------- | ---------------------------------------- |
-| **Route**        | `/workspace`                             |
-| **Purpose**      | Tools for doing your governance job      |
-| **Who sees it**  | DRep, SPO (not citizens, not anonymous)  |
-| **Nav position** | Second item in global nav (when visible) |
+| Attribute        | Value                                                          |
+| ---------------- | -------------------------------------------------------------- |
+| **Route**        | `/workspace`                                                   |
+| **Purpose**      | Tools for doing your governance job                            |
+| **Who sees it**  | DRep, SPO, delegated citizens (not undelegated, not anonymous) |
+| **Nav position** | Second item in global nav (when visible)                       |
 
-Workspace is where governance actors DO WORK — vote, write rationales, manage delegators, improve scores. It is action-oriented, not informational.
+Workspace is where governance actors DO WORK — author proposals, review and vote, write rationales, manage delegators, improve scores. It is action-oriented, not informational.
+
+**Author and Review are peer sub-sections** within Workspace. Both are full portfolio-management surfaces (portfolio → focused Studio mode). Author manages the proposal lifecycle (draft → community review → submission → monitoring). Review manages the voting queue (queue → deep-dive → vote → auto-advance).
 
 **Workspace adapts per persona:**
 
-DRep sub-pages:
+DRep sub-pages (Review-first — their primary JTBD):
 
-- `/workspace` — Action Queue (default: proposals needing votes, sorted by deadline)
+- `/workspace` — Dashboard / Action Queue (default: proposals needing votes, sorted by deadline)
+- `/workspace/review` — Review queue + deep-dive voting (Studio mode)
+- `/workspace/author` — Proposal portfolio + drafting (Studio mode)
 - `/workspace/votes` — Your voting record with rationales
-- `/workspace/rationales` — Your published rationales and their reception
 - `/workspace/delegators` — Who trusts you, delegator communication, growth trends
-- `/workspace/performance` — Your score breakdown, competitive position, improvement suggestions
 
 SPO sub-pages:
 
 - `/workspace` — Governance Score dashboard (default: score + trend + improvement tips)
+- `/workspace/review` — Review queue for SPO-relevant proposals
+- `/workspace/author` — Proposal portfolio + drafting
 - `/workspace/pool-profile` — Your pool's public governance identity (edit)
 - `/workspace/delegators` — Who stakes with you, delegator communication
 - `/workspace/position` — Competitive landscape, peer comparison, governance rankings
 
+Citizen (delegated) sub-pages:
+
+- `/workspace/author` — Proposal portfolio + drafting (default landing)
+- `/workspace/review` — Community draft review + feedback
+
 DRep+SPO: Both sets of sub-pages appear in the sidebar, grouped by role with clear headers ("DRep" / "Pool"). Action Queue remains the default landing.
-
-#### Author (All authenticated users)
-
-| Route | Label |
-| `/workspace/author` | Author — Draft governance proposals |
-| `/workspace/author/[draftId]` | Draft Editor — Edit a specific draft |
-
-#### Review (DRep/SPO/Citizen)
-
-| Route | Label |
-| `/workspace/review` | Review — Review active and pre-submission proposals |
 
 ### Governance
 
@@ -218,21 +216,21 @@ Entity pages are accessed via Hub cards, Governance sub-pages, search, or direct
 
 ## Mobile Bottom Bar (4 items, persona-adaptive)
 
-The bottom bar is the primary navigation surface on mobile. It adapts per persona to show the 4 most important sections.
+The bottom bar is the primary navigation surface on mobile. It adapts per persona to show the 3-4 most important sections.
 
 | Persona                   | Item 1 | Item 2     | Item 3     | Item 4 |
 | ------------------------- | ------ | ---------- | ---------- | ------ |
-| **Anonymous**             | Home   | Governance | Match      | Help   |
-| **Citizen (undelegated)** | Home   | Governance | Match      | You    |
-| **Citizen (delegated)**   | Home   | Governance | Delegation | You    |
+| **Anonymous**             | Home   | Governance | Match      |        |
+| **Citizen (undelegated)** | Home   | Governance | Match      |        |
+| **Citizen (delegated)**   | Home   | Workspace  | Governance | You    |
 | **DRep**                  | Home   | Workspace  | Governance | You    |
 | **SPO**                   | Home   | Workspace  | Governance | You    |
 | **DRep + SPO**            | Home   | Workspace  | Governance | You    |
-| **CC Member**             | Home   | Governance | Delegation | You    |
+| **CC Member**             | Home   | Governance | You        |        |
 
 **Bottom bar rules:**
 
-1. Always exactly 4 items
+1. 3-4 items depending on persona (operators get 4 with Workspace)
 2. Home is always first
 3. Items not in the bottom bar are accessible via the Hub, sidebar (desktop), or user menu
 4. Notification badge on You when unread inbox items exist
@@ -265,16 +263,16 @@ Example — entering Governance on mobile:
 On desktop (≥1024px), the left sidebar provides persistent navigation for all sections. It is collapsible to icons only.
 
 ```
-HOME                          ← Always visible
+HOME                          ← Always visible (single link, briefing surface)
 
-WORKSPACE                     ← DRep/SPO only
-├── Action Queue              ← DRep
+WORKSPACE                     ← DRep/SPO/delegated citizens
+├── Dashboard / Gov Score     ← DRep / SPO landing
+├── Review                    ← Review queue + deep-dive voting
+├── Author                    ← Proposal portfolio + drafting
 ├── Voting Record             ← DRep
-├── Rationales                ← DRep
-├── Gov Score                 ← SPO
-├── Pool Profile              ← SPO
 ├── Delegators                ← DRep, SPO (grouped if both)
-└── Performance / Position    ← DRep, SPO
+├── Pool Profile              ← SPO
+└── Position                  ← SPO
 
 GOVERNANCE                    ← Everyone
 ├── Proposals
@@ -285,16 +283,14 @@ GOVERNANCE                    ← Everyone
 └── Health
 
 ──────────────────
-DELEGATION                    ← Authenticated w/ delegation
 YOU                           ← Authenticated
-HELP                          ← Everyone
 ```
 
-**Sidebar rules:**
+**Sidebar / Rail rules:**
 
-1. Collapsible to icon-only mode (user preference, persisted)
-2. Sections without sub-pages (Home, Delegation) are single links, not expandable groups
-3. Workspace section only renders for DRep/SPO personas
+1. Collapsible to icon-only mode (user preference, persisted). Or 48px icon rail (feature-flagged).
+2. Home is always a single link (no sub-pages). The Hub is a briefing surface, not a workspace.
+3. Workspace section renders for DRep, SPO, and delegated citizen personas
 4. Sub-pages within each section are always visible (not collapsed by default) — the sidebar is the wayfinding surface, hiding items defeats its purpose
 5. Active page highlighted with distinct background + left border accent
 6. Width: 240px expanded, 64px collapsed
@@ -434,7 +430,7 @@ Agents MUST NOT:
 2. **Put entity directories in the top-level nav.** DReps, Pools, Proposals are sub-pages of Governance, not top-level sections. The nav reflects user intent (understand governance), not data type (browse DReps).
 3. **Show the same nav to all personas.** The bottom bar, sidebar items, and Hub content MUST adapt. If a citizen and a DRep see identical navigation, the implementation is wrong.
 4. **Hide depth behind the command palette.** ⌘K is a power-user shortcut, not a substitute for visible navigation. Every important page must be reachable via the sidebar or bottom bar within 2 taps.
-5. **Create new top-level sections without updating this spec.** The section inventory (Hub, Workspace, Governance, You, Match, Delegation, Help) is closed. New features go inside existing sections or this spec is updated first.
+5. **Create new top-level sections without updating this spec.** The section inventory (Hub, Workspace, Governance, You, Match, Help) is closed. New features go inside existing sections or this spec is updated first.
 6. **Use query params for persistent navigation state.** `?tab=dreps` is a smell. If it deserves a tab, it deserves a route.
 7. **Build engagement as a destination.** Engagement is a layer that surfaces through Hub cards and contextual prompts. There is no `/engage` section.
 

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -1,14 +1,19 @@
 /**
- * Navigation configuration — Three Worlds model.
+ * Navigation configuration — Four Worlds model.
  *
- * Three conceptual worlds:
- *   Home      = "What needs my attention?" (absorbs workspace for DRep/SPO)
+ * Four conceptual worlds:
+ *   Home      = "What needs my attention?" (briefing, alerts, status)
+ *   Workspace = "Do my governance work" (author, review, manage)
  *   Governance = "What's happening?" (universal exploration)
  *   You       = "Who am I in governance?" (identity, reflection, settings)
  *
+ * Home is a single briefing surface for all personas.
+ * Workspace is a separate section for governance operators (DRep, SPO,
+ * delegated citizens). Author and Review are peer sub-sections within it.
+ *
  * This is the single source of truth for all navigation surfaces:
- * - Desktop sidebar
- * - Mobile bottom bar (3 items, persona-adaptive)
+ * - Desktop sidebar / icon rail
+ * - Mobile bottom bar (3-4 items, persona-adaptive)
  * - Mobile pill bar (section sub-pages)
  * - Header help dropdown
  *
@@ -41,6 +46,7 @@ import {
   Rocket,
   Link2,
   PenLine,
+  Briefcase,
 } from 'lucide-react';
 import type { UserSegment } from '@/components/providers/SegmentProvider';
 import { type GovernanceDepth, getTunerLevel } from '@/lib/governanceTuner';
@@ -79,7 +85,7 @@ export interface NavSection {
   href: string;
   /** Sub-pages within this section (shown in sidebar + pill bar) */
   items?: NavItem[];
-  /** Role-grouped items (used for dual-role Home sections) */
+  /** Role-grouped items (used for dual-role workspace) */
   groups?: NavItemGroup[];
   /** Only show for these segments (undefined = all) */
   segments?: UserSegment[];
@@ -92,51 +98,82 @@ export interface BottomBarConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Section definitions (sidebar + pill bar source)
+// Workspace section definitions — Author & Review as peer sub-sections
 // ---------------------------------------------------------------------------
 
-/** Home sub-items for DRep persona (workspace tools shown under Home) */
-export const HOME_DREP_ITEMS: NavItem[] = [
-  { href: '/workspace', label: 'Home', icon: Vote, sublabelKey: 'home.pendingVotes' },
-  { href: '/workspace/review', label: 'Review', icon: FileText, sublabelKey: 'home.pendingReview' },
+/**
+ * DRep workspace: Review-first (their #1 JTBD), then Author, then operational tools.
+ * The /workspace landing doubles as a DRep action queue / dashboard.
+ */
+export const WORKSPACE_DREP_ITEMS: NavItem[] = [
+  {
+    href: '/workspace',
+    label: 'Dashboard',
+    icon: Vote,
+    sublabelKey: 'workspace.pendingVotes',
+  },
+  {
+    href: '/workspace/review',
+    label: 'Review',
+    icon: FileText,
+    sublabelKey: 'workspace.pendingReview',
+  },
+  { href: '/workspace/author', label: 'Author', icon: PenLine },
   {
     href: '/workspace/votes',
     label: 'Voting Record',
     icon: ScrollText,
-    sublabelKey: 'home.totalVotes',
+    sublabelKey: 'workspace.totalVotes',
   },
   {
     href: '/workspace/delegators',
     label: 'Delegators',
     icon: Users,
-    sublabelKey: 'home.delegatedAda',
+    sublabelKey: 'workspace.delegatedAda',
   },
-  { href: '/workspace/author', label: 'Author', icon: PenLine },
 ];
 
-/** Home sub-items for SPO persona (workspace tools shown under Home) */
-export const HOME_SPO_ITEMS: NavItem[] = [
-  { href: '/workspace', label: 'Gov Score', icon: BarChart3, sublabelKey: 'home.govScore' },
-  { href: '/workspace/review', label: 'Review', icon: FileText, sublabelKey: 'home.pendingReview' },
+/**
+ * SPO workspace: Gov Score dashboard, then Review, Author, and pool management.
+ */
+export const WORKSPACE_SPO_ITEMS: NavItem[] = [
+  {
+    href: '/workspace',
+    label: 'Gov Score',
+    icon: BarChart3,
+    sublabelKey: 'workspace.govScore',
+  },
+  {
+    href: '/workspace/review',
+    label: 'Review',
+    icon: FileText,
+    sublabelKey: 'workspace.pendingReview',
+  },
+  { href: '/workspace/author', label: 'Author', icon: PenLine },
   { href: '/workspace/pool-profile', label: 'Pool Profile', icon: Building },
   {
     href: '/workspace/delegators',
     label: 'Delegators',
     icon: Users,
-    sublabelKey: 'home.delegatedAda',
+    sublabelKey: 'workspace.delegatedAda',
   },
   { href: '/workspace/position', label: 'Position', icon: Trophy },
+];
+
+/**
+ * Citizen workspace: Author-first (their primary workspace activity),
+ * then Review for community draft feedback.
+ */
+export const WORKSPACE_CITIZEN_ITEMS: NavItem[] = [
   { href: '/workspace/author', label: 'Author', icon: PenLine },
+  { href: '/workspace/review', label: 'Review', icon: FileText },
 ];
 
-/** Home sub-items for citizen persona — minimal workspace with Author access */
-export const HOME_CITIZEN_ITEMS: NavItem[] = [
-  { href: '/workspace/author', label: 'Author', icon: PenLine, requiresAuth: true },
-];
-
-// Legacy aliases for any code that still references the old names
-export const WORKSPACE_DREP_ITEMS = HOME_DREP_ITEMS;
-export const WORKSPACE_SPO_ITEMS = HOME_SPO_ITEMS;
+// Legacy aliases — kept for any code that still references the old names.
+// These now point at the workspace definitions (identical content, new ordering).
+export const HOME_DREP_ITEMS = WORKSPACE_DREP_ITEMS;
+export const HOME_SPO_ITEMS = WORKSPACE_SPO_ITEMS;
+export const HOME_CITIZEN_ITEMS = WORKSPACE_CITIZEN_ITEMS;
 
 export const GOVERNANCE_ITEMS: NavItem[] = [
   {
@@ -224,7 +261,7 @@ export const HELP_ITEMS: NavItem[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Sidebar sections — Three Worlds: Home, Governance, You
+// Sidebar sections — Four Worlds: Home, Workspace, Governance, You
 // ---------------------------------------------------------------------------
 
 /** Context for sidebar generation — supports dual-role detection */
@@ -239,6 +276,8 @@ export interface SidebarContext {
 /** Extended context that includes governance depth for filtering */
 export interface NavContext extends SidebarContext {
   depth?: GovernanceDepth;
+  /** True when citizen has an active delegation (DRep or pool) */
+  isDelegated?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -269,18 +308,28 @@ function filterGroupsByDepth(
 }
 
 /**
- * Build deduplicated dual-role Home groups.
+ * Build deduplicated dual-role Workspace groups.
  * Items that appear in both lists (matched by href) are shown only in the
  * DRep group to avoid visual clutter.
  */
-function buildDualRoleGroups(): NavItemGroup[] {
-  const drepHrefs = new Set(HOME_DREP_ITEMS.map((i) => i.href));
-  const dedupedSpoItems = HOME_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href));
+function buildDualRoleWorkspaceGroups(): NavItemGroup[] {
+  const drepHrefs = new Set(WORKSPACE_DREP_ITEMS.map((i) => i.href));
+  const dedupedSpoItems = WORKSPACE_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href));
 
   return [
-    { id: 'home-drep', label: 'DRep', items: HOME_DREP_ITEMS },
-    { id: 'home-pool', label: 'Pool', items: dedupedSpoItems },
+    { id: 'ws-drep', label: 'DRep', items: WORKSPACE_DREP_ITEMS },
+    { id: 'ws-pool', label: 'Pool', items: dedupedSpoItems },
   ];
+}
+
+/** Returns true when a persona should see the Workspace section. */
+function hasWorkspace(ctx: NavContext): boolean {
+  const { segment, drepId, poolId, isDelegated } = ctx;
+  if (segment === 'drep' || segment === 'spo') return true;
+  if (drepId || poolId) return true; // dual-role detection
+  // Delegated citizens get Workspace (Author + Review)
+  if (segment === 'citizen' && isDelegated) return true;
+  return false;
 }
 
 export function getSidebarSections(
@@ -295,50 +344,60 @@ export function getSidebarSections(
 
   const sections: NavSection[] = [];
 
-  // ── World 1: Home ─────────────────────────────────────────────────────
-  // For DRep/SPO, Home has workspace sub-items (the workspace IS their home).
-  // For citizens/anonymous, Home is a single link.
-  if (isDualRole) {
-    const filteredGroups = filterGroupsByDepth(buildDualRoleGroups(), depth);
-    sections.push({
-      id: 'home',
-      label: 'Home',
-      icon: Home,
-      href: '/',
-      groups: filteredGroups.length > 0 ? filteredGroups : undefined,
-    });
-  } else if (segment === 'drep' || segment === 'spo') {
-    const homeItems = segment === 'drep' ? HOME_DREP_ITEMS : HOME_SPO_ITEMS;
-    const filteredItems = filterByDepth(homeItems, depth);
-    sections.push({
-      id: 'home',
-      label: 'Home',
-      icon: Home,
-      href: '/',
-      items: filteredItems,
-    });
-  } else if (segment === 'citizen' || segment === 'cc') {
-    // Authenticated citizens and CC members get Home with Author workspace access
-    const filteredItems = filterByDepth(HOME_CITIZEN_ITEMS, depth);
-    sections.push({
-      id: 'home',
-      label: 'Home',
-      icon: Home,
-      href: '/',
-      items: filteredItems.length > 0 ? filteredItems : undefined,
-      requiresAuth: true,
-    });
-  } else {
-    // Anonymous — Home is a single link
-    sections.push({
-      id: 'home',
-      label: 'Home',
-      icon: Home,
-      href: '/',
-    });
+  // ── World 1: Home — briefing surface (always a single link) ───────────
+  sections.push({
+    id: 'home',
+    label: 'Home',
+    icon: Home,
+    href: '/',
+  });
+
+  // ── World 2: Workspace — governance work surface ──────────────────────
+  // Appears for DRep, SPO, and delegated citizens. Author & Review are
+  // peer sub-sections; persona determines default landing and item order.
+  if (hasWorkspace(ctx)) {
+    if (isDualRole) {
+      const filteredGroups = filterGroupsByDepth(buildDualRoleWorkspaceGroups(), depth);
+      sections.push({
+        id: 'workspace',
+        label: 'Workspace',
+        icon: Briefcase,
+        href: '/workspace',
+        groups: filteredGroups.length > 0 ? filteredGroups : undefined,
+        requiresAuth: true,
+      });
+    } else if (segment === 'drep' || (drepId && !poolId)) {
+      sections.push({
+        id: 'workspace',
+        label: 'Workspace',
+        icon: Briefcase,
+        href: '/workspace',
+        items: filterByDepth(WORKSPACE_DREP_ITEMS, depth),
+        requiresAuth: true,
+      });
+    } else if (segment === 'spo' || (!drepId && poolId)) {
+      sections.push({
+        id: 'workspace',
+        label: 'Workspace',
+        icon: Briefcase,
+        href: '/workspace',
+        items: filterByDepth(WORKSPACE_SPO_ITEMS, depth),
+        requiresAuth: true,
+      });
+    } else {
+      // Delegated citizen
+      sections.push({
+        id: 'workspace',
+        label: 'Workspace',
+        icon: Briefcase,
+        href: '/workspace/author',
+        items: filterByDepth(WORKSPACE_CITIZEN_ITEMS, depth),
+        requiresAuth: true,
+      });
+    }
   }
 
-  // ── World 2: Governance ───────────────────────────────────────────────
+  // ── World 3: Governance ───────────────────────────────────────────────
   sections.push({
     id: 'governance',
     label: 'Governance',
@@ -347,7 +406,7 @@ export function getSidebarSections(
     items: filterByDepth(GOVERNANCE_ITEMS, depth),
   });
 
-  // ── World 3: You ──────────────────────────────────────────────────────
+  // ── World 4: You ──────────────────────────────────────────────────────
   if (segment !== 'anonymous') {
     sections.push({
       id: 'you',
@@ -363,7 +422,7 @@ export function getSidebarSections(
 }
 
 // ---------------------------------------------------------------------------
-// Bottom bar — 3 items, Three Worlds model
+// Bottom bar — 3 or 4 items, persona-adaptive
 // ---------------------------------------------------------------------------
 
 /** Anonymous: Home | Governance | Match */
@@ -380,23 +439,26 @@ const BOTTOM_BAR_CITIZEN: NavItem[] = [
   { href: '/match', label: 'Match', icon: Compass },
 ];
 
-/** Citizen (delegated/hands-off): Home | Governance | You */
+/** Citizen (delegated): Home | Workspace | Governance | You */
 const BOTTOM_BAR_CITIZEN_DELEGATED: NavItem[] = [
   { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace/author', label: 'Workspace', icon: Briefcase },
   { href: '/governance', label: 'Governance', icon: Globe },
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
 
-/** DRep: Home | Governance | You (workspace absorbed into Home) */
+/** DRep: Home | Workspace | Governance | You */
 const BOTTOM_BAR_DREP: NavItem[] = [
-  { href: '/', label: 'Home', icon: Home, badge: 'actions' },
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase, badge: 'actions' },
   { href: '/governance', label: 'Governance', icon: Globe },
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
 
-/** SPO: Home | Governance | You (workspace absorbed into Home) */
+/** SPO: Home | Workspace | Governance | You */
 const BOTTOM_BAR_SPO: NavItem[] = [
   { href: '/', label: 'Home', icon: Home },
+  { href: '/workspace', label: 'Workspace', icon: Briefcase },
   { href: '/governance', label: 'Governance', icon: Globe },
   { href: '/you', label: 'You', icon: User, badge: 'unread' },
 ];
@@ -419,7 +481,7 @@ export function getBottomBarItems(
     case 'anonymous':
       return BOTTOM_BAR_ANONYMOUS;
     case 'citizen':
-      // Undelegated citizens get Match; delegated/hands-off get You
+      // Delegated citizens (hands-off+ depth) get Workspace; undelegated get Match
       return isHandsOff ? BOTTOM_BAR_CITIZEN_DELEGATED : BOTTOM_BAR_CITIZEN;
     case 'drep':
       return BOTTOM_BAR_DREP;
@@ -446,21 +508,22 @@ export function getPillBarItems(
   if (pathname.startsWith('/governance')) {
     return filterByDepth(GOVERNANCE_ITEMS, depth);
   }
-  // Workspace routes are now part of the Home world
+  // Workspace routes show workspace sub-items in the pill bar
   if (pathname.startsWith('/workspace')) {
     const isDualRole = !!(context?.drepId && context?.poolId);
     if (isDualRole) {
-      const drepHrefs = new Set(HOME_DREP_ITEMS.map((i) => i.href));
+      const drepHrefs = new Set(WORKSPACE_DREP_ITEMS.map((i) => i.href));
       const combined = [
-        ...HOME_DREP_ITEMS,
-        ...HOME_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href)),
+        ...WORKSPACE_DREP_ITEMS,
+        ...WORKSPACE_SPO_ITEMS.filter((i) => !drepHrefs.has(i.href)),
       ];
       return filterByDepth(combined, depth);
     }
-    if (segment === 'drep') return filterByDepth(HOME_DREP_ITEMS, depth);
-    if (segment === 'spo') return filterByDepth(HOME_SPO_ITEMS, depth);
-    if (segment === 'citizen' || segment === 'cc') return filterByDepth(HOME_CITIZEN_ITEMS, depth);
-    return filterByDepth(HOME_DREP_ITEMS, depth);
+    if (segment === 'drep') return filterByDepth(WORKSPACE_DREP_ITEMS, depth);
+    if (segment === 'spo') return filterByDepth(WORKSPACE_SPO_ITEMS, depth);
+    if (segment === 'citizen' || segment === 'cc')
+      return filterByDepth(WORKSPACE_CITIZEN_ITEMS, depth);
+    return filterByDepth(WORKSPACE_DREP_ITEMS, depth);
   }
   if (pathname.startsWith('/you')) {
     return filterByDepth(getYouItems(segment, context), depth);
@@ -478,8 +541,7 @@ export function getPillBarItems(
 
 export function getCurrentSection(pathname: string): string | null {
   if (pathname === '/') return 'home';
-  // Workspace routes belong to the Home world
-  if (pathname.startsWith('/workspace')) return 'home';
+  if (pathname.startsWith('/workspace')) return 'workspace';
   if (pathname.startsWith('/governance')) return 'governance';
   if (pathname.startsWith('/you')) return 'you';
   if (pathname.startsWith('/match')) return 'match';


### PR DESCRIPTION
## Summary
- Separates Workspace from Home as a proper top-level navigation section for governance operators
- Author and Review elevated to peer sub-sections within Workspace (no longer buried as last items under Home)
- DRep/SPO/delegated citizens get 4-item mobile bottom bar: Home | Workspace | Governance | You
- Home becomes a pure briefing surface; Workspace is where governance work happens

## Impact
- **What changed**: Navigation restructured from Three Worlds (Home absorbs Workspace) to Four Worlds (Home + Workspace + Governance + You). Author moved from last position to prominent 2nd/3rd in workspace sub-nav.
- **User-facing**: Yes — DReps, SPOs, and delegated citizens see a dedicated Workspace icon in the nav rail and mobile bottom bar. Author and Review are immediately discoverable as peer workspace tools.
- **Risk**: Low — all changes are in navigation config and 3 nav components. No route changes, no data changes, no API changes. All existing workspace pages/components unchanged.
- **Scope**: `lib/nav/config.ts`, `NavigationRail.tsx`, `GovernadaBottomNav.tsx`, `GovernadaSidebar.tsx`, `navigation-architecture.md`

## Test plan
- [ ] Verify DRep persona sees 4 bottom bar items (Home | Workspace | Governance | You) on mobile
- [ ] Verify SPO persona sees Workspace in nav rail on desktop
- [ ] Verify delegated citizen sees Workspace with Author as default
- [ ] Verify anonymous/undelegated citizen sees 3 items (Home | Governance | Match)
- [ ] Verify G W keyboard shortcut navigates to Workspace
- [ ] Verify workspace routes highlight Workspace (not Home) in all nav surfaces
- [ ] Verify dual-role badge appears on Workspace icon, not Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)