### PR TITLE
feat: wire live temporal mode and add vote action shortcuts

### DIFF
--- a/components/governada/ShortcutProvider.tsx
+++ b/components/governada/ShortcutProvider.tsx
@@ -5,6 +5,8 @@
  *
  * Wraps the shell to provide:
  * - Navigation shortcuts (G + key chords)
+ * - Vote action shortcuts (V + Y/N/A chords, R for rationale)
+ * - List navigation shortcuts (N for next, P for previous)
  * - Action shortcuts (?, /, Escape)
  * - Density mode cycling (Cmd+Shift+M)
  * - Context for page-specific shortcut registration
@@ -216,10 +218,9 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
         id: 'panel-intelligence',
         keys: ']',
         label: 'Intelligence Panel',
-        description: 'Toggle intelligence panel (coming soon)',
+        description: 'Toggle intelligence panel',
         category: 'panels' as const,
         action: () => {
-          // Placeholder for Phase 5 intelligence panel
           window.dispatchEvent(new CustomEvent('toggleIntelligencePanel'));
         },
       },
@@ -232,6 +233,79 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
         description: 'Cycle density mode: Browse \u2192 Work \u2192 Analyze',
         category: 'modes' as const,
         action: () => cycleMode(),
+      },
+
+      // Vote action shortcuts (V + key chords, proposal pages only)
+      {
+        id: 'action-vote-yes',
+        keys: 'V Y',
+        label: 'Vote Yes',
+        description: 'Cast a Yes vote on the current proposal',
+        category: 'actions' as const,
+        isChord: true,
+        contextPaths: ['/governance/proposals/'],
+        action: () => window.dispatchEvent(new CustomEvent('shortcut:vote', { detail: 'yes' })),
+      },
+      {
+        id: 'action-vote-no',
+        keys: 'V N',
+        label: 'Vote No',
+        description: 'Cast a No vote on the current proposal',
+        category: 'actions' as const,
+        isChord: true,
+        contextPaths: ['/governance/proposals/'],
+        action: () => window.dispatchEvent(new CustomEvent('shortcut:vote', { detail: 'no' })),
+      },
+      {
+        id: 'action-vote-abstain',
+        keys: 'V A',
+        label: 'Vote Abstain',
+        description: 'Cast an Abstain vote on the current proposal',
+        category: 'actions' as const,
+        isChord: true,
+        contextPaths: ['/governance/proposals/'],
+        action: () => window.dispatchEvent(new CustomEvent('shortcut:vote', { detail: 'abstain' })),
+      },
+      {
+        id: 'action-rationale',
+        keys: 'R',
+        label: 'Write Rationale',
+        description: 'Open rationale editor for the current proposal',
+        category: 'actions' as const,
+        contextPaths: ['/governance/proposals/'],
+        action: () => window.dispatchEvent(new CustomEvent('shortcut:rationale')),
+      },
+
+      // List navigation shortcuts
+      {
+        id: 'action-next',
+        keys: 'N',
+        label: 'Next Item',
+        description: 'Focus the next item in the list',
+        category: 'actions' as const,
+        contextPaths: [
+          '/governance/proposals',
+          '/governance/representatives',
+          '/governance/committee',
+          '/governance/pools',
+        ],
+        action: () =>
+          window.dispatchEvent(new CustomEvent('shortcut:navigate', { detail: 'next' })),
+      },
+      {
+        id: 'action-previous',
+        keys: 'P',
+        label: 'Previous Item',
+        description: 'Focus the previous item in the list',
+        category: 'actions' as const,
+        contextPaths: [
+          '/governance/proposals',
+          '/governance/representatives',
+          '/governance/committee',
+          '/governance/pools',
+        ],
+        action: () =>
+          window.dispatchEvent(new CustomEvent('shortcut:navigate', { detail: 'prev' })),
       },
     ],
     [router, cycleMode],

--- a/hooks/useGovernanceMode.ts
+++ b/hooks/useGovernanceMode.ts
@@ -11,9 +11,11 @@
  * - 'calm':    No urgent proposals, analysis/research period
  *             (urgency score < 40)
  *
- * TODO: Wire to GET /api/intelligence/governance-state when Phase 4 ships.
- *       Currently defaults to 'active' mode.
+ * Fetches live data from GET /api/intelligence/governance-state, cached 60s.
  */
+
+import { useQuery } from '@tanstack/react-query';
+import type { GovernanceStateResult } from '@/lib/intelligence/governance-state';
 
 export type GovernanceMode = 'urgent' | 'active' | 'calm';
 
@@ -24,8 +26,10 @@ interface UseGovernanceModeResult {
   isUrgent: boolean;
   /** Convenience boolean for calm state checks */
   isCalm: boolean;
-  /** Raw urgency score (0-100). Default: 50 until Phase 4 API ships. */
+  /** Raw urgency score (0-100) */
   urgencyScore: number;
+  /** Whether the data is still loading (returns safe defaults while loading) */
+  isLoading: boolean;
 }
 
 /**
@@ -37,16 +41,26 @@ function scoreToMode(score: number): GovernanceMode {
   return 'calm';
 }
 
+async function fetchGovernanceState(): Promise<GovernanceStateResult> {
+  const res = await fetch('/api/intelligence/governance-state');
+  if (!res.ok) throw new Error(`Governance state fetch failed: ${res.status}`);
+  return res.json();
+}
+
 /**
- * Returns the current governance temporal mode based on governance urgency.
- *
- * Currently returns a static 'active' mode. Will be wired to the
- * governance state API endpoint when Phase 4 intelligence panel ships.
+ * Returns the current governance temporal mode based on live governance urgency.
+ * Falls back to 'active' (urgency 50) while loading or on error.
  */
 export function useGovernanceMode(): UseGovernanceModeResult {
-  // TODO: Wire to GET /api/intelligence/governance-state when Phase 4 ships.
-  // For now, default to 'active' (urgency score 50).
-  const urgencyScore = 50;
+  const { data, isLoading } = useQuery({
+    queryKey: ['governance-state'],
+    queryFn: fetchGovernanceState,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const urgencyScore = data?.urgency ?? 50;
   const mode = scoreToMode(urgencyScore);
 
   return {
@@ -54,5 +68,6 @@ export function useGovernanceMode(): UseGovernanceModeResult {
     isUrgent: mode === 'urgent',
     isCalm: mode === 'calm',
     urgencyScore,
+    isLoading,
   };
 }

--- a/hooks/useGovernanceTemperature.ts
+++ b/hooks/useGovernanceTemperature.ts
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * useGovernanceTemperature — Maps governance temperature score to a CSS color
+ * useGovernanceTemperature — Maps live governance temperature score to a CSS color
  * for the ambient governance tint on the constellation globe.
  *
  * Temperature ranges:
@@ -13,9 +13,11 @@
  * Returns a CSS color value for the `--governance-tint` custom property,
  * applied as a subtle (10-15% opacity) overlay on the constellation container.
  *
- * TODO: Wire to governance temperature API when Phase 4 ships.
- *       Currently defaults to 'neutral' (temperature 50).
+ * Fetches live data from GET /api/intelligence/governance-state, cached 60s.
  */
+
+import { useQuery } from '@tanstack/react-query';
+import type { GovernanceStateResult } from '@/lib/intelligence/governance-state';
 
 export interface GovernanceTemperatureResult {
   /** Governance temperature score (0-100) */
@@ -24,6 +26,8 @@ export interface GovernanceTemperatureResult {
   tintColor: string;
   /** Human-readable label for the current state */
   label: 'cool' | 'neutral' | 'warm' | 'urgent';
+  /** Whether the data is still loading */
+  isLoading: boolean;
 }
 
 /**
@@ -34,36 +38,43 @@ function temperatureToTint(temperature: number): {
   label: GovernanceTemperatureResult['label'];
 } {
   if (temperature > 80) {
-    // Urgent red — intense governance moment
     return { color: 'rgba(239, 68, 68, 0.12)', label: 'urgent' };
   }
   if (temperature > 60) {
-    // Warm amber — active governance
     return { color: 'rgba(245, 158, 11, 0.10)', label: 'warm' };
   }
   if (temperature >= 30) {
-    // Neutral — normal activity, transparent (no tint)
     return { color: 'rgba(148, 163, 184, 0.05)', label: 'neutral' };
   }
-  // Cool blue — quiet governance period
   return { color: 'rgba(56, 189, 248, 0.10)', label: 'cool' };
+}
+
+async function fetchGovernanceState(): Promise<GovernanceStateResult> {
+  const res = await fetch('/api/intelligence/governance-state');
+  if (!res.ok) throw new Error(`Governance state fetch failed: ${res.status}`);
+  return res.json();
 }
 
 /**
  * Returns the governance temperature color for ambient tinting.
- *
- * Currently returns a static 'neutral' state. Will be wired to the
- * governance temperature API when Phase 4 ships.
+ * Falls back to neutral (temperature 50) while loading or on error.
  */
 export function useGovernanceTemperature(): GovernanceTemperatureResult {
-  // TODO: Wire to governance temperature API when Phase 4 ships.
-  // Default to neutral (temperature 50).
-  const temperature = 50;
+  const { data, isLoading } = useQuery({
+    queryKey: ['governance-state'],
+    queryFn: fetchGovernanceState,
+    staleTime: 60_000,
+    refetchInterval: 120_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const temperature = data?.temperature ?? 50;
   const { color, label } = temperatureToTint(temperature);
 
   return {
     temperature,
     tintColor: color,
     label,
+    isLoading,
   };
 }


### PR DESCRIPTION
## Summary
- Wire `useGovernanceMode` and `useGovernanceTemperature` hooks to live governance state API (were hardcoded to static values)
- Add vote action shortcuts (V+Y, V+N, V+A), rationale shortcut (R), and list navigation (N/P)
- All shortcuts context-gated to relevant pages

## Impact
- **What changed**: Temporal mode and temperature hooks now fetch real data from `/api/intelligence/governance-state` via TanStack Query. Vote and navigation shortcuts added to keyboard system.
- **User-facing**: Yes — constellation globe will now tint based on governance activity (cool blue → warm amber → urgent red). Hub cards reorder by urgency. DReps can vote with V+Y/N/A keyboard shortcuts on proposal pages.
- **Risk**: Low — hooks fall back to safe defaults (active mode, neutral temperature) while loading or on error. Shortcuts only fire on relevant pages. No changes to existing behavior.
- **Scope**: 3 files modified (useGovernanceMode.ts, useGovernanceTemperature.ts, ShortcutProvider.tsx). No migrations, no new deps, no Inngest changes.

## Test plan
- [ ] Verify constellation globe tints based on governance activity
- [ ] Verify Hub card ordering changes with temporal mode
- [ ] Verify V+Y/V+N/V+A shortcuts fire on proposal detail pages
- [ ] Verify N/P shortcuts navigate list items on governance list pages
- [ ] Verify shortcuts don't fire on non-relevant pages
- [ ] Verify fallback behavior when API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)