### PR TITLE
feat: conversational governance advisor in command palette (Phase 9)

### DIFF
--- a/app/api/intelligence/advisor/route.ts
+++ b/app/api/intelligence/advisor/route.ts
@@ -1,0 +1,203 @@
+/**
+ * POST /api/intelligence/advisor — Streaming SSE endpoint for the governance advisor.
+ *
+ * Accepts a conversation history and governance context, streams an AI-generated
+ * response with entity references and actionable insights.
+ *
+ * Authentication is optional — anonymous users get generic responses,
+ * authenticated users get personalized governance intelligence.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { validateSessionToken } from '@/lib/supabaseAuth';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import {
+  streamAdvisorResponse,
+  type ConversationMessage,
+  type AdvisorContext,
+} from '@/lib/intelligence/advisor';
+import { logger } from '@/lib/logger';
+
+export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+const MessageSchema = z.object({
+  role: z.enum(['user', 'assistant']),
+  content: z.string().min(1).max(4000),
+});
+
+const AdvisorRequestSchema = z.object({
+  messages: z.array(MessageSchema).min(1).max(20),
+  context: z.object({
+    epoch: z.number(),
+    daysRemaining: z.number(),
+    activeProposalCount: z.number(),
+    segment: z.string(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting (simple in-memory, per-IP or per-user)
+// ---------------------------------------------------------------------------
+
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT_MAX = 20; // 20 advisor queries per minute
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+function checkRateLimit(key: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) return false;
+  entry.count++;
+  return true;
+}
+
+// Evict stale entries periodically
+function evictStaleEntries() {
+  if (rateLimitMap.size > 500) {
+    const now = Date.now();
+    for (const [key, entry] of rateLimitMap) {
+      if (now > entry.resetAt) rateLimitMap.delete(key);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Governance snapshot builder
+// ---------------------------------------------------------------------------
+
+async function buildGovernanceSnapshot(ctx: {
+  epoch: number;
+  activeProposalCount: number;
+}): Promise<string> {
+  try {
+    const supabase = getSupabaseAdmin();
+
+    // Fetch active proposals summary
+    const { data: proposals } = await supabase
+      .from('proposals')
+      .select('title, type, status, tx_hash, index')
+      .in('status', ['active', 'voting'])
+      .order('created_at', { ascending: false })
+      .limit(20);
+
+    const lines: string[] = [];
+
+    if (proposals && proposals.length > 0) {
+      lines.push(`Active proposals (${proposals.length}):`);
+      for (const p of proposals) {
+        lines.push(
+          `- [${p.type}] "${p.title}" (${p.status}) — /governance/proposals/${p.tx_hash}#${p.index}`,
+        );
+      }
+    } else {
+      lines.push(`Active proposals: ${ctx.activeProposalCount} (details unavailable)`);
+    }
+
+    return lines.join('\n');
+  } catch (err) {
+    logger.warn('[Advisor] Failed to build governance snapshot', { error: err });
+    return `Current epoch: ${ctx.epoch}. Active proposals: ${ctx.activeProposalCount}.`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest): Promise<Response> {
+  try {
+    // --- Feature flag check ---
+    const enabled = await getFeatureFlag('conversational_nav', false);
+    if (!enabled) {
+      return NextResponse.json(
+        { error: 'Conversational navigation is not enabled' },
+        { status: 403 },
+      );
+    }
+
+    // --- Rate limit ---
+    evictStaleEntries();
+    const rateLimitKey =
+      request.headers.get('x-forwarded-for') ?? request.headers.get('x-real-ip') ?? 'anonymous';
+    if (!checkRateLimit(rateLimitKey)) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again in a moment.' },
+        { status: 429 },
+      );
+    }
+
+    // --- Parse request ---
+    const body = await request.json();
+    const parsed = AdvisorRequestSchema.parse(body);
+
+    // --- Optional auth for personalization ---
+    let personalContext: string | undefined;
+    const auth = request.headers.get('authorization');
+    if (auth?.startsWith('Bearer ')) {
+      try {
+        const session = await validateSessionToken(auth.slice(7));
+        if (session) {
+          const { assemblePersonalContext, formatPersonalContext } =
+            await import('@/lib/ai/context');
+          const ctx = await assemblePersonalContext(
+            session.walletAddress,
+            parsed.context.segment as 'drep' | 'spo' | 'citizen',
+          );
+          personalContext = formatPersonalContext(ctx);
+        }
+      } catch {
+        // Non-critical: continue without personal context
+      }
+    }
+
+    // --- Build governance snapshot ---
+    const governanceSnapshot = await buildGovernanceSnapshot(parsed.context);
+
+    // --- Build advisor context ---
+    const advisorContext: AdvisorContext = {
+      epoch: parsed.context.epoch,
+      daysRemaining: parsed.context.daysRemaining,
+      activeProposalCount: parsed.context.activeProposalCount,
+      segment: parsed.context.segment,
+      personalContext,
+      governanceSnapshot,
+    };
+
+    // --- Stream response ---
+    const stream = await streamAdvisorResponse({
+      messages: parsed.messages as ConversationMessage[],
+      context: advisorContext,
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: err.issues.map((e) => e.message) },
+        { status: 400 },
+      );
+    }
+
+    logger.error('[Advisor] Request error', { error: err });
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Command } from 'cmdk';
 import { useRouter, usePathname } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Search, ArrowRight, Clock } from 'lucide-react';
+import { Search, ArrowRight, Clock, Bot } from 'lucide-react';
 import { useWallet } from '@/utils/wallet';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { useEpochContext } from '@/hooks/useEpochContext';
@@ -13,6 +13,9 @@ import { useLocale } from '@/components/providers/LocaleProvider';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { SUPPORTED_LOCALES, LOCALE_NAMES, type SupportedLocale } from '@/lib/i18n/config';
 import { getStoredSession } from '@/lib/supabaseAuth';
+import { useFeatureFlag } from '@/components/FeatureGate';
+import { isConversationalQuery } from '@/lib/intelligence/advisor';
+import { ConversationThread } from '@/components/commandpalette/ConversationThread';
 import type { GovernanceDepth } from '@/lib/governanceTuner';
 import { cn } from '@/lib/utils';
 import {
@@ -76,6 +79,8 @@ function useTrackDestinations() {
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const [conversationalMode, setConversationalMode] = useState(false);
+  const [conversationalQuery, setConversationalQuery] = useState('');
   const router = useRouter();
   const { t } = useTranslation();
   const { isAuthenticated, logout } = useWallet();
@@ -84,9 +89,28 @@ export function CommandPalette() {
   const { depth } = useGovernanceDepth();
   const { locale, setLocale } = useLocale();
   const queryClient = useQueryClient();
+  const conversationalNavEnabled = useFeatureFlag('conversational_nav');
 
   // Track page visits for recent destinations
   useTrackDestinations();
+
+  // Reset conversational mode when palette closes
+  useEffect(() => {
+    if (!open) {
+      setConversationalMode(false);
+      setConversationalQuery('');
+    }
+  }, [open]);
+
+  // Listen for closeCommandPalette events (from AI response entity cards)
+  useEffect(() => {
+    const handler = () => {
+      setOpen(false);
+      setQuery('');
+    };
+    window.addEventListener('closeCommandPalette', handler);
+    return () => window.removeEventListener('closeCommandPalette', handler);
+  }, []);
 
   // Recent destinations state — refreshed when palette opens
   const [recentItems, setRecentItems] = useState<RecentDestination[]>([]);
@@ -257,6 +281,25 @@ export function CommandPalette() {
     activeProposalCount !== null ? `${activeProposalCount} active proposals` : '';
   const contextLine = [epochLabel, timeLabel, proposalLabel].filter(Boolean).join(' \u00B7 ');
 
+  // ── Conversational query detection ────────────────────────────────────
+  const isQueryConversational =
+    conversationalNavEnabled && q.length >= 8 && isConversationalQuery(q);
+
+  // Activate conversational mode on Enter when query looks like a question
+  const handleConversationalSubmit = useCallback(() => {
+    if (isQueryConversational && !conversationalMode) {
+      setConversationalQuery(query.trim());
+      setConversationalMode(true);
+      setQuery('');
+    }
+  }, [isQueryConversational, conversationalMode, query]);
+
+  // Exit conversational mode back to search
+  const handleExitConversational = useCallback(() => {
+    setConversationalMode(false);
+    setConversationalQuery('');
+  }, []);
+
   // ── Select handler ─────────────────────────────────────────────────────
   const onSelect = useCallback(
     (item: CommandItem) => {
@@ -303,231 +346,291 @@ export function CommandPalette() {
             {contextLine}
           </div>
 
-          {/* Input */}
-          <div className="flex items-center gap-3 border-b border-border/50 px-4">
-            <Search className="h-4 w-4 text-muted-foreground shrink-0" />
-            <Command.Input
-              value={query}
-              onValueChange={setQuery}
-              placeholder={t('Search DReps, proposals, pages...')}
-              className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          {/* Conversational mode — show AI thread instead of command list */}
+          {conversationalMode ? (
+            <ConversationThread
+              initialQuery={conversationalQuery}
+              onExit={handleExitConversational}
+              onClose={() => setOpen(false)}
             />
-            <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
-              ESC
-            </kbd>
-          </div>
+          ) : (
+            <>
+              {/* Input */}
+              <div className="flex items-center gap-3 border-b border-border/50 px-4">
+                {isQueryConversational ? (
+                  <Bot className="h-4 w-4 text-primary shrink-0" />
+                ) : (
+                  <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+                )}
+                <Command.Input
+                  value={query}
+                  onValueChange={setQuery}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter' && isQueryConversational) {
+                      e.preventDefault();
+                      handleConversationalSubmit();
+                    }
+                  }}
+                  placeholder={t('Search DReps, proposals, pages...')}
+                  className="flex-1 h-12 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                />
+                {isQueryConversational && (
+                  <span className="text-[10px] text-primary font-medium whitespace-nowrap">
+                    &#8629; Ask AI
+                  </span>
+                )}
+                <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 rounded border border-border/50 bg-muted/50 px-1.5 font-mono text-[10px] text-muted-foreground">
+                  ESC
+                </kbd>
+              </div>
 
-          {/* Results */}
-          <Command.List className="max-h-[360px] overflow-y-auto p-2">
-            <Command.Empty className="py-8 text-center text-sm text-muted-foreground">
-              {t('No results found.')}
-            </Command.Empty>
-
-            {/* Recent destinations (empty query only) */}
-            {visibleRecents.length > 0 && (
-              <Command.Group heading={t('Recent')} className={groupCls}>
-                {visibleRecents.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={item.id}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
+              {/* Results */}
+              <Command.List className="max-h-[360px] overflow-y-auto p-2">
+                <Command.Empty className="py-8 text-center text-sm text-muted-foreground">
+                  {isQueryConversational ? (
+                    <button
+                      onClick={handleConversationalSubmit}
+                      className="flex flex-col items-center gap-2 mx-auto hover:text-foreground transition-colors"
                     >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground/60 shrink-0" />}
-                      <span className="flex-1 truncate">{item.label}</span>
-                      <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
-
-            {/* DRep results */}
-            {drepResults.length > 0 && (
-              <Command.Group heading={t('DReps')} className={groupCls}>
-                {drepResults.map((item) => (
-                  <Command.Item
-                    key={item.id}
-                    value={item.id}
-                    onSelect={() => onSelect(item)}
-                    className={cn(itemCls, 'py-2.5')}
-                  >
-                    {item.score !== undefined && (
-                      <span className="inline-flex items-center justify-center h-6 w-6 rounded text-[10px] font-bold font-mono bg-primary/10 text-primary shrink-0">
-                        {item.score}
+                      <Bot className="h-6 w-6 text-primary" />
+                      <span>
+                        Press{' '}
+                        <kbd className="font-mono bg-muted px-1 py-0.5 rounded text-xs">Enter</kbd>{' '}
+                        to ask the Governance Advisor
                       </span>
-                    )}
-                    <span className="flex-1 truncate">{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-xs text-muted-foreground font-mono">
-                        ${item.sublabel}
+                    </button>
+                  ) : (
+                    t('No results found.')
+                  )}
+                </Command.Empty>
+
+                {/* Recent destinations (empty query only) */}
+                {visibleRecents.length > 0 && (
+                  <Command.Group heading={t('Recent')} className={groupCls}>
+                    {visibleRecents.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={item.id}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground/60 shrink-0" />}
+                          <span className="flex-1 truncate">{item.label}</span>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* DRep results */}
+                {drepResults.length > 0 && (
+                  <Command.Group heading={t('DReps')} className={groupCls}>
+                    {drepResults.map((item) => (
+                      <Command.Item
+                        key={item.id}
+                        value={item.id}
+                        onSelect={() => onSelect(item)}
+                        className={cn(itemCls, 'py-2.5')}
+                      >
+                        {item.score !== undefined && (
+                          <span className="inline-flex items-center justify-center h-6 w-6 rounded text-[10px] font-bold font-mono bg-primary/10 text-primary shrink-0">
+                            {item.score}
+                          </span>
+                        )}
+                        <span className="flex-1 truncate">{item.label}</span>
+                        {item.sublabel && (
+                          <span className="text-xs text-muted-foreground font-mono">
+                            ${item.sublabel}
+                          </span>
+                        )}
+                        <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                      </Command.Item>
+                    ))}
+                  </Command.Group>
+                )}
+
+                {/* Proposal results */}
+                {proposalResults.length > 0 && (
+                  <Command.Group heading={t('Proposals')} className={groupCls}>
+                    {proposalResults.map((item) => (
+                      <Command.Item
+                        key={item.id}
+                        value={item.id}
+                        onSelect={() => onSelect(item)}
+                        className={cn(itemCls, 'py-2.5')}
+                      >
+                        <span className="flex-1 truncate">{item.label}</span>
+                        {item.sublabel && (
+                          <span className="text-xs text-muted-foreground capitalize">
+                            {item.sublabel}
+                          </span>
+                        )}
+                        <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                      </Command.Item>
+                    ))}
+                  </Command.Group>
+                )}
+
+                {/* Governance actions (persona-specific) */}
+                {visibleGovActions.length > 0 && (
+                  <Command.Group heading={t('Governance')} className={groupCls}>
+                    {visibleGovActions.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={`${item.id} ${item.label}`}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                          <span className="flex-1">{t(item.label)}</span>
+                          {item.sublabel && (
+                            <span className="text-xs text-muted-foreground truncate max-w-[160px]">
+                              {t(item.sublabel)}
+                            </span>
+                          )}
+                          <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* Pages */}
+                {visiblePages.length > 0 && (
+                  <Command.Group heading={t('Pages')} className={groupCls}>
+                    {visiblePages.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={`${item.id} ${item.label}`}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                          <span className="flex-1">{t(item.label)}</span>
+                          {item.shortcut && (
+                            <kbd className="ml-auto text-[10px] text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded font-mono">
+                              {item.shortcut}
+                            </kbd>
+                          )}
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* Help */}
+                {visibleHelp.length > 0 && (
+                  <Command.Group heading={t('Help')} className={groupCls}>
+                    {visibleHelp.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={`${item.id} ${item.label}`}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                          <span className="flex-1">{t(item.label)}</span>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* Actions */}
+                {visibleActions.length > 0 && (
+                  <Command.Group heading={t('Actions')} className={groupCls}>
+                    {visibleActions.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={`${item.id} ${item.label}`}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                          <span className="flex-1">{t(item.label)}</span>
+                          {item.shortcut && (
+                            <kbd className="ml-auto text-[10px] text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded font-mono">
+                              {item.shortcut}
+                            </kbd>
+                          )}
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* Settings (depth + language — shown only when searching) */}
+                {visibleSettings.length > 0 && (
+                  <Command.Group heading={t('Settings')} className={groupCls}>
+                    {visibleSettings.map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <Command.Item
+                          key={item.id}
+                          value={`${item.id} ${item.label}`}
+                          onSelect={() => onSelect(item)}
+                          className={itemCls}
+                        >
+                          {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
+                          <span className="flex-1">{t(item.label)}</span>
+                          {item.sublabel && (
+                            <span className="text-xs text-muted-foreground truncate max-w-[160px]">
+                              {t(item.sublabel)}
+                            </span>
+                          )}
+                        </Command.Item>
+                      );
+                    })}
+                  </Command.Group>
+                )}
+
+                {/* AI Advisor suggestion — shown when query looks conversational */}
+                {isQueryConversational && (
+                  <Command.Group heading="AI Advisor" className={groupCls}>
+                    <Command.Item
+                      value="ask-advisor"
+                      onSelect={handleConversationalSubmit}
+                      className={cn(itemCls, 'border border-primary/20 bg-primary/5')}
+                    >
+                      <Bot className="h-4 w-4 text-primary shrink-0" />
+                      <span className="flex-1 text-primary">
+                        Ask: &ldquo;{query.trim().slice(0, 60)}
+                        {query.trim().length > 60 ? '...' : ''}&rdquo;
                       </span>
-                    )}
-                    <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
-                  </Command.Item>
-                ))}
-              </Command.Group>
-            )}
-
-            {/* Proposal results */}
-            {proposalResults.length > 0 && (
-              <Command.Group heading={t('Proposals')} className={groupCls}>
-                {proposalResults.map((item) => (
-                  <Command.Item
-                    key={item.id}
-                    value={item.id}
-                    onSelect={() => onSelect(item)}
-                    className={cn(itemCls, 'py-2.5')}
-                  >
-                    <span className="flex-1 truncate">{item.label}</span>
-                    {item.sublabel && (
-                      <span className="text-xs text-muted-foreground capitalize">
-                        {item.sublabel}
-                      </span>
-                    )}
-                    <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
-                  </Command.Item>
-                ))}
-              </Command.Group>
-            )}
-
-            {/* Governance actions (persona-specific) */}
-            {visibleGovActions.length > 0 && (
-              <Command.Group heading={t('Governance')} className={groupCls}>
-                {visibleGovActions.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={`${item.id} ${item.label}`}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
-                    >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
-                      <span className="flex-1">{t(item.label)}</span>
-                      {item.sublabel && (
-                        <span className="text-xs text-muted-foreground truncate max-w-[160px]">
-                          {t(item.sublabel)}
-                        </span>
-                      )}
-                      <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                      <kbd className="text-[10px] text-primary/60 bg-primary/10 px-1.5 py-0.5 rounded font-mono">
+                        &#8629;
+                      </kbd>
                     </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
+                  </Command.Group>
+                )}
+              </Command.List>
 
-            {/* Pages */}
-            {visiblePages.length > 0 && (
-              <Command.Group heading={t('Pages')} className={groupCls}>
-                {visiblePages.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={`${item.id} ${item.label}`}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
-                    >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
-                      <span className="flex-1">{t(item.label)}</span>
-                      {item.shortcut && (
-                        <kbd className="ml-auto text-[10px] text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded font-mono">
-                          {item.shortcut}
-                        </kbd>
-                      )}
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
-
-            {/* Help */}
-            {visibleHelp.length > 0 && (
-              <Command.Group heading={t('Help')} className={groupCls}>
-                {visibleHelp.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={`${item.id} ${item.label}`}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
-                    >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
-                      <span className="flex-1">{t(item.label)}</span>
-                      <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
-
-            {/* Actions */}
-            {visibleActions.length > 0 && (
-              <Command.Group heading={t('Actions')} className={groupCls}>
-                {visibleActions.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={`${item.id} ${item.label}`}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
-                    >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
-                      <span className="flex-1">{t(item.label)}</span>
-                      {item.shortcut && (
-                        <kbd className="ml-auto text-[10px] text-muted-foreground/60 bg-muted px-1.5 py-0.5 rounded font-mono">
-                          {item.shortcut}
-                        </kbd>
-                      )}
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
-
-            {/* Settings (depth + language — shown only when searching) */}
-            {visibleSettings.length > 0 && (
-              <Command.Group heading={t('Settings')} className={groupCls}>
-                {visibleSettings.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Command.Item
-                      key={item.id}
-                      value={`${item.id} ${item.label}`}
-                      onSelect={() => onSelect(item)}
-                      className={itemCls}
-                    >
-                      {Icon && <Icon className="h-4 w-4 text-muted-foreground shrink-0" />}
-                      <span className="flex-1">{t(item.label)}</span>
-                      {item.sublabel && (
-                        <span className="text-xs text-muted-foreground truncate max-w-[160px]">
-                          {t(item.sublabel)}
-                        </span>
-                      )}
-                    </Command.Item>
-                  );
-                })}
-              </Command.Group>
-            )}
-          </Command.List>
-
-          {/* Footer */}
-          <div
-            className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[10px] text-muted-foreground"
-            aria-hidden="true"
-          >
-            <span>
-              <kbd className="font-mono">&#8593;&#8595;</kbd> {t('Navigate')}{' '}
-              <kbd className="font-mono">&#8629;</kbd> {t('Select')}{' '}
-              <kbd className="font-mono">esc</kbd> {t('Close')}
-            </span>
-            <span className="font-mono text-primary/60">$governada</span>
-          </div>
+              {/* Footer */}
+              <div
+                className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-[10px] text-muted-foreground"
+                aria-hidden="true"
+              >
+                <span>
+                  <kbd className="font-mono">&#8593;&#8595;</kbd> {t('Navigate')}{' '}
+                  <kbd className="font-mono">&#8629;</kbd> {t('Select')}{' '}
+                  <kbd className="font-mono">esc</kbd> {t('Close')}
+                </span>
+                <span className="font-mono text-primary/60">$governada</span>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </Command.Dialog>

--- a/components/commandpalette/AIResponse.tsx
+++ b/components/commandpalette/AIResponse.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+/**
+ * AIResponse — Rich AI response renderer for the command palette.
+ *
+ * Renders streaming markdown-like content with:
+ * - Entity links (proposals, DReps) as clickable cards
+ * - Bold text, bullet points, inline formatting
+ * - Typing indicator during streaming
+ * - Error state handling
+ */
+
+import { memo, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { Bot, FileText, User, ExternalLink, AlertCircle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AIResponseProps {
+  /** The response content (may be partial during streaming) */
+  content: string;
+  /** Whether the response is still streaming */
+  isStreaming: boolean;
+  /** Error message if the response failed */
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Entity link parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedSegment {
+  type: 'text' | 'proposal_link' | 'drep_link';
+  text: string;
+  href?: string;
+  label?: string;
+}
+
+function parseEntityLinks(text: string): ParsedSegment[] {
+  const segments: ParsedSegment[] = [];
+  // Match [Proposal: <title>](/governance/proposals/<hash>#<index>) and [DRep: <name>](/governance/dreps/<id>)
+  const entityPattern = /\[(Proposal|DRep):\s*([^\]]+)\]\(([^)]+)\)/g;
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = entityPattern.exec(text)) !== null) {
+    // Add text before this match
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', text: text.slice(lastIndex, match.index) });
+    }
+
+    const entityType = match[1].toLowerCase() as 'proposal' | 'drep';
+    segments.push({
+      type: entityType === 'proposal' ? 'proposal_link' : 'drep_link',
+      text: match[2],
+      href: match[3],
+      label: match[1],
+    });
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', text: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Entity Card component
+// ---------------------------------------------------------------------------
+
+function EntityCard({
+  type,
+  label,
+  href,
+  onClick,
+}: {
+  type: 'proposal_link' | 'drep_link';
+  label: string;
+  href: string;
+  onClick: (href: string) => void;
+}) {
+  const Icon = type === 'proposal_link' ? FileText : User;
+  const typeLabel = type === 'proposal_link' ? 'Proposal' : 'DRep';
+
+  return (
+    <button
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onClick(href);
+      }}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md',
+        'bg-primary/10 hover:bg-primary/20 text-primary',
+        'text-xs font-medium transition-colors cursor-pointer',
+        'border border-primary/20 hover:border-primary/30',
+      )}
+    >
+      <Icon className="h-3 w-3 shrink-0" />
+      <span className="truncate max-w-[200px]">{label}</span>
+      <ExternalLink className="h-2.5 w-2.5 shrink-0 opacity-60" />
+      <span className="sr-only">View {typeLabel}</span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Text renderer with inline formatting
+// ---------------------------------------------------------------------------
+
+function FormattedText({
+  content,
+  onNavigate,
+}: {
+  content: string;
+  onNavigate: (href: string) => void;
+}) {
+  const segments = useMemo(() => parseEntityLinks(content), [content]);
+
+  return (
+    <>
+      {segments.map((seg, i) => {
+        if (seg.type === 'text') {
+          // Apply basic inline formatting: **bold**, *italic*
+          return <InlineFormatted key={i} text={seg.text} />;
+        }
+
+        return (
+          <EntityCard
+            key={i}
+            type={seg.type}
+            label={seg.text}
+            href={seg.href ?? '#'}
+            onClick={onNavigate}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function InlineFormatted({ text }: { text: string }) {
+  // Split on **bold** patterns
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          return (
+            <strong key={i} className="font-semibold text-foreground">
+              {part.slice(2, -2)}
+            </strong>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main AIResponse component
+// ---------------------------------------------------------------------------
+
+export const AIResponse = memo(function AIResponse({
+  content,
+  isStreaming,
+  error,
+}: AIResponseProps) {
+  const router = useRouter();
+
+  const handleNavigate = (href: string) => {
+    // Dispatch event to close command palette before navigating
+    window.dispatchEvent(new CustomEvent('closeCommandPalette'));
+    router.push(href);
+  };
+
+  if (error) {
+    return (
+      <div className="flex items-start gap-2 px-3 py-3 text-sm text-destructive">
+        <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+        <span>{error}</span>
+      </div>
+    );
+  }
+
+  if (!content && isStreaming) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+        <span>Thinking about your governance question...</span>
+      </div>
+    );
+  }
+
+  if (!content) return null;
+
+  // Split content into lines for rendering
+  const lines = content.split('\n');
+
+  return (
+    <div className="px-3 py-3 space-y-1.5">
+      {/* AI indicator */}
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground font-medium uppercase tracking-wide">
+        <Bot className="h-3 w-3" />
+        <span>Governance Advisor</span>
+        {isStreaming && <Loader2 className="h-2.5 w-2.5 animate-spin ml-1" />}
+      </div>
+
+      {/* Response content */}
+      <div className="text-sm text-foreground/90 leading-relaxed space-y-1">
+        {lines.map((line, i) => {
+          const trimmed = line.trim();
+
+          // Empty line = paragraph break
+          if (!trimmed) {
+            return <div key={i} className="h-1" />;
+          }
+
+          // Bullet points
+          if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
+            return (
+              <div key={i} className="flex gap-2 pl-2">
+                <span className="text-muted-foreground shrink-0 select-none">&bull;</span>
+                <span>
+                  <FormattedText content={trimmed.slice(2)} onNavigate={handleNavigate} />
+                </span>
+              </div>
+            );
+          }
+
+          // Numbered lists
+          const numberedMatch = trimmed.match(/^(\d+)\.\s+(.+)/);
+          if (numberedMatch) {
+            return (
+              <div key={i} className="flex gap-2 pl-2">
+                <span className="text-muted-foreground shrink-0 select-none font-mono text-xs min-w-[1rem] text-right">
+                  {numberedMatch[1]}.
+                </span>
+                <span>
+                  <FormattedText content={numberedMatch[2]} onNavigate={handleNavigate} />
+                </span>
+              </div>
+            );
+          }
+
+          // Regular text
+          return (
+            <p key={i}>
+              <FormattedText content={trimmed} onNavigate={handleNavigate} />
+            </p>
+          );
+        })}
+      </div>
+
+      {/* Streaming cursor */}
+      {isStreaming && (
+        <span className="inline-block w-1.5 h-4 bg-primary/60 animate-pulse rounded-sm" />
+      )}
+    </div>
+  );
+});

--- a/components/commandpalette/ConversationThread.tsx
+++ b/components/commandpalette/ConversationThread.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+/**
+ * ConversationThread — manages multi-turn conversation with the governance advisor.
+ *
+ * Renders a scrollable thread of user messages and AI responses,
+ * supports follow-up questions, and manages streaming state.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Send, RotateCcw, X } from 'lucide-react';
+import { AIResponse } from './AIResponse';
+import { useEpochContext } from '@/hooks/useEpochContext';
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { getStoredSession } from '@/lib/supabaseAuth';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ConversationThreadProps {
+  /** The initial question that triggered conversational mode */
+  initialQuery: string;
+  /** Callback to exit conversational mode */
+  onExit: () => void;
+  /** Callback to close the entire palette */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// SSE stream reader
+// ---------------------------------------------------------------------------
+
+async function readAdvisorStream(
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+  context: {
+    epoch: number;
+    daysRemaining: number;
+    activeProposalCount: number;
+    segment: string;
+  },
+  onDelta: (text: string) => void,
+  onError: (error: string) => void,
+  onDone: () => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    // Include auth token if available
+    const token = getStoredSession();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const res = await fetch('/api/intelligence/advisor', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ messages, context }),
+      signal,
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: 'Request failed' }));
+      onError(err.error ?? `Request failed (${res.status})`);
+      return;
+    }
+
+    const reader = res.body?.getReader();
+    if (!reader) {
+      onError('No response stream available');
+      return;
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Process SSE events in buffer
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? ''; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        try {
+          const data = JSON.parse(line.slice(6)) as {
+            type: string;
+            content?: string;
+          };
+
+          if (data.type === 'text_delta' && data.content) {
+            onDelta(data.content);
+          } else if (data.type === 'error' && data.content) {
+            onError(data.content);
+          } else if (data.type === 'done') {
+            onDone();
+            return;
+          }
+        } catch {
+          // Skip malformed SSE events
+        }
+      }
+    }
+
+    onDone();
+  } catch (err) {
+    if (signal?.aborted) return;
+    onError(err instanceof Error ? err.message : 'Connection failed');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ConversationThread component
+// ---------------------------------------------------------------------------
+
+export function ConversationThread({
+  initialQuery,
+  onExit,
+  onClose: _onClose,
+}: ConversationThreadProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamError, setStreamError] = useState<string | null>(null);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const streamContentRef = useRef('');
+
+  const { epoch, day, totalDays, activeProposalCount } = useEpochContext();
+  const { segment } = useSegment();
+
+  const daysRemaining = totalDays - day;
+
+  // Auto-scroll to bottom on new content
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, isStreaming]);
+
+  // Send a message to the advisor
+  const sendMessage = useCallback(
+    (text: string) => {
+      if (!text.trim() || isStreaming) return;
+
+      const userMsg: Message = {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content: text.trim(),
+      };
+
+      const assistantMsg: Message = {
+        id: `assistant-${Date.now()}`,
+        role: 'assistant',
+        content: '',
+      };
+
+      setMessages((prev) => [...prev, userMsg, assistantMsg]);
+      setInput('');
+      setIsStreaming(true);
+      setStreamError(null);
+      streamContentRef.current = '';
+
+      // Build conversation history for API
+      const allMessages = [...messages, userMsg].map((m) => ({
+        role: m.role,
+        content: m.content,
+      }));
+
+      const abort = new AbortController();
+      abortRef.current = abort;
+
+      readAdvisorStream(
+        allMessages,
+        {
+          epoch,
+          daysRemaining,
+          activeProposalCount: activeProposalCount ?? 0,
+          segment,
+        },
+        // onDelta
+        (delta) => {
+          streamContentRef.current += delta;
+          const currentContent = streamContentRef.current;
+          setMessages((prev) => {
+            const updated = [...prev];
+            const last = updated[updated.length - 1];
+            if (last?.role === 'assistant') {
+              updated[updated.length - 1] = { ...last, content: currentContent };
+            }
+            return updated;
+          });
+        },
+        // onError
+        (error) => {
+          setStreamError(error);
+          setIsStreaming(false);
+        },
+        // onDone
+        () => {
+          setIsStreaming(false);
+        },
+        abort.signal,
+      );
+    },
+    [messages, isStreaming, epoch, daysRemaining, activeProposalCount, segment],
+  );
+
+  // Send initial query on mount
+  useEffect(() => {
+    if (initialQuery && messages.length === 0) {
+      sendMessage(initialQuery);
+    }
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cleanup abort on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  // Handle follow-up submit
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    sendMessage(input);
+  };
+
+  // Handle keyboard
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      if (isStreaming) {
+        abortRef.current?.abort();
+        setIsStreaming(false);
+      } else {
+        onExit();
+      }
+    }
+  };
+
+  // Retry last failed message
+  const handleRetry = () => {
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
+    if (lastUserMsg) {
+      // Remove the failed assistant message
+      setMessages((prev) => prev.slice(0, -1));
+      setStreamError(null);
+      sendMessage(lastUserMsg.content);
+    }
+  };
+
+  return (
+    <div className="flex flex-col" onKeyDown={handleKeyDown}>
+      {/* Thread header */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30">
+        <span className="text-[11px] text-muted-foreground font-medium">Governance Advisor</span>
+        <div className="flex items-center gap-1">
+          {streamError && (
+            <button
+              onClick={handleRetry}
+              className="p-1 rounded hover:bg-muted/50 text-muted-foreground hover:text-foreground transition-colors"
+              title="Retry"
+            >
+              <RotateCcw className="h-3 w-3" />
+            </button>
+          )}
+          <button
+            onClick={onExit}
+            className="p-1 rounded hover:bg-muted/50 text-muted-foreground hover:text-foreground transition-colors"
+            title="Back to search"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="max-h-[360px] overflow-y-auto">
+        {messages.map((msg, idx) => {
+          if (msg.role === 'user') {
+            return (
+              <div
+                key={msg.id}
+                className="px-3 py-2 text-sm text-foreground bg-muted/20 border-b border-border/20"
+              >
+                {msg.content}
+              </div>
+            );
+          }
+
+          const isLast = idx === messages.length - 1;
+          return (
+            <AIResponse
+              key={msg.id}
+              content={msg.content}
+              isStreaming={isLast && isStreaming}
+              error={isLast ? (streamError ?? undefined) : undefined}
+            />
+          );
+        })}
+      </div>
+
+      {/* Follow-up input */}
+      <form
+        onSubmit={handleSubmit}
+        className="flex items-center gap-2 border-t border-border/50 px-3 py-2"
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={isStreaming ? 'Waiting for response...' : 'Ask a follow-up...'}
+          disabled={isStreaming}
+          className={cn(
+            'flex-1 bg-transparent text-sm outline-none',
+            'placeholder:text-muted-foreground/60',
+            'disabled:opacity-50',
+          )}
+          autoFocus
+        />
+        <button
+          type="submit"
+          disabled={!input.trim() || isStreaming}
+          className={cn(
+            'p-1.5 rounded-md transition-colors',
+            'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+            'disabled:opacity-30 disabled:cursor-not-allowed',
+          )}
+          title="Send"
+        >
+          <Send className="h-3.5 w-3.5" />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -34,6 +34,7 @@
  * peek_drawer                    — Entity peek drawer on list pages (Phase 3 nav renaissance)
  * keyboard_shortcuts              — Global keyboard shortcut system with chords and help overlay (Phase 8)
  * governance_copilot               — Right-side intelligence panel with AI governance briefings (Phase 5)
+ * conversational_nav               — Governance advisor in command palette (Phase 9 nav renaissance)
  *
  * ---------------------------------------------------------------------------
  * RETIRED FLAGS (code checks removed or hardcoded)

--- a/lib/intelligence/advisor.ts
+++ b/lib/intelligence/advisor.ts
@@ -1,0 +1,300 @@
+/**
+ * Governance Advisor — conversational AI orchestration for the command palette.
+ *
+ * Detects whether user input is a question/intent (route to AI) vs a command/search
+ * (route to existing cmdk logic). When routed to AI, streams a governance-aware
+ * response with embedded entity references.
+ *
+ * The advisor has access to:
+ * - Active proposals and their status
+ * - DRep information and scores
+ * - Epoch context (current epoch, time remaining, active proposals)
+ * - User's personal governance context (if authenticated)
+ */
+
+import { logger } from '@/lib/logger';
+
+// ---------------------------------------------------------------------------
+// Question / intent detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic to detect if user input is a question or governance intent
+ * rather than a search/command query.
+ *
+ * Questions: start with question words, end with "?", or are intent statements.
+ * Commands/searches: short keywords, known command patterns, entity names.
+ */
+export function isConversationalQuery(input: string): boolean {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.length < 8) return false;
+
+  const lower = trimmed.toLowerCase();
+
+  // Ends with question mark = question
+  if (trimmed.endsWith('?')) return true;
+
+  // Starts with question words
+  const questionStarters = [
+    'who ',
+    'what ',
+    'when ',
+    'where ',
+    'why ',
+    'how ',
+    'which ',
+    'can ',
+    'could ',
+    'should ',
+    'would ',
+    'is ',
+    'are ',
+    'do ',
+    'does ',
+    'did ',
+    'will ',
+    'has ',
+    'have ',
+    'tell me',
+    'show me',
+    'explain',
+    'help me',
+    'prepare me',
+    'find me',
+    'compare',
+    'summarize',
+    'analyze',
+    "what's",
+    "who's",
+    "how's",
+  ];
+
+  for (const starter of questionStarters) {
+    if (lower.startsWith(starter)) return true;
+  }
+
+  // Intent patterns (imperative + governance context)
+  const intentPatterns = [
+    /^prepare\b/i,
+    /^find\s+(dreps?|proposals?|votes?)\b/i,
+    /^list\s+(all|active|recent)\b/i,
+    /^give me\b/i,
+    /^i (want|need|would like)\b/i,
+    /^what('s| is| are)\b/i,
+    /\baffect(s|ing)?\s+(treasury|budget|constitution)\b/i,
+    /\bperform(ing|ance)?\b/i,
+    /\balign(ed|ment)?\b/i,
+    /\bvoting\s+(this|next|current)\b/i,
+  ];
+
+  for (const pattern of intentPatterns) {
+    if (pattern.test(lower)) return true;
+  }
+
+  // If it has multiple words (4+) and reads like a sentence, likely conversational
+  const words = trimmed.split(/\s+/);
+  if (words.length >= 5) {
+    // Check for sentence-like structure (contains a verb-like word)
+    const verbIndicators = [
+      'affect',
+      'impact',
+      'vote',
+      'delegate',
+      'perform',
+      'change',
+      'align',
+      'support',
+      'oppose',
+      'recommend',
+      'suggest',
+      'think',
+      'happen',
+      'going',
+    ];
+    if (verbIndicators.some((v) => lower.includes(v))) return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Advisor system prompt builder
+// ---------------------------------------------------------------------------
+
+export interface AdvisorContext {
+  /** Current epoch number */
+  epoch: number;
+  /** Days remaining in epoch */
+  daysRemaining: number;
+  /** Number of active proposals */
+  activeProposalCount: number;
+  /** User's governance segment */
+  segment: string;
+  /** Personal context string (from AI context assembler) */
+  personalContext?: string;
+  /** Recent governance data summaries for grounding */
+  governanceSnapshot?: string;
+}
+
+export function buildAdvisorSystemPrompt(ctx: AdvisorContext): string {
+  const lines = [
+    'You are the Governada Governance Advisor, an AI assistant embedded in the command palette of Governada — a governance intelligence platform for Cardano.',
+    '',
+    '## Your Role',
+    '- Answer governance questions with accurate, data-grounded responses',
+    '- Reference specific proposals, DReps, and governance actions by name when relevant',
+    '- Help users understand governance context, prepare for voting, and analyze proposals',
+    '- Be concise but thorough — users are in a command palette, not a chat window',
+    '',
+    '## Current Governance Context',
+    `- Epoch: ${ctx.epoch}`,
+    `- Days remaining: ${ctx.daysRemaining}`,
+    `- Active proposals: ${ctx.activeProposalCount}`,
+    `- User segment: ${ctx.segment}`,
+    '',
+    '## Response Format',
+    'Format your responses with these conventions:',
+    '- Use **bold** for entity names and key terms',
+    '- Reference proposals as: [Proposal: <title>](/governance/proposals/<hash>#<index>)',
+    '- Reference DReps as: [DRep: <name>](/governance/dreps/<id>)',
+    '- Use bullet points for lists',
+    '- Keep responses under 300 words unless the question demands detail',
+    '- End with actionable next steps when appropriate',
+    '',
+    '## Anti-patterns',
+    '- Never fabricate proposal names, DRep names, or vote counts',
+    '- If you lack data to answer, say so and suggest where to look in Governada',
+    '- Do not produce generic blockchain explanations — users are governance participants',
+    '- Do not recommend specific votes — present analysis, let users decide',
+  ];
+
+  if (ctx.personalContext) {
+    lines.push('', "## User's Governance Profile", ctx.personalContext);
+  }
+
+  if (ctx.governanceSnapshot) {
+    lines.push('', '## Current Governance Data', ctx.governanceSnapshot);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Conversation message types
+// ---------------------------------------------------------------------------
+
+export interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming advisor call (used by the API route)
+// ---------------------------------------------------------------------------
+
+export interface AdvisorStreamOptions {
+  messages: ConversationMessage[];
+  context: AdvisorContext;
+  signal?: AbortSignal;
+}
+
+/**
+ * Stream a governance advisor response.
+ * Returns a ReadableStream that emits SSE-formatted events.
+ */
+export async function streamAdvisorResponse(
+  options: AdvisorStreamOptions,
+): Promise<ReadableStream> {
+  const { messages, context, signal } = options;
+  const systemPrompt = buildAdvisorSystemPrompt(context);
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    logger.error('[Advisor] ANTHROPIC_API_KEY not configured');
+    return createErrorStream('AI advisor is not configured. Please try again later.');
+  }
+
+  const { default: Anthropic } = await import('@anthropic-ai/sdk');
+  const client = new Anthropic({ apiKey });
+
+  const anthropicMessages = messages.map((m) => ({
+    role: m.role as 'user' | 'assistant',
+    content: m.content,
+  }));
+
+  try {
+    const stream = await client.messages.create({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 1024,
+      temperature: 0.3,
+      system: systemPrompt,
+      messages: anthropicMessages,
+      stream: true,
+    });
+
+    const encoder = new TextEncoder();
+
+    return new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const event of stream as AsyncIterable<{
+            type: string;
+            delta?: { type?: string; text?: string };
+            message?: { usage?: { output_tokens?: number } };
+            usage?: { output_tokens?: number };
+          }>) {
+            if (signal?.aborted) {
+              controller.close();
+              return;
+            }
+
+            if (
+              event.type === 'content_block_delta' &&
+              event.delta?.type === 'text_delta' &&
+              event.delta.text
+            ) {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: 'text_delta', content: event.delta.text })}\n\n`,
+                ),
+              );
+            }
+
+            if (event.type === 'message_stop') {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
+            }
+          }
+
+          // Ensure we always send done
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
+          controller.close();
+        } catch (err) {
+          logger.error('[Advisor] Stream processing error', { error: err });
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: 'error', content: 'Stream interrupted. Please try again.' })}\n\n`,
+            ),
+          );
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
+          controller.close();
+        }
+      },
+    });
+  } catch (err) {
+    logger.error('[Advisor] Failed to create stream', { error: err });
+    return createErrorStream('Failed to connect to AI. Please try again.');
+  }
+}
+
+function createErrorStream(message: string): ReadableStream {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(`data: ${JSON.stringify({ type: 'error', content: message })}\n\n`),
+      );
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: 'done' })}\n\n`));
+      controller.close();
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a conversational AI mode to the command palette (Cmd+K / Ctrl+K)
- When users type questions or governance intent statements, the palette detects this and routes to an AI-powered Governance Advisor
- The advisor streams responses with rich entity cards (proposals, DReps) that are clickable
- Supports multi-turn follow-up conversations without re-opening the palette
- Authenticated users get personalized responses based on their governance profile

## What's New
- **Question detection**: Heuristic in `lib/intelligence/advisor.ts` identifies conversational queries vs search/command input
- **Streaming API**: `POST /api/intelligence/advisor` with SSE streaming, rate limiting, and optional auth personalization
- **Rich response UI**: `components/commandpalette/AIResponse.tsx` renders markdown-like content with inline entity cards
- **Conversation thread**: `components/commandpalette/ConversationThread.tsx` manages multi-turn conversations
- **Feature flag**: Gated behind `conversational_nav` flag (default off)

## Impact
- **What changed**: Command palette gains AI conversational mode for governance questions
- **User-facing**: Yes — users can ask questions like "Which proposals affect treasury?" and get AI-synthesized answers with clickable entity links
- **Risk**: Low — entirely feature-flagged behind `conversational_nav`, existing command palette behavior unchanged when flag is off
- **Scope**: 4 new files, 2 modified files. No migrations. No new dependencies.

## Files
| File | Change |
|------|--------|
| `components/CommandPalette.tsx` | Modified — AI routing, conversational mode state |
| `lib/intelligence/advisor.ts` | New — question detection, system prompt, streaming |
| `app/api/intelligence/advisor/route.ts` | New — streaming SSE endpoint with rate limiting |
| `components/commandpalette/AIResponse.tsx` | New — rich AI response renderer |
| `components/commandpalette/ConversationThread.tsx` | New — multi-turn conversation UI |
| `lib/featureFlags.ts` | Modified — added `conversational_nav` flag docs |

## Test plan
- [ ] Verify command palette opens normally (Cmd+K) with flag off — no changes visible
- [ ] Enable `conversational_nav` flag and type a question (e.g., "How is my DRep performing?")
- [ ] Verify Bot icon appears and "Ask AI" hint shows in input
- [ ] Press Enter to activate conversational mode
- [ ] Verify streaming response appears with entity cards
- [ ] Click an entity card — verify navigation works and palette closes
- [ ] Ask a follow-up question in the conversation thread
- [ ] Press Escape to return to normal search mode
- [ ] Verify rate limiting works (20 requests/minute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)