### PR TITLE
feat: treasury impact chip on proposal cards and peek drawer

### DIFF
--- a/components/governada/discover/ProposalCard.tsx
+++ b/components/governada/discover/ProposalCard.tsx
@@ -7,7 +7,9 @@ import { getProposalTheme, getVerdict } from '@/components/governada/proposals/p
 import { ProposalDeliveryBadge } from '@/components/governada/proposals/ProposalDeliveryBadge';
 import { NclImpactIndicator } from '@/components/shared/NclImpactIndicator';
 import { PeekTrigger } from '@/components/governada/peeks/PeekTrigger';
+import { TreasuryImpactChip } from '@/components/governada/shared/TreasuryImpactChip';
 import { useTreasuryNcl } from '@/hooks/queries';
+import { useTreasuryContext } from '@/hooks/useTreasuryContext';
 import type { DeliveryStatus } from '@/lib/proposalOutcomes';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -153,6 +155,7 @@ export function ProposalCard({
   onPeek,
 }: ProposalCardProps) {
   const { data: nclData } = useTreasuryNcl();
+  const { data: treasuryCtx } = useTreasuryContext();
   const status = p.status ?? 'Open';
   const statusLower = status.toLowerCase();
   const isOpen = statusLower === 'open';
@@ -348,6 +351,14 @@ export function ProposalCard({
               endEpoch={ncl!.period.endEpoch}
               isEnacted={statusLower === 'enacted'}
               variant="compact"
+            />
+          )}
+          {hasTreasury && treasuryCtx && treasuryCtx.burnRatePerEpoch > 0 && (
+            <TreasuryImpactChip
+              withdrawalAda={p.withdrawalAmount!}
+              burnRatePerEpoch={treasuryCtx.burnRatePerEpoch}
+              runwayMonths={treasuryCtx.runwayMonths}
+              size="sm"
             />
           )}
           <div className="flex items-center gap-1.5 ml-auto">

--- a/components/governada/peeks/ProposalPeek.tsx
+++ b/components/governada/peeks/ProposalPeek.tsx
@@ -15,6 +15,9 @@ import { useProposals, useDRepVotes } from '@/hooks/queries';
 import { useWallet } from '@/utils/wallet-context';
 import { getProposalTheme, getVerdict } from '@/components/governada/proposals/proposal-theme';
 import type { BrowseProposal } from '@/components/governada/discover/ProposalCard';
+import { TreasuryImpactChip } from '@/components/governada/shared/TreasuryImpactChip';
+import { TreasuryImpactWidget } from '@/components/workspace/review/TreasuryImpactWidget';
+import { useTreasuryContext } from '@/hooks/useTreasuryContext';
 import type { VotesResponseData, VoteItem } from '@/types/api';
 import { useMemo } from 'react';
 
@@ -82,6 +85,7 @@ export function ProposalPeek({ txHash, index }: ProposalPeekProps) {
   const data = rawData as { proposals?: BrowseProposal[]; currentEpoch?: number } | undefined;
   const { delegatedDrepId } = useWallet();
   const { data: drepVotesRaw } = useDRepVotes(delegatedDrepId);
+  const { data: treasuryCtx } = useTreasuryContext();
 
   const proposal = useMemo(() => {
     const proposals = data?.proposals ?? [];
@@ -183,6 +187,26 @@ export function ProposalPeek({ txHash, index }: ProposalPeekProps) {
           </span>
         </div>
       )}
+
+      {/* Treasury impact for withdrawal proposals */}
+      {proposal.type === 'TreasuryWithdrawals' &&
+        proposal.withdrawalAmount != null &&
+        proposal.withdrawalAmount > 0 && (
+          <div className="space-y-3">
+            {treasuryCtx && treasuryCtx.burnRatePerEpoch > 0 && (
+              <TreasuryImpactChip
+                withdrawalAda={proposal.withdrawalAmount}
+                burnRatePerEpoch={treasuryCtx.burnRatePerEpoch}
+                runwayMonths={treasuryCtx.runwayMonths}
+                size="md"
+              />
+            )}
+            <TreasuryImpactWidget
+              withdrawalAmount={proposal.withdrawalAmount * 1_000_000}
+              proposalType={proposal.type}
+            />
+          </div>
+        )}
 
       {/* Open full link */}
       <Link

--- a/components/governada/shared/TreasuryImpactChip.tsx
+++ b/components/governada/shared/TreasuryImpactChip.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Landmark } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface TreasuryImpactChipProps {
+  withdrawalAda: number;
+  burnRatePerEpoch: number;
+  runwayMonths: number;
+  size?: 'sm' | 'md';
+}
+
+export function TreasuryImpactChip({
+  withdrawalAda,
+  burnRatePerEpoch,
+  runwayMonths,
+  size = 'sm',
+}: TreasuryImpactChipProps) {
+  if (withdrawalAda <= 0 || burnRatePerEpoch <= 0) return null;
+
+  const deltaMonths = Math.round((withdrawalAda / burnRatePerEpoch) * (5 / 30.44));
+  if (deltaMonths <= 0) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              'inline-flex items-center gap-0.5 rounded-full font-mono font-semibold tabular-nums',
+              size === 'sm' ? 'text-xs px-1.5 py-0.5' : 'text-sm px-2 py-1',
+              'bg-amber-500/10 text-amber-400 border border-amber-500/20',
+            )}
+            role="status"
+            aria-label={`Treasury runway decreases by approximately ${deltaMonths} months`}
+          >
+            <Landmark
+              className={cn('shrink-0', size === 'sm' ? 'h-2.5 w-2.5' : 'h-3.5 w-3.5')}
+              aria-hidden="true"
+            />
+            -{deltaMonths}mo runway
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          If enacted, treasury runway decreases by ~{deltaMonths} months
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `TreasuryImpactChip` component showing runway impact (-Xmo) for treasury withdrawal proposals
- Integrate chip on `ProposalCard` and `ProposalPeek` for TreasuryWithdrawals proposals
- Surface existing `TreasuryImpactWidget` on peek drawer for deeper treasury context

## Impact
- **What changed**: Treasury withdrawal proposals now show their runway impact inline
- **User-facing**: Yes — citizens and DReps see "-Xmo runway" chips on treasury proposals everywhere
- **Risk**: Low — new component + minimal integration, no data changes
- **Scope**: 1 new component, 2 modified components

## Test plan
- [ ] Verify chip appears on TreasuryWithdrawals proposal cards in /discover
- [ ] Verify chip + widget appear in ProposalPeek for treasury proposals
- [ ] Verify non-treasury proposals show no chip
- [ ] Verify tooltip shows on chip hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)