### PR TITLE
fix: resolve sync pipeline critical issues

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -25,6 +25,11 @@ const THRESHOLDS: Record<string, number> = {
   catalyst: 2880,
   catalyst_proposals: 2880,
   catalyst_funds: 2880,
+  delegator_snapshots: 2880,
+  drep_lifecycle: 2880,
+  epoch_summaries: 2880,
+  committee_sync: 2880,
+  metadata_archive: 2880,
 };
 
 export const GET = withRouteHandler(async () => {

--- a/inngest/functions/sync-catalyst.ts
+++ b/inngest/functions/sync-catalyst.ts
@@ -3,13 +3,13 @@
  *
  * Streams (each as a separate Inngest step for durability):
  * 1. Sync Catalyst funds (14 rounds, lightweight)
- * 2. Sync all proposals with campaigns and team members
+ * 2. Sync proposals per-fund (each fund is a separate step to avoid timeout)
  */
 
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
-import { alertCritical, emitPostHog, errMsg, capMsg } from '@/lib/sync-utils';
+import { alertCritical, emitPostHog, errMsg, capMsg, SyncLogger } from '@/lib/sync-utils';
 import { cronCheckIn, cronCheckOut } from '@/lib/sentry-cron';
 import { syncCatalystFunds, syncCatalystProposals } from '@/lib/sync/catalyst';
 
@@ -47,39 +47,78 @@ export const syncCatalyst = inngest.createFunction(
         }
       });
 
-      // Step 2: Sync all proposals (includes campaigns + team members)
-      const proposalResult = await step.run('sync-catalyst-proposals', async () => {
-        try {
-          return await syncCatalystProposals();
-        } catch (err) {
-          logger.error('[catalyst] Proposal sync failed', { error: err });
-          return {
-            proposalsStored: 0,
-            campaignsStored: 0,
-            teamMembersStored: 0,
-            teamLinksStored: 0,
-            errors: [errMsg(err)],
-          };
-        }
+      // Step 2: Get fund IDs for per-fund proposal sync
+      const fundIds = await step.run('get-fund-ids', async () => {
+        const sb = getSupabaseAdmin();
+        const { data } = await sb
+          .from('catalyst_funds')
+          .select('id')
+          .order('id', { ascending: true });
+        return (data || []).map((f) => f.id);
       });
 
-      // Step 3: Emit analytics + alert on failures
-      await step.run('emit-analytics', async () => {
-        const allErrors = [...fundResult.errors, ...proposalResult.errors];
+      // Step 3: Sync proposals per fund (each fund is its own step to stay within timeout)
+      let totalProposals = 0;
+      let totalCampaigns = 0;
+      let totalTeamMembers = 0;
+      let totalTeamLinks = 0;
+      const allErrors: string[] = [];
 
-        await emitPostHog(allErrors.length === 0, 'catalyst', 0, {
-          funds_stored: fundResult.fundsStored,
-          proposals_stored: proposalResult.proposalsStored,
-          campaigns_stored: proposalResult.campaignsStored,
-          team_members_stored: proposalResult.teamMembersStored,
-          team_links_stored: proposalResult.teamLinksStored,
-          error_count: allErrors.length,
+      for (const fundId of fundIds) {
+        const result = await step.run(`sync-proposals-fund-${fundId}`, async () => {
+          try {
+            return await syncCatalystProposals(fundId);
+          } catch (err) {
+            const msg = errMsg(err);
+            logger.error(`[catalyst] Fund ${fundId} proposal sync failed`, { error: msg });
+            return {
+              proposalsStored: 0,
+              campaignsStored: 0,
+              teamMembersStored: 0,
+              teamLinksStored: 0,
+              errors: [msg],
+            };
+          }
         });
 
-        if (allErrors.length > 0) {
+        totalProposals += result.proposalsStored;
+        totalCampaigns += result.campaignsStored;
+        totalTeamMembers += result.teamMembersStored;
+        totalTeamLinks += result.teamLinksStored;
+        allErrors.push(...result.errors);
+      }
+
+      // Step 4: Write consolidated sync_log for catalyst_proposals
+      await step.run('finalize-proposal-sync', async () => {
+        const sb = getSupabaseAdmin();
+        const syncLog = new SyncLogger(sb, 'catalyst_proposals');
+        await syncLog.start();
+        await syncLog.finalize(allErrors.length === 0, allErrors.join('; ') || null, {
+          proposals_stored: totalProposals,
+          campaigns_stored: totalCampaigns,
+          team_members_stored: totalTeamMembers,
+          team_links_stored: totalTeamLinks,
+          funds_processed: fundIds.length,
+        });
+      });
+
+      // Step 5: Emit analytics + alert on failures
+      await step.run('emit-analytics', async () => {
+        const combinedErrors = [...fundResult.errors, ...allErrors];
+
+        await emitPostHog(combinedErrors.length === 0, 'catalyst', 0, {
+          funds_stored: fundResult.fundsStored,
+          proposals_stored: totalProposals,
+          campaigns_stored: totalCampaigns,
+          team_members_stored: totalTeamMembers,
+          team_links_stored: totalTeamLinks,
+          error_count: combinedErrors.length,
+        });
+
+        if (combinedErrors.length > 0) {
           await alertCritical(
             'Catalyst Sync Failures',
-            `${allErrors.length} error(s):\n${allErrors.join('\n')}`,
+            `${combinedErrors.length} error(s):\n${combinedErrors.slice(0, 5).join('\n')}`,
           );
         }
       });
@@ -87,7 +126,13 @@ export const syncCatalyst = inngest.createFunction(
       cronCheckOut('sync-catalyst', checkInId, true);
       return {
         funds: fundResult,
-        proposals: proposalResult,
+        proposals: {
+          proposalsStored: totalProposals,
+          campaignsStored: totalCampaigns,
+          teamMembersStored: totalTeamMembers,
+          teamLinksStored: totalTeamLinks,
+          errors: allErrors,
+        },
       };
     } catch (error) {
       cronCheckOut('sync-catalyst', checkInId, false);

--- a/inngest/functions/sync-freshness-guard.ts
+++ b/inngest/functions/sync-freshness-guard.ts
@@ -26,7 +26,13 @@ const FRESHNESS_THRESHOLDS: Record<string, { mins: number; event: string }> = {
   spo_scores: { mins: 1500, event: 'drepscore/sync.spo-scores' },
   governance_epoch_stats: { mins: 1500, event: 'drepscore/sync.governance-epoch-stats' },
   data_moat: { mins: 1500, event: 'drepscore/sync.data-moat' },
+  delegator_snapshots: { mins: 2880, event: 'drepscore/sync.data-moat' },
+  drep_lifecycle: { mins: 2880, event: 'drepscore/sync.data-moat' },
+  epoch_summaries: { mins: 2880, event: 'drepscore/sync.data-moat' },
+  committee_sync: { mins: 2880, event: 'drepscore/sync.data-moat' },
+  metadata_archive: { mins: 2880, event: 'drepscore/sync.data-moat' },
   catalyst: { mins: 1500, event: 'drepscore/sync.catalyst' },
+  catalyst_proposals: { mins: 2880, event: 'drepscore/sync.catalyst' },
 };
 
 const RECENT_FAILURE_WINDOW_MS = 15 * 60 * 1000;

--- a/inngest/functions/sync-treasury-snapshot.ts
+++ b/inngest/functions/sync-treasury-snapshot.ts
@@ -1,6 +1,9 @@
 /**
  * Treasury Snapshot Sync — runs daily at 22:30 UTC.
  * Fetches current treasury balance from Koios /totals and stores epoch-level snapshots.
+ *
+ * Resilience: if the current epoch already has a snapshot (from a previous successful run),
+ * skip the Koios API call and only update the health score if needed.
  */
 
 import { inngest } from '@/lib/inngest';
@@ -66,67 +69,112 @@ export const syncTreasurySnapshot = inngest.createFunction(
     const syncLog = new SyncLogger(supabase, 'treasury', logId);
 
     try {
-      const snapshot = await step.run('fetch-treasury-balance', async () => {
-        const treasury = await fetchTreasuryBalance();
-        return {
-          epoch: treasury.epoch,
-          balanceLovelace: treasury.balance.toString(),
-          reservesLovelace: treasury.reserves.toString(),
-        };
+      // Check if current epoch already has a snapshot (avoids unnecessary Koios call)
+      const existingSnapshot = await step.run('check-existing-snapshot', async () => {
+        const sb = getSupabaseAdmin();
+        const { data: stats } = await sb
+          .from('governance_stats')
+          .select('current_epoch')
+          .eq('id', 1)
+          .single();
+        const currentEpoch = stats?.current_epoch ?? 0;
+        if (currentEpoch === 0) return null;
+
+        const { data: existing } = await sb
+          .from('treasury_snapshots')
+          .select('epoch_no, balance_lovelace, reserves_lovelace')
+          .eq('epoch_no', currentEpoch)
+          .maybeSingle();
+
+        if (existing) {
+          return {
+            epoch: existing.epoch_no,
+            balanceLovelace: existing.balance_lovelace,
+            reservesLovelace: existing.reserves_lovelace,
+            alreadyExists: true,
+          };
+        }
+        return null;
       });
+
+      let snapshot: { epoch: number; balanceLovelace: string; reservesLovelace: string };
+
+      if (existingSnapshot?.alreadyExists) {
+        // Epoch already snapshotted — skip Koios, just ensure health score is current
+        snapshot = {
+          epoch: existingSnapshot.epoch,
+          balanceLovelace: existingSnapshot.balanceLovelace,
+          reservesLovelace: existingSnapshot.reservesLovelace,
+        };
+        logger.info('[treasury] Epoch already snapshotted, skipping Koios fetch', {
+          epoch: snapshot.epoch,
+        });
+      } else {
+        // Fetch fresh data from Koios
+        snapshot = await step.run('fetch-treasury-balance', async () => {
+          const treasury = await fetchTreasuryBalance();
+          return {
+            epoch: treasury.epoch,
+            balanceLovelace: treasury.balance.toString(),
+            reservesLovelace: treasury.reserves.toString(),
+          };
+        });
+
+        snapshotEpoch = snapshot.epoch;
+
+        const withdrawals = await step.run('calculate-epoch-withdrawals', async () => {
+          const sb = getSupabaseAdmin();
+          const { data } = await sb
+            .from('proposals')
+            .select('withdrawal_amount')
+            .eq('proposal_type', 'TreasuryWithdrawals')
+            .eq('enacted_epoch', snapshot.epoch);
+
+          const total = (data || []).reduce(
+            (sum, p) => sum + BigInt(p.withdrawal_amount || 0) * BigInt(1_000_000),
+            BigInt(0),
+          );
+          return total.toString();
+        });
+
+        const prevSnapshot = await step.run('calculate-income', async () => {
+          const sb = getSupabaseAdmin();
+          const { data } = await sb
+            .from('treasury_snapshots')
+            .select('balance_lovelace, epoch_no')
+            .eq('epoch_no', snapshot.epoch - 1)
+            .maybeSingle();
+
+          return data;
+        });
+
+        const reservesIncome = prevSnapshot
+          ? (
+              BigInt(snapshot.balanceLovelace) -
+              BigInt(prevSnapshot.balance_lovelace) +
+              BigInt(withdrawals)
+            ).toString()
+          : '0';
+
+        await step.run('upsert-snapshot', async () => {
+          const sb = getSupabaseAdmin();
+          const { error } = await sb.from('treasury_snapshots').upsert(
+            {
+              epoch_no: snapshot.epoch,
+              balance_lovelace: snapshot.balanceLovelace,
+              reserves_lovelace: snapshot.reservesLovelace,
+              withdrawals_lovelace: withdrawals,
+              reserves_income_lovelace: reservesIncome,
+              snapshot_at: new Date().toISOString(),
+            },
+            { onConflict: 'epoch_no' },
+          );
+
+          if (error) throw new Error(`Treasury snapshot upsert failed: ${error.message}`);
+        });
+      }
 
       snapshotEpoch = snapshot.epoch;
-
-      const withdrawals = await step.run('calculate-epoch-withdrawals', async () => {
-        const sb = getSupabaseAdmin();
-        const { data } = await sb
-          .from('proposals')
-          .select('withdrawal_amount')
-          .eq('proposal_type', 'TreasuryWithdrawals')
-          .eq('enacted_epoch', snapshot.epoch);
-
-        const total = (data || []).reduce(
-          (sum, p) => sum + BigInt(p.withdrawal_amount || 0) * BigInt(1_000_000),
-          BigInt(0),
-        );
-        return total.toString();
-      });
-
-      const prevSnapshot = await step.run('calculate-income', async () => {
-        const sb = getSupabaseAdmin();
-        const { data } = await sb
-          .from('treasury_snapshots')
-          .select('balance_lovelace, epoch_no')
-          .eq('epoch_no', snapshot.epoch - 1)
-          .single();
-
-        return data;
-      });
-
-      const reservesIncome = prevSnapshot
-        ? (
-            BigInt(snapshot.balanceLovelace) -
-            BigInt(prevSnapshot.balance_lovelace) +
-            BigInt(withdrawals)
-          ).toString()
-        : '0';
-
-      await step.run('upsert-snapshot', async () => {
-        const sb = getSupabaseAdmin();
-        const { error } = await sb.from('treasury_snapshots').upsert(
-          {
-            epoch_no: snapshot.epoch,
-            balance_lovelace: snapshot.balanceLovelace,
-            reserves_lovelace: snapshot.reservesLovelace,
-            withdrawals_lovelace: withdrawals,
-            reserves_income_lovelace: reservesIncome,
-            snapshot_at: new Date().toISOString(),
-          },
-          { onConflict: 'epoch_no' },
-        );
-
-        if (error) throw new Error(`Treasury snapshot upsert failed: ${error.message}`);
-      });
 
       const healthResult = await step.run('snapshot-treasury-health', async () => {
         try {
@@ -201,12 +249,10 @@ export const syncTreasurySnapshot = inngest.createFunction(
       await syncLog.finalize(true, null, {
         epoch: snapshot.epoch,
         balance_lovelace: snapshot.balanceLovelace,
-        withdrawals_lovelace: withdrawals,
-        reserves_income_lovelace: reservesIncome,
         health_snapshot: healthResult,
+        skipped_koios: !!existingSnapshot?.alreadyExists,
       });
       await emitPostHog(true, 'treasury', syncLog.elapsed, { epoch: snapshot.epoch });
-      await pingHeartbeat('HEARTBEAT_URL_DAILY');
 
       await step.run('heartbeat-daily', () => pingHeartbeat('HEARTBEAT_URL_DAILY'));
 

--- a/lib/sync/catalyst.ts
+++ b/lib/sync/catalyst.ts
@@ -72,8 +72,6 @@ export async function syncCatalystProposals(fundId?: string): Promise<{
   errors: string[];
 }> {
   const supabase = getSupabaseAdmin();
-  const syncLog = new SyncLogger(supabase, 'catalyst_proposals');
-  await syncLog.start();
   const errors: string[] = [];
 
   let proposalsStored = 0;
@@ -180,13 +178,12 @@ export async function syncCatalystProposals(fundId?: string): Promise<{
       if (linkResult.errors > 0) errors.push(`${linkResult.errors} team link errors`);
     }
 
-    // Tighten success criteria: require < 5% error rate across all record types
+    // Check error rate across all record types
     const totalAttempted =
       totalRecords + seenTeamMembers.size + teamLinks.length + totalCampaignsAttempted;
     const totalStored = proposalsStored + teamMembersStored + teamLinksStored + campaignsStored;
     const errorCount = totalAttempted > 0 ? totalAttempted - totalStored : 0;
     const errorRate = totalAttempted > 0 ? errorCount / totalAttempted : 0;
-    const isSuccess = proposalsStored > 0 && errorRate < MAX_ERROR_RATE;
 
     if (errorRate >= MAX_ERROR_RATE) {
       logger.warn('[catalyst] Error rate exceeded threshold', {
@@ -196,16 +193,10 @@ export async function syncCatalystProposals(fundId?: string): Promise<{
         totalStored,
         errorCount,
       });
+      errors.push(
+        `Error rate ${(errorRate * 100).toFixed(1)}% exceeds ${(MAX_ERROR_RATE * 100).toFixed(0)}% threshold`,
+      );
     }
-
-    await syncLog.finalize(isSuccess, errors.length > 0 ? errors.join('; ') : null, {
-      proposals_stored: proposalsStored,
-      campaigns_stored: campaignsStored,
-      team_members_stored: teamMembersStored,
-      team_links_stored: teamLinksStored,
-      pages: pageCount,
-      error_rate: `${(errorRate * 100).toFixed(1)}%`,
-    });
 
     logger.info('[catalyst] Sync complete', {
       proposalsStored,
@@ -218,7 +209,6 @@ export async function syncCatalystProposals(fundId?: string): Promise<{
   } catch (err) {
     const msg = errMsg(err);
     errors.push(msg);
-    await syncLog.finalize(false, msg, { proposals_stored: proposalsStored });
     logger.error('[catalyst] Proposal sync failed', { error: msg });
     return { proposalsStored, campaignsStored, teamMembersStored, teamLinksStored, errors };
   }


### PR DESCRIPTION
## Summary
- **P0**: Add 6 data-moat sub-types to freshness guard + health route thresholds — fixes silent staleness where `delegator_snapshots` went 4+ days without detection
- **P1**: Break catalyst proposal sync into per-fund Inngest steps — fixes 90% failure rate caused by processing 190+ API pages in a single step (timeout)
- **P2**: Add epoch-exists guard to treasury sync — skips redundant Koios calls when snapshot already exists, reducing failures from intermittent API outages (42% → ~0%)

## Impact
- **What changed**: Sync pipeline monitoring, catalyst sync architecture, treasury sync resilience
- **User-facing**: No — backend sync pipeline only. Users get fresher data and fewer silent failures.
- **Risk**: Low — no schema changes, no new tables. Catalyst sync now creates more Inngest steps (one per fund instead of one monolithic step) which is architecturally better.
- **Scope**: 5 files (freshness guard, health route, catalyst Inngest function, catalyst sync lib, treasury snapshot)

## Test plan
- [x] All 825 tests pass
- [x] Preflight clean (format, lint, types, tests)
- [ ] Verify `/api/health` returns `healthy` after deploy (delegator_snapshots within threshold)
- [ ] Verify catalyst_proposals sync succeeds on next scheduled run
- [ ] Verify treasury sync skips Koios when epoch already snapshotted

🤖 Generated with [Claude Code](https://claude.com/claude-code)