### PR TITLE
fix: workspace polish — amendment route, badge contrast, tab gating

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -153,8 +153,8 @@
   --primary: oklch(0.72 0.12 192);
   --primary-foreground: oklch(0.12 0.015 260);
 
-  /* Secondary: Wayfinder Amber — softer glow */
-  --secondary: oklch(0.78 0.12 75);
+  /* Secondary: Wayfinder Amber — darker bg for legible white text */
+  --secondary: oklch(0.45 0.1 75);
   --secondary-foreground: oklch(0.95 0.005 260);
 
   --muted: oklch(0.18 0.015 260);

--- a/app/workspace/layout.tsx
+++ b/app/workspace/layout.tsx
@@ -7,7 +7,8 @@ import { SectionSpotlightTrigger } from '@/components/discovery/SectionSpotlight
 export default function WorkspaceLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isStudioMode =
-    pathname === '/workspace/review' || /^\/workspace\/(author|editor)\/[^/]+/.test(pathname);
+    pathname === '/workspace/review' ||
+    /^\/workspace\/(author|editor|amendment)\/[^/]+/.test(pathname);
 
   return (
     <>

--- a/components/governada/SectionTabBar.tsx
+++ b/components/governada/SectionTabBar.tsx
@@ -48,6 +48,19 @@ export function SectionTabBar({ section: _section }: SectionTabBarProps) {
             const active = isActive(item.href);
             const count = item.sublabelKey ? metrics[item.sublabelKey] : undefined;
 
+            if (item.disabled) {
+              return (
+                <span
+                  key={item.href}
+                  className="shrink-0 px-3 py-2 text-sm font-medium whitespace-nowrap relative min-h-[40px] inline-flex items-center text-muted-foreground/40 cursor-not-allowed"
+                  title={item.disabledTooltip}
+                  aria-disabled="true"
+                >
+                  {t(item.label)}
+                </span>
+              );
+            }
+
             return (
               <Link
                 key={item.href}

--- a/components/workspace/shared/PortfolioSearch.tsx
+++ b/components/workspace/shared/PortfolioSearch.tsx
@@ -73,7 +73,7 @@ export function PortfolioSearch({
 
       {/* Archive toggle */}
       {showArchiveToggle && onShowArchivedChange && (
-        <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer select-none">
+        <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer select-none rounded-md bg-accent/60 backdrop-blur-sm px-3 py-1.5 border border-border/30">
           <Switch size="sm" checked={showArchived} onCheckedChange={onShowArchivedChange} />
           Archived
         </label>

--- a/lib/nav/config.ts
+++ b/lib/nav/config.ts
@@ -69,6 +69,10 @@ export interface NavItem {
   minDepth?: GovernanceDepth;
   /** Key for Living Sidebar sub-label (e.g., 'home.pendingVotes') */
   sublabelKey?: string;
+  /** Render as disabled (visible but not clickable) */
+  disabled?: boolean;
+  /** Tooltip shown on hover when disabled */
+  disabledTooltip?: string;
 }
 
 /** A labelled group of items within a section (for dual-role workspace) */
@@ -166,7 +170,13 @@ export const WORKSPACE_SPO_ITEMS: NavItem[] = [
  */
 export const WORKSPACE_CITIZEN_ITEMS: NavItem[] = [
   { href: '/workspace/author', label: 'Author', icon: PenLine },
-  { href: '/workspace/review', label: 'Review', icon: FileText },
+  {
+    href: '/workspace/review',
+    label: 'Review',
+    icon: FileText,
+    disabled: true,
+    disabledTooltip: 'Connect as a DRep or SPO to review and vote on proposals',
+  },
 ];
 
 export const GOVERNANCE_ITEMS: NavItem[] = [


### PR DESCRIPTION
## Summary
- **Amendment route fix**: `/workspace/amendment/[id]` was broken because the workspace layout's `isStudioMode` regex didn't include `amendment` — studio components rendered under the section tab bar
- **Badge contrast**: Dark-mode secondary (Wayfinder Amber) background lightness reduced from 0.78 to 0.45 so white text is legible
- **Review tab gating**: Citizens without a DRep/SPO profile now see the Review tab as disabled with a tooltip explaining why
- **Archived toggle visibility**: Added glassmorphic background (`bg-accent/60 backdrop-blur-sm`) so the toggle doesn't disappear against transparent backgrounds

## Impact
- **What changed**: 4 targeted fixes across workspace layout, color tokens, nav config, and search component
- **User-facing**: Yes — amendment editor works again, badges readable, Review tab properly gated, archived toggle visible
- **Risk**: Low — each fix is isolated and minimal
- **Scope**: 5 files, 29 insertions, 5 deletions

## Test plan
- [ ] Navigate to `/workspace/amendment/[draftId]` — should render full-screen studio editor without section tab bar
- [ ] Check secondary badges (proposal counts, view toggle) — amber background should have readable white text
- [ ] View workspace as citizen (no DRep) — Review tab should be greyed out with tooltip on hover
- [ ] Author page — archived toggle should have visible glassmorphic background

🤖 Generated with [Claude Code](https://claude.com/claude-code)