### PR TITLE
feat: Governance Co-Pilot panel with AI intelligence briefings

### DIFF
--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -20,6 +20,15 @@ import { useTranslation } from '@/lib/i18n/useTranslation';
 import { useSentryContext } from '@/hooks/useSentryContext';
 import { useSentryFeatureFlags } from '@/hooks/useSentryFeatureFlags';
 import { useGovernanceTemperature } from '@/hooks/useGovernanceTemperature';
+import { useIntelligencePanel } from '@/hooks/useIntelligencePanel';
+
+const IntelligencePanel = dynamic(
+  () =>
+    import('@/components/governada/IntelligencePanel').then((m) => ({
+      default: m.IntelligencePanel,
+    })),
+  { ssr: false },
+);
 
 const ConstellationScene = dynamic(
   () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
@@ -151,7 +160,11 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
   const navigationRailFlag = useFeatureFlag('navigation_rail');
   const navigationRail = navigationRailFlag === true;
   const temporalAdaptation = useFeatureFlag('temporal_adaptation') === true;
+  const governanceCopilotFlag = useFeatureFlag('governance_copilot');
+  const showCopilot = governanceCopilotFlag === true && !isStudioMode;
   const { tintColor } = useGovernanceTemperature();
+  const intelligencePanel = useIntelligencePanel();
+  const panelVisible = showCopilot && intelligencePanel.isOpen && intelligencePanel.canShowPanel;
 
   useEffect(() => {
     const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
@@ -179,7 +192,10 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
           {!isStudioMode && <GovernadaHeader />}
           {!isStudioMode &&
             (navigationRail ? (
-              <NavigationRail />
+              <NavigationRail
+                onToggleCopilot={showCopilot ? intelligencePanel.toggle : undefined}
+                copilotOpen={panelVisible}
+              />
             ) : (
               <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
             ))}
@@ -211,6 +227,7 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
                           sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-60',
                         ),
                 )}
+                style={panelVisible ? { paddingRight: intelligencePanel.panelWidth } : undefined}
                 tabIndex={-1}
               >
                 {children}
@@ -219,6 +236,15 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
               {!isStudioMode && <MilestoneTrigger />}
             </DiscoveryHub>
           </SpotlightProvider>
+          {/* Governance Co-Pilot Intelligence Panel */}
+          {showCopilot && intelligencePanel.canShowPanel && (
+            <IntelligencePanel
+              isOpen={intelligencePanel.isOpen}
+              onClose={intelligencePanel.close}
+              panelWidth={intelligencePanel.panelWidth}
+            />
+          )}
+
           {!isStudioMode && (
             <footer
               className={cn(

--- a/components/governada/IntelligencePanel.tsx
+++ b/components/governada/IntelligencePanel.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+/**
+ * IntelligencePanel — Governance Co-Pilot right-side panel.
+ *
+ * The crown jewel of the Navigation Renaissance. A collapsible right-side
+ * intelligence panel powered by AI-synthesized governance briefings.
+ *
+ * Features:
+ * - Glassmorphic design matching existing shell chrome
+ * - WHOOP-style Governance Readiness Signal at top
+ * - Route-based AI briefings via PanelRouter
+ * - Arc Browser-style compress/expand sections
+ * - Perplexity-style inline source citations
+ * - Responsive width (320px on >=1440px, 280px on 1280-1439px)
+ * - Framer Motion slide animation with reduced-motion fallback
+ * - Density mode support via ModeProvider
+ * - Feature-flagged behind `governance_copilot`
+ */
+
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { X, BrainCircuit } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useIntelligencePanel } from '@/hooks/useIntelligencePanel';
+import { ReadinessSignal } from './panel/ReadinessSignal';
+import { PanelRouter } from './panel/PanelRouter';
+
+interface IntelligencePanelProps {
+  /** Whether the panel is open */
+  isOpen: boolean;
+  /** Close the panel */
+  onClose: () => void;
+  /** Panel width in pixels */
+  panelWidth: number;
+}
+
+export function IntelligencePanel({ isOpen, onClose, panelWidth }: IntelligencePanelProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const { panelRoute, entityId } = useIntelligencePanel();
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.aside
+          initial={prefersReducedMotion ? { opacity: 0 } : { x: panelWidth, opacity: 0 }}
+          animate={prefersReducedMotion ? { opacity: 1 } : { x: 0, opacity: 1 }}
+          exit={prefersReducedMotion ? { opacity: 0 } : { x: panelWidth, opacity: 0 }}
+          transition={{ duration: 0.2, ease: 'easeOut' }}
+          className={cn(
+            'fixed top-10 bottom-0 right-0 z-30',
+            'bg-background/60 backdrop-blur-xl',
+            'border-l border-border/20',
+            'flex flex-col',
+            'overflow-hidden',
+          )}
+          style={{ width: panelWidth }}
+          role="complementary"
+          aria-label="Governance intelligence panel"
+        >
+          {/* Panel Header */}
+          <div className="flex items-center justify-between px-3 py-2 border-b border-border/10 shrink-0">
+            <div className="flex items-center gap-2">
+              <BrainCircuit className="h-4 w-4 text-primary/70" aria-hidden="true" />
+              <h2 className="text-xs font-semibold text-foreground/80">Co-Pilot</h2>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className={cn(
+                'h-6 w-6 flex items-center justify-center rounded-md',
+                'text-muted-foreground/60 hover:text-foreground hover:bg-accent/30',
+                'transition-colors',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+              )}
+              aria-label="Close intelligence panel"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+
+          {/* Governance Readiness Signal */}
+          <ReadinessSignal />
+
+          {/* Scrollable panel content */}
+          <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-border/30 scrollbar-track-transparent">
+            <PanelRouter panelRoute={panelRoute} entityId={entityId} />
+          </div>
+
+          {/* Panel footer — keyboard hint */}
+          <div className="shrink-0 border-t border-border/10 px-3 py-1.5">
+            <p className="text-[10px] text-muted-foreground/40 text-center">
+              Press{' '}
+              <kbd className="px-1 py-0.5 rounded bg-muted/30 text-muted-foreground/50 text-[9px] font-mono">
+                ]
+              </kbd>{' '}
+              to toggle
+            </p>
+          </div>
+        </motion.aside>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/governada/NavigationRail.tsx
+++ b/components/governada/NavigationRail.tsx
@@ -23,7 +23,7 @@ import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { usePinnedItems, type PinnedEntityType } from '@/hooks/usePinnedItems';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { User, FileText, Building2, Shield } from 'lucide-react';
+import { User, FileText, Building2, Shield, BrainCircuit } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -66,7 +66,14 @@ const MAX_RAIL_PINS = 4;
 // Component
 // ---------------------------------------------------------------------------
 
-export function NavigationRail() {
+interface NavigationRailProps {
+  /** Callback to toggle the Co-Pilot panel (only present when governance_copilot flag is on) */
+  onToggleCopilot?: () => void;
+  /** Whether the Co-Pilot panel is currently open */
+  copilotOpen?: boolean;
+}
+
+export function NavigationRail({ onToggleCopilot, copilotOpen }: NavigationRailProps = {}) {
   const pathname = usePathname();
   const { t } = useTranslation();
   const { segment, stakeAddress, drepId, poolId } = useSegment();
@@ -158,6 +165,33 @@ export function NavigationRail() {
 
         {/* Spacer */}
         <div className="flex-1" />
+
+        {/* Co-Pilot toggle */}
+        {onToggleCopilot && (
+          <div className="flex flex-col items-center pb-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onToggleCopilot}
+                  className={cn(
+                    'relative w-10 h-10 flex items-center justify-center rounded-lg transition-colors',
+                    'hover:bg-accent/50',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                    copilotOpen ? 'text-primary bg-primary/10' : 'text-muted-foreground',
+                  )}
+                  aria-label={copilotOpen ? 'Close intelligence panel' : 'Open intelligence panel'}
+                  aria-pressed={copilotOpen}
+                >
+                  <BrainCircuit className="h-4.5 w-4.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={8}>
+                {t('Co-Pilot')} &middot; ]
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
 
         {/* Pinned entities */}
         {visiblePins.length > 0 && (

--- a/components/governada/panel/CitedClaim.tsx
+++ b/components/governada/panel/CitedClaim.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+/**
+ * CitedClaim — Perplexity-style inline source citation.
+ *
+ * Every AI claim in the intelligence panel should use this component
+ * to link back to the source data, providing a provenance chain:
+ * data -> reasoning -> conclusion.
+ */
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+interface Citation {
+  /** Display label for the citation (e.g., "On-chain data", "AI Analysis") */
+  label: string;
+  /** Link to the source (page or API) */
+  href?: string;
+}
+
+interface CitedClaimProps {
+  /** The claim text */
+  children: React.ReactNode;
+  /** Source citations */
+  citations: Citation[];
+  /** Additional class names */
+  className?: string;
+}
+
+export function CitedClaim({ children, citations, className }: CitedClaimProps) {
+  if (citations.length === 0) {
+    return <span className={className}>{children}</span>;
+  }
+
+  return (
+    <span className={cn('inline', className)}>
+      {children}
+      {citations.map((cite, i) => (
+        <sup key={i} className="inline-flex ml-0.5">
+          {cite.href ? (
+            <Link
+              href={cite.href}
+              className={cn(
+                'inline-flex items-center justify-center',
+                'min-w-[14px] h-[14px] px-0.5 rounded-sm',
+                'text-[9px] font-medium leading-none',
+                'bg-primary/15 text-primary hover:bg-primary/25',
+                'transition-colors no-underline',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary',
+              )}
+              title={cite.label}
+            >
+              {i + 1}
+            </Link>
+          ) : (
+            <span
+              className={cn(
+                'inline-flex items-center justify-center',
+                'min-w-[14px] h-[14px] px-0.5 rounded-sm',
+                'text-[9px] font-medium leading-none',
+                'bg-muted/50 text-muted-foreground',
+              )}
+              title={cite.label}
+            >
+              {i + 1}
+            </span>
+          )}
+        </sup>
+      ))}
+    </span>
+  );
+}

--- a/components/governada/panel/CollapsibleSection.tsx
+++ b/components/governada/panel/CollapsibleSection.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * CollapsibleSection — Arc Browser-style compress/expand section.
+ *
+ * Sections default to compressed state (one-line summary).
+ * Click to expand and see full content.
+ * Smooth height animation with reduced-motion fallback.
+ */
+
+import { useState, useCallback, useId } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface CollapsibleSectionProps {
+  /** Section title */
+  title: string;
+  /** One-line summary shown in compressed state */
+  summary?: string;
+  /** Sentiment indicator color */
+  sentiment?: 'positive' | 'neutral' | 'negative';
+  /** Whether the section starts expanded */
+  defaultExpanded?: boolean;
+  /** Content to show when expanded */
+  children: React.ReactNode;
+  /** Additional class names for the wrapper */
+  className?: string;
+}
+
+const SENTIMENT_COLORS = {
+  positive: 'bg-emerald-500',
+  neutral: 'bg-amber-500',
+  negative: 'bg-red-500',
+} as const;
+
+export function CollapsibleSection({
+  title,
+  summary,
+  sentiment,
+  defaultExpanded = false,
+  children,
+  className,
+}: CollapsibleSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const prefersReducedMotion = useReducedMotion();
+  const contentId = useId();
+  const headerId = useId();
+
+  const toggle = useCallback(() => setExpanded((prev) => !prev), []);
+
+  return (
+    <div className={cn('border-b border-border/10 last:border-b-0', className)}>
+      {/* Header — always visible */}
+      <button
+        id={headerId}
+        type="button"
+        onClick={toggle}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        className={cn(
+          'w-full flex items-center gap-2 py-2 px-3 text-left transition-colors',
+          'hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset',
+          'group',
+        )}
+      >
+        {/* Chevron */}
+        <ChevronRight
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200',
+            expanded && 'rotate-90',
+          )}
+          aria-hidden="true"
+        />
+
+        {/* Sentiment dot */}
+        {sentiment && (
+          <span
+            className={cn('h-1.5 w-1.5 rounded-full shrink-0', SENTIMENT_COLORS[sentiment])}
+            aria-hidden="true"
+          />
+        )}
+
+        {/* Title + summary */}
+        <span className="flex-1 min-w-0">
+          <span className="text-xs font-medium text-foreground/80">{title}</span>
+          {!expanded && summary && (
+            <span className="text-xs text-muted-foreground/60 ml-2 truncate">{summary}</span>
+          )}
+        </span>
+      </button>
+
+      {/* Expandable content */}
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            id={contentId}
+            role="region"
+            aria-labelledby={headerId}
+            initial={prefersReducedMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            animate={prefersReducedMotion ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className="overflow-hidden"
+          >
+            <div className="px-3 pb-2 pt-0.5">{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/governada/panel/DRepPanel.tsx
+++ b/components/governada/panel/DRepPanel.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * DRepPanel — Intelligence panel content for individual DRep pages.
+ *
+ * Shows alignment match, score trajectory, key divergences.
+ * Fetches from GET /api/intelligence/context?path=/dreps/[id]
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { CitedClaim } from './CitedClaim';
+import { PanelSkeleton } from './PanelSkeleton';
+import type { ContextSynthesisResult } from '@/lib/intelligence/context';
+import { cn } from '@/lib/utils';
+
+interface DRepPanelProps {
+  entityId?: string;
+}
+
+export function DRepPanel({ entityId }: DRepPanelProps) {
+  const { stakeAddress } = useSegment();
+
+  const { data, isLoading, error } = useQuery<ContextSynthesisResult>({
+    queryKey: ['intelligence-context', 'drep', entityId, stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams({ path: `/dreps/${entityId}` });
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      if (entityId) params.set('entityId', entityId);
+      const res = await fetch(`/api/intelligence/context?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch DRep context');
+      return res.json();
+    },
+    enabled: !!entityId,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (!entityId) {
+    return <div className="px-3 py-4 text-xs text-muted-foreground/60">No DRep selected.</div>;
+  }
+
+  if (isLoading) return <PanelSkeleton sections={3} />;
+
+  if (error || !data) {
+    return (
+      <div className="px-3 py-4 text-xs text-muted-foreground/60">
+        Unable to load DRep intelligence.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* DRep Intelligence */}
+      {data.briefing && (
+        <CollapsibleSection title="DRep Intelligence" defaultExpanded>
+          <p className="text-xs text-muted-foreground/80 leading-relaxed">
+            <CitedClaim
+              citations={[
+                { label: 'DRep profile', href: `/drep/${encodeURIComponent(entityId)}` },
+                { label: 'Scoring engine' },
+              ]}
+            >
+              {data.briefing}
+            </CitedClaim>
+          </p>
+        </CollapsibleSection>
+      )}
+
+      {/* Metrics */}
+      {data.highlights.length > 0 && (
+        <CollapsibleSection
+          title="Performance Signals"
+          summary={data.highlights
+            .map((h) => h.value)
+            .slice(0, 3)
+            .join(' · ')}
+        >
+          <div className="space-y-1.5">
+            {data.highlights.map((highlight, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">{highlight.label}</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    highlight.sentiment === 'positive' && 'text-emerald-400',
+                    highlight.sentiment === 'negative' && 'text-red-400',
+                    highlight.sentiment === 'neutral' && 'text-foreground/80',
+                  )}
+                >
+                  {highlight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/components/governada/panel/DefaultPanel.tsx
+++ b/components/governada/panel/DefaultPanel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * DefaultPanel — Fallback intelligence panel content.
+ *
+ * Shows a generic governance state overview when no route-specific
+ * panel is available. Uses the governance-state API for basic signals.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { PanelSkeleton } from './PanelSkeleton';
+import type { GovernanceStateResult } from '@/lib/intelligence/governance-state';
+import { cn } from '@/lib/utils';
+
+export function DefaultPanel() {
+  const { stakeAddress } = useSegment();
+
+  const { data, isLoading } = useQuery<GovernanceStateResult>({
+    queryKey: ['governance-state', stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      const res = await fetch(`/api/intelligence/governance-state?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch governance state');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading || !data) return <PanelSkeleton sections={2} />;
+
+  return (
+    <div>
+      <CollapsibleSection title="Governance Overview" defaultExpanded>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground/70">Active Proposals</span>
+            <span className="font-medium text-foreground/80">{data.epoch.activeProposalCount}</span>
+          </div>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground/70">Epoch</span>
+            <span className="font-medium text-foreground/80">{data.epoch.currentEpoch}</span>
+          </div>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground/70">Epoch Progress</span>
+            <span className="font-medium text-foreground/80">
+              {Math.round(data.epoch.progress * 100)}%
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground/70">Temperature</span>
+            <span
+              className={cn(
+                'font-medium',
+                data.temperature >= 70
+                  ? 'text-red-400'
+                  : data.temperature >= 40
+                    ? 'text-amber-400'
+                    : 'text-emerald-400',
+              )}
+            >
+              {data.temperature}/100
+            </span>
+          </div>
+        </div>
+      </CollapsibleSection>
+
+      {data.userState && (
+        <CollapsibleSection
+          title="Your Status"
+          summary={data.userState.hasPendingActions ? 'Actions pending' : 'Up to date'}
+        >
+          <div className="space-y-1.5">
+            {data.userState.pendingVotes > 0 && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">Pending Votes</span>
+                <span className="font-medium text-amber-400">{data.userState.pendingVotes}</span>
+              </div>
+            )}
+            {data.userState.drepScore != null && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">DRep Score</span>
+                <span className="font-medium text-foreground/80">
+                  {data.userState.drepScore}/100
+                </span>
+              </div>
+            )}
+            {data.userState.drepRank != null && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">Rank</span>
+                <span className="font-medium text-foreground/80">#{data.userState.drepRank}</span>
+              </div>
+            )}
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground/70">Delegation</span>
+              <span
+                className={cn(
+                  'font-medium',
+                  data.userState.delegatedDrepId ? 'text-emerald-400' : 'text-muted-foreground/60',
+                )}
+              >
+                {data.userState.delegatedDrepId ? 'Active' : 'None'}
+              </span>
+            </div>
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/components/governada/panel/GovernancePanel.tsx
+++ b/components/governada/panel/GovernancePanel.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+/**
+ * GovernancePanel — Intelligence panel content for governance list pages.
+ *
+ * Used on /governance/proposals, /governance/representatives, /governance/health.
+ * Shows temperature, trending signals, alignment-matched content.
+ * Fetches from GET /api/intelligence/context?path=[pathname]
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { CitedClaim } from './CitedClaim';
+import { PanelSkeleton } from './PanelSkeleton';
+import type { ContextSynthesisResult } from '@/lib/intelligence/context';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import type { PanelRoute } from '@/hooks/useIntelligencePanel';
+
+interface GovernancePanelProps {
+  panelRoute: PanelRoute;
+}
+
+const PANEL_TITLES: Record<string, string> = {
+  'proposals-list': 'Proposals Overview',
+  'representatives-list': 'Representatives Overview',
+  health: 'Governance Health',
+  workspace: 'Workspace Intelligence',
+};
+
+const PANEL_PATHS: Record<string, string> = {
+  'proposals-list': '/governance/proposals',
+  'representatives-list': '/governance/representatives',
+  health: '/governance/health',
+  workspace: '/workspace',
+};
+
+export function GovernancePanel({ panelRoute }: GovernancePanelProps) {
+  const { stakeAddress } = useSegment();
+  const contextPath = PANEL_PATHS[panelRoute] ?? '/governance';
+  const title = PANEL_TITLES[panelRoute] ?? 'Governance';
+
+  const { data, isLoading, error } = useQuery<ContextSynthesisResult>({
+    queryKey: ['intelligence-context', contextPath, stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams({ path: contextPath });
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      const res = await fetch(`/api/intelligence/context?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch governance context');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) return <PanelSkeleton sections={2} />;
+
+  if (error || !data) {
+    return (
+      <div className="px-3 py-4 text-xs text-muted-foreground/60">
+        Unable to load governance intelligence.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Briefing */}
+      {data.briefing && (
+        <CollapsibleSection title={title} defaultExpanded>
+          <p className="text-xs text-muted-foreground/80 leading-relaxed">
+            <CitedClaim citations={[{ label: 'Governance data', href: contextPath }]}>
+              {data.briefing}
+            </CitedClaim>
+          </p>
+        </CollapsibleSection>
+      )}
+
+      {/* Highlights */}
+      {data.highlights.length > 0 && (
+        <CollapsibleSection
+          title="Signals"
+          summary={data.highlights.map((h) => h.value).join(' · ')}
+        >
+          <div className="space-y-1.5">
+            {data.highlights.map((highlight, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">{highlight.label}</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    highlight.sentiment === 'positive' && 'text-emerald-400',
+                    highlight.sentiment === 'negative' && 'text-red-400',
+                    highlight.sentiment === 'neutral' && 'text-foreground/80',
+                  )}
+                >
+                  {highlight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Suggested Actions */}
+      {data.suggestedActions.length > 0 && (
+        <CollapsibleSection title="Suggested" summary={`${data.suggestedActions.length} actions`}>
+          <div className="space-y-1">
+            {data.suggestedActions.map((action, i) => (
+              <Link
+                key={i}
+                href={action.href}
+                className={cn(
+                  'flex items-center justify-between py-1.5 px-2 rounded-md text-xs',
+                  'hover:bg-accent/30 transition-colors group',
+                  action.priority === 'high' && 'text-amber-300',
+                  action.priority === 'medium' && 'text-foreground/80',
+                  action.priority === 'low' && 'text-muted-foreground/70',
+                )}
+              >
+                <span>{action.label}</span>
+                <ArrowRight className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Link>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/components/governada/panel/HubPanel.tsx
+++ b/components/governada/panel/HubPanel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * HubPanel — Intelligence panel content for the Hub/home page.
+ *
+ * Shows personalized governance briefing with priority actions.
+ * Fetches from GET /api/intelligence/context?path=/
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { CitedClaim } from './CitedClaim';
+import { PanelSkeleton } from './PanelSkeleton';
+import type { ContextSynthesisResult } from '@/lib/intelligence/context';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+export function HubPanel() {
+  const { stakeAddress } = useSegment();
+
+  const { data, isLoading, error } = useQuery<ContextSynthesisResult>({
+    queryKey: ['intelligence-context', '/', stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams({ path: '/' });
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      const res = await fetch(`/api/intelligence/context?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch hub context');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) return <PanelSkeleton sections={3} />;
+
+  if (error || !data) {
+    return (
+      <div className="px-3 py-4 text-xs text-muted-foreground/60">
+        Unable to load governance briefing. Try refreshing.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Briefing */}
+      {data.briefing && (
+        <CollapsibleSection title="Governance Briefing" defaultExpanded>
+          <p className="text-xs text-muted-foreground/80 leading-relaxed">
+            <CitedClaim citations={[{ label: 'On-chain data', href: '/governance/proposals' }]}>
+              {data.briefing}
+            </CitedClaim>
+          </p>
+        </CollapsibleSection>
+      )}
+
+      {/* Highlights */}
+      {data.highlights.length > 0 && (
+        <CollapsibleSection
+          title="Key Signals"
+          summary={data.highlights.map((h) => h.value).join(' · ')}
+        >
+          <div className="space-y-1.5">
+            {data.highlights.map((highlight, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">{highlight.label}</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    highlight.sentiment === 'positive' && 'text-emerald-400',
+                    highlight.sentiment === 'negative' && 'text-red-400',
+                    highlight.sentiment === 'neutral' && 'text-foreground/80',
+                  )}
+                >
+                  {highlight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Suggested Actions */}
+      {data.suggestedActions.length > 0 && (
+        <CollapsibleSection
+          title="Priority Actions"
+          summary={`${data.suggestedActions.length} actions`}
+        >
+          <div className="space-y-1">
+            {data.suggestedActions.map((action, i) => (
+              <Link
+                key={i}
+                href={action.href}
+                className={cn(
+                  'flex items-center justify-between py-1.5 px-2 rounded-md text-xs',
+                  'hover:bg-accent/30 transition-colors group',
+                  action.priority === 'high' && 'text-amber-300',
+                  action.priority === 'medium' && 'text-foreground/80',
+                  action.priority === 'low' && 'text-muted-foreground/70',
+                )}
+              >
+                <span>{action.label}</span>
+                <ArrowRight className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Link>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/components/governada/panel/PanelRouter.tsx
+++ b/components/governada/panel/PanelRouter.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+/**
+ * PanelRouter — Route-based content switcher for the intelligence panel.
+ *
+ * Renders the appropriate panel component based on the current page route.
+ * Each route gets AI-synthesized briefing content from the intelligence API.
+ */
+
+import type { PanelRoute } from '@/hooks/useIntelligencePanel';
+import { HubPanel } from './HubPanel';
+import { ProposalPanel } from './ProposalPanel';
+import { DRepPanel } from './DRepPanel';
+import { GovernancePanel } from './GovernancePanel';
+import { DefaultPanel } from './DefaultPanel';
+
+interface PanelRouterProps {
+  /** Current panel route */
+  panelRoute: PanelRoute;
+  /** Entity ID for entity-specific panels */
+  entityId?: string;
+}
+
+export function PanelRouter({ panelRoute, entityId }: PanelRouterProps) {
+  switch (panelRoute) {
+    case 'hub':
+      return <HubPanel />;
+    case 'proposal':
+      return <ProposalPanel entityId={entityId} />;
+    case 'drep':
+      return <DRepPanel entityId={entityId} />;
+    case 'proposals-list':
+    case 'representatives-list':
+    case 'health':
+    case 'workspace':
+      return <GovernancePanel panelRoute={panelRoute} />;
+    case 'default':
+    default:
+      return <DefaultPanel />;
+  }
+}

--- a/components/governada/panel/PanelSkeleton.tsx
+++ b/components/governada/panel/PanelSkeleton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * PanelSkeleton — Loading skeleton for panel content.
+ *
+ * Renders a configurable number of section placeholders
+ * with animation to indicate loading state.
+ */
+
+interface PanelSkeletonProps {
+  /** Number of section skeletons to render */
+  sections?: number;
+}
+
+export function PanelSkeleton({ sections = 2 }: PanelSkeletonProps) {
+  return (
+    <div className="animate-pulse" aria-busy="true" aria-label="Loading intelligence briefing">
+      {Array.from({ length: sections }, (_, i) => (
+        <div key={i} className="border-b border-border/10 last:border-b-0 p-3 space-y-2">
+          {/* Title bar */}
+          <div className="flex items-center gap-2">
+            <div className="h-3.5 w-3.5 rounded bg-muted/15" />
+            <div className="h-3 bg-muted/20 rounded w-24" />
+          </div>
+          {/* Content lines */}
+          <div className="space-y-1.5 pl-5">
+            <div className="h-2.5 bg-muted/15 rounded w-full" />
+            <div className="h-2.5 bg-muted/15 rounded w-3/4" />
+            {i === 0 && <div className="h-2.5 bg-muted/15 rounded w-1/2" />}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/governada/panel/ProposalPanel.tsx
+++ b/components/governada/panel/ProposalPanel.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * ProposalPanel — Intelligence panel content for individual proposal pages.
+ *
+ * Shows constitutional concerns, sentiment, DRep position, precedent.
+ * Fetches from GET /api/intelligence/context?path=/proposals/[hash]-[index]
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { CitedClaim } from './CitedClaim';
+import { PanelSkeleton } from './PanelSkeleton';
+import type { ContextSynthesisResult } from '@/lib/intelligence/context';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+interface ProposalPanelProps {
+  entityId?: string;
+}
+
+export function ProposalPanel({ entityId }: ProposalPanelProps) {
+  const { stakeAddress } = useSegment();
+
+  const { data, isLoading, error } = useQuery<ContextSynthesisResult>({
+    queryKey: ['intelligence-context', 'proposal', entityId, stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams({ path: `/proposals/${entityId}` });
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      if (entityId) params.set('entityId', entityId);
+      const res = await fetch(`/api/intelligence/context?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch proposal context');
+      return res.json();
+    },
+    enabled: !!entityId,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (!entityId) {
+    return <div className="px-3 py-4 text-xs text-muted-foreground/60">No proposal selected.</div>;
+  }
+
+  if (isLoading) return <PanelSkeleton sections={3} />;
+
+  if (error || !data) {
+    return (
+      <div className="px-3 py-4 text-xs text-muted-foreground/60">
+        Unable to load proposal intelligence.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* AI Briefing */}
+      {data.briefing && (
+        <CollapsibleSection title="Proposal Intelligence" defaultExpanded>
+          <p className="text-xs text-muted-foreground/80 leading-relaxed">
+            <CitedClaim
+              citations={[
+                { label: 'Proposal data', href: `/proposal/${entityId}/0` },
+                { label: 'Vote aggregation' },
+              ]}
+            >
+              {data.briefing}
+            </CitedClaim>
+          </p>
+        </CollapsibleSection>
+      )}
+
+      {/* Key Metrics */}
+      {data.highlights.length > 0 && (
+        <CollapsibleSection
+          title="Key Metrics"
+          summary={data.highlights
+            .map((h) => `${h.label}: ${h.value}`)
+            .slice(0, 2)
+            .join(' · ')}
+        >
+          <div className="space-y-1.5">
+            {data.highlights.map((highlight, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">{highlight.label}</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    highlight.sentiment === 'positive' && 'text-emerald-400',
+                    highlight.sentiment === 'negative' && 'text-red-400',
+                    highlight.sentiment === 'neutral' && 'text-foreground/80',
+                  )}
+                >
+                  {highlight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Actions */}
+      {data.suggestedActions.length > 0 && (
+        <CollapsibleSection title="Next Steps" summary={`${data.suggestedActions.length} actions`}>
+          <div className="space-y-1">
+            {data.suggestedActions.map((action, i) => (
+              <Link
+                key={i}
+                href={action.href}
+                className={cn(
+                  'flex items-center justify-between py-1.5 px-2 rounded-md text-xs',
+                  'hover:bg-accent/30 transition-colors group',
+                  action.priority === 'high' && 'text-amber-300',
+                  action.priority === 'medium' && 'text-foreground/80',
+                  action.priority === 'low' && 'text-muted-foreground/70',
+                )}
+              >
+                <span>{action.label}</span>
+                <ArrowRight className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Link>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/components/governada/panel/ReadinessSignal.tsx
+++ b/components/governada/panel/ReadinessSignal.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+/**
+ * ReadinessSignal — WHOOP-pattern governance readiness indicator.
+ *
+ * A single compressed visual at the top of the intelligence panel summarizing:
+ * - Delegation health
+ * - Pending actions
+ * - Alignment drift
+ * - Epoch urgency
+ *
+ * Fetches from GET /api/intelligence/governance-state?stakeAddress=[addr]
+ * Uses TanStack Query with 5-minute stale time.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { cn } from '@/lib/utils';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import type { GovernanceStateResult } from '@/lib/intelligence/governance-state';
+
+// ---------------------------------------------------------------------------
+// Readiness computation
+// ---------------------------------------------------------------------------
+
+interface ReadinessData {
+  /** Overall readiness score 0-100 */
+  score: number;
+  /** Semantic label */
+  label: string;
+  /** Color class for the ring/indicator */
+  colorClass: string;
+  /** Stroke color for the SVG ring */
+  strokeColor: string;
+  /** Brief description */
+  summary: string;
+  /** Individual component signals */
+  signals: { label: string; value: string; sentiment: 'good' | 'warn' | 'critical' }[];
+}
+
+function computeReadiness(state: GovernanceStateResult): ReadinessData {
+  const signals: ReadinessData['signals'] = [];
+
+  // Epoch urgency signal
+  const urgency = state.urgency;
+  signals.push({
+    label: 'Urgency',
+    value: urgency >= 70 ? 'High' : urgency >= 40 ? 'Moderate' : 'Low',
+    sentiment: urgency >= 70 ? 'critical' : urgency >= 40 ? 'warn' : 'good',
+  });
+
+  // Epoch progress signal
+  const epochPct = Math.round(state.epoch.progress * 100);
+  signals.push({
+    label: 'Epoch',
+    value: `${epochPct}%`,
+    sentiment: epochPct >= 80 ? 'warn' : 'good',
+  });
+
+  // Active proposals signal
+  const activeCount = state.epoch.activeProposalCount;
+  signals.push({
+    label: 'Active',
+    value: `${activeCount} proposal${activeCount === 1 ? '' : 's'}`,
+    sentiment: activeCount > 10 ? 'warn' : 'good',
+  });
+
+  // User-specific signals
+  if (state.userState) {
+    if (state.userState.pendingVotes > 0) {
+      signals.push({
+        label: 'Pending',
+        value: `${state.userState.pendingVotes} vote${state.userState.pendingVotes === 1 ? '' : 's'}`,
+        sentiment: state.userState.pendingVotes > 3 ? 'critical' : 'warn',
+      });
+    }
+
+    if (state.userState.delegatedDrepId) {
+      signals.push({
+        label: 'Delegation',
+        value: 'Active',
+        sentiment: 'good',
+      });
+    } else if (state.userState.drepScore === null) {
+      // Not a DRep and not delegated
+      signals.push({
+        label: 'Delegation',
+        value: 'None',
+        sentiment: 'warn',
+      });
+    }
+  }
+
+  // Composite readiness score
+  // Higher = more governance attention needed (inverted from "readiness" to "attention")
+  let score = 50; // baseline
+  score += (urgency / 100) * 30; // urgency contributes 0-30
+  if (state.userState?.pendingVotes) {
+    score += Math.min(20, state.userState.pendingVotes * 5); // pending votes contribute 0-20
+  }
+  score = Math.min(100, Math.max(0, Math.round(score)));
+
+  // Invert: readiness = 100 - attention needed
+  const readiness = 100 - score;
+
+  let label: string;
+  let colorClass: string;
+  let strokeColor: string;
+  if (readiness >= 70) {
+    label = 'Ready';
+    colorClass = 'text-emerald-400';
+    strokeColor = '#34d399';
+  } else if (readiness >= 40) {
+    label = 'Attention';
+    colorClass = 'text-amber-400';
+    strokeColor = '#fbbf24';
+  } else {
+    label = 'Action Needed';
+    colorClass = 'text-red-400';
+    strokeColor = '#f87171';
+  }
+
+  const summaryParts: string[] = [];
+  if (state.userState?.pendingVotes) {
+    summaryParts.push(
+      `${state.userState.pendingVotes} pending vote${state.userState.pendingVotes === 1 ? '' : 's'}`,
+    );
+  }
+  if (urgency >= 70) {
+    summaryParts.push('urgent governance activity');
+  }
+  if (epochPct >= 80) {
+    summaryParts.push('epoch ending soon');
+  }
+  const summary = summaryParts.length > 0 ? summaryParts.join(' · ') : 'Governance is stable';
+
+  return { score: readiness, label, colorClass, strokeColor, summary, signals };
+}
+
+// ---------------------------------------------------------------------------
+// Readiness Ring SVG
+// ---------------------------------------------------------------------------
+
+function ReadinessRing({
+  score,
+  strokeColor,
+  size = 48,
+}: {
+  score: number;
+  strokeColor: string;
+  size?: number;
+}) {
+  const radius = (size - 6) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = (score / 100) * circumference;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="transform -rotate-90"
+      aria-hidden="true"
+    >
+      {/* Background ring */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={3}
+        className="text-muted/20"
+      />
+      {/* Progress ring */}
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke={strokeColor}
+        strokeWidth={3}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference - progress}
+        className="transition-all duration-500"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function ReadinessSkeleton() {
+  return (
+    <div className="flex items-center gap-3 p-3 animate-pulse" aria-busy="true">
+      <div className="w-12 h-12 rounded-full bg-muted/20" />
+      <div className="flex-1 space-y-1.5">
+        <div className="h-3 bg-muted/20 rounded w-20" />
+        <div className="h-2.5 bg-muted/15 rounded w-32" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ReadinessSignal() {
+  const { stakeAddress } = useSegment();
+
+  const { data: governanceState, isLoading } = useQuery<GovernanceStateResult>({
+    queryKey: ['governance-state', stakeAddress],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (stakeAddress) params.set('stakeAddress', stakeAddress);
+      const res = await fetch(`/api/intelligence/governance-state?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch governance state');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading || !governanceState) {
+    return <ReadinessSkeleton />;
+  }
+
+  const readiness = computeReadiness(governanceState);
+
+  return (
+    <div
+      className="flex items-center gap-3 p-3 border-b border-border/10"
+      role="status"
+      aria-label={`Governance readiness: ${readiness.label}, ${readiness.score}%`}
+    >
+      {/* Ring with score */}
+      <div className="relative shrink-0">
+        <ReadinessRing score={readiness.score} strokeColor={readiness.strokeColor} size={48} />
+        <span
+          className={cn(
+            'absolute inset-0 flex items-center justify-center text-sm font-semibold',
+            readiness.colorClass,
+          )}
+        >
+          {readiness.score}
+        </span>
+      </div>
+
+      {/* Label + summary */}
+      <div className="flex-1 min-w-0">
+        <p className={cn('text-xs font-semibold', readiness.colorClass)}>{readiness.label}</p>
+        <p className="text-[11px] text-muted-foreground/70 truncate">{readiness.summary}</p>
+      </div>
+    </div>
+  );
+}

--- a/hooks/useIntelligencePanel.ts
+++ b/hooks/useIntelligencePanel.ts
@@ -1,0 +1,184 @@
+'use client';
+
+/**
+ * useIntelligencePanel — Panel state management for the Governance Co-Pilot.
+ *
+ * Manages:
+ * - Open/closed state (persisted in localStorage)
+ * - Current route detection for panel content routing
+ * - Responsive width based on viewport
+ * - Toggle function (wired to `]` keyboard shortcut + rail icon)
+ * - CustomEvent listener for ShortcutProvider integration
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { usePathname } from 'next/navigation';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'governada_intelligence_panel';
+const PANEL_WIDTH_LARGE = 320; // >=1440px
+const PANEL_WIDTH_MEDIUM = 280; // 1280-1439px
+const BREAKPOINT_LARGE = 1440;
+const BREAKPOINT_MEDIUM = 1280;
+
+// ---------------------------------------------------------------------------
+// Route types for panel content routing
+// ---------------------------------------------------------------------------
+
+export type PanelRoute =
+  | 'hub'
+  | 'proposal'
+  | 'drep'
+  | 'proposals-list'
+  | 'representatives-list'
+  | 'health'
+  | 'workspace'
+  | 'default';
+
+function detectPanelRoute(pathname: string): PanelRoute {
+  if (pathname === '/' || pathname === '/hub') return 'hub';
+  if (/^\/proposal\/[^/]+\/\d+/.test(pathname)) return 'proposal';
+  if (/^\/drep\/[^/]+/.test(pathname)) return 'drep';
+  if (pathname === '/governance/proposals' || pathname === '/proposals') return 'proposals-list';
+  if (pathname === '/governance/representatives' || pathname === '/representatives')
+    return 'representatives-list';
+  if (pathname === '/governance/health') return 'health';
+  if (pathname.startsWith('/workspace')) return 'workspace';
+  return 'default';
+}
+
+/**
+ * Extract entity ID from pathname for intelligence API calls.
+ */
+function extractEntityId(pathname: string): string | undefined {
+  // /proposal/[hash]/[index]
+  const proposalMatch = pathname.match(/^\/proposal\/([a-f0-9]+)\/(\d+)/);
+  if (proposalMatch) return proposalMatch[1];
+
+  // /drep/[id]
+  const drepMatch = pathname.match(/^\/drep\/([^/]+)/);
+  if (drepMatch) return decodeURIComponent(drepMatch[1]);
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseIntelligencePanelResult {
+  /** Whether the panel is open */
+  isOpen: boolean;
+  /** Toggle the panel open/closed */
+  toggle: () => void;
+  /** Open the panel */
+  open: () => void;
+  /** Close the panel */
+  close: () => void;
+  /** Current panel route (determines content) */
+  panelRoute: PanelRoute;
+  /** Entity ID extracted from current route (for API calls) */
+  entityId: string | undefined;
+  /** Panel width in pixels (responsive to viewport) */
+  panelWidth: number;
+  /** Whether the viewport is wide enough for the panel */
+  canShowPanel: boolean;
+}
+
+export function useIntelligencePanel(): UseIntelligencePanelResult {
+  const pathname = usePathname();
+  const [isOpen, setIsOpen] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(0);
+
+  // Restore persisted state on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === 'true') setIsOpen(true);
+    } catch {
+      // localStorage unavailable
+    }
+    setViewportWidth(window.innerWidth);
+  }, []);
+
+  // Track viewport width
+  useEffect(() => {
+    function handleResize() {
+      setViewportWidth(window.innerWidth);
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Listen for CustomEvent from ShortcutProvider
+  useEffect(() => {
+    function handleToggle() {
+      setIsOpen((prev) => {
+        const next = !prev;
+        try {
+          localStorage.setItem(STORAGE_KEY, String(next));
+        } catch {
+          // localStorage unavailable
+        }
+        return next;
+      });
+    }
+    window.addEventListener('toggleIntelligencePanel', handleToggle);
+    return () => window.removeEventListener('toggleIntelligencePanel', handleToggle);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {
+        // localStorage unavailable
+      }
+      return next;
+    });
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, 'false');
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  const panelRoute = useMemo(() => detectPanelRoute(pathname), [pathname]);
+  const entityId = useMemo(() => extractEntityId(pathname), [pathname]);
+
+  const canShowPanel = viewportWidth >= BREAKPOINT_MEDIUM;
+  const panelWidth =
+    viewportWidth >= BREAKPOINT_LARGE
+      ? PANEL_WIDTH_LARGE
+      : viewportWidth >= BREAKPOINT_MEDIUM
+        ? PANEL_WIDTH_MEDIUM
+        : PANEL_WIDTH_LARGE; // fallback (hidden anyway)
+
+  return {
+    isOpen,
+    toggle,
+    open,
+    close,
+    panelRoute,
+    entityId,
+    panelWidth,
+    canShowPanel,
+  };
+}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -33,6 +33,7 @@
  * temporal_adaptation             — Governance temporal mode + ambient temperature tinting (Phase 6)
  * peek_drawer                    — Entity peek drawer on list pages (Phase 3 nav renaissance)
  * keyboard_shortcuts              — Global keyboard shortcut system with chords and help overlay (Phase 8)
+ * governance_copilot               — Right-side intelligence panel with AI governance briefings (Phase 5)
  *
  * ---------------------------------------------------------------------------
  * RETIRED FLAGS (code checks removed or hardcoded)


### PR DESCRIPTION
## Summary
- Adds the Governance Co-Pilot intelligence panel (Phase 5a of Navigation Renaissance) -- a collapsible right-side panel powered by Phase 4 AI synthesis APIs
- WHOOP-pattern governance readiness signal at panel top, route-based AI briefings (Hub/Proposal/DRep/Governance lists), Arc Browser compress/expand sections, Perplexity-style inline citations
- Integrated into GovernadaShell with responsive width (320px/280px), NavigationRail toggle icon, `]` keyboard shortcut, and `governance_copilot` feature flag

## Impact
- **What changed**: New intelligence panel shell with AI-powered contextual governance briefings, route-aware content switching, and governance readiness signal
- **User-facing**: Yes -- when `governance_copilot` flag is enabled, users see a collapsible right panel with personalized governance intelligence. Hidden by default behind feature flag.
- **Risk**: Low -- entirely additive, behind feature flag, no existing behavior changed. Panel hidden in studio mode and on screens < 1280px.
- **Scope**: 12 new files (panel components + hook), 3 modified files (GovernadaShell, NavigationRail, featureFlags). No migrations, no API changes, no Inngest functions.

## New Files
- `components/governada/IntelligencePanel.tsx` -- panel shell with glassmorphic styling and Framer Motion animation
- `components/governada/panel/ReadinessSignal.tsx` -- WHOOP-pattern governance readiness ring
- `components/governada/panel/PanelRouter.tsx` -- route-based content switcher
- `components/governada/panel/HubPanel.tsx` -- Hub page intelligence briefing
- `components/governada/panel/ProposalPanel.tsx` -- Proposal page intelligence
- `components/governada/panel/DRepPanel.tsx` -- DRep page intelligence
- `components/governada/panel/GovernancePanel.tsx` -- List page governance briefing
- `components/governada/panel/DefaultPanel.tsx` -- Fallback governance overview
- `components/governada/panel/CollapsibleSection.tsx` -- Arc-style compress/expand
- `components/governada/panel/CitedClaim.tsx` -- Perplexity-style inline citations
- `components/governada/panel/PanelSkeleton.tsx` -- Loading skeleton
- `hooks/useIntelligencePanel.ts` -- Panel state management

## Test plan
- [ ] Enable `governance_copilot` feature flag in admin
- [ ] Verify panel appears on desktop (>= 1280px) with NavigationRail toggle
- [ ] Verify `]` keyboard shortcut toggles panel
- [ ] Verify readiness signal shows governance state data
- [ ] Navigate to different routes and verify panel content updates
- [ ] Verify panel hidden in studio mode pages
- [ ] Verify panel hidden on screens < 1280px
- [ ] Verify `prefers-reduced-motion` disables slide animation
- [ ] Verify panel state persists across page navigation (localStorage)
- [ ] Verify density modes affect panel spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)