### PR TITLE
fix: governance pages batch 2 — match-aware views, CC votes, treasury hero, health enrichment

### DIFF
--- a/app/api/governance/committee/route.ts
+++ b/app/api/governance/committee/route.ts
@@ -63,16 +63,37 @@ export const GET = withRouteHandler(async () => {
     }
   }
 
-  // Build vote counts per member using cold ID as canonical identity
-  // This ensures votes are properly aggregated across hot key rotations
+  // Build vote counts per member, indexed by BOTH hot_id and cold_id.
+  // Votes may have cc_cold_id=null (hot→cold mapping wasn't built at sync time),
+  // but members typically have cc_cold_id set. Dual-keying ensures lookups succeed
+  // regardless of which ID is canonical on each side.
   const voteMap = new Map<string, { yes: number; no: number; abstain: number }>();
   for (const v of votes ?? []) {
-    const memberId = v.cc_cold_id ?? v.cc_hot_id;
-    const existing = voteMap.get(memberId) || { yes: 0, no: 0, abstain: 0 };
+    // Use a shared counter object so both keys reference the same counts
+    const primaryKey = v.cc_hot_id;
+    const existing = voteMap.get(primaryKey) || { yes: 0, no: 0, abstain: 0 };
     if (v.vote === 'Yes') existing.yes++;
     else if (v.vote === 'No') existing.no++;
     else existing.abstain++;
-    voteMap.set(memberId, existing);
+    voteMap.set(primaryKey, existing);
+    // Also index under cold_id so member lookup by cold_id finds the same counts
+    if (v.cc_cold_id && v.cc_cold_id !== primaryKey) {
+      voteMap.set(v.cc_cold_id, existing);
+    }
+  }
+  // Ensure members with cold_id can find votes indexed only by hot_id:
+  // build a hot→cold mapping from active members and cross-link
+  for (const m of activeMembers ?? []) {
+    if (m.cc_cold_id && m.cc_hot_id) {
+      const hotCounts = voteMap.get(m.cc_hot_id);
+      if (hotCounts && !voteMap.has(m.cc_cold_id)) {
+        voteMap.set(m.cc_cold_id, hotCounts);
+      }
+      const coldCounts = voteMap.get(m.cc_cold_id);
+      if (coldCounts && !voteMap.has(m.cc_hot_id)) {
+        voteMap.set(m.cc_hot_id, coldCounts);
+      }
+    }
   }
 
   // Compute aggregate stats
@@ -204,8 +225,31 @@ export const GET = withRouteHandler(async () => {
       }
     : null;
 
+  // Derive actionable improvement areas from member data
+  const improvementAreas: string[] = [];
+  const nonVoters = members.filter((m) => m.voteCount === 0).length;
+  if (nonVoters > 0) {
+    improvementAreas.push(
+      `${nonVoters} of ${members.length} active members have not voted on any proposal`,
+    );
+  }
+  if (health && health.avgFidelity != null && health.avgFidelity < 60) {
+    improvementAreas.push(
+      `Average constitutional fidelity is ${Math.round(health.avgFidelity)}/100 — stronger reasoning needed`,
+    );
+  }
+  if (avgRationaleRate != null && avgRationaleRate < 50) {
+    improvementAreas.push(`Only ${avgRationaleRate}% of votes include written rationales`);
+  }
+  if (health && health.tensionCount > 2) {
+    improvementAreas.push(`${health.tensionCount} CC–DRep disagreements on recent proposals`);
+  }
+
+  // Attach improvement areas to health for client consumption
+  const healthWithAreas = health ? { ...health, improvementAreas } : health;
+
   return NextResponse.json(
-    { members, health, stats, agreementMatrix, blocs, archetypes, briefing },
+    { members, health: healthWithAreas, stats, agreementMatrix, blocs, archetypes, briefing },
     {
       headers: {
         'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300',

--- a/app/api/governance/pools/route.ts
+++ b/app/api/governance/pools/route.ts
@@ -40,6 +40,12 @@ export const GET = withRouteHandler(async () => {
         governanceStatement: p.governance_statement ?? null,
         poolStatus: p.pool_status ?? 'registered',
         scoreMomentum: p.score_momentum ?? null,
+        alignmentTreasuryConservative: p.alignment_treasury_conservative ?? null,
+        alignmentTreasuryGrowth: p.alignment_treasury_growth ?? null,
+        alignmentDecentralization: p.alignment_decentralization ?? null,
+        alignmentSecurity: p.alignment_security ?? null,
+        alignmentInnovation: p.alignment_innovation ?? null,
+        alignmentTransparency: p.alignment_transparency ?? null,
       }));
       return { pools };
     }

--- a/app/api/og/treasury/route.tsx
+++ b/app/api/og/treasury/route.tsx
@@ -42,7 +42,7 @@ export async function GET() {
       );
     }
 
-    const burnRate = calculateBurnRate(snapshots, 10);
+    const burnRate = calculateBurnRate(snapshots);
     const runway = calculateRunwayMonths(balance.balanceAda, burnRate);
     const score = healthScore?.score ?? 0;
     const balanceStr = formatLargeNumber(balance.balanceAda);

--- a/app/api/treasury/current/route.ts
+++ b/app/api/treasury/current/route.ts
@@ -15,7 +15,7 @@ export const GET = withRouteHandler(
   async () => {
     const [balance, snapshots, healthScore] = await Promise.all([
       getTreasuryBalance(),
-      getTreasuryTrend(30),
+      getTreasuryTrend(200),
       calculateTreasuryHealthScore(),
     ]);
 
@@ -23,7 +23,7 @@ export const GET = withRouteHandler(
       return NextResponse.json({ error: 'No treasury data available' }, { status: 404 });
     }
 
-    const burnRate = calculateBurnRate(snapshots, 10);
+    const burnRate = calculateBurnRate(snapshots);
     const runwayMonths = calculateRunwayMonths(balance.balanceAda, burnRate);
     const pending = await getPendingTreasuryProposals(balance.balanceAda);
     const totalPendingAda = pending.reduce((s, p) => s + (p.withdrawalAda ?? 0), 0);

--- a/app/api/treasury/simulate/route.ts
+++ b/app/api/treasury/simulate/route.ts
@@ -17,13 +17,13 @@ export const GET = withRouteHandler(async (request) => {
     ? parseFloat(searchParams.get('pendingAda')!)
     : undefined;
 
-  const [balance, snapshots] = await Promise.all([getTreasuryBalance(), getTreasuryTrend(30)]);
+  const [balance, snapshots] = await Promise.all([getTreasuryBalance(), getTreasuryTrend(200)]);
 
   if (!balance) {
     return NextResponse.json({ error: 'No treasury data' }, { status: 404 });
   }
 
-  const burnRate = calculateBurnRate(snapshots, 10) * burnAdjust;
+  const burnRate = calculateBurnRate(snapshots) * burnAdjust;
   const avgIncome =
     snapshots.length > 0
       ? snapshots.reduce((s, r) => s + r.reservesIncomeAda, 0) / snapshots.length

--- a/app/governance/treasury/TreasuryOverview.tsx
+++ b/app/governance/treasury/TreasuryOverview.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { TreasuryVerdict } from '@/components/treasury/TreasuryVerdict';
-import { NclBudgetBar } from '@/components/treasury/NclBudgetBar';
+import { TreasuryHero } from '@/components/treasury/TreasuryHero';
 import { NclUtilizationTrend } from '@/components/treasury/NclUtilizationTrend';
-import { TreasuryKeyMetrics } from '@/components/treasury/TreasuryKeyMetrics';
 import { TreasuryEpochFlow } from '@/components/treasury/TreasuryEpochFlow';
 import { TreasuryPendingProposals } from '@/components/TreasuryPendingProposals';
 import { TreasuryAccountabilitySection } from '@/components/TreasuryAccountabilitySection';
@@ -108,11 +106,10 @@ export function TreasuryOverview() {
   return (
     <div className="space-y-6">
       {/* ──────────────────────────────────────────────────────────────
-          LEVEL 1 — THE VERDICT
-          One glanceable health indicator + inline stats.
-          Passes the 5-second test on its own.
+          LEVEL 1 — THE HERO
+          5-second glanceable verdict + budget bar + key stats.
          ────────────────────────────────────────────────────────────── */}
-      <TreasuryVerdict
+      <TreasuryHero
         balanceAda={balance}
         trend={trend}
         ncl={ncl}
@@ -121,33 +118,6 @@ export function TreasuryOverview() {
         pendingTotalAda={pendingTotalAda}
         runwayMonths={runway}
       />
-
-      {/* ──────────────────────────────────────────────────────────────
-          LEVEL 2 — THE BUDGET STORY
-          Where is the money going this period?
-         ────────────────────────────────────────────────────────────── */}
-      <section className="space-y-4">
-        {ncl && (
-          <p className="text-sm text-muted-foreground">
-            The community set a ₳{formatAda(ncl.period.nclAda)} spending limit for epochs{' '}
-            {ncl.period.startEpoch}–{ncl.period.endEpoch}. Here&apos;s how it&apos;s being used.
-          </p>
-        )}
-
-        {ncl && <NclBudgetBar ncl={ncl} />}
-        {!ncl && treasury && (
-          <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 text-sm text-muted-foreground">
-            No active NCL period. The community has not yet set a spending limit for the current
-            epoch range.
-          </div>
-        )}
-
-        <TreasuryKeyMetrics
-          ncl={ncl}
-          pendingCount={pendingCount}
-          effectivenessRate={effectivenessRate}
-        />
-      </section>
 
       {/* ──────────────────────────────────────────────────────────────
           LEVEL 3 — ACTIVE DECISIONS

--- a/components/cc/CCHealthVerdict.tsx
+++ b/components/cc/CCHealthVerdict.tsx
@@ -213,6 +213,24 @@ export function CCHealthVerdict({ health }: CCHealthVerdictProps) {
               </span>
             )}
           </div>
+
+          {/* Improvement areas */}
+          {health.improvementAreas && health.improvementAreas.length > 0 && (
+            <div className="space-y-1.5 rounded-lg bg-amber-500/5 border border-amber-500/15 px-3 py-2.5">
+              <p className="text-[10px] font-medium text-amber-400/80 uppercase tracking-wider">
+                What would improve this score
+              </p>
+              {health.improvementAreas.map((area, i) => (
+                <p
+                  key={i}
+                  className="flex items-start gap-2 text-xs text-muted-foreground leading-relaxed"
+                >
+                  <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-amber-500/50" />
+                  <span>{area}</span>
+                </p>
+              ))}
+            </div>
+          )}
         </motion.div>
       </div>
     </motion.div>

--- a/components/governada/cards/GovernadaSPOCard.tsx
+++ b/components/governada/cards/GovernadaSPOCard.tsx
@@ -35,6 +35,12 @@ export interface GovernadaSPOData {
   governanceStatement?: string | null;
   poolStatus?: string | null;
   scoreMomentum?: number | null;
+  alignmentTreasuryConservative?: number | null;
+  alignmentTreasuryGrowth?: number | null;
+  alignmentDecentralization?: number | null;
+  alignmentSecurity?: number | null;
+  alignmentInnovation?: number | null;
+  alignmentTransparency?: number | null;
 }
 
 function formatAda(ada: number): string {
@@ -44,16 +50,17 @@ function formatAda(ada: number): string {
   return String(ada);
 }
 
-/** Returns the top 1-2 governance strengths (scores >= 60) as citizen-friendly labels. */
+/** Returns the top 1-2 differentiating governance strengths as citizen-friendly labels.
+ *  Only shows pillars where the pool genuinely excels (>= 75), sorted by score. */
 export function getPoolStrengths(pool: GovernadaSPOData): string[] {
   const pillars: [string, number][] = [
-    ['Active voter', pool.participationPct ?? 0],
-    ['Thoughtful', pool.deliberationPct ?? 0],
-    ['Reliable', pool.reliabilityPct ?? 0],
-    ['Clear identity', pool.governanceIdentityPct ?? 0],
+    ['Consistent voter', pool.participationPct ?? 0],
+    ['Deep deliberator', pool.deliberationPct ?? 0],
+    ['Always online', pool.reliabilityPct ?? 0],
+    ['Verified operator', pool.governanceIdentityPct ?? 0],
   ];
   return pillars
-    .filter(([, v]) => v >= 60)
+    .filter(([, v]) => v >= 75)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 2)
     .map(([label]) => label);
@@ -62,9 +69,10 @@ export function getPoolStrengths(pool: GovernadaSPOData): string[] {
 interface GovernadaSPOCardProps {
   pool: GovernadaSPOData;
   rank?: number;
+  matchScore?: number;
 }
 
-export function GovernadaSPOCard({ pool, rank }: GovernadaSPOCardProps) {
+export function GovernadaSPOCard({ pool, rank, matchScore }: GovernadaSPOCardProps) {
   const score = pool.governanceScore ?? 0;
   const tier = tierKey(computeTier(score));
   const isProvisional = pool.confidence != null && pool.confidence < 60;
@@ -145,6 +153,20 @@ export function GovernadaSPOCard({ pool, rank }: GovernadaSPOCardProps) {
               <TierBadge tier={tier} />
               {isProvisional && <AlertTriangle className="h-2.5 w-2.5 text-amber-500" />}
             </div>
+            {matchScore != null && (
+              <span
+                className={cn(
+                  'text-[10px] font-bold tabular-nums px-1.5 py-0.5 rounded-full mt-1',
+                  matchScore >= 70
+                    ? 'bg-emerald-500/10 text-emerald-400'
+                    : matchScore >= 50
+                      ? 'bg-amber-500/10 text-amber-400'
+                      : 'bg-muted text-muted-foreground',
+                )}
+              >
+                {matchScore}% match
+              </span>
+            )}
           </div>
         </div>
 

--- a/components/governada/discover/GovernadaDRepBrowse.tsx
+++ b/components/governada/discover/GovernadaDRepBrowse.tsx
@@ -37,6 +37,7 @@ import { PeekTrigger } from '@/components/governada/peeks/PeekTrigger';
 import { usePeekTrigger } from '@/components/governada/peeks/PeekDrawerProvider';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
+import { MatchAwareDiscoverHero } from './MatchAwareDiscoverHero';
 import {
   loadMatchProfile,
   alignmentDistance,
@@ -384,6 +385,7 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
   const drepsData = rawData as { allDReps?: EnrichedDRep[] } | undefined;
   const dreps: EnrichedDRep[] = useMemo(() => drepsData?.allDReps ?? [], [drepsData]);
   const { isAtLeast } = useGovernanceDepth();
+  const { delegatedDrepId } = useWallet();
 
   const searchParams = useSearchParams();
   const contentRef = useRef<HTMLDivElement>(null);
@@ -537,9 +539,33 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
     );
   }
 
-  // ── Hands-Off: focused single-DRep card ────────────────────────────────
+  // ── Hands-Off: match-aware discovery or delegation summary ──────────
   if (!isAtLeast('informed')) {
-    return <YourDRepSummary dreps={dreps} />;
+    // Wallet-connected users with a delegation: show their DRep summary
+    if (delegatedDrepId) {
+      return <YourDRepSummary dreps={dreps} />;
+    }
+    // Anonymous / no delegation: show match-aware hero
+    const drepEntities = dreps.map((d) => ({
+      id: d.drepId,
+      name: d.name || d.ticker || d.handle || `${d.drepId.slice(0, 16)}\u2026`,
+      score: d.drepScore ?? 0,
+      participationPct: d.participationRate ?? null,
+      alignmentTreasuryConservative: d.alignmentTreasuryConservative,
+      alignmentTreasuryGrowth: d.alignmentTreasuryGrowth,
+      alignmentDecentralization: d.alignmentDecentralization,
+      alignmentSecurity: d.alignmentSecurity,
+      alignmentInnovation: d.alignmentInnovation,
+      alignmentTransparency: d.alignmentTransparency,
+    }));
+    return (
+      <MatchAwareDiscoverHero
+        entityType="drep"
+        entities={drepEntities}
+        isLoading={isLoading}
+        totalCount={dreps.length}
+      />
+    );
   }
 
   // ── Informed: top DReps by activity + your DRep highlighted ─────────────

--- a/components/governada/discover/GovernadaSPOBrowse.tsx
+++ b/components/governada/discover/GovernadaSPOBrowse.tsx
@@ -28,8 +28,10 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { PeekTrigger } from '@/components/governada/peeks/PeekTrigger';
 import { usePeekTrigger } from '@/components/governada/peeks/PeekDrawerProvider';
+import { useGovernanceDepth } from '@/hooks/useGovernanceDepth';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
+import { MatchAwareDiscoverHero } from './MatchAwareDiscoverHero';
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -234,6 +236,7 @@ export function GovernadaSPOBrowse() {
     () => (rawPools as GovernadaSPOData[]) ?? [],
     [rawPools],
   );
+  const { isAtLeast } = useGovernanceDepth();
 
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const [page, setPage] = useState(0);
@@ -308,6 +311,30 @@ export function GovernadaSPOBrowse() {
           ))}
         </div>
       </div>
+    );
+  }
+
+  // ── Hands-Off: match-aware discovery hero ──────────────────────────
+  if (!isAtLeast('informed')) {
+    const poolEntities = pools.map((p) => ({
+      id: p.poolId,
+      name: p.ticker || p.poolName || `${p.poolId.slice(0, 16)}\u2026`,
+      score: p.governanceScore ?? 0,
+      participationPct: p.participationPct ?? null,
+      alignmentTreasuryConservative: p.alignmentTreasuryConservative,
+      alignmentTreasuryGrowth: p.alignmentTreasuryGrowth,
+      alignmentDecentralization: p.alignmentDecentralization,
+      alignmentSecurity: p.alignmentSecurity,
+      alignmentInnovation: p.alignmentInnovation,
+      alignmentTransparency: p.alignmentTransparency,
+    }));
+    return (
+      <MatchAwareDiscoverHero
+        entityType="spo"
+        entities={poolEntities}
+        isLoading={isLoading}
+        totalCount={pools.length}
+      />
     );
   }
 

--- a/components/governada/discover/MatchAwareDiscoverHero.tsx
+++ b/components/governada/discover/MatchAwareDiscoverHero.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { ChevronRight, Sparkles, Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton';
+import { computeTier } from '@/lib/scoring/tiers';
+import { TIER_SCORE_COLOR, tierKey } from '@/components/governada/cards/tierStyles';
+import { loadMatchProfile, alignmentDistance, distanceToMatchScore } from '@/lib/matchStore';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+
+/* ── Types ──────────────────────────────────────────────────────────── */
+
+interface DiscoverEntity {
+  id: string;
+  name: string;
+  score: number;
+  participationPct: number | null;
+  alignmentTreasuryConservative?: number | null;
+  alignmentTreasuryGrowth?: number | null;
+  alignmentDecentralization?: number | null;
+  alignmentSecurity?: number | null;
+  alignmentInnovation?: number | null;
+  alignmentTransparency?: number | null;
+}
+
+interface MatchAwareDiscoverHeroProps {
+  entityType: 'drep' | 'spo';
+  entities: DiscoverEntity[];
+  isLoading: boolean;
+  /** Total registered count (may differ from entities.length if filtered) */
+  totalCount?: number;
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────────── */
+
+function getEntityAlignment(entity: DiscoverEntity): AlignmentScores {
+  return {
+    treasuryConservative: entity.alignmentTreasuryConservative ?? 50,
+    treasuryGrowth: entity.alignmentTreasuryGrowth ?? 50,
+    decentralization: entity.alignmentDecentralization ?? 50,
+    security: entity.alignmentSecurity ?? 50,
+    innovation: entity.alignmentInnovation ?? 50,
+    transparency: entity.alignmentTransparency ?? 50,
+  };
+}
+
+const LABELS = {
+  drep: {
+    singular: 'representative',
+    plural: 'representatives',
+    heading: 'Representatives',
+    findCta: 'Find your representative',
+    matchCta: 'Take the 60-second match quiz',
+    retakeCta: 'Retake the match quiz',
+    browseHref: '/governance/representatives',
+    matchHref: '/match',
+  },
+  spo: {
+    singular: 'pool',
+    plural: 'pools',
+    heading: 'Stake Pools',
+    findCta: 'Find a governance-active pool',
+    matchCta: 'Take the 60-second match quiz',
+    retakeCta: 'Retake the match quiz',
+    browseHref: '/governance/pools',
+    matchHref: '/match',
+  },
+} as const;
+
+/* ── Compact entity row ──────────────────────────────────────────────── */
+
+function EntityRow({
+  entity,
+  entityType,
+  matchScore,
+  rank,
+}: {
+  entity: DiscoverEntity;
+  entityType: 'drep' | 'spo';
+  matchScore?: number;
+  rank: number;
+}) {
+  const score = entity.score;
+  const tier = tierKey(computeTier(score));
+  const href = entityType === 'drep' ? `/drep/${entity.id}` : `/pool/${entity.id}`;
+
+  return (
+    <Link
+      href={href}
+      className="group flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-muted/30 transition-colors"
+    >
+      <span className="text-xs text-muted-foreground/50 font-mono tabular-nums w-5 text-center shrink-0">
+        {rank}
+      </span>
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium truncate block group-hover:text-primary transition-colors">
+          {entity.name}
+        </span>
+      </div>
+      {matchScore != null && (
+        <span
+          className={cn(
+            'text-[10px] font-bold tabular-nums px-1.5 py-0.5 rounded-full shrink-0',
+            matchScore >= 70
+              ? 'bg-emerald-500/10 text-emerald-400'
+              : matchScore >= 50
+                ? 'bg-amber-500/10 text-amber-400'
+                : 'bg-muted text-muted-foreground',
+          )}
+        >
+          {matchScore}% match
+        </span>
+      )}
+      <span className={cn('text-sm font-bold tabular-nums shrink-0', TIER_SCORE_COLOR[tier])}>
+        {score}
+      </span>
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/30 shrink-0" />
+    </Link>
+  );
+}
+
+/* ── Main component ──────────────────────────────────────────────────── */
+
+export function MatchAwareDiscoverHero({
+  entityType,
+  entities,
+  isLoading,
+  totalCount,
+}: MatchAwareDiscoverHeroProps) {
+  const labels = LABELS[entityType];
+  const count = totalCount ?? entities.length;
+
+  // Check for match profile in localStorage
+  const matchProfile = useMemo(() => {
+    try {
+      return loadMatchProfile();
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Compute match scores and sort
+  const rankedEntities = useMemo(() => {
+    if (!matchProfile) {
+      // No match profile — sort by governance score, show top 5
+      return entities
+        .slice()
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 5)
+        .map((e) => ({ entity: e, matchScore: undefined as number | undefined }));
+    }
+
+    // Has match profile — compute match scores and sort by blended score
+    const userAlign = matchProfile.userAlignments;
+    return entities
+      .map((e) => {
+        const entityAlign = getEntityAlignment(e);
+        const distance = alignmentDistance(userAlign, entityAlign);
+        const matchScore = distanceToMatchScore(distance);
+        const blended = (matchScore / 100) * 0.7 + (e.score / 100) * 0.3;
+        return { entity: e, matchScore, blended };
+      })
+      .sort((a, b) => b.blended - a.blended)
+      .slice(0, 5)
+      .map(({ entity, matchScore }) => ({ entity, matchScore }));
+  }, [entities, matchProfile]);
+
+  // Stats
+  const avgParticipation = useMemo(() => {
+    const withPct = entities.filter((e) => e.participationPct != null);
+    if (withPct.length === 0) return null;
+    return Math.round(
+      withPct.reduce((sum, e) => sum + (e.participationPct ?? 0), 0) / withPct.length,
+    );
+  }, [entities]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-6 w-48" />
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const hasMatches = matchProfile != null;
+
+  return (
+    <div className="space-y-3" data-discovery={`gov-${entityType}`}>
+      <h1 className="text-xl font-bold tracking-tight">{labels.heading}</h1>
+
+      {/* Stats bar */}
+      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <Users className="h-3.5 w-3.5" />
+          <span className="font-semibold text-foreground">{count.toLocaleString()}</span>{' '}
+          governance-active {labels.plural}
+        </span>
+        {avgParticipation != null && (
+          <span>
+            <span className="font-semibold text-foreground">{avgParticipation}%</span> avg
+            participation
+          </span>
+        )}
+      </div>
+
+      {/* Ranked entities */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md overflow-hidden">
+        {hasMatches && (
+          <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/30 bg-primary/5">
+            <Sparkles className="h-3.5 w-3.5 text-primary" />
+            <span className="text-xs font-medium text-foreground">
+              Your top matches based on governance alignment
+            </span>
+          </div>
+        )}
+        {!hasMatches && rankedEntities.length > 0 && (
+          <div className="px-4 py-2.5 border-b border-border/30">
+            <span className="text-xs font-medium text-muted-foreground">
+              Top {labels.plural} by governance score
+            </span>
+          </div>
+        )}
+        <div className="divide-y divide-border/20">
+          {rankedEntities.map(({ entity, matchScore }, i) => (
+            <EntityRow
+              key={entity.id}
+              entity={entity}
+              entityType={entityType}
+              matchScore={matchScore}
+              rank={i + 1}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* CTA */}
+      <Link
+        href={labels.matchHref}
+        className="group flex items-center justify-between rounded-lg border border-border/40 bg-primary/5 hover:bg-primary/10 px-4 py-2.5 transition-colors"
+      >
+        <span className="text-sm font-medium text-foreground">
+          {hasMatches ? labels.retakeCta : labels.matchCta}
+        </span>
+        <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+      </Link>
+    </div>
+  );
+}

--- a/components/governada/pulse/GovernadaPulseOverview.tsx
+++ b/components/governada/pulse/GovernadaPulseOverview.tsx
@@ -71,30 +71,51 @@ const TABS: { id: PulseTab; label: string }[] = [
 const VALID_PULSE_TABS = new Set<PulseTab>(TABS.map((t) => t.id));
 
 /* ── Hands-Off: single score + trend arrow ─────────────────────────────────── */
+/* ── Anonymous: enriched health overview with component breakdown + CTA ──── */
 function GHIMinimal() {
-  const { data: rawGhi, isLoading } = useGovernanceHealthIndex(1);
+  const { data: rawGhi, isLoading, isError, refetch } = useGovernanceHealthIndex(5);
   const ghi = rawGhi as
     | {
-        current?: { score: number; band: string };
+        current?: {
+          score: number;
+          band: string;
+          components: { name: string; value: number; weight: number; contribution: number }[];
+        };
         trend?: { direction: string; delta: number };
       }
     | undefined;
 
   if (isLoading) {
     return (
-      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 flex items-center gap-4">
-        <div className="h-12 w-12 rounded-full bg-muted/40 animate-pulse" />
-        <div className="space-y-1">
-          <div className="h-4 w-32 bg-muted/40 rounded animate-pulse" />
-          <div className="h-3 w-20 bg-muted/40 rounded animate-pulse" />
+      <div className="space-y-4">
+        <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 flex items-center gap-4">
+          <div className="h-[80px] w-[80px] rounded-full bg-muted/40 animate-pulse" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-40 bg-muted/40 rounded animate-pulse" />
+            <div className="h-3 w-60 bg-muted/40 rounded animate-pulse" />
+          </div>
         </div>
       </div>
     );
   }
 
-  const score = ghi?.current?.score ?? 0;
-  const band = ghi?.current?.band ?? 'fair';
-  const direction = (ghi?.trend?.direction ?? 'flat') as 'up' | 'down' | 'flat';
+  if (isError || !ghi?.current) {
+    return (
+      <ErrorCard message="Governance Health temporarily unavailable." onRetry={() => refetch()} />
+    );
+  }
+
+  const { score, band, components } = ghi.current;
+  const direction = (ghi.trend?.direction ?? 'flat') as 'up' | 'down' | 'flat';
+  const delta = ghi.trend?.delta ?? 0;
+
+  const BAND_STYLE: Record<string, { text: string; bg: string }> = {
+    strong: { text: 'text-emerald-500', bg: 'bg-emerald-500' },
+    good: { text: 'text-green-500', bg: 'bg-green-500' },
+    fair: { text: 'text-amber-500', bg: 'bg-amber-500' },
+    critical: { text: 'text-rose-500', bg: 'bg-rose-500' },
+  };
+  const style = BAND_STYLE[band] ?? BAND_STYLE.fair;
   const TrendIcon = direction === 'up' ? TrendingUp : direction === 'down' ? TrendingDown : Minus;
   const trendColor =
     direction === 'up'
@@ -103,41 +124,90 @@ function GHIMinimal() {
         ? 'text-rose-500'
         : 'text-muted-foreground';
 
-  const BAND_COLORS: Record<string, string> = {
-    strong: 'text-emerald-500',
-    good: 'text-green-500',
-    fair: 'text-amber-500',
-    critical: 'text-rose-500',
-  };
-  const scoreColor = BAND_COLORS[band] ?? BAND_COLORS.fair;
-
+  // Positive framing: lead with what's working
   const BAND_VERDICTS: Record<string, string> = {
-    strong: 'Governance is thriving. Nothing needs your attention.',
-    good: 'Governance is healthy. No action needed.',
-    fair: 'Governance needs attention. Some areas are underperforming.',
-    critical: 'Governance is struggling. Participation and accountability are low.',
+    strong: 'Governance is thriving — strong participation across all dimensions.',
+    good: 'Governance is healthy — representatives are actively participating.',
+    fair: 'Governance is active and evolving. Some areas have room to grow.',
+    critical: 'Governance is in its early stages. Participation is growing as the system matures.',
   };
   const verdict = BAND_VERDICTS[band] ?? BAND_VERDICTS.fair;
 
+  // Top 4 components by weight
+  const topComponents = [...components].sort((a, b) => b.weight - a.weight).slice(0, 4);
+
   return (
-    <div
-      className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5"
-      data-discovery="gov-health"
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-1.5 flex-1 min-w-0">
-          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-            Governance Health
-          </p>
-          <p className={cn('text-sm font-medium', scoreColor)}>{verdict}</p>
+    <div className="space-y-4" data-discovery="gov-health">
+      {/* Score + verdict */}
+      <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5">
+        <div className="flex items-center gap-4 mb-4">
+          <div className="text-center">
+            <span className={cn('text-3xl font-bold tabular-nums', style.text)}>
+              {Math.round(score)}
+            </span>
+            <span className="text-xs text-muted-foreground">/100</span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold">Governance Health</h2>
+              <span
+                className={cn(
+                  'text-xs font-semibold px-2 py-0.5 rounded-full',
+                  style.bg + '/10',
+                  style.text,
+                )}
+              >
+                {band.charAt(0).toUpperCase() + band.slice(1)}
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground mt-0.5">{verdict}</p>
+            {delta !== 0 && (
+              <span
+                className={cn(
+                  'inline-flex items-center gap-0.5 text-xs font-medium mt-1',
+                  trendColor,
+                )}
+              >
+                <TrendIcon className="h-3 w-3" />
+                {delta > 0 ? '+' : ''}
+                {Math.round(delta * 10) / 10} this epoch
+              </span>
+            )}
+          </div>
         </div>
-        <div className="flex items-baseline gap-1.5 shrink-0">
-          <span className={cn('text-lg font-bold tabular-nums', scoreColor)}>
-            {Math.round(score)}
-          </span>
-          <TrendIcon className={cn('h-3.5 w-3.5', trendColor)} />
+
+        {/* 4-component breakdown */}
+        <div className="grid grid-cols-2 gap-3">
+          {topComponents.map((comp) => (
+            <div key={comp.name} className="space-y-1">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground truncate">{comp.name}</span>
+                <span className="text-xs font-medium tabular-nums">{Math.round(comp.value)}</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted/40 overflow-hidden">
+                <div
+                  className={cn('h-full rounded-full transition-all', style.bg + '/60')}
+                  style={{ width: `${Math.min(100, comp.value)}%` }}
+                />
+              </div>
+            </div>
+          ))}
         </div>
       </div>
+
+      {/* Compact governance briefing */}
+      <GovernanceBriefing compact />
+
+      {/* CTA */}
+      <Link
+        href="/match"
+        className="group flex items-center justify-between rounded-lg border border-border/40 bg-primary/5 hover:bg-primary/10 px-4 py-2.5 transition-colors"
+      >
+        <span className="text-sm font-medium text-foreground">
+          Want personalized governance insights? Take the quick match quiz
+        </span>
+        <ChevronRight className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+      </Link>
     </div>
   );
 }

--- a/components/treasury/TreasuryHero.tsx
+++ b/components/treasury/TreasuryHero.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { formatAda } from '@/lib/treasury';
+import type { NclUtilization } from '@/lib/treasury';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+/* ── Types ──────────────────────────────────────────────────────────── */
+
+interface TreasuryHeroProps {
+  balanceAda: number;
+  trend: 'growing' | 'shrinking' | 'stable';
+  ncl: NclUtilization | null;
+  effectivenessRate: number | null;
+  pendingCount: number;
+  pendingTotalAda?: number;
+  runwayMonths: number;
+}
+
+type VerdictStatus = 'healthy' | 'attention' | 'critical';
+
+/* ── Status derivation ──────────────────────────────────────────────── */
+
+function deriveStatus(
+  ncl: NclUtilization | null,
+  effectivenessRate: number | null,
+  trend: 'growing' | 'shrinking' | 'stable',
+  runwayMonths: number,
+): VerdictStatus {
+  if (ncl?.status === 'critical') return 'critical';
+  if (runwayMonths > 0 && runwayMonths < 12) return 'critical';
+  if (ncl?.status === 'elevated') return 'attention';
+  if (effectivenessRate !== null && effectivenessRate < 50) return 'attention';
+  if (trend === 'shrinking') return 'attention';
+  return 'healthy';
+}
+
+const STATUS_CONFIG = {
+  healthy: {
+    label: 'Treasury is Healthy',
+    color: 'text-emerald-400',
+    ring: 'ring-emerald-500/20',
+    dot: 'bg-emerald-500',
+    glow: 'shadow-[0_0_12px_rgba(16,185,129,0.15)]',
+    barEnacted: 'bg-emerald-500',
+    barPending: 'bg-emerald-500/40',
+    barGlow: '#10b981',
+  },
+  attention: {
+    label: 'Treasury Needs Attention',
+    color: 'text-amber-400',
+    ring: 'ring-amber-500/20',
+    dot: 'bg-amber-500',
+    glow: 'shadow-[0_0_12px_rgba(245,158,11,0.15)]',
+    barEnacted: 'bg-amber-500',
+    barPending: 'bg-amber-500/40',
+    barGlow: '#f59e0b',
+  },
+  critical: {
+    label: 'Treasury Under Pressure',
+    color: 'text-red-400',
+    ring: 'ring-red-500/20',
+    dot: 'bg-red-500',
+    glow: 'shadow-[0_0_12px_rgba(239,68,68,0.15)]',
+    barEnacted: 'bg-red-500',
+    barPending: 'bg-red-500/40',
+    barGlow: '#ef4444',
+  },
+} as const;
+
+/* ── Component ──────────────────────────────────────────────────────── */
+
+export function TreasuryHero({
+  balanceAda,
+  trend,
+  ncl,
+  effectivenessRate,
+  pendingCount,
+  pendingTotalAda,
+  runwayMonths,
+}: TreasuryHeroProps) {
+  const status = deriveStatus(ncl, effectivenessRate, trend, runwayMonths);
+  const config = STATUS_CONFIG[status];
+
+  const enactedPct = ncl ? Math.min(100, ncl.utilizationPct) : 0;
+  const pendingPct = ncl
+    ? Math.min(100 - enactedPct, ncl.projectedUtilizationPct - ncl.utilizationPct)
+    : 0;
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-5 ring-1 space-y-4',
+        config.ring,
+        config.glow,
+      )}
+    >
+      {/* ── Verdict headline ────────────────────────────────────── */}
+      <div className="flex items-center gap-2.5">
+        <span className={cn('h-2.5 w-2.5 rounded-full animate-pulse', config.dot)} />
+        <h2 className={cn('text-lg font-semibold', config.color)}>{config.label}</h2>
+      </div>
+
+      {/* ── Key stats row ───────────────────────────────────────── */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        <span className="text-muted-foreground">
+          ₳<span className="font-semibold text-foreground">{formatAda(balanceAda)}</span> balance
+          {trend !== 'stable' && (
+            <span className="ml-1 text-xs">({trend === 'growing' ? '↑' : '↓'})</span>
+          )}
+        </span>
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-foreground">{pendingCount}</span>{' '}
+          {pendingCount === 1 ? 'proposal' : 'proposals'} pending
+          {pendingTotalAda != null && pendingTotalAda > 0 && (
+            <span className="ml-1">(₳{formatAda(pendingTotalAda)})</span>
+          )}
+        </span>
+        {runwayMonths > 0 && (
+          <span className="text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              {runwayMonths < 12 ? `${runwayMonths}mo` : `${Math.round(runwayMonths / 12)}yr`}
+            </span>{' '}
+            runway
+          </span>
+        )}
+      </div>
+
+      {/* ── NCL Budget bar (inline) ─────────────────────────────── */}
+      {ncl && (
+        <div className="space-y-2.5">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              NCL Budget: ₳{formatAda(ncl.period.nclAda)}{' '}
+              <span className="text-muted-foreground/60">
+                (Epochs {ncl.period.startEpoch}–{ncl.period.endEpoch})
+              </span>
+            </span>
+            <span className="font-medium">
+              {Math.round(ncl.utilizationPct)}% used · ₳{formatAda(ncl.remainingAda)} remaining
+            </span>
+          </div>
+
+          {/* Segmented bar */}
+          <TooltipProvider>
+            <div className="relative h-3 w-full">
+              <div className="absolute inset-0 rounded-full bg-muted/30" />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={cn(
+                      'absolute inset-y-0 left-0 rounded-l-full transition-all',
+                      config.barEnacted,
+                    )}
+                    style={{
+                      width: `${enactedPct}%`,
+                      boxShadow: `0 0 6px ${config.barGlow}40`,
+                    }}
+                  >
+                    <div className="absolute inset-x-0 top-0 h-[40%] rounded-t-full bg-white/[0.12]" />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  Enacted: ₳{formatAda(ncl.enactedWithdrawalsAda)} ({Math.round(ncl.utilizationPct)}
+                  %)
+                </TooltipContent>
+              </Tooltip>
+              {pendingPct > 0 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn('absolute inset-y-0 transition-all', config.barPending)}
+                      style={{
+                        left: `${enactedPct}%`,
+                        width: `${pendingPct}%`,
+                        backgroundImage:
+                          'repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,0.1) 3px, rgba(255,255,255,0.1) 6px)',
+                      }}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Pending: ₳{formatAda(ncl.pendingWithdrawalsAda)} ({Math.round(pendingPct)}%)
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </TooltipProvider>
+
+          {/* Context */}
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              Epoch {ncl.epochsElapsed} of {ncl.period.endEpoch - ncl.period.startEpoch} in this
+              budget period ({Math.round(ncl.periodProgressPct)}%)
+            </span>
+            {ncl.sustainabilityRatio < 1 && (
+              <span className="text-amber-400">
+                NCL exceeds projected annual income (ratio: {ncl.sustainabilityRatio}x)
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!ncl && (
+        <p className="text-xs text-muted-foreground">
+          No active NCL period. The community has not yet set a spending limit.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/hooks/queries.ts
+++ b/hooks/queries.ts
@@ -25,6 +25,7 @@ export interface CCHealthSummaryResponse {
   totalMembers: number;
   avgFidelity: number | null;
   tensionCount: number;
+  improvementAreas?: string[];
 }
 
 export interface CCCommitteeStats {

--- a/lib/proposalBrief.ts
+++ b/lib/proposalBrief.ts
@@ -328,7 +328,7 @@ export async function assembleProposalBriefInput(
         }
 
         if (trend.length >= 2) {
-          const burnRate = calculateBurnRate(trend, 10);
+          const burnRate = calculateBurnRate(trend);
           if (burnRate > 0 && balance) {
             const runway = calculateRunwayMonths(balance.balanceAda, burnRate);
             parts.push(

--- a/lib/treasury.ts
+++ b/lib/treasury.ts
@@ -85,11 +85,27 @@ export async function getTreasuryTrend(epochs = 30): Promise<TreasurySnapshot[]>
   }));
 }
 
-export function calculateBurnRate(snapshots: TreasurySnapshot[], windowEpochs = 10): number {
+/**
+ * Calculate average burn rate using exponential decay weighting over all snapshots.
+ * Recent epochs are weighted more heavily (half-life = 20 epochs ≈ 100 days).
+ * This produces a more representative burn rate in early governance when spending
+ * is sporadic, compared to the previous fixed 10-epoch window.
+ */
+export function calculateBurnRate(snapshots: TreasurySnapshot[]): number {
   if (snapshots.length < 2) return 0;
-  const recent = snapshots.slice(-windowEpochs);
-  const totalWithdrawals = recent.reduce((sum, s) => sum + s.withdrawalsAda, 0);
-  return totalWithdrawals / recent.length;
+  const HALF_LIFE = 20; // epochs (~100 days)
+  const lambda = Math.LN2 / HALF_LIFE;
+  const latestEpoch = snapshots[snapshots.length - 1].epoch;
+
+  let weightedSum = 0;
+  let totalWeight = 0;
+  for (const s of snapshots) {
+    const age = latestEpoch - s.epoch;
+    const weight = Math.exp(-lambda * age);
+    weightedSum += s.withdrawalsAda * weight;
+    totalWeight += weight;
+  }
+  return totalWeight > 0 ? weightedSum / totalWeight : 0;
 }
 
 export function calculateRunwayMonths(balanceAda: number, burnRatePerEpoch: number): number {
@@ -133,11 +149,11 @@ export interface TreasuryHealthScore {
 }
 
 export async function calculateTreasuryHealthScore(): Promise<TreasuryHealthScore | null> {
-  const snapshots = await getTreasuryTrend(30);
+  const snapshots = await getTreasuryTrend(200);
   if (snapshots.length < 1) return null;
 
   const current = snapshots[snapshots.length - 1];
-  const burnRate = calculateBurnRate(snapshots, 10);
+  const burnRate = calculateBurnRate(snapshots);
   const runwayMonths = calculateRunwayMonths(current.balanceAda, burnRate);
 
   // 1. Balance trend (0-100): is the treasury growing or shrinking?


### PR DESCRIPTION
## Summary
7 improvements across all governance sections, addressing user feedback from production review:

- **Representatives + Pools (anonymous UX)**: New `MatchAwareDiscoverHero` shared component. If user completed the match quiz, shows top 5 matched DReps/SPOs with match scores. Otherwise shows stats bar + top 5 by governance score + "Take the match quiz" CTA. Consistent UX across both DRep and SPO pages.
- **Pool cards**: Raised badge threshold from 60→75 and improved labels ("Consistent voter", "Deep deliberator", "Always online", "Verified operator") so only genuinely strong traits show
- **CC member votes**: Fixed vote count sync bug — votes were keyed by hot_id but members looked up by cold_id. Added dual-key lookup so both IDs resolve correctly. Should fix 6/7 members showing "0 votes"
- **Committee health**: Added "What would improve this score" section listing specific gaps (non-voting members, low fidelity, low rationale rates, CC-DRep tensions)
- **Treasury runway**: Replaced fixed 10-epoch window with exponential decay (half-life 20 epochs ≈ 100 days) over all available snapshots. More representative in early governance with sporadic spending
- **Treasury layout**: Merged TreasuryVerdict + NclBudgetBar + TreasuryKeyMetrics into single `TreasuryHero` — verdict headline, budget bar, key stats in one glanceable widget
- **Health page**: Enriched anonymous view from bare single-number to full component breakdown + governance briefing + match quiz CTA. Positive framing for all band levels
- **Pools API**: Now exposes alignment dimensions for SPO match scoring
- **SPO card**: Added matchScore badge display (mirrors DRep card)

## Impact
- **What changed**: 7 UX improvements across 5 governance sections + 1 data fix
- **User-facing**: Yes — richer anonymous experiences, visible CC vote counts, consolidated treasury view, enriched health page
- **Risk**: Medium — CC vote fix changes data display, treasury burn rate affects runway numbers, new match-aware views for anonymous users
- **Scope**: 16 files (14 modified, 2 new), no migrations, no Inngest changes

## Test plan
- [x] Preflight passes (format + lint + types + 825 tests)
- [ ] Visit /governance/representatives as anonymous — verify stats bar + top DReps or match results
- [ ] Visit /governance/pools as anonymous — verify same pattern for SPOs
- [ ] Visit /governance/committee — verify all 7 CC members show vote counts, improvement areas visible
- [ ] Visit /governance/treasury — verify single hero widget with verdict + budget bar
- [ ] Visit /governance/health as anonymous — verify enriched view with component bars + briefing
- [ ] Verify pool card badges show differentiating labels at higher threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)