### PR TITLE
feat: Linear-style table row list mode for Author & Review

### DIFF
--- a/components/workspace/author/DraftTableRow.tsx
+++ b/components/workspace/author/DraftTableRow.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle2, ShieldCheck, XCircle, Clock } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import { useFocusStore } from '@/lib/workspace/focus';
+import { useProposalMonitor } from '@/hooks/useProposalMonitor';
+import { DraftQuickActions } from './DraftQuickActions';
+import type { ProposalDraft } from '@/lib/workspace/types';
+import type { ProposalMonitorData } from '@/lib/workspace/monitor-types';
+
+// ---------------------------------------------------------------------------
+// Helpers (shared with DraftCard)
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const date = new Date(dateStr).getTime();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
+  return Math.max(0, Math.floor((Date.now() - new Date(dateStr).getTime()) / 86_400_000));
+}
+
+function completenessCount(draft: ProposalDraft): { filled: number; total: number } {
+  const fields = [draft.title, draft.abstract, draft.motivation, draft.rationale];
+  const filled = fields.filter((f) => f && f.trim().length > 0).length;
+  return { filled, total: 4 };
+}
+
+const ON_CHAIN_STATUS_LABELS: Record<
+  ProposalMonitorData['status'],
+  { label: string; className: string }
+> = {
+  voting: { label: 'Voting', className: 'bg-blue-500/15 text-blue-400' },
+  ratified: {
+    label: 'Ratified',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  enacted: {
+    label: 'Enacted',
+    className: 'bg-[var(--compass-teal)]/15 text-[var(--compass-teal)]',
+  },
+  expired: { label: 'Expired', className: 'bg-muted text-muted-foreground' },
+  dropped: { label: 'Dropped', className: 'bg-destructive/15 text-destructive' },
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ColumnType = 'drafts' | 'inReview' | 'onChain' | 'archived';
+
+interface DraftTableRowProps {
+  draft: ProposalDraft;
+  column: ColumnType;
+  itemProps?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DraftTableRow({ draft, column, itemProps }: DraftTableRowProps) {
+  const router = useRouter();
+  const setInputMethod = useFocusStore((s) => s.setInputMethod);
+
+  const editorPath =
+    draft.status === 'submitted'
+      ? `/workspace/author/${draft.id}/monitor`
+      : draft.proposalType === 'NewConstitution'
+        ? `/workspace/amendment/${draft.id}`
+        : `/workspace/author/${draft.id}`;
+
+  const href =
+    column === 'onChain' && draft.status === 'submitted'
+      ? `/workspace/author/${draft.id}/debrief`
+      : editorPath;
+
+  return (
+    <div
+      className="group/row relative border-b border-border/50 last:border-b-0 hover:bg-accent/40 transition-colors"
+      {...(itemProps ?? {})}
+    >
+      <Link
+        href={href}
+        onClick={() => setInputMethod('pointer')}
+        className="flex items-center gap-4 px-3 py-2.5 min-h-[44px]"
+      >
+        {/* Title — takes remaining space */}
+        <span
+          className="flex-1 min-w-0 font-medium text-sm truncate"
+          style={{ viewTransitionName: `draft-title-${draft.id}` }}
+        >
+          {draft.title || 'Untitled proposal'}
+        </span>
+
+        {/* Metadata — right-aligned, fixed-width slots */}
+        <div className="flex items-center gap-3 shrink-0">
+          {/* Type badge */}
+          <Badge variant="outline" className="text-xs hidden sm:inline-flex">
+            {PROPOSAL_TYPE_LABELS[draft.proposalType] ?? draft.proposalType}
+          </Badge>
+
+          {/* Column-specific metadata */}
+          {column === 'drafts' && <DraftMeta draft={draft} />}
+          {column === 'inReview' && <InReviewMeta draft={draft} />}
+          {column === 'onChain' && <OnChainMeta draft={draft} />}
+
+          {/* Version */}
+          <span className="text-xs text-muted-foreground tabular-nums w-6 text-right">
+            v{draft.currentVersion}
+          </span>
+
+          {/* Updated time */}
+          <span className="text-xs text-muted-foreground w-16 text-right hidden md:block">
+            {formatRelativeTime(draft.updatedAt)}
+          </span>
+        </div>
+      </Link>
+
+      {/* Quick actions — hover only on desktop, always on mobile */}
+      <div
+        className="absolute right-1 top-1/2 -translate-y-1/2 opacity-100 sm:opacity-0 sm:group-hover/row:opacity-100 focus-within:opacity-100 transition-opacity duration-150"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <DraftQuickActions draft={draft} router={router} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline metadata sub-components
+// ---------------------------------------------------------------------------
+
+function DraftMeta({ draft }: { draft: ProposalDraft }) {
+  const { filled, total } = completenessCount(draft);
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="flex gap-0.5">
+        {Array.from({ length: total }).map((_, i) => (
+          <span
+            key={i}
+            className={cn(
+              'inline-block h-1.5 w-1.5 rounded-full',
+              i < filled ? 'bg-emerald-500' : 'bg-muted-foreground/30',
+            )}
+          />
+        ))}
+      </div>
+      <span className="text-xs text-muted-foreground tabular-nums">
+        {filled}/{total}
+      </span>
+    </div>
+  );
+}
+
+function InReviewMeta({ draft }: { draft: ProposalDraft }) {
+  const { filled } = completenessCount(draft);
+  const fieldsOk = filled >= 4;
+  const constCheck = draft.lastConstitutionalCheck?.score ?? null;
+
+  const days = daysSince(draft.communityReviewStartedAt);
+
+  return (
+    <div className="flex items-center gap-2.5">
+      {days !== null && <span className="text-xs text-muted-foreground tabular-nums">{days}d</span>}
+      <span
+        className={cn(
+          'flex items-center gap-0.5 text-xs',
+          fieldsOk ? 'text-emerald-400' : 'text-muted-foreground',
+        )}
+      >
+        {fieldsOk ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
+        {filled}/4
+      </span>
+      {constCheck && (
+        <span
+          className={cn(
+            'flex items-center gap-0.5 text-xs',
+            constCheck === 'pass'
+              ? 'text-emerald-400'
+              : constCheck === 'warning'
+                ? 'text-amber-400'
+                : 'text-destructive',
+          )}
+        >
+          <ShieldCheck className="h-3 w-3" />
+        </span>
+      )}
+    </div>
+  );
+}
+
+function OnChainMeta({ draft }: { draft: ProposalDraft }) {
+  const { data: monitor } = useProposalMonitor(draft.submittedTxHash, 0);
+
+  if (!monitor) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Badge className={cn('text-xs', ON_CHAIN_STATUS_LABELS[monitor.status].className)}>
+        {ON_CHAIN_STATUS_LABELS[monitor.status].label}
+      </Badge>
+      {monitor.epochsRemaining != null && monitor.status === 'voting' && (
+        <span className="flex items-center gap-0.5 text-xs text-muted-foreground tabular-nums">
+          <Clock className="h-3 w-3" />
+          {monitor.epochsRemaining}e
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/workspace/author/PortfolioView.tsx
+++ b/components/workspace/author/PortfolioView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useWorkspaceStore } from '@/lib/workspace/store';
 import { useFocusableList } from '@/hooks/useFocusableList';
@@ -10,8 +10,17 @@ import { commandRegistry } from '@/lib/workspace/commands';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { FileText, FileEdit, MessageSquare, Globe, Archive } from 'lucide-react';
+import {
+  FileText,
+  FileEdit,
+  MessageSquare,
+  Globe,
+  Archive,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
 import { DraftCard } from './DraftCard';
+import { DraftTableRow } from './DraftTableRow';
 import type { ProposalDraft, DraftStatus } from '@/lib/workspace/types';
 
 // ---------------------------------------------------------------------------
@@ -283,16 +292,16 @@ export function PortfolioView({ drafts, isLoading, showArchived }: PortfolioView
     );
   }
 
-  // List mode
+  // List mode — Linear-style stacked rows grouped by status
   const listColumns: ColumnType[] = ['drafts', 'inReview', 'onChain'];
   if (showArchived && groups.archived.length > 0) {
     listColumns.push('archived');
   }
 
   return (
-    <div className="space-y-6" {...listProps}>
+    <div className="space-y-1" {...listProps}>
       {listColumns.map((col) => (
-        <ListGroup
+        <TableGroup
           key={col}
           column={col}
           drafts={groups[col]}
@@ -354,45 +363,57 @@ function KanbanColumn({ column, drafts, flatOffset, getItemProps }: KanbanColumn
 }
 
 // ---------------------------------------------------------------------------
-// List Group
+// Table Group (Linear-style stacked rows with collapsible header)
 // ---------------------------------------------------------------------------
 
-interface ListGroupProps {
+interface TableGroupProps {
   column: ColumnType;
   drafts: ProposalDraft[];
   flatOffset: number;
   getItemProps: (index: number) => Record<string, unknown>;
 }
 
-function ListGroup({ column, drafts, flatOffset, getItemProps }: ListGroupProps) {
+function TableGroup({ column, drafts, flatOffset, getItemProps }: TableGroupProps) {
   const meta = COLUMN_META[column];
   const Icon = meta.icon;
+  const [expanded, setExpanded] = useState(true);
 
   return (
     <div data-column={column}>
-      {/* Group header */}
-      <div className="flex items-center gap-2 mb-3 border-b border-border pb-2">
+      {/* Group header — clickable to collapse */}
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex items-center gap-2 w-full px-1 py-1.5 text-left hover:bg-accent/30 rounded transition-colors"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
         <Icon className="h-4 w-4 text-muted-foreground" />
-        <h3 className="text-sm font-medium text-muted-foreground">{meta.label}</h3>
+        <span className="text-sm font-medium text-muted-foreground">{meta.label}</span>
         <Badge variant="secondary" className="text-xs tabular-nums">
           {drafts.length}
         </Badge>
-      </div>
+      </button>
 
-      {/* Group content */}
-      {drafts.length === 0 ? (
-        <EmptyColumnState title={meta.emptyTitle} description={meta.emptyDescription} />
-      ) : (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: 'var(--workspace-gap)' }}>
-          {drafts.map((draft, i) => (
-            <DraftCard
-              key={draft.id}
-              draft={draft}
-              index={i}
-              column={column}
-              itemProps={getItemProps(flatOffset + i)}
-            />
-          ))}
+      {/* Rows */}
+      {expanded && (
+        <div className="border border-border/50 rounded-md overflow-hidden">
+          {drafts.length === 0 ? (
+            <div className="px-3 py-3 text-xs text-muted-foreground/60">
+              {meta.emptyDescription}
+            </div>
+          ) : (
+            drafts.map((draft, i) => (
+              <DraftTableRow
+                key={draft.id}
+                draft={draft}
+                column={column}
+                itemProps={getItemProps(flatOffset + i)}
+              />
+            ))
+          )}
         </div>
       )}
     </div>

--- a/components/workspace/review/ReviewPortfolio.tsx
+++ b/components/workspace/review/ReviewPortfolio.tsx
@@ -16,6 +16,7 @@ import { PortfolioStats } from '@/components/workspace/shared/PortfolioStats';
 import { TriageSummary } from '@/components/workspace/shared/TriageSummary';
 import type { TriageInsight } from '@/components/workspace/shared/TriageSummary';
 import { ReviewCard } from './ReviewCard';
+import { ReviewTableRow } from './ReviewTableRow';
 import type { ReviewCardVariant } from './ReviewCard';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -487,26 +488,26 @@ export function ReviewPortfolio() {
           </div>
         </div>
       ) : (
-        <div className="space-y-6" {...listProps}>
-          <ListGroup
+        <div className="space-y-1" {...listProps}>
+          <ReviewTableGroup
             column="feedback"
             drafts={filteredGroups.feedback}
             flatOffset={groupOffsets.feedback}
             getItemProps={getItemProps}
           />
-          <ListGroup
+          <ReviewTableGroup
             column="voting"
             proposals={filteredGroups.voting}
             flatOffset={groupOffsets.voting}
             getItemProps={getItemProps}
           />
-          {filteredGroups.completed.length > 0 && (
-            <CollapsibleCompletedSection
-              proposals={filteredGroups.completed}
-              flatOffset={groupOffsets.completed}
-              getItemProps={getItemProps}
-            />
-          )}
+          <ReviewTableGroup
+            column="completed"
+            proposals={filteredGroups.completed}
+            flatOffset={groupOffsets.completed}
+            getItemProps={getItemProps}
+            defaultCollapsed
+          />
         </div>
       )}
     </div>
@@ -591,108 +592,83 @@ function KanbanColumn({ column, drafts, proposals, flatOffset, getItemProps }: K
 }
 
 // ---------------------------------------------------------------------------
-// List Group
+// Table Group (Linear-style stacked rows with collapsible header)
 // ---------------------------------------------------------------------------
 
-interface ListGroupProps {
+interface ReviewTableGroupProps {
   column: ReviewColumnType;
   drafts?: ProposalDraft[];
   proposals?: ReviewQueueItem[];
   flatOffset: number;
   getItemProps: (index: number) => Record<string, unknown>;
+  defaultCollapsed?: boolean;
 }
 
-function ListGroup({ column, drafts, proposals, flatOffset, getItemProps }: ListGroupProps) {
-  const meta = COLUMN_META[column];
-  const count = (drafts?.length ?? 0) + (proposals?.length ?? 0);
-  const Icon = meta.icon;
-
-  return (
-    <div data-column={column}>
-      {/* Group header */}
-      <div className="flex items-center gap-2 mb-3 border-b border-border pb-2">
-        <Icon className="h-4 w-4 text-muted-foreground" />
-        <h3 className="text-sm font-medium text-muted-foreground">{meta.label}</h3>
-        <Badge variant="secondary" className="text-xs tabular-nums">
-          {count}
-        </Badge>
-      </div>
-
-      {/* Group content */}
-      {count === 0 ? (
-        <EmptyColumnState title={meta.emptyTitle} description={meta.emptyDescription} />
-      ) : (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: 'var(--workspace-gap)' }}>
-          {drafts?.map((draft, i) => (
-            <ReviewCard
-              key={draft.id}
-              variant="feedback"
-              draft={draft}
-              index={i}
-              itemProps={getItemProps(flatOffset + i)}
-            />
-          ))}
-          {proposals?.map((proposal, i) => (
-            <ReviewCard
-              key={`${proposal.txHash}-${proposal.proposalIndex}`}
-              variant={column === 'completed' ? 'completed' : 'voting'}
-              proposal={proposal}
-              index={i + (drafts?.length ?? 0)}
-              itemProps={getItemProps(flatOffset + (drafts?.length ?? 0) + i)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Collapsible Completed Section (list mode only — default collapsed)
-// ---------------------------------------------------------------------------
-
-interface CollapsibleCompletedSectionProps {
-  proposals: ReviewQueueItem[];
-  flatOffset: number;
-  getItemProps: (index: number) => Record<string, unknown>;
-}
-
-function CollapsibleCompletedSection({
+function ReviewTableGroup({
+  column,
+  drafts,
   proposals,
   flatOffset,
   getItemProps,
-}: CollapsibleCompletedSectionProps) {
-  const [expanded, setExpanded] = useState(false);
+  defaultCollapsed = false,
+}: ReviewTableGroupProps) {
+  const meta = COLUMN_META[column];
+  const count = (drafts?.length ?? 0) + (proposals?.length ?? 0);
+  const Icon = meta.icon;
+  const [expanded, setExpanded] = useState(!defaultCollapsed);
+
+  // Don't render empty groups when defaultCollapsed (completed with 0 items)
+  if (count === 0 && defaultCollapsed) return null;
+
+  const variant: ReviewCardVariant =
+    column === 'completed' ? 'completed' : column === 'voting' ? 'voting' : 'feedback';
 
   return (
-    <div data-column="completed">
+    <div data-column={column}>
+      {/* Group header — clickable to collapse */}
       <button
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex items-center gap-2 mb-3 border-b border-border pb-2 w-full text-left"
+        className="flex items-center gap-2 w-full px-1 py-1.5 text-left hover:bg-accent/30 rounded transition-colors"
       >
         {expanded ? (
           <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
         ) : (
           <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
         )}
-        <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium text-muted-foreground">Completed</span>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-muted-foreground">{meta.label}</span>
         <Badge variant="secondary" className="text-xs tabular-nums">
-          {proposals.length}
+          {count}
         </Badge>
       </button>
 
+      {/* Rows */}
       {expanded && (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3" style={{ gap: 'var(--workspace-gap)' }}>
-          {proposals.map((proposal, i) => (
-            <ReviewCard
-              key={`${proposal.txHash}-${proposal.proposalIndex}`}
-              variant="completed"
-              proposal={proposal}
-              index={i}
-              itemProps={getItemProps(flatOffset + i)}
-            />
-          ))}
+        <div className="border border-border/50 rounded-md overflow-hidden">
+          {count === 0 ? (
+            <div className="px-3 py-3 text-xs text-muted-foreground/60">
+              {meta.emptyDescription}
+            </div>
+          ) : (
+            <>
+              {drafts?.map((draft, i) => (
+                <ReviewTableRow
+                  key={draft.id}
+                  variant="feedback"
+                  draft={draft}
+                  itemProps={getItemProps(flatOffset + i)}
+                />
+              ))}
+              {proposals?.map((proposal, i) => (
+                <ReviewTableRow
+                  key={`${proposal.txHash}-${proposal.proposalIndex}`}
+                  variant={variant}
+                  proposal={proposal}
+                  itemProps={getItemProps(flatOffset + (drafts?.length ?? 0) + i)}
+                />
+              ))}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/components/workspace/review/ReviewTableRow.tsx
+++ b/components/workspace/review/ReviewTableRow.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Clock, Vote } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { PROPOSAL_TYPE_LABELS } from '@/lib/workspace/types';
+import { useFocusStore } from '@/lib/workspace/focus';
+import type { ProposalDraft, ProposalType, ReviewQueueItem } from '@/lib/workspace/types';
+import type { ReviewCardVariant } from './ReviewCard';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function daysSince(dateStr: string | null): number | null {
+  if (!dateStr) return null;
+  return Math.max(0, Math.floor((Date.now() - new Date(dateStr).getTime()) / 86_400_000));
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface ReviewTableRowProps {
+  variant: ReviewCardVariant;
+  draft?: ProposalDraft;
+  proposal?: ReviewQueueItem;
+  itemProps?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Routing helper
+// ---------------------------------------------------------------------------
+
+function getHref(
+  variant: ReviewCardVariant,
+  draft?: ProposalDraft,
+  proposal?: ReviewQueueItem,
+): string {
+  if (variant === 'feedback' && draft) {
+    return `/workspace/author/${draft.id}`;
+  }
+  if (proposal) {
+    return `/workspace/review?proposal=${encodeURIComponent(proposal.txHash)}:${proposal.proposalIndex}`;
+  }
+  return '/workspace/review';
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ReviewTableRow({ variant, draft, proposal, itemProps }: ReviewTableRowProps) {
+  const setInputMethod = useFocusStore((s) => s.setInputMethod);
+  const href = getHref(variant, draft, proposal);
+  const isCompleted = variant === 'completed';
+
+  const title =
+    variant === 'feedback' ? draft?.title || 'Untitled Draft' : proposal?.title || 'Untitled';
+
+  const proposalType =
+    variant === 'feedback'
+      ? draft?.proposalType
+      : (proposal?.proposalType as ProposalType | undefined);
+
+  return (
+    <div
+      className={cn(
+        'group/row relative border-b border-border/50 last:border-b-0 transition-colors',
+        isCompleted ? 'opacity-60 hover:opacity-80' : 'hover:bg-accent/40',
+      )}
+      {...(itemProps ?? {})}
+    >
+      <Link
+        href={href}
+        onClick={() => setInputMethod('pointer')}
+        className="flex items-center gap-4 px-3 py-2.5 min-h-[44px]"
+      >
+        {/* Title */}
+        <span className="flex-1 min-w-0 font-medium text-sm truncate">{title}</span>
+
+        {/* Metadata */}
+        <div className="flex items-center gap-3 shrink-0">
+          {/* Type badge */}
+          {proposalType && (
+            <Badge variant="outline" className="text-xs hidden sm:inline-flex">
+              {PROPOSAL_TYPE_LABELS[proposalType] ?? proposalType}
+            </Badge>
+          )}
+
+          {/* Variant-specific metadata */}
+          {variant === 'feedback' && draft && <FeedbackMeta draft={draft} />}
+          {variant === 'voting' && proposal && <VotingMeta proposal={proposal} />}
+          {variant === 'completed' && proposal && <CompletedMeta proposal={proposal} />}
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline metadata
+// ---------------------------------------------------------------------------
+
+function FeedbackMeta({ draft }: { draft: ProposalDraft }) {
+  const days = daysSince(draft.communityReviewStartedAt);
+
+  return days !== null ? (
+    <span className="flex items-center gap-1 text-xs text-muted-foreground tabular-nums">
+      <Clock className="h-3 w-3" />
+      {days}d
+    </span>
+  ) : null;
+}
+
+function VotingMeta({ proposal }: { proposal: ReviewQueueItem }) {
+  const epochsRemaining = proposal.epochsRemaining;
+  const isFinalEpoch = epochsRemaining != null && epochsRemaining <= 1;
+  const isUrgent = epochsRemaining != null && epochsRemaining <= 3;
+
+  // Mini DRep approval bar
+  const drep = proposal.interBodyVotes?.drep;
+  const totalDrep = drep ? drep.yes + drep.no + drep.abstain : 0;
+  const yesPct = totalDrep > 0 && drep ? Math.round((drep.yes / totalDrep) * 100) : null;
+
+  return (
+    <div className="flex items-center gap-3">
+      {/* Treasury amount */}
+      {proposal.withdrawalAmount != null && (
+        <span className="text-xs text-muted-foreground tabular-nums hidden lg:block">
+          ₳{Number(proposal.withdrawalAmount).toLocaleString()}
+        </span>
+      )}
+
+      {/* Approval % */}
+      {yesPct !== null && (
+        <div className="flex items-center gap-1.5 w-16">
+          <div className="h-1 flex-1 rounded-full bg-muted/50 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-emerald-500 voting-progress-live"
+              style={{ width: `${yesPct}%` }}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground tabular-nums">{yesPct}%</span>
+        </div>
+      )}
+
+      {/* Epochs */}
+      {epochsRemaining != null && (
+        <span
+          className={cn(
+            'flex items-center gap-0.5 text-xs tabular-nums',
+            isFinalEpoch
+              ? 'text-red-400 font-medium'
+              : isUrgent
+                ? 'text-amber-400'
+                : 'text-muted-foreground',
+          )}
+        >
+          <Clock className="h-3 w-3" />
+          {epochsRemaining}e
+        </span>
+      )}
+
+      {/* Urgency badge */}
+      {isFinalEpoch && (
+        <Badge className="text-xs bg-red-500/20 text-red-400 hidden sm:inline-flex">Final!</Badge>
+      )}
+    </div>
+  );
+}
+
+function CompletedMeta({ proposal }: { proposal: ReviewQueueItem }) {
+  const vote = proposal.existingVote;
+
+  const voteColor: Record<string, string> = {
+    Yes: 'bg-emerald-500/20 text-emerald-400',
+    yes: 'bg-emerald-500/20 text-emerald-400',
+    No: 'bg-red-500/20 text-red-400',
+    no: 'bg-red-500/20 text-red-400',
+    Abstain: 'bg-muted text-muted-foreground',
+    abstain: 'bg-muted text-muted-foreground',
+  };
+
+  return vote ? (
+    <Badge className={cn('text-xs', voteColor[vote] ?? 'bg-muted text-muted-foreground')}>
+      <Vote className="h-3 w-3 mr-1" />
+      {vote}
+    </Badge>
+  ) : null;
+}


### PR DESCRIPTION
## Summary
- Replace card-grid list mode with Linear-style stacked full-width rows grouped by status
- `DraftTableRow`: title left, inline type badge, completeness dots, constitutional check icon, version, timestamp right-aligned
- `ReviewTableRow`: title left, mini approval bar, epochs countdown, treasury amount, vote badge
- Collapsible group headers with chevron toggle (completed default-collapsed in Review)
- Full-row hover highlight matching Linear's pattern
- Kanban mode unchanged — only list view replaced

## Impact
- **What changed**: List mode is now a dense, scannable table-row layout instead of a card grid
- **User-facing**: Yes — switching to list view shows a fundamentally different, more information-dense layout
- **Risk**: Low — kanban mode untouched, new components are additive, old ListGroup removed
- **Scope**: 2 new components, 2 modified components

## Test plan
- [ ] Author list mode: rows show title, type badge, completeness, version, timestamp
- [ ] Author list mode: click group header to collapse/expand
- [ ] Author list mode: hover highlights full row
- [ ] Author list mode: quick actions appear on row hover
- [ ] Review list mode: voting rows show approval bar, epochs, treasury amount
- [ ] Review list mode: completed group starts collapsed
- [ ] Review list mode: completed rows show vote badge (Yes/No/Abstain)
- [ ] Kanban mode: unchanged, still shows cards
- [ ] Mobile: type badges hidden, rows still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)