### PR TITLE
fix: polish governance pages — proposals, pools, committee, treasury

### DIFF
--- a/app/api/sidebar-metrics/route.ts
+++ b/app/api/sidebar-metrics/route.ts
@@ -60,33 +60,35 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
 
   // ── Governance metrics (everyone) ─────────────────────────────────────
 
-  const [activeProposals, drepCount, ghiSnapshots, treasury, criticalCount] = await Promise.all([
-    supabase
-      .from('proposals')
-      .select('tx_hash', { count: 'exact', head: true })
-      .is('ratified_epoch', null)
-      .is('enacted_epoch', null)
-      .is('dropped_epoch', null)
-      .is('expired_epoch', null),
-    supabase
-      .from('dreps')
-      .select('id', { count: 'exact', head: true })
-      .eq('info->>isActive', 'true'),
-    supabase
-      .from('ghi_snapshots')
-      .select('ghi_score')
-      .order('epoch_no', { ascending: false })
-      .limit(2),
-    getTreasuryBalance(),
-    supabase
-      .from('proposals')
-      .select('tx_hash', { count: 'exact', head: true })
-      .in('proposal_type', CRITICAL_TYPES)
-      .is('ratified_epoch', null)
-      .is('enacted_epoch', null)
-      .is('dropped_epoch', null)
-      .is('expired_epoch', null),
-  ]);
+  const [activeProposals, drepCount, poolCount, ghiSnapshots, treasury, criticalCount] =
+    await Promise.all([
+      supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .is('ratified_epoch', null)
+        .is('enacted_epoch', null)
+        .is('dropped_epoch', null)
+        .is('expired_epoch', null),
+      supabase
+        .from('dreps')
+        .select('id', { count: 'exact', head: true })
+        .eq('info->>isActive', 'true'),
+      supabase.from('pools').select('pool_id', { count: 'exact', head: true }).gt('vote_count', 0),
+      supabase
+        .from('ghi_snapshots')
+        .select('ghi_score')
+        .order('epoch_no', { ascending: false })
+        .limit(2),
+      getTreasuryBalance(),
+      supabase
+        .from('proposals')
+        .select('tx_hash', { count: 'exact', head: true })
+        .in('proposal_type', CRITICAL_TYPES)
+        .is('ratified_epoch', null)
+        .is('enacted_epoch', null)
+        .is('dropped_epoch', null)
+        .is('expired_epoch', null),
+    ]);
 
   // Active proposals with critical count
   const totalActive = activeProposals.count ?? 0;
@@ -95,6 +97,7 @@ export const GET = withRouteHandler(async (request: NextRequest) => {
     critical > 0 ? `${totalActive} active · ${critical} critical` : `${totalActive} active`;
 
   metrics['gov.activeDreps'] = `${drepCount.count ?? 0} DReps`;
+  metrics['gov.activePools'] = `${poolCount.count ?? 0} pools`;
 
   // GHI with trend
   const ghiData = ghiSnapshots.data ?? [];

--- a/app/governance/committee/page.tsx
+++ b/app/governance/committee/page.tsx
@@ -152,7 +152,7 @@ function MemberCard({
   return (
     <Link
       href={`/governance/committee/${encodeURIComponent(member.ccHotId)}`}
-      className="group block rounded-xl border border-border/60 p-4 transition-colors hover:bg-muted/40 active:bg-muted/60"
+      className="group block rounded-xl border border-border/50 p-4 transition-colors hover:bg-muted/40 active:bg-muted/60"
     >
       <div className="flex items-start gap-3">
         {/* Grade badge */}
@@ -242,7 +242,7 @@ function Methodology() {
   ];
 
   return (
-    <div className="rounded-xl border border-border/60 bg-card/30">
+    <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md">
       <button
         onClick={() => setOpen(!open)}
         className="flex w-full items-center justify-between px-5 py-3.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -416,7 +416,7 @@ export default function CommitteePage() {
             ) : (
               <>
                 {/* Desktop: compact rows */}
-                <div className="hidden sm:block rounded-xl border border-border/60 divide-y divide-border/40 overflow-hidden">
+                <div className="hidden sm:block rounded-xl border border-border/50 bg-card/70 backdrop-blur-md divide-y divide-border/40 overflow-hidden">
                   {sorted.map((member) => (
                     <MemberRow
                       key={member.ccHotId}

--- a/app/governance/treasury/TreasuryOverview.tsx
+++ b/app/governance/treasury/TreasuryOverview.tsx
@@ -47,7 +47,7 @@ interface TreasuryCurrentData {
   healthScore: number | null;
   healthComponents: Record<string, number> | null;
   pendingCount: number;
-  pendingTotalAda: number;
+  pendingTotalAda?: number;
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -94,6 +94,7 @@ export function TreasuryOverview() {
   const epoch = treasury?.epoch ?? 0;
   const trend = treasury?.trend ?? 'stable';
   const pendingCount = treasury?.pendingCount ?? 0;
+  const pendingTotalAda = treasury?.pendingTotalAda ?? 0;
   const effectivenessRate = rawEffectiveness?.effectivenessRate ?? null;
 
   const nclImpact = ncl
@@ -117,6 +118,7 @@ export function TreasuryOverview() {
         ncl={ncl}
         effectivenessRate={effectivenessRate}
         pendingCount={pendingCount}
+        pendingTotalAda={pendingTotalAda}
         runwayMonths={runway}
       />
 

--- a/components/TreasuryPendingProposals.tsx
+++ b/components/TreasuryPendingProposals.tsx
@@ -101,7 +101,7 @@ export function TreasuryPendingProposals({ nclImpact, drepVotes }: Props) {
         {data.proposals.map((p) => (
           <Link
             key={`${p.txHash}-${p.index}`}
-            href={`/proposals/${p.txHash}/${p.index}`}
+            href={`/proposal/${p.txHash}/${p.index}`}
             className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors"
           >
             <div className="flex-1 min-w-0">
@@ -130,9 +130,13 @@ export function TreasuryPendingProposals({ nclImpact, drepVotes }: Props) {
               </div>
               <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
                 <span className="font-mono tabular-nums">
-                  {p.withdrawalAda != null ? `${formatAda(p.withdrawalAda)} ADA` : 'Amount TBD'}
+                  {p.withdrawalAda != null
+                    ? `₳${formatAda(p.withdrawalAda)}`
+                    : 'Amount not specified'}
                 </span>
-                <span>{p.pctOfBalance.toFixed(2)}% of treasury</span>
+                {p.withdrawalAda != null && p.pctOfBalance > 0 && (
+                  <span>{p.pctOfBalance.toFixed(2)}% of treasury</span>
+                )}
                 <span>Epoch {p.proposedEpoch}</span>
               </div>
               {nclImpact && p.withdrawalAda != null && p.withdrawalAda > 0 && (

--- a/components/cc/CCBriefingCard.tsx
+++ b/components/cc/CCBriefingCard.tsx
@@ -19,6 +19,32 @@ const SEVERITY_STYLES: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse whatChanged text — handles JSON arrays, newline-separated, or raw strings */
+function parseChangeLines(raw: string): string[] {
+  const trimmed = raw.trim();
+  // If it looks like a JSON array, try parsing it
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((s: unknown) => String(s).replace(/^[-*]\s*/, '')).filter(Boolean);
+      }
+    } catch {
+      // Not valid JSON — fall through to text parsing
+    }
+  }
+  // Strip leading/trailing brackets and quotes that might wrap the whole string
+  const cleaned = trimmed.replace(/^\[["']?|["']?\]$/g, '');
+  return cleaned
+    .split(/["\n]/)
+    .map((s) => s.replace(/^[-*,;\s]+|[",;\s]+$/g, '').trim())
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -35,7 +61,7 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
   return (
     <motion.div
       variants={fadeInUp}
-      className="rounded-xl border border-border/60 bg-card/30 p-5 sm:p-6 space-y-4"
+      className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 sm:p-6 space-y-4"
     >
       {/* Header with AI badge */}
       <div className="flex items-start justify-between gap-3">
@@ -58,18 +84,15 @@ export function CCBriefingCard({ briefing }: CCBriefingCardProps) {
           <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
             Recent changes
           </p>
-          {briefing.whatChanged
-            .split('\n')
-            .filter(Boolean)
-            .map((line, idx) => (
-              <p
-                key={idx}
-                className="flex items-start gap-2 text-sm text-muted-foreground leading-relaxed"
-              >
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/40" />
-                <span>{line.replace(/^[-*]\s*/, '')}</span>
-              </p>
-            ))}
+          {parseChangeLines(briefing.whatChanged).map((line, idx) => (
+            <p
+              key={idx}
+              className="flex items-start gap-2 text-sm text-muted-foreground leading-relaxed"
+            >
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary/40" />
+              <span>{line.replace(/^[-*]\s*/, '')}</span>
+            </p>
+          ))}
         </div>
       )}
 

--- a/components/governada/discover/ProposalsBrowse.tsx
+++ b/components/governada/discover/ProposalsBrowse.tsx
@@ -66,10 +66,9 @@ function ProposalStatusSummary({ proposals }: { proposals: BrowseProposal[] }) {
             <span className="text-sm text-muted-foreground">decided</span>
           </div>
         </div>
-        {/* Show most recent open proposals as compact clickable rows */}
+        {/* Show all open proposals as compact clickable rows */}
         {proposals
           .filter((p) => (p.status ?? 'Open').toLowerCase() === 'open')
-          .slice(0, 3)
           .map((p) => {
             const theme = p.type ? getProposalTheme(p.type) : null;
             const TypeIcon = theme?.icon;
@@ -87,16 +86,11 @@ function ProposalStatusSummary({ proposals }: { proposals: BrowseProposal[] }) {
               </Link>
             );
           })}
-        <Link
-          href="/governance/proposals"
-          className="text-xs text-primary hover:underline"
-          onClick={(e) => {
-            // Prevent navigation loop — we're already on this page, just prompt depth change
-            e.preventDefault();
-          }}
-        >
-          See all proposals &rarr;
-        </Link>
+        {decided > 0 && (
+          <Link href="/governance/proposals" className="text-xs text-primary hover:underline">
+            See all {active + decided} proposals &rarr;
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/components/treasury/TreasuryVerdict.tsx
+++ b/components/treasury/TreasuryVerdict.tsx
@@ -10,6 +10,7 @@ interface TreasuryVerdictProps {
   ncl: NclUtilization | null;
   effectivenessRate: number | null;
   pendingCount: number;
+  pendingTotalAda?: number;
   runwayMonths: number;
 }
 
@@ -66,6 +67,7 @@ export function TreasuryVerdict({
   ncl,
   effectivenessRate,
   pendingCount,
+  pendingTotalAda,
   runwayMonths,
 }: TreasuryVerdictProps) {
   const status = deriveStatus(ncl, effectivenessRate, trend, runwayMonths);
@@ -101,7 +103,11 @@ export function TreasuryVerdict({
           </span>
         )}
         <span className="text-muted-foreground">
-          <span className="font-semibold text-foreground">{pendingCount}</span> pending
+          <span className="font-semibold text-foreground">{pendingCount}</span>{' '}
+          {pendingCount === 1 ? 'proposal' : 'proposals'} pending
+          {pendingTotalAda != null && pendingTotalAda > 0 && (
+            <span className="ml-1">(₳{formatAda(pendingTotalAda)})</span>
+          )}
         </span>
         <span className="text-muted-foreground">
           ₳<span className="font-semibold text-foreground">{formatAda(balanceAda)}</span> balance


### PR DESCRIPTION
## Summary
- Show all open proposals in hands-off view (was limited to 3); fix dead "See all proposals" CTA
- Add SPO count to governance header tab (was missing unlike Proposals, DReps, Treasury)
- Fix JSON bracket wrapping `["..."]` in committee AI brief "Recent Changes" section
- Clarify treasury verdict: "3 pending" → "3 proposals pending (₳X)" with ADA amount
- Improve treasury pending proposals: "Amount TBD" → "Amount not specified", hide meaningless 0% stat
- Fix treasury pending proposal links (`/proposals/` → `/proposal/`)
- Align committee page glassmorphic styling (`bg-card/70 backdrop-blur-md`) with other governance pages

## Impact
- **What changed**: 7 small UX fixes across 4 governance pages
- **User-facing**: Yes — clearer treasury info, more proposals visible, consistent committee styling
- **Risk**: Low — styling and display-only changes, one new DB query (pool count) in sidebar-metrics
- **Scope**: 7 files, no migrations, no Inngest changes

## Test plan
- [x] Preflight passes (format + lint + types + 825 tests)
- [ ] Verify proposals page shows all open proposals
- [ ] Verify pools tab shows count in header
- [ ] Verify committee AI brief renders without brackets
- [ ] Verify treasury verdict shows "N proposals pending (₳X)"
- [ ] Verify treasury pending proposals show "Amount not specified" instead of "Amount TBD"

🤖 Generated with [Claude Code](https://claude.com/claude-code)