### PR TITLE
feat: Co-Pilot entity preview and mobile intelligence sheet

### DIFF
--- a/components/governada/panel/EntityPreview.tsx
+++ b/components/governada/panel/EntityPreview.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+/**
+ * EntityPreview — inline entity preview within the Co-Pilot panel.
+ *
+ * When the panel shows entity links (e.g., "Related Proposals" on a DRep page),
+ * clicking one slides a preview in from the right. Supports breadcrumb navigation
+ * with a max stack depth of 3 levels.
+ *
+ * Animations: slide left/right with Framer Motion (200ms).
+ * Respects `prefers-reduced-motion`.
+ *
+ * Feature-flagged behind `governance_copilot`.
+ */
+
+import { useCallback, useRef, useEffect } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ExternalLink, ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { EntityPreviewCard } from './EntityPreviewCard';
+import type { UseEntityPreviewStackReturn, PreviewEntity } from '@/hooks/useEntityPreviewStack';
+import type { PeekEntityType } from '@/hooks/usePeekDrawer';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface EntityPreviewProps {
+  /** The preview stack hook return — pass from the parent panel */
+  previewStack: UseEntityPreviewStackReturn;
+  /** Children = the panel's root content (shown when no preview is active) */
+  children: React.ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SLIDE_DURATION = 0.2;
+
+// Easing: custom ease-out for smooth slide
+const SLIDE_EASE = [0.16, 1, 0.3, 1] as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function entityHref(type: PeekEntityType, id: string, secondaryId?: string | number): string {
+  switch (type) {
+    case 'proposal':
+      return `/proposal/${id}/${secondaryId ?? 0}`;
+    case 'drep':
+      return `/drep/${id}`;
+    case 'pool':
+      return `/pool/${id}`;
+    case 'cc':
+      return `/governance/committee/${encodeURIComponent(id)}`;
+    default:
+      return '#';
+  }
+}
+
+function entityTypeLabel(type: PeekEntityType): string {
+  switch (type) {
+    case 'proposal':
+      return 'Proposal';
+    case 'drep':
+      return 'DRep';
+    case 'pool':
+      return 'Pool';
+    case 'cc':
+      return 'CC Member';
+    default:
+      return 'Entity';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function EntityPreview({ previewStack, children }: EntityPreviewProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const { current, breadcrumbs, depth, isActive, pop, navigateTo, reset } = previewStack;
+
+  const duration = prefersReducedMotion ? 0 : SLIDE_DURATION;
+
+  // Scroll to top when a new preview is pushed
+  useEffect(() => {
+    if (isActive && contentRef.current) {
+      contentRef.current.scrollTop = 0;
+    }
+  }, [depth, isActive]);
+
+  // Keyboard: Escape pops the preview stack
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape' && isActive) {
+        e.stopPropagation();
+        pop();
+      }
+    },
+    [isActive, pop],
+  );
+
+  return (
+    <div className="relative h-full overflow-hidden" onKeyDown={handleKeyDown}>
+      {/* Root panel content */}
+      <AnimatePresence mode="popLayout">
+        {!isActive && (
+          <motion.div
+            key="panel-root"
+            className="h-full overflow-y-auto"
+            initial={false}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{
+              x: prefersReducedMotion ? 0 : -60,
+              opacity: 0,
+            }}
+            transition={{ duration, ease: SLIDE_EASE }}
+          >
+            {children}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Preview layer */}
+      <AnimatePresence mode="popLayout">
+        {isActive && current && (
+          <motion.div
+            key={`preview-${depth}-${current.type}-${current.id}`}
+            ref={contentRef}
+            className="absolute inset-0 h-full overflow-y-auto"
+            initial={{
+              x: prefersReducedMotion ? 0 : '100%',
+              opacity: prefersReducedMotion ? 0 : 1,
+            }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{
+              x: prefersReducedMotion ? 0 : '100%',
+              opacity: prefersReducedMotion ? 0 : 1,
+            }}
+            transition={{ duration, ease: SLIDE_EASE }}
+          >
+            {/* Navigation header */}
+            <div className="sticky top-0 z-10 bg-background/80 backdrop-blur-md border-b border-border/10 px-3 py-2 space-y-1.5">
+              {/* Back button */}
+              <button
+                type="button"
+                onClick={depth === 1 ? reset : pop}
+                className={cn(
+                  'flex items-center gap-1.5 text-xs font-medium transition-colors',
+                  'text-muted-foreground hover:text-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md px-1 py-0.5',
+                )}
+                aria-label={depth === 1 ? 'Back to panel' : 'Back to previous preview'}
+              >
+                <ArrowLeft className="h-3.5 w-3.5" />
+                {depth === 1 ? 'Back to Co-Pilot' : `Back`}
+              </button>
+
+              {/* Breadcrumb trail */}
+              {breadcrumbs.length > 1 && (
+                <nav
+                  className="flex items-center gap-1 text-[10px] text-muted-foreground overflow-x-auto"
+                  aria-label="Preview navigation"
+                >
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="shrink-0 hover:text-foreground transition-colors"
+                  >
+                    Panel
+                  </button>
+                  {breadcrumbs.map((crumb, i) => {
+                    const isLast = i === breadcrumbs.length - 1;
+                    return (
+                      <span key={crumb.depth} className="flex items-center gap-1 shrink-0">
+                        <ChevronRight className="h-2.5 w-2.5 text-muted-foreground/50" />
+                        {isLast ? (
+                          <span className="text-foreground font-medium truncate max-w-[120px]">
+                            {crumb.label}
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => navigateTo(crumb.depth)}
+                            className="hover:text-foreground transition-colors truncate max-w-[100px]"
+                          >
+                            {crumb.label}
+                          </button>
+                        )}
+                      </span>
+                    );
+                  })}
+                </nav>
+              )}
+            </div>
+
+            {/* Entity preview content */}
+            <div className="px-4 pb-4">
+              <EntityPreviewCard
+                type={current.type}
+                id={current.id}
+                secondaryId={current.secondaryId}
+              />
+
+              {/* Open full page link */}
+              <div className="mt-4 pt-3 border-t border-border/20">
+                <Link
+                  href={entityHref(current.type, current.id, current.secondaryId)}
+                  className={cn(
+                    'flex items-center justify-center gap-2 w-full py-2 rounded-lg',
+                    'text-xs font-medium transition-colors',
+                    'text-muted-foreground hover:text-foreground hover:bg-muted/30',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                  )}
+                >
+                  Open full {entityTypeLabel(current.type)} page
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Re-export types for convenience
+// ---------------------------------------------------------------------------
+
+export type { PreviewEntity, UseEntityPreviewStackReturn };

--- a/components/governada/panel/EntityPreviewCard.tsx
+++ b/components/governada/panel/EntityPreviewCard.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * EntityPreviewCard — compact entity card rendered within the Co-Pilot panel
+ * entity preview.
+ *
+ * Reuses the same data-fetching patterns as peek drawer variants (DRepPeek,
+ * ProposalPeek, PoolPeek, CCMemberPeek) but in a panel-width layout.
+ *
+ * Feature-flagged behind `governance_copilot`.
+ */
+
+import type { PeekEntityType } from '@/hooks/usePeekDrawer';
+import { ProposalPeek } from '@/components/governada/peeks/ProposalPeek';
+import { DRepPeek } from '@/components/governada/peeks/DRepPeek';
+import { PoolPeek } from '@/components/governada/peeks/PoolPeek';
+import { CCMemberPeek } from '@/components/governada/peeks/CCMemberPeek';
+
+interface EntityPreviewCardProps {
+  type: PeekEntityType;
+  id: string;
+  secondaryId?: string | number;
+}
+
+/**
+ * Routes to the correct peek variant based on entity type.
+ * The peek components already fetch their own data and render
+ * loading skeletons — they work identically inside the panel.
+ */
+export function EntityPreviewCard({ type, id, secondaryId }: EntityPreviewCardProps) {
+  switch (type) {
+    case 'proposal':
+      return (
+        <ProposalPeek
+          txHash={id}
+          index={
+            typeof secondaryId === 'number' ? secondaryId : parseInt(String(secondaryId ?? '0'), 10)
+          }
+        />
+      );
+    case 'drep':
+      return <DRepPeek drepId={id} />;
+    case 'pool':
+      return <PoolPeek poolId={id} />;
+    case 'cc':
+      return <CCMemberPeek ccHotId={id} />;
+    default:
+      return null;
+  }
+}

--- a/components/governada/panel/MobileIntelSheet.tsx
+++ b/components/governada/panel/MobileIntelSheet.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+/**
+ * MobileIntelSheet — gesture-driven bottom sheet for mobile (<1024px).
+ *
+ * Replaces the desktop intelligence panel on smaller screens with a
+ * native-feeling bottom sheet. Three states:
+ *
+ * 1. **Closed** — only the PeekBar is visible
+ * 2. **Half sheet** (default open) — 50% screen height
+ * 3. **Full sheet** — 85% screen height
+ *
+ * Interactions:
+ * - Drag handle at top for resize
+ * - Drag down past 30% threshold to close
+ * - Drag up to expand from half -> full
+ * - Tap outside (backdrop) to close
+ * - Escape key to close
+ * - Spring physics for momentum feel
+ *
+ * Respects `prefers-reduced-motion` and `safe-area-inset-bottom`.
+ *
+ * Feature-flagged behind `governance_copilot`.
+ */
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  motion,
+  AnimatePresence,
+  useMotionValue,
+  useReducedMotion,
+  type PanInfo,
+} from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { PeekBar } from './PeekBar';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type SheetState = 'closed' | 'half' | 'full';
+
+interface MobileIntelSheetProps {
+  /** Sheet content (same content as the desktop panel) */
+  children: ReactNode;
+  /** Additional class on the sheet container */
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Half-sheet occupies 50% of viewport height */
+const HALF_RATIO = 0.5;
+
+/** Full-sheet occupies 85% of viewport height */
+const FULL_RATIO = 0.85;
+
+/** Drag down past this ratio of current height to close */
+const CLOSE_THRESHOLD = 0.3;
+
+/** Minimum velocity (px/s) for a flick to trigger state change */
+const VELOCITY_THRESHOLD = 300;
+
+/** Spring config for native-feeling transitions */
+const SPRING_CONFIG = {
+  type: 'spring' as const,
+  damping: 30,
+  stiffness: 350,
+  mass: 0.8,
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MobileIntelSheet({ children, className }: MobileIntelSheetProps) {
+  const [state, setState] = useState<SheetState>('closed');
+  const prefersReducedMotion = useReducedMotion();
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const isOpen = state !== 'closed';
+
+  // Motion value for drag offset
+  const y = useMotionValue(0);
+
+  // ---------------------------------------------------------------------------
+  // Height calculations
+  // ---------------------------------------------------------------------------
+
+  const getTargetHeight = useCallback((s: SheetState): number => {
+    if (typeof window === 'undefined') return 0;
+    const vh = window.innerHeight;
+    switch (s) {
+      case 'half':
+        return vh * HALF_RATIO;
+      case 'full':
+        return vh * FULL_RATIO;
+      default:
+        return 0;
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // State transitions
+  // ---------------------------------------------------------------------------
+
+  const open = useCallback(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    setState('half');
+    y.set(0);
+  }, [y]);
+
+  const close = useCallback(() => {
+    setState('closed');
+    y.set(0);
+    // Restore focus
+    if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [y]);
+
+  const expand = useCallback(() => {
+    setState('full');
+    y.set(0);
+  }, [y]);
+
+  // ---------------------------------------------------------------------------
+  // Drag handling
+  // ---------------------------------------------------------------------------
+
+  const handleDragEnd = useCallback(
+    (_: unknown, info: PanInfo) => {
+      const velocityY = info.velocity.y;
+      const offsetY = info.offset.y;
+      const currentHeight = getTargetHeight(state);
+
+      if (state === 'half') {
+        // Dragging DOWN from half sheet
+        if (offsetY > currentHeight * CLOSE_THRESHOLD || velocityY > VELOCITY_THRESHOLD) {
+          close();
+          return;
+        }
+        // Dragging UP from half sheet
+        if (offsetY < -50 || velocityY < -VELOCITY_THRESHOLD) {
+          expand();
+          return;
+        }
+      } else if (state === 'full') {
+        // Dragging DOWN from full sheet
+        if (velocityY > VELOCITY_THRESHOLD * 1.5) {
+          // Fast swipe down = close entirely
+          close();
+          return;
+        }
+        if (offsetY > currentHeight * CLOSE_THRESHOLD) {
+          // Slow drag past threshold = collapse to half
+          setState('half');
+          y.set(0);
+          return;
+        }
+      }
+
+      // Snap back
+      y.set(0);
+    },
+    [state, getTargetHeight, close, expand, y],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Keyboard
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        e.preventDefault();
+        close();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen, close]);
+
+  // ---------------------------------------------------------------------------
+  // Body scroll lock when sheet is open
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (isOpen) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [isOpen]);
+
+  // Focus sheet when opened
+  useEffect(() => {
+    if (isOpen) {
+      const timer = setTimeout(() => {
+        sheetRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  // ---------------------------------------------------------------------------
+  // Animation config
+  // ---------------------------------------------------------------------------
+
+  const transition = prefersReducedMotion ? { duration: 0 } : SPRING_CONFIG;
+
+  const targetHeight = getTargetHeight(state);
+
+  return (
+    <>
+      {/* Peek bar — visible only when sheet is closed, on mobile only */}
+      <PeekBar onOpen={open} isSheetOpen={isOpen} />
+
+      {/* Sheet + backdrop */}
+      <AnimatePresence>
+        {isOpen && (
+          <>
+            {/* Backdrop */}
+            <motion.div
+              className="fixed inset-0 z-40 lg:hidden bg-black/30"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: prefersReducedMotion ? 0 : 0.15 }}
+              onClick={close}
+              aria-hidden="true"
+            />
+
+            {/* Sheet */}
+            <motion.aside
+              ref={sheetRef}
+              role="complementary"
+              aria-label="Governance intelligence"
+              tabIndex={-1}
+              className={cn(
+                'fixed left-0 right-0 bottom-0 z-50 lg:hidden',
+                'rounded-t-2xl outline-none',
+                'border-t border-border/20',
+                'bg-background/90 backdrop-blur-xl',
+                'flex flex-col',
+                className,
+              )}
+              style={{
+                height: targetHeight,
+                paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+              }}
+              // Animate in from bottom
+              initial={{
+                y: prefersReducedMotion ? 0 : '100%',
+              }}
+              animate={{
+                y: 0,
+                height: targetHeight,
+              }}
+              exit={{
+                y: prefersReducedMotion ? 0 : '100%',
+              }}
+              transition={transition}
+              // Drag behavior
+              drag="y"
+              dragConstraints={{ top: 0, bottom: 0 }}
+              dragElastic={0.2}
+              dragMomentum={false}
+              onDragEnd={handleDragEnd}
+              _dragY={y}
+            >
+              {/* Drag handle */}
+              <div
+                className="flex justify-center pt-2.5 pb-1.5 cursor-grab active:cursor-grabbing touch-none"
+                aria-hidden="true"
+              >
+                <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+              </div>
+
+              {/* State indicator (half/full) */}
+              <div className="flex items-center justify-between px-4 pb-2">
+                <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+                  Intelligence
+                </span>
+                {state === 'half' && (
+                  <button
+                    type="button"
+                    onClick={expand}
+                    className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Expand to full height"
+                  >
+                    Expand
+                  </button>
+                )}
+                {state === 'full' && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setState('half');
+                      y.set(0);
+                    }}
+                    className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Collapse to half height"
+                  >
+                    Collapse
+                  </button>
+                )}
+              </div>
+
+              {/* Scrollable content */}
+              <div className="flex-1 overflow-y-auto overscroll-contain px-4 pb-4">{children}</div>
+            </motion.aside>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/components/governada/panel/PeekBar.tsx
+++ b/components/governada/panel/PeekBar.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * PeekBar — always-visible 40px hint bar on mobile (<1024px).
+ *
+ * Shows a 1-line context hint from governance state data (e.g.,
+ * "3 active proposals · 42% epoch progress"). Tapping opens the
+ * mobile intelligence bottom sheet.
+ *
+ * Positioned fixed at the bottom, above the bottom nav bar.
+ * Subtle glassmorphic styling matching the app.
+ *
+ * Feature-flagged behind `governance_copilot`.
+ */
+
+import { useMemo } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ChevronUp, Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PeekBarProps {
+  /** Handler called when the bar is tapped / swiped up */
+  onOpen: () => void;
+  /** Whether the sheet is currently open (hide bar when open) */
+  isSheetOpen: boolean;
+  /** Additional classes */
+  className?: string;
+}
+
+interface GovernanceStateResponse {
+  urgency: number;
+  temperature: number;
+  epoch: {
+    currentEpoch: number;
+    progress: number;
+    remainingSeconds: number;
+    activeProposalCount: number;
+  };
+  userState: {
+    delegatedDrepId: string | null;
+    pendingVotes: number;
+    hasPendingActions: boolean;
+    drepScore: number | null;
+    drepRank: number | null;
+  } | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildHintText(data: GovernanceStateResponse | undefined): string {
+  if (!data) return 'Governance intelligence loading...';
+
+  const parts: string[] = [];
+
+  // Active proposals count
+  if (data.epoch.activeProposalCount > 0) {
+    const count = data.epoch.activeProposalCount;
+    parts.push(`${count} active proposal${count === 1 ? '' : 's'}`);
+  }
+
+  // User-specific hints
+  if (data.userState) {
+    if (data.userState.pendingVotes > 0) {
+      parts.push(
+        `${data.userState.pendingVotes} pending vote${data.userState.pendingVotes === 1 ? '' : 's'}`,
+      );
+    }
+    if (data.userState.delegatedDrepId) {
+      parts.push('DRep delegated');
+    }
+  }
+
+  // Epoch progress
+  const epochPct = Math.round(data.epoch.progress * 100);
+  if (epochPct > 0) {
+    parts.push(`Epoch ${epochPct}%`);
+  }
+
+  if (parts.length === 0) {
+    return 'Governance is quiet';
+  }
+
+  // Show up to 2 parts for brevity in the bar
+  return parts.slice(0, 2).join(' \u00B7 ');
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PeekBar({ onOpen, isSheetOpen, className }: PeekBarProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const { data } = useQuery<GovernanceStateResponse>({
+    queryKey: ['governance-state-peek'],
+    queryFn: async () => {
+      const res = await fetch('/api/intelligence/governance-state');
+      if (!res.ok) throw new Error('Failed to fetch governance state');
+      return res.json();
+    },
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+  });
+
+  const hintText = useMemo(() => buildHintText(data), [data]);
+
+  // Urgency indicator (subtle tint)
+  const urgencyColor = useMemo(() => {
+    if (!data) return 'text-muted-foreground';
+    if (data.urgency >= 70) return 'text-amber-400';
+    if (data.urgency >= 40) return 'text-primary/80';
+    return 'text-muted-foreground';
+  }, [data]);
+
+  if (isSheetOpen) return null;
+
+  return (
+    <motion.button
+      type="button"
+      onClick={onOpen}
+      className={cn(
+        // Fixed at bottom, above bottom nav (bottom-nav is typically 64px)
+        'fixed left-0 right-0 z-40 lg:hidden',
+        'h-10 flex items-center justify-between gap-2 px-4',
+        // Glassmorphic
+        'bg-background/70 backdrop-blur-xl',
+        'border-t border-border/20',
+        // Safe area
+        'pb-[env(safe-area-inset-bottom)]',
+        className,
+      )}
+      style={{
+        bottom: 'calc(64px + env(safe-area-inset-bottom, 0px))',
+      }}
+      initial={prefersReducedMotion ? false : { y: 40, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{
+        duration: prefersReducedMotion ? 0 : 0.3,
+        ease: [0.16, 1, 0.3, 1],
+      }}
+      aria-label="Open governance intelligence panel"
+    >
+      {/* Left: context hint */}
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <Zap className={cn('h-3.5 w-3.5 shrink-0', urgencyColor)} />
+        <span className="text-xs text-muted-foreground truncate">{hintText}</span>
+      </div>
+
+      {/* Right: expand indicator */}
+      <ChevronUp className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+    </motion.button>
+  );
+}

--- a/hooks/useEntityPreviewStack.ts
+++ b/hooks/useEntityPreviewStack.ts
@@ -1,0 +1,126 @@
+'use client';
+
+/**
+ * useEntityPreviewStack — manages a stack of previewed entities within
+ * the Co-Pilot panel.
+ *
+ * Supports push/pop/reset with a max depth of 3 to prevent infinite nesting.
+ * Provides a breadcrumb trail for navigation UI.
+ */
+
+import { useCallback, useState, useMemo } from 'react';
+import type { PeekEntityType } from '@/hooks/usePeekDrawer';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PreviewEntity {
+  type: PeekEntityType;
+  id: string;
+  /** Secondary key for composite IDs (e.g., proposal index) */
+  secondaryId?: string | number;
+  /** Display label for breadcrumb trail (e.g., "DRep: CardanoSpark") */
+  label: string;
+}
+
+export interface Breadcrumb {
+  label: string;
+  depth: number;
+}
+
+export interface UseEntityPreviewStackReturn {
+  /** Current entity being previewed (top of stack), or null if stack is empty */
+  current: PreviewEntity | null;
+  /** Full stack of previewed entities */
+  stack: PreviewEntity[];
+  /** Breadcrumb trail for navigation */
+  breadcrumbs: Breadcrumb[];
+  /** Current depth (0 = no preview, 1-3 = preview levels) */
+  depth: number;
+  /** Whether the stack has reached max depth */
+  isAtMaxDepth: boolean;
+  /** Whether a preview is currently active */
+  isActive: boolean;
+  /** Push a new entity onto the stack (no-op if at max depth) */
+  push: (entity: PreviewEntity) => void;
+  /** Pop the top entity off the stack (go back one level) */
+  pop: () => void;
+  /** Navigate to a specific depth in the breadcrumb trail */
+  navigateTo: (depth: number) => void;
+  /** Clear the entire stack (return to panel root) */
+  reset: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_DEPTH = 3;
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useEntityPreviewStack(): UseEntityPreviewStackReturn {
+  const [stack, setStack] = useState<PreviewEntity[]>([]);
+
+  const current = stack.length > 0 ? stack[stack.length - 1] : null;
+  const depth = stack.length;
+  const isAtMaxDepth = depth >= MAX_DEPTH;
+  const isActive = depth > 0;
+
+  const breadcrumbs: Breadcrumb[] = useMemo(
+    () => stack.map((entity, i) => ({ label: entity.label, depth: i + 1 })),
+    [stack],
+  );
+
+  const push = useCallback((entity: PreviewEntity) => {
+    setStack((prev) => {
+      if (prev.length >= MAX_DEPTH) return prev;
+      // Prevent pushing the same entity that's already on top
+      const top = prev[prev.length - 1];
+      if (
+        top &&
+        top.type === entity.type &&
+        top.id === entity.id &&
+        top.secondaryId === entity.secondaryId
+      ) {
+        return prev;
+      }
+      return [...prev, entity];
+    });
+  }, []);
+
+  const pop = useCallback(() => {
+    setStack((prev) => {
+      if (prev.length === 0) return prev;
+      return prev.slice(0, -1);
+    });
+  }, []);
+
+  const navigateTo = useCallback((targetDepth: number) => {
+    setStack((prev) => {
+      if (targetDepth <= 0) return [];
+      if (targetDepth >= prev.length) return prev;
+      return prev.slice(0, targetDepth);
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setStack([]);
+  }, []);
+
+  return {
+    current,
+    stack,
+    breadcrumbs,
+    depth,
+    isAtMaxDepth,
+    isActive,
+    push,
+    pop,
+    navigateTo,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- **Entity preview stack** (`useEntityPreviewStack`) with push/pop/reset, max 3 depth, and breadcrumb trail for inline entity browsing within the Co-Pilot panel
- **EntityPreview** component with Framer Motion slide animations (200ms), breadcrumb navigation, back button, and "Open full page" link -- reuses existing peek drawer variants (DRep, Proposal, Pool, CC Member)
- **MobileIntelSheet** gesture-driven bottom sheet (<1024px) with half/full/close states, spring physics, drag handle, body scroll lock, safe-area-inset-bottom
- **PeekBar** always-visible 40px mobile hint bar showing governance state context (fetched from `/api/intelligence/governance-state`)
- All components respect `prefers-reduced-motion`, are dark-mode optimized, and gated behind `governance_copilot` feature flag

## Dependency
This is Phase 5b of the navigation renaissance. **Merge after Phase 5a** (Panel Shell + Content Router) ships -- these components are designed as self-contained modules that integrate into the panel layout from 5a.

## Impact
- **What changed**: Added 5 new files (4 components + 1 hook) for entity preview navigation and mobile intelligence sheet
- **User-facing**: Yes -- mobile users get a bottom sheet for governance intelligence; panel users get inline entity preview browsing
- **Risk**: Low -- all new code behind feature flag, no existing code modified (only featureFlags.ts doc comment updated)
- **Scope**: `components/governada/panel/` (4 files), `hooks/useEntityPreviewStack.ts`, `lib/featureFlags.ts`

## Test plan
- [ ] Verify `useEntityPreviewStack` push/pop/reset/navigateTo/maxDepth behavior
- [ ] Verify EntityPreview slide animations and breadcrumb rendering
- [ ] Verify MobileIntelSheet drag gestures (half/full/close) on mobile viewport
- [ ] Verify PeekBar fetches governance state and shows context hints
- [ ] Verify `prefers-reduced-motion` disables animations
- [ ] Verify all components render correctly in dark mode
- [ ] Verify feature flag gating (components hidden when `governance_copilot` disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)