### PR TITLE
feat: governance identity card and match result cards

### DIFF
--- a/components/matching/ConversationalMatchFlow.tsx
+++ b/components/matching/ConversationalMatchFlow.tsx
@@ -7,7 +7,9 @@ import { Button } from '@/components/ui/button';
 import { PillCloud } from './PillCloud';
 import { ConfidenceRing } from './ConfidenceRing';
 import { ConversationalRound } from './ConversationalRound';
+import { MatchResults } from './MatchResults';
 import { useConversationalMatch } from '@/hooks/useConversationalMatch';
+import { saveConversationalProfile } from '@/lib/matchStore';
 import { cn } from '@/lib/utils';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
 
@@ -98,6 +100,7 @@ export function ConversationalMatchFlow({
     status,
     preview,
     matches,
+    userAlignments,
     personalityLabel,
     identityColor,
     confidence,
@@ -137,9 +140,27 @@ export function ConversationalMatchFlow({
       pushUrlState('results', 'results');
       if (matches) {
         onMatchComplete?.(matches);
+        // Persist conversational profile for later use
+        if (personalityLabel && identityColor && userAlignments) {
+          saveConversationalProfile({
+            personalityLabel,
+            identityColor,
+            alignments: userAlignments,
+            matchResults: matches,
+            timestamp: Date.now(),
+          });
+        }
       }
     }
-  }, [status, flowState, matches, onMatchComplete]);
+  }, [
+    status,
+    flowState,
+    matches,
+    personalityLabel,
+    identityColor,
+    userAlignments,
+    onMatchComplete,
+  ]);
 
   /* ─── Update globe highlights after each answer ────────── */
 
@@ -385,69 +406,26 @@ export function ConversationalMatchFlow({
 
   return (
     <div className="w-full space-y-6">
-      {/* Identity summary */}
-      {personalityLabel && identityColor && (
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="rounded-xl border border-white/[0.08] bg-card/60 p-4 text-center backdrop-blur-xl"
-        >
-          <div
-            className="mx-auto mb-2 h-3 w-3 rounded-full"
-            style={{ backgroundColor: identityColor }}
-          />
-          <p className="text-lg font-semibold text-foreground">{personalityLabel}</p>
-          <p className="text-xs text-muted-foreground">Your governance identity</p>
-        </motion.div>
+      {personalityLabel && identityColor && userAlignments && matches ? (
+        <MatchResults
+          personalityLabel={personalityLabel}
+          identityColor={identityColor}
+          userAlignments={userAlignments}
+          matches={matches}
+          onReset={handleReset}
+          globeRef={globeRef}
+        />
+      ) : (
+        <>
+          {error && <p className="text-center text-sm text-destructive">{error}</p>}
+          <div className="flex justify-center">
+            <Button variant="outline" onClick={handleReset} className="gap-2">
+              <RotateCcw className="h-4 w-4" />
+              Start over
+            </Button>
+          </div>
+        </>
       )}
-
-      {/* Match results list */}
-      {matches && matches.length > 0 && (
-        <div className="space-y-3">
-          <h3 className="text-sm font-medium text-muted-foreground">Your top matches</h3>
-          {matches.slice(0, 5).map((match, i) => (
-            <motion.div
-              key={match.drepId}
-              initial={{ opacity: 0, x: 20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: i * 0.1 }}
-              className="flex items-center gap-3 rounded-lg border border-white/[0.08] bg-card/40 p-3 backdrop-blur-sm"
-            >
-              <div
-                className="h-8 w-8 rounded-full"
-                style={{ backgroundColor: match.identityColor }}
-              />
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-foreground">
-                  {match.drepName ?? match.drepId.slice(0, 16) + '...'}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {Math.round(match.score * 100)}% match
-                  {match.agreeDimensions.length > 0 &&
-                    ` \u00b7 Agree on ${match.agreeDimensions.join(', ')}`}
-                </p>
-              </div>
-            </motion.div>
-          ))}
-        </div>
-      )}
-
-      {/* No matches fallback */}
-      {matches && matches.length === 0 && (
-        <p className="text-center text-sm text-muted-foreground">
-          No strong matches found. Try again with different priorities.
-        </p>
-      )}
-
-      {error && <p className="text-center text-sm text-destructive">{error}</p>}
-
-      {/* Start over */}
-      <div className="flex justify-center">
-        <Button variant="outline" onClick={handleReset} className="gap-2">
-          <RotateCcw className="h-4 w-4" />
-          Start over
-        </Button>
-      </div>
     </div>
   );
 }

--- a/components/matching/GovernanceIdentityCard.tsx
+++ b/components/matching/GovernanceIdentityCard.tsx
@@ -1,63 +1,140 @@
 'use client';
 
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { motion } from 'framer-motion';
+import { Share2, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
-import { ConfidenceBar } from './ConfidenceBar';
-import { Dna } from 'lucide-react';
-import type { AlignmentScores } from '@/lib/drepIdentity';
-import type { ConfidenceSource } from '@/lib/matching/confidence';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import { getDominantDimension, getDimensionLabel } from '@/lib/drepIdentity';
+import { cn } from '@/lib/utils';
+
+/* ─── Types ─────────────────────────────────────────────── */
 
 interface GovernanceIdentityCardProps {
-  personalityLabel: string | null;
-  votesUsed: number;
-  confidence: number;
-  alignmentScores: Record<string, number | null> | null;
-  /** Progressive confidence source breakdown (optional, enhances display) */
-  confidenceSources?: ConfidenceSource[] | null;
+  personalityLabel: string;
+  identityColor: string;
+  alignments: AlignmentScores;
+  onShare?: () => void;
+  onContinue?: () => void;
 }
+
+/* ─── Helpers ───────────────────────────────────────────── */
+
+function hexToRgb(hex: string): [number, number, number] {
+  const cleaned = hex.replace('#', '');
+  const num = parseInt(cleaned, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function getShortDescription(alignments: AlignmentScores): string {
+  const dominant = getDominantDimension(alignments);
+  const descriptions: Record<AlignmentDimension, string> = {
+    treasuryConservative: 'You prioritize fiscal responsibility and careful treasury stewardship.',
+    treasuryGrowth: 'You champion strategic investment and ecosystem growth.',
+    decentralization: 'You stand for distributed power and community autonomy.',
+    security: 'You value protocol safety and network resilience above all.',
+    innovation: 'You push for progress, experimentation, and bold change.',
+    transparency: 'You demand openness, accountability, and clear governance.',
+  };
+  return descriptions[dominant];
+}
+
+/* ─── Component ─────────────────────────────────────────── */
 
 export function GovernanceIdentityCard({
   personalityLabel,
-  votesUsed,
-  confidence,
-  alignmentScores,
-  confidenceSources,
+  identityColor,
+  alignments,
+  onShare,
+  onContinue,
 }: GovernanceIdentityCardProps) {
-  if (!alignmentScores || !personalityLabel) return null;
-
-  const scores = alignmentScores as unknown as AlignmentScores;
-  const hasValues = Object.values(scores).some((v) => v !== null);
-  if (!hasValues) return null;
-
-  const hasSources = confidenceSources && confidenceSources.length > 0;
+  const [r, g, b] = hexToRgb(identityColor);
+  const description = getShortDescription(alignments);
+  const dominantLabel = getDimensionLabel(getDominantDimension(alignments));
 
   return (
-    <Card className="border-primary/20 bg-gradient-to-r from-primary/5 to-transparent">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          <GovernanceRadar alignments={scores} size="mini" />
-          <div className="flex-1 min-w-0 space-y-1.5">
-            <div className="flex items-center gap-2">
-              <Dna className="h-3.5 w-3.5 text-primary shrink-0" />
-              <span className="text-xs text-muted-foreground">Your governance identity</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge variant="outline" className="text-xs">
-                {personalityLabel}
-              </Badge>
-              <span className="text-[10px] text-muted-foreground">
-                {votesUsed} vote{votesUsed !== 1 ? 's' : ''} · {confidence}% confidence
-              </span>
-            </div>
-            {hasSources ? (
-              <ConfidenceBar confidence={confidence} sources={confidenceSources} expandable />
-            ) : (
-              <ConfidenceBar votesUsed={votesUsed} />
-            )}
-          </div>
+    <motion.div
+      initial={{ opacity: 0, y: 40 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+      className={cn(
+        'relative w-full rounded-2xl border bg-black/60 backdrop-blur-xl',
+        'p-6 md:p-8 overflow-hidden',
+      )}
+      style={{
+        borderColor: `rgba(${r}, ${g}, ${b}, 0.4)`,
+        boxShadow: `0 0 30px rgba(${r}, ${g}, ${b}, 0.3)`,
+      }}
+    >
+      {/* Entrance glow pulse */}
+      <motion.div
+        className="pointer-events-none absolute inset-0 rounded-2xl"
+        initial={{ opacity: 0.6 }}
+        animate={{ opacity: 0 }}
+        transition={{ duration: 1.5, ease: 'easeOut' }}
+        style={{
+          boxShadow: `inset 0 0 60px rgba(${r}, ${g}, ${b}, 0.25)`,
+        }}
+      />
+
+      <div className="relative z-10 flex flex-col items-center text-center gap-4">
+        {/* Preamble */}
+        <p className="text-sm text-muted-foreground uppercase tracking-widest">You&apos;re a</p>
+
+        {/* Archetype name */}
+        <h2
+          className="font-display text-2xl md:text-4xl lg:text-5xl font-bold tracking-tight leading-tight"
+          style={{ color: identityColor }}
+        >
+          {personalityLabel}
+        </h2>
+
+        {/* Short description */}
+        <p className="text-sm md:text-base text-muted-foreground max-w-md">{description}</p>
+
+        {/* Dominant dimension badge */}
+        <span
+          className="inline-flex items-center rounded-full px-3 py-1 text-xs font-medium"
+          style={{
+            backgroundColor: `rgba(${r}, ${g}, ${b}, 0.12)`,
+            color: identityColor,
+          }}
+        >
+          Strongest dimension: {dominantLabel}
+        </span>
+
+        {/* Mini radar */}
+        <div className="my-2">
+          <GovernanceRadar alignments={alignments} size="medium" animate={false} />
         </div>
-      </CardContent>
-    </Card>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row items-center gap-3 w-full mt-2">
+          {onShare && (
+            <Button
+              variant="outline"
+              onClick={onShare}
+              className="gap-2 min-h-[44px] w-full sm:w-auto"
+            >
+              <Share2 className="h-4 w-4" />
+              Share your governance identity
+            </Button>
+          )}
+          {onContinue && (
+            <Button
+              onClick={onContinue}
+              className="gap-2 min-h-[44px] w-full sm:w-auto"
+              style={{
+                backgroundColor: identityColor,
+                color: '#fff',
+              }}
+            >
+              See your matches
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </motion.div>
   );
 }

--- a/components/matching/MatchResultCard.tsx
+++ b/components/matching/MatchResultCard.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronDown, ChevronUp, ExternalLink, Vote } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { GovernanceRadar } from '@/components/GovernanceRadar';
+import { generateMatchNarrative } from '@/lib/matching/matchNarrative';
+import { DIMENSION_LABELS } from '@/lib/matching/dimensionAgreement';
+import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
+import { getDimensionOrder } from '@/lib/drepIdentity';
+import type { ConstellationRef } from '@/components/GovernanceConstellation';
+import { cn } from '@/lib/utils';
+
+/* ─── Types ─────────────────────────────────────────────── */
+
+interface MatchResultCardProps {
+  match: {
+    drepId: string;
+    drepName: string | null;
+    score: number;
+    alignments: AlignmentScores;
+    agreeDimensions: string[];
+    differDimensions: string[];
+    identityColor: string;
+    tier?: string | null;
+    matchingRationales?: Array<{
+      proposalTitle: string;
+      excerpt: string;
+      similarity: number;
+    }>;
+  };
+  rank: number;
+  isBridge?: boolean;
+  userAlignments: AlignmentScores;
+  expanded: boolean;
+  onExpand: () => void;
+  onDelegate?: (drepId: string) => void;
+  globeRef?: React.RefObject<ConstellationRef | null>;
+}
+
+/* ─── Helpers ───────────────────────────────────────────── */
+
+function hexToRgb(hex: string): [number, number, number] {
+  const cleaned = hex.replace('#', '');
+  const num = parseInt(cleaned, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
+function computePerDimensionAgreement(
+  userAlignments: AlignmentScores,
+  drepAlignments: AlignmentScores,
+): Array<{
+  dim: AlignmentDimension;
+  label: string;
+  agreement: number;
+  status: 'agree' | 'neutral' | 'differ';
+}> {
+  const dims = getDimensionOrder();
+  return dims.map((dim) => {
+    const userVal = userAlignments[dim] ?? 50;
+    const drepVal = drepAlignments[dim] ?? 50;
+    const agreement = Math.round(100 - Math.abs(userVal - drepVal));
+    const status = agreement >= 70 ? 'agree' : agreement < 40 ? 'differ' : 'neutral';
+    return { dim, label: DIMENSION_LABELS[dim], agreement, status };
+  });
+}
+
+/* ─── Component ─────────────────────────────────────────── */
+
+export function MatchResultCard({
+  match,
+  rank,
+  isBridge = false,
+  userAlignments,
+  expanded,
+  onExpand,
+  onDelegate,
+  globeRef,
+}: MatchResultCardProps) {
+  const hasPulsed = useRef(false);
+  const displayName = match.drepName || match.drepId.slice(0, 16) + '...';
+  const scorePercent = Math.round(match.score * 100);
+  const [r, g, b] = hexToRgb(match.identityColor);
+
+  const narrative = generateMatchNarrative({
+    agreeDimensions: match.agreeDimensions,
+    differDimensions: match.differDimensions,
+  });
+
+  // Pulse globe node when card first appears
+  useEffect(() => {
+    if (!hasPulsed.current && globeRef?.current) {
+      globeRef.current.pulseNode(match.drepId);
+      hasPulsed.current = true;
+    }
+  }, [globeRef, match.drepId]);
+
+  // Collapsed dimension badges: first 2 agree + first 1 differ
+  const collapsedBadges = [
+    ...match.agreeDimensions.slice(0, 2).map((d) => ({ label: d, type: 'agree' as const })),
+    ...match.differDimensions.slice(0, 1).map((d) => ({ label: d, type: 'differ' as const })),
+  ];
+
+  const perDimension = computePerDimensionAgreement(userAlignments, match.alignments);
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: rank * 0.2, type: 'spring', stiffness: 300, damping: 28 }}
+      className={cn(
+        'rounded-xl border bg-card/40 backdrop-blur-sm overflow-hidden transition-colors',
+        isBridge ? 'border-violet-500/30' : 'border-white/[0.08]',
+      )}
+      style={expanded ? { boxShadow: `0 0 0 1px rgba(${r}, ${g}, ${b}, 0.3)` } : undefined}
+    >
+      {/* Bridge header */}
+      {isBridge && (
+        <div className="px-4 py-1.5 bg-violet-500/10 text-violet-400 text-xs font-medium">
+          A different perspective
+        </div>
+      )}
+
+      {/* Collapsed view */}
+      <button
+        onClick={onExpand}
+        className="w-full text-left px-4 py-3 min-h-[44px]"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-3">
+          {/* Rank badge */}
+          <span
+            className={cn(
+              'w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white shrink-0',
+              isBridge && 'bg-violet-500',
+            )}
+            style={!isBridge ? { backgroundColor: match.identityColor } : undefined}
+          >
+            {isBridge ? '?' : rank}
+          </span>
+
+          {/* Name + tier */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-sm text-foreground truncate">{displayName}</span>
+              {match.tier && (
+                <span className="text-[10px] text-muted-foreground shrink-0">{match.tier}</span>
+              )}
+            </div>
+          </div>
+
+          {/* Score */}
+          <span
+            className="font-display text-2xl font-bold tabular-nums shrink-0"
+            style={{ color: match.identityColor }}
+          >
+            {scorePercent}%
+          </span>
+
+          {/* Expand chevron */}
+          <span className="text-muted-foreground shrink-0">
+            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </span>
+        </div>
+
+        {/* Dimension badges */}
+        {collapsedBadges.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2 ml-10">
+            {collapsedBadges.map((badge) => (
+              <span
+                key={badge.label}
+                className={cn(
+                  'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium',
+                  badge.type === 'agree'
+                    ? 'bg-green-500/10 text-green-400'
+                    : 'bg-muted/30 text-muted-foreground',
+                )}
+              >
+                {badge.label} {badge.type === 'agree' ? '\u2713' : '\u2717'}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* One-sentence narrative */}
+        <p className="text-xs text-muted-foreground mt-2 ml-10 line-clamp-2">{narrative}</p>
+      </button>
+
+      {/* Expanded view */}
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-4 space-y-4 border-t border-white/[0.06] pt-4">
+              {/* Radar comparison: user vs DRep */}
+              <div className="flex justify-center">
+                <GovernanceRadar
+                  alignments={userAlignments}
+                  compareAlignments={match.alignments}
+                  size="full"
+                  animate
+                />
+              </div>
+
+              {/* Per-dimension agreement bars */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium text-muted-foreground mb-2">
+                  Dimension agreement
+                </p>
+                {perDimension.map((d) => (
+                  <div key={d.dim} className="flex items-center gap-2 text-xs">
+                    <span
+                      className={cn(
+                        'w-16 shrink-0 font-medium truncate',
+                        d.status === 'agree'
+                          ? 'text-green-400'
+                          : d.status === 'differ'
+                            ? 'text-amber-400'
+                            : 'text-muted-foreground',
+                      )}
+                    >
+                      {d.label}
+                    </span>
+                    <div className="flex-1 h-1.5 rounded-full bg-muted/20 overflow-hidden">
+                      <div
+                        className={cn(
+                          'h-full rounded-full transition-all',
+                          d.status === 'agree'
+                            ? 'bg-green-500'
+                            : d.status === 'differ'
+                              ? 'bg-amber-500'
+                              : 'bg-muted-foreground/40',
+                        )}
+                        style={{ width: `${d.agreement}%` }}
+                      />
+                    </div>
+                    <span className="w-8 text-right tabular-nums text-muted-foreground">
+                      {d.agreement}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Matching rationales */}
+              {match.matchingRationales && match.matchingRationales.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    What they&apos;ve said
+                  </p>
+                  {match.matchingRationales.slice(0, 2).map((rationale, i) => (
+                    <blockquote
+                      key={i}
+                      className="border-l-2 border-primary/30 pl-3 py-1 text-xs text-muted-foreground italic"
+                    >
+                      <p>&ldquo;{rationale.excerpt}&rdquo;</p>
+                      <cite className="not-italic text-[10px] text-muted-foreground/60 block mt-1">
+                        On: {rationale.proposalTitle}
+                      </cite>
+                    </blockquote>
+                  ))}
+                </div>
+              )}
+
+              {/* CTAs */}
+              <div className="flex flex-col sm:flex-row gap-2 pt-1">
+                {onDelegate && (
+                  <Button
+                    onClick={() => onDelegate(match.drepId)}
+                    className="gap-2 min-h-[44px] flex-1"
+                    style={{
+                      backgroundColor: match.identityColor,
+                      color: '#fff',
+                    }}
+                  >
+                    <Vote className="h-4 w-4" />
+                    Delegate to this DRep
+                  </Button>
+                )}
+                <Button variant="outline" asChild className="gap-2 min-h-[44px] flex-1">
+                  <a href={`/drep/${encodeURIComponent(match.drepId)}`}>
+                    View profile
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/components/matching/MatchResults.tsx
+++ b/components/matching/MatchResults.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { RotateCcw, ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { GovernanceIdentityCard } from './GovernanceIdentityCard';
+import { MatchResultCard } from './MatchResultCard';
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import type { MatchResult } from '@/lib/matching/conversationalMatch';
+import type { ConstellationRef } from '@/components/GovernanceConstellation';
+import Link from 'next/link';
+
+/* ─── Types ─────────────────────────────────────────────── */
+
+interface MatchResultsProps {
+  personalityLabel: string;
+  identityColor: string;
+  userAlignments: AlignmentScores;
+  matches: MatchResult[];
+  onReset: () => void;
+  onDelegate?: (drepId: string) => void;
+  globeRef?: React.RefObject<ConstellationRef | null>;
+}
+
+/* ─── Helpers ───────────────────────────────────────────── */
+
+/**
+ * Pick the best "bridge" match: the match with the lowest score
+ * but highest disagreement on at least one dimension.
+ * Falls back to the last match if no clear bridge exists.
+ */
+function pickBridgeMatch(matches: MatchResult[]): MatchResult | null {
+  if (matches.length < 4) return null;
+
+  // Candidates: matches ranked 4+ (skip top 3)
+  const candidates = matches.slice(3);
+
+  // Sort by most differ dimensions descending, then lowest score
+  const sorted = [...candidates].sort((a, b) => {
+    const differDiff = b.differDimensions.length - a.differDimensions.length;
+    if (differDiff !== 0) return differDiff;
+    return a.score - b.score;
+  });
+
+  return sorted[0] ?? null;
+}
+
+/* ─── Component ─────────────────────────────────────────── */
+
+export function MatchResults({
+  personalityLabel,
+  identityColor,
+  userAlignments,
+  matches,
+  onReset,
+  onDelegate,
+  globeRef,
+}: MatchResultsProps) {
+  const [showMatches, setShowMatches] = useState(false);
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const topMatches = useMemo(() => matches.slice(0, 3), [matches]);
+  const bridgeMatch = useMemo(() => pickBridgeMatch(matches), [matches]);
+
+  const handleContinue = useCallback(() => {
+    setShowMatches(true);
+  }, []);
+
+  const handleExpand = useCallback((index: number) => {
+    setExpandedIndex((prev) => (prev === index ? null : index));
+  }, []);
+
+  return (
+    <div className="w-full space-y-6">
+      {/* Identity card — always visible */}
+      <GovernanceIdentityCard
+        personalityLabel={personalityLabel}
+        identityColor={identityColor}
+        alignments={userAlignments}
+        onContinue={!showMatches ? handleContinue : undefined}
+      />
+
+      {/* Match result cards — revealed after "See your matches" */}
+      {showMatches && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+          className="space-y-4"
+        >
+          <h3 className="text-sm font-medium text-muted-foreground">Your top matches</h3>
+
+          {/* Top 3 matches */}
+          {topMatches.map((match, i) => (
+            <MatchResultCard
+              key={match.drepId}
+              match={match}
+              rank={i + 1}
+              userAlignments={userAlignments}
+              expanded={expandedIndex === i}
+              onExpand={() => handleExpand(i)}
+              onDelegate={onDelegate}
+              globeRef={globeRef}
+            />
+          ))}
+
+          {/* Bridge match */}
+          {bridgeMatch && (
+            <MatchResultCard
+              key={`bridge-${bridgeMatch.drepId}`}
+              match={bridgeMatch}
+              rank={4}
+              isBridge
+              userAlignments={userAlignments}
+              expanded={expandedIndex === 99}
+              onExpand={() => handleExpand(99)}
+              onDelegate={onDelegate}
+              globeRef={globeRef}
+            />
+          )}
+
+          {/* No matches fallback */}
+          {matches.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-4">
+              No strong matches found. Try again with different priorities.
+            </p>
+          )}
+
+          {/* Bottom CTAs */}
+          <div className="flex flex-col items-center gap-3 pt-4">
+            <Button variant="outline" onClick={onReset} className="gap-2 min-h-[44px]">
+              <RotateCcw className="h-4 w-4" />
+              Start over
+            </Button>
+
+            <Link
+              href="/match?type=spo"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1"
+            >
+              Looking for a stake pool? Complete your governance team
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/lib/matchStore.ts
+++ b/lib/matchStore.ts
@@ -58,6 +58,59 @@ export function hasMatchProfile(): boolean {
   }
 }
 
+/* ─── Conversational Match Profile ─────────────────────── */
+
+const CONV_STORAGE_KEY = 'governada_conv_match_profile';
+
+export interface StoredConversationalProfile {
+  personalityLabel: string;
+  identityColor: string;
+  alignments: AlignmentScores;
+  matchResults: Array<{
+    drepId: string;
+    drepName: string | null;
+    score: number;
+    agreeDimensions: string[];
+    differDimensions: string[];
+    identityColor: string;
+  }>;
+  timestamp: number;
+}
+
+/** Save conversational match profile to localStorage. */
+export function saveConversationalProfile(profile: StoredConversationalProfile): void {
+  try {
+    localStorage.setItem(CONV_STORAGE_KEY, JSON.stringify(profile));
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+/** Load conversational match profile. Returns null if not found or expired (>30 days). */
+export function loadConversationalProfile(): StoredConversationalProfile | null {
+  try {
+    const raw = localStorage.getItem(CONV_STORAGE_KEY);
+    if (!raw) return null;
+    const profile: StoredConversationalProfile = JSON.parse(raw);
+    if (Date.now() - profile.timestamp > 30 * 24 * 60 * 60 * 1000) {
+      localStorage.removeItem(CONV_STORAGE_KEY);
+      return null;
+    }
+    return profile;
+  } catch {
+    return null;
+  }
+}
+
+/** Clear stored conversational match profile. */
+export function clearConversationalProfile(): void {
+  try {
+    localStorage.removeItem(CONV_STORAGE_KEY);
+  } catch {
+    // Ignore
+  }
+}
+
 /**
  * Compute Euclidean distance between user alignment and a DRep/SPO alignment.
  * Used by Discover page to sort by match compatibility.


### PR DESCRIPTION
## Summary
- **GovernanceIdentityCard**: "Spotify Wrapped" style governance identity reveal with archetype name in Fraunces display font, identity color glow/pulse animation, governance radar, and share CTA
- **MatchResultCard**: Expandable DRep match cards with rank badges, dimension agreement badges/bars, radar comparison overlay, rationale quote blocks, delegate and profile CTAs
- **MatchResults**: Orchestrator container showing identity card first, then top-3 matches + a "bridge" match (different perspective) on continue, with start-over and SPO navigation CTAs
- **ConversationalMatchFlow**: Wired results state to render full MatchResults instead of placeholder list
- **matchStore**: Added `saveConversationalProfile` / `loadConversationalProfile` / `clearConversationalProfile` for persisting conversational match results in localStorage

## Impact
- **What changed**: The conversational matching flow now has its emotional payoff — a governance identity reveal card and rich DRep match result cards with radar comparison, dimension agreement, and delegation CTAs
- **User-facing**: Yes — users completing the conversational match flow will see their governance archetype and detailed match results instead of a minimal placeholder list
- **Risk**: Low — behind existing conversational match feature flow, no data changes, no migrations
- **Scope**: 5 files (3 new components, 1 modified orchestrator, 1 extended store)

## Test plan
- [ ] Complete conversational matching flow and verify identity card appears with correct archetype, color, and radar
- [ ] Click "See your matches" and verify 3 match cards + bridge card appear with staggered animation
- [ ] Expand a match card and verify radar comparison, dimension agreement bars, and CTAs render correctly
- [ ] Verify bridge card has violet border and "A different perspective" header
- [ ] Verify globe pulses when match cards appear
- [ ] Verify "Start over" resets the flow completely
- [ ] Check mobile responsiveness — full-width cards, proper text scaling
- [ ] Verify localStorage persistence via `loadConversationalProfile()` in dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)