### PR TITLE
feat: shell polish — logo in rail, glassmorphic nav, Compass rename

### DIFF
--- a/components/governada/GovernadaHeader.tsx
+++ b/components/governada/GovernadaHeader.tsx
@@ -23,6 +23,7 @@ import {
   X,
   Loader2,
   UserCog,
+  Compass,
 } from 'lucide-react';
 import { AdminViewAsPicker } from './AdminViewAsPicker';
 import { DepthPromptModal } from './DepthPromptModal';
@@ -187,7 +188,12 @@ function truncateImpersonateAddress(addr: string): string {
   return `${addr.slice(0, 8)}...${addr.slice(-8)}`;
 }
 
-export function GovernadaHeader() {
+interface GovernadaHeaderProps {
+  compassToggle?: () => void;
+  compassOpen?: boolean;
+}
+
+export function GovernadaHeader({ compassToggle, compassOpen }: GovernadaHeaderProps = {}) {
   const router = useRouter();
   const { t } = useTranslation();
   const { connected, disconnect, logout, isAuthenticated } = useWallet();
@@ -421,13 +427,13 @@ export function GovernadaHeader() {
           : 'border-b border-border/20 bg-background/60 backdrop-blur-xl',
       )}
     >
-      <div className="mx-auto max-w-7xl flex items-center justify-between h-10 px-4">
-        {/* Logo + breadcrumbs */}
+      <div className="flex items-center justify-between h-10 px-4 lg:pl-14 lg:pr-4">
+        {/* Logo (mobile only) + breadcrumbs */}
         <div className="flex items-center min-w-0">
           <Link
             href="/"
             className={cn(
-              'font-display text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded shrink-0',
+              'lg:hidden font-display text-lg font-bold tracking-tight text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded shrink-0',
               headerTransparent && 'nav-text-shadow',
             )}
           >
@@ -455,6 +461,25 @@ export function GovernadaHeader() {
 
           {/* Governance pulse */}
           <GovernancePulse />
+
+          {/* Compass toggle */}
+          {compassToggle && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                'hidden lg:inline-flex h-8 w-8',
+                compassOpen
+                  ? 'text-primary bg-primary/10'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              onClick={compassToggle}
+              aria-label={compassOpen ? 'Close Compass panel' : 'Open Compass panel'}
+              aria-pressed={compassOpen}
+            >
+              <Compass className="h-4 w-4" />
+            </Button>
+          )}
 
           {/* Notification bell dropdown */}
           {connected && isAuthenticated && <NotificationBell unreadCount={unreadCount} />}

--- a/components/governada/GovernadaShell.tsx
+++ b/components/governada/GovernadaShell.tsx
@@ -196,13 +196,15 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
           </Suspense>
           <SyncFreshnessBanner />
           <PreviewBanner />
-          {!isStudioMode && <GovernadaHeader />}
+          {!isStudioMode && (
+            <GovernadaHeader
+              compassToggle={showCopilot ? intelligencePanel.toggle : undefined}
+              compassOpen={panelVisible}
+            />
+          )}
           {!isStudioMode &&
             (navigationRail ? (
-              <NavigationRail
-                onToggleCopilot={showCopilot ? intelligencePanel.toggle : undefined}
-                copilotOpen={panelVisible}
-              />
+              <NavigationRail />
             ) : (
               <GovernadaSidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
             ))}
@@ -243,7 +245,7 @@ export function GovernadaShell({ children }: { children: React.ReactNode }) {
               {!isStudioMode && <MilestoneTrigger />}
             </DiscoveryHub>
           </SpotlightProvider>
-          {/* Governance Co-Pilot Intelligence Panel */}
+          {/* Governance Compass Intelligence Panel */}
           {showCopilot && intelligencePanel.canShowPanel && (
             <IntelligencePanel
               isOpen={intelligencePanel.isOpen}

--- a/components/governada/IntelligencePanel.tsx
+++ b/components/governada/IntelligencePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * IntelligencePanel — Governance Co-Pilot right-side panel.
+ * IntelligencePanel — Governance Compass right-side panel.
  *
  * The crown jewel of the Navigation Renaissance. A collapsible right-side
  * intelligence panel powered by AI-synthesized governance briefings.
@@ -61,7 +61,7 @@ export function IntelligencePanel({ isOpen, onClose, panelWidth }: IntelligenceP
           <div className="flex items-center justify-between px-3 py-2 border-b border-border/10 shrink-0">
             <div className="flex items-center gap-2">
               <BrainCircuit className="h-4 w-4 text-primary/70" aria-hidden="true" />
-              <h2 className="text-xs font-semibold text-foreground/80">Co-Pilot</h2>
+              <h2 className="text-xs font-semibold text-foreground/80">Compass</h2>
             </div>
             <button
               type="button"

--- a/components/governada/NavigationRail.tsx
+++ b/components/governada/NavigationRail.tsx
@@ -18,12 +18,11 @@ import { motion, LayoutGroup, useReducedMotion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { useSegment } from '@/components/providers/SegmentProvider';
 import { getSidebarSections, getCurrentSection } from '@/lib/nav/config';
-import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { usePinnedItems, type PinnedEntityType } from '@/hooks/usePinnedItems';
 import { useTranslation } from '@/lib/i18n/useTranslation';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { User, FileText, Building2, Shield, BrainCircuit } from 'lucide-react';
+import { User, FileText, Building2, Shield } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // ---------------------------------------------------------------------------
@@ -67,19 +66,11 @@ const MAX_RAIL_PINS = 4;
 // Component
 // ---------------------------------------------------------------------------
 
-interface NavigationRailProps {
-  /** Callback to toggle the Co-Pilot panel (only present when governance_copilot flag is on) */
-  onToggleCopilot?: () => void;
-  /** Whether the Co-Pilot panel is currently open */
-  copilotOpen?: boolean;
-}
-
-export function NavigationRail({ onToggleCopilot, copilotOpen }: NavigationRailProps = {}) {
+export function NavigationRail() {
   const pathname = usePathname();
   const { t } = useTranslation();
-  const { segment, stakeAddress, drepId, poolId, delegatedDrep, delegatedPool } = useSegment();
+  const { segment, drepId, poolId, delegatedDrep, delegatedPool } = useSegment();
   const { depth } = useGovernanceDepth();
-  const unreadCount = useUnreadNotifications(stakeAddress ?? null);
   const prefersReducedMotion = useReducedMotion();
   const { pinnedItems } = usePinnedItems();
 
@@ -96,12 +87,21 @@ export function NavigationRail({ onToggleCopilot, copilotOpen }: NavigationRailP
   return (
     <TooltipProvider delayDuration={200}>
       <aside
-        className="hidden lg:flex flex-col items-center fixed left-0 top-10 bottom-0 w-12 z-30 border-r border-border/20 bg-background/60 backdrop-blur-xl"
+        className="hidden lg:flex flex-col items-center fixed left-0 top-0 bottom-0 w-12 z-40 border-r border-border/20 bg-background/40 backdrop-blur-xl"
         aria-label={t('Main navigation')}
       >
+        {/* Logo — top of rail */}
+        <Link
+          href="/"
+          className="flex items-center justify-center w-12 h-10 shrink-0 text-foreground hover:bg-accent/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset"
+          aria-label="Governada home"
+        >
+          <span className="font-display text-sm font-bold tracking-tight">g</span>
+        </Link>
+
         {/* Navigation icons */}
         <nav
-          className="flex flex-col items-center gap-1 pt-3"
+          className="flex flex-col items-center gap-1 pt-1"
           role="navigation"
           aria-label={t('Main navigation')}
         >
@@ -143,10 +143,7 @@ export function NavigationRail({ onToggleCopilot, copilotOpen }: NavigationRailP
                           />
                         ))}
 
-                      {/* Notification badge on You */}
-                      {section.id === 'you' && unreadCount > 0 && (
-                        <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500" />
-                      )}
+                      {/* Notification badge removed — bell in header handles notifications */}
 
                       {/* Dual-role badge on Workspace */}
                       {section.id === 'workspace' && isDualRole && (
@@ -167,33 +164,6 @@ export function NavigationRail({ onToggleCopilot, copilotOpen }: NavigationRailP
 
         {/* Spacer */}
         <div className="flex-1" />
-
-        {/* Co-Pilot toggle */}
-        {onToggleCopilot && (
-          <div className="flex flex-col items-center pb-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={onToggleCopilot}
-                  className={cn(
-                    'relative w-10 h-10 flex items-center justify-center rounded-lg transition-colors',
-                    'hover:bg-accent/50',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
-                    copilotOpen ? 'text-primary bg-primary/10' : 'text-muted-foreground',
-                  )}
-                  aria-label={copilotOpen ? 'Close intelligence panel' : 'Open intelligence panel'}
-                  aria-pressed={copilotOpen}
-                >
-                  <BrainCircuit className="h-4.5 w-4.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                {t('Co-Pilot')} &middot; ]
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
 
         {/* Pinned entities */}
         {visiblePins.length > 0 && (

--- a/components/governada/SectionTabBar.tsx
+++ b/components/governada/SectionTabBar.tsx
@@ -38,7 +38,7 @@ export function SectionTabBar({ section: _section }: SectionTabBarProps) {
   };
 
   return (
-    <div className="sticky top-0 md:top-10 z-20 border-b border-border/20 bg-background/80 backdrop-blur-md pt-[env(safe-area-inset-top)] md:pt-0">
+    <div className="sticky top-0 md:top-10 z-20 border-b border-border/10 bg-background/40 backdrop-blur-xl pt-[env(safe-area-inset-top)] md:pt-0">
       <nav
         className="flex items-center gap-1 px-4 lg:px-6 h-10 overflow-x-auto scrollbar-none"
         aria-label="Section navigation"

--- a/components/governada/ShortcutProvider.tsx
+++ b/components/governada/ShortcutProvider.tsx
@@ -217,8 +217,8 @@ export function ShortcutProvider({ children }: { children: ReactNode }) {
       {
         id: 'panel-intelligence',
         keys: ']',
-        label: 'Intelligence Panel',
-        description: 'Toggle intelligence panel',
+        label: 'Compass',
+        description: 'Toggle Compass panel',
         category: 'panels' as const,
         action: () => {
           window.dispatchEvent(new CustomEvent('toggleIntelligencePanel'));

--- a/components/governada/panel/CollapsibleSection.tsx
+++ b/components/governada/panel/CollapsibleSection.tsx
@@ -3,8 +3,8 @@
 /**
  * CollapsibleSection — Arc Browser-style compress/expand section.
  *
- * Sections default to compressed state (one-line summary).
- * Click to expand and see full content.
+ * Sections default to expanded state (full content visible).
+ * Click to compress to one-line summary.
  * Smooth height animation with reduced-motion fallback.
  */
 
@@ -38,7 +38,7 @@ export function CollapsibleSection({
   title,
   summary,
   sentiment,
-  defaultExpanded = false,
+  defaultExpanded = true,
   children,
   className,
 }: CollapsibleSectionProps) {

--- a/components/governada/panel/EntityPreview.tsx
+++ b/components/governada/panel/EntityPreview.tsx
@@ -159,7 +159,7 @@ export function EntityPreview({ previewStack, children }: EntityPreviewProps) {
                 aria-label={depth === 1 ? 'Back to panel' : 'Back to previous preview'}
               >
                 <ArrowLeft className="h-3.5 w-3.5" />
-                {depth === 1 ? 'Back to Co-Pilot' : `Back`}
+                {depth === 1 ? 'Back to Compass' : `Back`}
               </button>
 
               {/* Breadcrumb trail */}


### PR DESCRIPTION
## Summary
- Logo moves to top of navigation rail (Linear/Slack pattern), hidden from header on desktop
- Rail + SectionTabBar get glassmorphic treatment matching header (bg-background/40 backdrop-blur-xl)
- Header spans full width with tighter right padding — controls anchored closer to right edge
- Co-Pilot renamed to Compass throughout (panel, shortcuts, entity preview back button)
- Compass toggle moved from bottom of rail to header right section (spatially coherent with right panel)
- Red notification dot removed from rail — header bell dropdown is the canonical notification UI
- Collapsible sections in Compass panel default to expanded (fewer clicks to see content)

## Impact
- **What changed**: Navigation shell visual refinements — layout, naming, glassmorphic consistency
- **User-facing**: Yes — logo in rail, transparent nav surfaces, "Compass" branding, expanded panel sections
- **Risk**: Low — visual/layout changes only, no data or API changes, no new feature flags
- **Scope**: 8 files modified. No migrations, no new deps, no Inngest changes.

## Test plan
- [ ] Logo appears at top-left of rail, clicking navigates to home
- [ ] Header shows breadcrumbs starting from left (no logo on desktop)
- [ ] Mobile header still shows "governada" text logo
- [ ] SectionTabBar is transparent/glassmorphic, globe visible behind it
- [ ] Rail is glassmorphic, globe visible behind it
- [ ] No red dot on rail nav items
- [ ] Compass toggle in header right section (compass icon)
- [ ] Panel header says "Compass" not "Co-Pilot"
- [ ] Panel sections default expanded
- [ ] "Back to Compass" text in entity preview
- [ ] ] keyboard shortcut still toggles panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)