### PR TITLE
feat: treasury intelligence across all Compass panels

### DIFF
--- a/components/governada/panel/PanelRouter.tsx
+++ b/components/governada/panel/PanelRouter.tsx
@@ -11,6 +11,7 @@ import type { PanelRoute } from '@/hooks/useIntelligencePanel';
 import { HubPanel } from './HubPanel';
 import { ProposalPanel } from './ProposalPanel';
 import { DRepPanel } from './DRepPanel';
+import { TreasuryPanel } from './TreasuryPanel';
 import { GovernancePanel } from './GovernancePanel';
 import { DefaultPanel } from './DefaultPanel';
 
@@ -29,6 +30,8 @@ export function PanelRouter({ panelRoute, entityId }: PanelRouterProps) {
       return <ProposalPanel entityId={entityId} />;
     case 'drep':
       return <DRepPanel entityId={entityId} />;
+    case 'treasury':
+      return <TreasuryPanel />;
     case 'proposals-list':
     case 'representatives-list':
     case 'health':

--- a/components/governada/panel/ReadinessSignal.tsx
+++ b/components/governada/panel/ReadinessSignal.tsx
@@ -131,6 +131,10 @@ function computeReadiness(state: GovernanceStateResult): ReadinessData {
   if (epochPct >= 80) {
     summaryParts.push('epoch ending soon');
   }
+  // Treasury urgency contributes to readiness if urgency is very high
+  if (urgency >= 80) {
+    summaryParts.push('major treasury decisions pending');
+  }
   const summary = summaryParts.length > 0 ? summaryParts.join(' · ') : 'Governance is stable';
 
   return { score: readiness, label, colorClass, strokeColor, summary, signals };

--- a/components/governada/panel/TreasuryPanel.tsx
+++ b/components/governada/panel/TreasuryPanel.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+/**
+ * TreasuryPanel — Intelligence panel content for /governance/treasury.
+ *
+ * Shows treasury briefing, key signals, personal treasury stance, and suggested actions.
+ * Fetches treasury data from client-side hooks and generates narrative locally.
+ */
+
+import { useSegment } from '@/components/providers/SegmentProvider';
+import { CollapsibleSection } from './CollapsibleSection';
+import { CitedClaim } from './CitedClaim';
+import { PanelSkeleton } from './PanelSkeleton';
+import { useTreasuryCurrent, useTreasuryNcl } from '@/hooks/queries';
+import { useDRepTreasuryRecord } from '@/hooks/useDRepTreasuryRecord';
+import {
+  generateTreasuryNarrative,
+  formatAda,
+  calculateRunwayMonths,
+  calculateBurnRate,
+} from '@/lib/treasury';
+import type { TreasuryNarrativeData, NclUtilization } from '@/lib/treasury';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import type { ContextHighlight, SuggestedAction } from '@/lib/intelligence/context';
+
+export function TreasuryPanel() {
+  const { stakeAddress, drepId } = useSegment();
+
+  const { data: currentData, isLoading: currentLoading } = useTreasuryCurrent();
+  const { data: nclData, isLoading: nclLoading } = useTreasuryNcl();
+  const { data: drepRecordData } = useDRepTreasuryRecord(drepId);
+
+  const isLoading = currentLoading || nclLoading;
+
+  if (isLoading) return <PanelSkeleton sections={3} />;
+
+  // Extract treasury data
+  const treasury = currentData as
+    | {
+        balance?: { balanceAda: number; epoch: number };
+        trend?: {
+          snapshots: Array<{
+            epoch: number;
+            balanceAda: number;
+            withdrawalsAda: number;
+            reservesIncomeAda: number;
+            snapshotAt: string;
+          }>;
+        };
+        pending?: {
+          proposals: Array<{ withdrawalAda: number | null }>;
+          totalAda: number;
+          count: number;
+        };
+        effectiveness?: { rate: number | null };
+      }
+    | undefined;
+  const ncl = (nclData?.ncl ?? null) as NclUtilization | null;
+
+  const balanceAda = treasury?.balance?.balanceAda ?? 0;
+  const pendingCount = treasury?.pending?.count ?? 0;
+  const pendingTotalAda = treasury?.pending?.totalAda ?? 0;
+  const effectivenessRate = treasury?.effectiveness?.rate ?? null;
+
+  // Compute burn rate and runway from trend snapshots
+  const snapshots = treasury?.trend?.snapshots ?? [];
+  const burnRate = calculateBurnRate(snapshots);
+  const runwayMonths = calculateRunwayMonths(balanceAda, burnRate);
+
+  // Determine trend direction
+  let trend: TreasuryNarrativeData['trend'] = 'stable';
+  if (snapshots.length >= 3) {
+    const recent = snapshots.slice(-3);
+    const first = recent[0].balanceAda;
+    const last = recent[recent.length - 1].balanceAda;
+    if (last > first * 1.01) trend = 'growing';
+    else if (last < first * 0.99) trend = 'shrinking';
+  }
+
+  // Generate narrative
+  const narrativeData: TreasuryNarrativeData = {
+    balanceAda,
+    trend,
+    effectivenessRate,
+    pendingCount,
+    pendingTotalAda,
+    runwayMonths,
+    ncl,
+  };
+  const briefing = balanceAda > 0 ? generateTreasuryNarrative(narrativeData) : '';
+
+  // Build highlights
+  const highlights: ContextHighlight[] = [];
+
+  // Runway signal
+  const runwayYears = runwayMonths / 12;
+  highlights.push({
+    label: 'Runway',
+    value: runwayYears > 20 ? '10+ years' : `${Math.round(runwayMonths)}mo`,
+    sentiment: runwayMonths > 24 ? 'positive' : runwayMonths > 12 ? 'neutral' : 'negative',
+  });
+
+  // NCL utilization signal
+  if (ncl) {
+    highlights.push({
+      label: 'NCL Used',
+      value: `${Math.round(ncl.utilizationPct)}%`,
+      sentiment:
+        ncl.utilizationPct > 75 ? 'negative' : ncl.utilizationPct > 50 ? 'neutral' : 'positive',
+    });
+  }
+
+  // Effectiveness signal
+  if (effectivenessRate !== null) {
+    highlights.push({
+      label: 'Effectiveness',
+      value: `${effectivenessRate}%`,
+      sentiment:
+        effectivenessRate > 70 ? 'positive' : effectivenessRate > 50 ? 'neutral' : 'negative',
+    });
+  }
+
+  // Pending proposals signal
+  if (pendingCount > 0) {
+    highlights.push({
+      label: 'Pending',
+      value: `${pendingCount} (${formatAda(pendingTotalAda)} ADA)`,
+      sentiment: pendingTotalAda > 50_000_000 ? 'negative' : 'neutral',
+    });
+  }
+
+  // Build suggested actions
+  const suggestedActions: SuggestedAction[] = [];
+  if (pendingCount > 0) {
+    suggestedActions.push({
+      label: `Review ${pendingCount} pending treasury proposal${pendingCount !== 1 ? 's' : ''}`,
+      href: '/governance/proposals',
+      priority: 'high',
+    });
+  }
+  suggestedActions.push({
+    label: 'Explore treasury details',
+    href: '/governance/treasury',
+    priority: 'low',
+  });
+
+  // DRep treasury record
+  const drepRecord = drepRecordData?.record;
+
+  return (
+    <div>
+      {/* Treasury Briefing */}
+      {briefing && (
+        <CollapsibleSection title="Treasury Briefing" defaultExpanded>
+          <p className="text-xs text-muted-foreground/80 leading-relaxed">
+            <CitedClaim
+              citations={[
+                { label: 'Treasury data', href: '/governance/treasury' },
+                { label: 'On-chain snapshots' },
+              ]}
+            >
+              {briefing}
+            </CitedClaim>
+          </p>
+        </CollapsibleSection>
+      )}
+
+      {/* Key Signals */}
+      {highlights.length > 0 && (
+        <CollapsibleSection
+          title="Key Signals"
+          summary={highlights
+            .map((h) => `${h.label}: ${h.value}`)
+            .slice(0, 2)
+            .join(' · ')}
+        >
+          <div className="space-y-1.5">
+            {highlights.map((highlight, i) => (
+              <div key={i} className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">{highlight.label}</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    highlight.sentiment === 'positive' && 'text-emerald-400',
+                    highlight.sentiment === 'negative' && 'text-red-400',
+                    highlight.sentiment === 'neutral' && 'text-foreground/80',
+                  )}
+                >
+                  {highlight.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Your Treasury Stance (connected only) */}
+      {stakeAddress && drepRecord && (
+        <CollapsibleSection
+          title="Your Treasury Stance"
+          summary={
+            drepRecord.approvedAda > drepRecord.opposedAda
+              ? 'Growth-leaning'
+              : drepRecord.opposedAda > drepRecord.approvedAda
+                ? 'Conservative-leaning'
+                : 'Balanced'
+          }
+        >
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground/70">Proposals Voted</span>
+              <span className="font-medium text-foreground/80">{drepRecord.totalProposals}</span>
+            </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground/70">Approved</span>
+              <span className="font-medium text-emerald-400">
+                {drepRecord.approvedCount} ({formatAda(drepRecord.approvedAda)} ADA)
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground/70">Opposed</span>
+              <span className="font-medium text-red-400">
+                {drepRecord.opposedCount} ({formatAda(drepRecord.opposedAda)} ADA)
+              </span>
+            </div>
+            {drepRecord.judgmentScore !== null && (
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground/70">Judgment Score</span>
+                <span
+                  className={cn(
+                    'font-medium',
+                    drepRecord.judgmentScore >= 70
+                      ? 'text-emerald-400'
+                      : drepRecord.judgmentScore >= 40
+                        ? 'text-foreground/80'
+                        : 'text-red-400',
+                  )}
+                >
+                  {drepRecord.judgmentScore}/100
+                </span>
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Suggested Actions */}
+      {suggestedActions.length > 0 && (
+        <CollapsibleSection title="Suggested" summary={`${suggestedActions.length} actions`}>
+          <div className="space-y-1">
+            {suggestedActions.map((action, i) => (
+              <Link
+                key={i}
+                href={action.href}
+                className={cn(
+                  'flex items-center justify-between py-1.5 px-2 rounded-md text-xs',
+                  'hover:bg-accent/30 transition-colors group',
+                  action.priority === 'high' && 'text-amber-300',
+                  action.priority === 'medium' && 'text-foreground/80',
+                  action.priority === 'low' && 'text-muted-foreground/70',
+                )}
+              >
+                <span>{action.label}</span>
+                <ArrowRight className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </Link>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/hooks/useIntelligencePanel.ts
+++ b/hooks/useIntelligencePanel.ts
@@ -35,6 +35,7 @@ export type PanelRoute =
   | 'proposals-list'
   | 'representatives-list'
   | 'health'
+  | 'treasury'
   | 'workspace'
   | 'default';
 
@@ -46,6 +47,7 @@ function detectPanelRoute(pathname: string): PanelRoute {
   if (pathname === '/governance/representatives' || pathname === '/representatives')
     return 'representatives-list';
   if (pathname === '/governance/health') return 'health';
+  if (pathname === '/governance/treasury') return 'treasury';
   if (pathname.startsWith('/workspace')) return 'workspace';
   return 'default';
 }

--- a/lib/intelligence/context.ts
+++ b/lib/intelligence/context.ts
@@ -15,6 +15,30 @@
 import { createClient } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
 import { cached } from '@/lib/redis';
+import {
+  getTreasuryBalance,
+  getNclUtilization,
+  getDRepTreasuryTrackRecord,
+  formatAda,
+  calculateRunwayMonths,
+  calculateBurnRate,
+  getTreasuryTrend,
+} from '@/lib/treasury';
+
+// ---------------------------------------------------------------------------
+// Shared treasury context helper (server-side, used across synthesis fns)
+// ---------------------------------------------------------------------------
+
+async function getTreasuryContext() {
+  const [treasuryData, ncl, trend] = await Promise.all([
+    getTreasuryBalance().catch(() => null),
+    getNclUtilization().catch(() => null),
+    getTreasuryTrend(10).catch(() => []),
+  ]);
+  const burnRate = calculateBurnRate(trend);
+  const runwayMonths = treasuryData ? calculateRunwayMonths(treasuryData.balanceAda, burnRate) : 0;
+  return { treasuryData, ncl, runwayMonths };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,6 +82,7 @@ type RouteType =
   | 'proposals-list'
   | 'representatives-list'
   | 'health'
+  | 'treasury'
   | 'workspace'
   | 'governance'
   | 'list'
@@ -98,6 +123,9 @@ function parseRoute(pathname: string): ParsedRoute {
   }
   if (pathname === '/governance/health') {
     return { type: 'health' };
+  }
+  if (pathname === '/governance/treasury') {
+    return { type: 'treasury' };
   }
   if (pathname.startsWith('/workspace')) {
     return { type: 'workspace' };
@@ -216,6 +244,57 @@ async function synthesizeProposalContext(
         label: 'Expiration',
         value: `${epochsRemaining} epoch${epochsRemaining === 1 ? '' : 's'} remaining`,
         sentiment: epochsRemaining <= 1 ? 'negative' : 'neutral',
+      });
+    }
+  }
+
+  // Treasury context for withdrawal proposals
+  if (proposal.withdrawal_amount) {
+    const withdrawalAda = Math.round(Number(proposal.withdrawal_amount) / 1_000_000);
+    const treasury = await getTreasuryContext().catch(() => null);
+    if (treasury?.treasuryData) {
+      // Runway impact
+      const currentRunway = treasury.runwayMonths;
+      if (currentRunway > 0 && withdrawalAda > 0) {
+        const impactMonths = Math.round(
+          currentRunway -
+            calculateRunwayMonths(
+              treasury.treasuryData.balanceAda - withdrawalAda,
+              treasury.treasuryData.balanceAda > 0
+                ? (treasury.treasuryData.balanceAda -
+                    (treasury.treasuryData.balanceAda - withdrawalAda)) /
+                    (currentRunway / 12)
+                : 0,
+            ),
+        );
+        if (impactMonths > 0) {
+          highlights.push({
+            label: 'Runway Impact',
+            value: `-${impactMonths}mo`,
+            sentiment: impactMonths > 6 ? 'negative' : 'neutral',
+          });
+        }
+      }
+    }
+    if (treasury?.ncl) {
+      const newUtilization =
+        treasury.ncl.utilizationPct +
+        (withdrawalAda / (treasury.ncl.remainingAda + withdrawalAda)) * 100;
+      highlights.push({
+        label: 'NCL Impact',
+        value: `Budget → ${Math.round(Math.min(100, newUtilization))}%`,
+        sentiment: newUtilization > 75 ? 'negative' : newUtilization > 50 ? 'neutral' : 'positive',
+      });
+    }
+  } else {
+    // Non-treasury proposal: lighter treasury status
+    const treasury = await getTreasuryContext().catch(() => null);
+    if (treasury?.treasuryData) {
+      const healthy = treasury.runwayMonths > 24;
+      highlights.push({
+        label: 'Treasury',
+        value: healthy ? 'Healthy' : 'Needs Attention',
+        sentiment: healthy ? 'positive' : 'negative',
       });
     }
   }
@@ -351,6 +430,27 @@ async function synthesizeDrepContext(
     }
   }
 
+  // Treasury track record
+  const treasuryRecord = await getDRepTreasuryTrackRecord(drepId).catch(() => null);
+  if (treasuryRecord && treasuryRecord.totalProposals > 0) {
+    const stance =
+      treasuryRecord.approvedAda > treasuryRecord.opposedAda * 2
+        ? 'Growth'
+        : treasuryRecord.opposedAda > treasuryRecord.approvedAda * 2
+          ? 'Conservative'
+          : 'Balanced';
+    highlights.push({
+      label: 'Treasury Stance',
+      value: stance,
+      sentiment: 'neutral',
+    });
+    highlights.push({
+      label: 'Treasury Votes',
+      value: `${treasuryRecord.totalProposals} (${formatAda(treasuryRecord.approvedAda)} approved)`,
+      sentiment: 'neutral',
+    });
+  }
+
   const briefing = `${name} is a ${drep.size_tier ?? ''} DRep with a score of ${drep.score}/100. Participation rate: ${Math.round(drep.effective_participation ?? 0)}%. Rationale rate: ${Math.round(drep.rationale_rate ?? 0)}%.`;
 
   return {
@@ -396,6 +496,38 @@ async function synthesizeHubContext(stakeAddress?: string): Promise<ContextSynth
         sentiment: 'neutral',
       });
     }
+  }
+
+  // Treasury awareness
+  const treasury = await getTreasuryContext().catch(() => null);
+  if (treasury?.treasuryData) {
+    const runwayYears = treasury.runwayMonths / 12;
+    const runwayLabel =
+      runwayYears > 20 ? '10+ yr runway' : `${Math.round(treasury.runwayMonths)}mo runway`;
+    const healthy = treasury.runwayMonths > 24;
+    highlights.push({
+      label: 'Treasury',
+      value: `${healthy ? 'Healthy' : 'Attention'} · ${runwayLabel}`,
+      sentiment: healthy ? 'positive' : 'negative',
+    });
+  }
+
+  // Pending treasury proposals action
+  const pendingTreasuryResult = await supabase
+    .from('proposals')
+    .select('*', { count: 'exact', head: true })
+    .is('ratified_epoch', null)
+    .is('enacted_epoch', null)
+    .is('dropped_epoch', null)
+    .is('expired_epoch', null)
+    .not('withdrawal_amount', 'is', null);
+  const pendingTreasuryCount = pendingTreasuryResult.count ?? 0;
+  if (pendingTreasuryCount > 0) {
+    suggestedActions.push({
+      label: `Review ${pendingTreasuryCount} treasury proposal${pendingTreasuryCount !== 1 ? 's' : ''}`,
+      href: '/governance/treasury',
+      priority: 'high',
+    });
   }
 
   if (stakeAddress) {
@@ -501,6 +633,19 @@ async function synthesizeProposalsListContext(
       label: 'Treasury at Stake',
       value: `${totalTreasuryAda.toLocaleString()} ADA`,
       sentiment: totalTreasuryAda > 50_000_000 ? 'negative' : 'neutral',
+    });
+  }
+
+  // NCL utilization context
+  const nclData = await getNclUtilization().catch(() => null);
+  if (nclData && totalTreasuryAda > 0) {
+    const projectedIfAllPass =
+      nclData.utilizationPct + (totalTreasuryAda / (nclData.remainingAda + totalTreasuryAda)) * 100;
+    highlights.push({
+      label: 'NCL Budget',
+      value: `${Math.round(nclData.utilizationPct)}% used, ${Math.round(Math.min(100, projectedIfAllPass))}% if all pass`,
+      sentiment:
+        projectedIfAllPass > 75 ? 'negative' : projectedIfAllPass > 50 ? 'neutral' : 'positive',
     });
   }
 
@@ -880,6 +1025,19 @@ async function synthesizeHealthContext(stakeAddress?: string): Promise<ContextSy
     priority: 'low',
   });
 
+  // Treasury health contribution
+  const treasury = await getTreasuryContext().catch(() => null);
+  if (treasury?.treasuryData) {
+    const healthy = treasury.runwayMonths > 24;
+    const runwayYears = treasury.runwayMonths / 12;
+    const runwayLabel = runwayYears > 20 ? '10+ yr' : `${Math.round(treasury.runwayMonths)}mo`;
+    highlights.push({
+      label: 'Treasury Health',
+      value: `${healthy ? 'Healthy' : 'Attention'} · ${runwayLabel} runway`,
+      sentiment: healthy ? 'positive' : 'negative',
+    });
+  }
+
   return {
     briefing: briefingParts.join(' '),
     highlights,
@@ -1018,11 +1176,128 @@ async function synthesizeWorkspaceContext(stakeAddress?: string): Promise<Contex
     });
   }
 
+  // Treasury awareness for workspace
+  const pendingTreasuryResult = await supabase
+    .from('proposals')
+    .select('*', { count: 'exact', head: true })
+    .is('ratified_epoch', null)
+    .is('enacted_epoch', null)
+    .is('dropped_epoch', null)
+    .is('expired_epoch', null)
+    .not('withdrawal_amount', 'is', null);
+  const pendingTreasuryCount = pendingTreasuryResult.count ?? 0;
+  if (pendingTreasuryCount > 0) {
+    highlights.push({
+      label: 'Pending Treasury',
+      value: `${pendingTreasuryCount} proposal${pendingTreasuryCount !== 1 ? 's' : ''}`,
+      sentiment: pendingTreasuryCount > 5 ? 'negative' : 'neutral',
+    });
+    suggestedActions.push({
+      label: `Review ${pendingTreasuryCount} pending treasury proposal${pendingTreasuryCount !== 1 ? 's' : ''}`,
+      href: '/governance/treasury',
+      priority: 'medium',
+    });
+  }
+
   return {
     briefing: briefingParts.join(' '),
     highlights,
     suggestedActions,
     routeType: 'workspace',
+    computedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Treasury — dedicated treasury page intelligence
+// ---------------------------------------------------------------------------
+
+async function synthesizeTreasuryContext(stakeAddress?: string): Promise<ContextSynthesisResult> {
+  const highlights: ContextHighlight[] = [];
+  const suggestedActions: SuggestedAction[] = [];
+
+  const treasury = await getTreasuryContext().catch(() => null);
+
+  if (!treasury?.treasuryData) {
+    return emptyResult('treasury');
+  }
+
+  const runwayYears = treasury.runwayMonths / 12;
+  const runwayLabel = runwayYears > 20 ? '10+ years' : `${Math.round(treasury.runwayMonths)}mo`;
+  const healthy = treasury.runwayMonths > 24;
+
+  highlights.push({
+    label: 'Runway',
+    value: runwayLabel,
+    sentiment: healthy ? 'positive' : treasury.runwayMonths > 12 ? 'neutral' : 'negative',
+  });
+
+  if (treasury.ncl) {
+    highlights.push({
+      label: 'NCL Used',
+      value: `${Math.round(treasury.ncl.utilizationPct)}%`,
+      sentiment:
+        treasury.ncl.utilizationPct > 75
+          ? 'negative'
+          : treasury.ncl.utilizationPct > 50
+            ? 'neutral'
+            : 'positive',
+    });
+  }
+
+  // Pending treasury proposals
+  const supabase = createClient();
+  const pendingResult = await supabase
+    .from('proposals')
+    .select('tx_hash, withdrawal_amount', { count: 'exact' })
+    .is('ratified_epoch', null)
+    .is('enacted_epoch', null)
+    .is('dropped_epoch', null)
+    .is('expired_epoch', null)
+    .not('withdrawal_amount', 'is', null);
+  const pendingCount = pendingResult.count ?? 0;
+  const pendingTotalAda = (pendingResult.data ?? []).reduce(
+    (sum, p) => sum + Math.round(Number(p.withdrawal_amount ?? 0) / 1_000_000),
+    0,
+  );
+
+  if (pendingCount > 0) {
+    highlights.push({
+      label: 'Pending',
+      value: `${pendingCount} (${formatAda(pendingTotalAda)} ADA)`,
+      sentiment: pendingTotalAda > 50_000_000 ? 'negative' : 'neutral',
+    });
+    suggestedActions.push({
+      label: `Review ${pendingCount} pending treasury proposal${pendingCount !== 1 ? 's' : ''}`,
+      href: '/governance/proposals',
+      priority: 'high',
+    });
+  }
+
+  const briefingParts: string[] = [];
+  briefingParts.push(
+    `Treasury balance: ${formatAda(treasury.treasuryData.balanceAda)} ADA with ${runwayLabel} runway.`,
+  );
+  if (treasury.ncl) {
+    briefingParts.push(`NCL budget is ${Math.round(treasury.ncl.utilizationPct)}% utilized.`);
+  }
+  if (pendingCount > 0) {
+    briefingParts.push(
+      `${pendingCount} treasury withdrawal${pendingCount !== 1 ? 's' : ''} totaling ${formatAda(pendingTotalAda)} ADA are pending.`,
+    );
+  }
+
+  suggestedActions.push({
+    label: 'Explore treasury details',
+    href: '/governance/treasury',
+    priority: 'low',
+  });
+
+  return {
+    briefing: briefingParts.join(' '),
+    highlights,
+    suggestedActions,
+    routeType: 'treasury',
     computedAt: new Date().toISOString(),
   };
 }
@@ -1066,6 +1341,8 @@ export async function synthesizeContext(
           return synthesizeRepresentativesListContext(stakeAddress);
         case 'health':
           return synthesizeHealthContext(stakeAddress);
+        case 'treasury':
+          return synthesizeTreasuryContext(stakeAddress);
         case 'workspace':
           return synthesizeWorkspaceContext(stakeAddress);
         case 'governance':
@@ -1096,6 +1373,8 @@ export async function synthesizeContext(
           return await synthesizeRepresentativesListContext(stakeAddress);
         case 'health':
           return await synthesizeHealthContext(stakeAddress);
+        case 'treasury':
+          return await synthesizeTreasuryContext(stakeAddress);
         case 'workspace':
           return await synthesizeWorkspaceContext(stakeAddress);
         case 'hub':

--- a/lib/intelligence/governance-state.ts
+++ b/lib/intelligence/governance-state.ts
@@ -137,9 +137,12 @@ async function computeGlobalState(): Promise<Omit<GovernanceStateResult, 'userSt
     // Active proposals (not ratified/enacted/dropped/expired)
     supabase
       .from('proposals')
-      .select('tx_hash, proposal_index, expiration_epoch, proposed_epoch, block_time', {
-        count: 'exact',
-      })
+      .select(
+        'tx_hash, proposal_index, expiration_epoch, proposed_epoch, block_time, withdrawal_amount',
+        {
+          count: 'exact',
+        },
+      )
       .is('ratified_epoch', null)
       .is('enacted_epoch', null)
       .is('dropped_epoch', null)
@@ -189,6 +192,7 @@ function computeUrgency(
     expiration_epoch: number | null;
     proposed_epoch: number | null;
     block_time: number | null;
+    withdrawal_amount: string | number | null;
   }>,
   currentEpoch: number,
   epochProgress: number,
@@ -220,6 +224,17 @@ function computeUrgency(
 
   // Factor 4: Volume of active proposals (many = more urgency)
   urgencyScore += Math.min(10, Math.round(activeProposals.length * 1.5));
+
+  // Factor 5: Major treasury proposals (>10M ADA) expiring within 3 epochs
+  const MAJOR_THRESHOLD = 10_000_000 * 1_000_000; // 10M ADA in lovelace
+  const majorTreasuryExpiring = activeProposals.filter(
+    (p) =>
+      p.withdrawal_amount != null &&
+      Number(p.withdrawal_amount) >= MAJOR_THRESHOLD &&
+      p.expiration_epoch != null &&
+      p.expiration_epoch <= currentEpoch + 3,
+  );
+  urgencyScore += Math.min(15, majorTreasuryExpiring.length * 8);
 
   return Math.min(100, Math.max(0, urgencyScore));
 }


### PR DESCRIPTION
## Summary
- Add dedicated `TreasuryPanel` for Compass sidebar on `/governance/treasury` route
- Enrich context synthesis across ALL routes (Hub, Proposal, DRep, Workspace, Health, Proposals list) with treasury intelligence
- Add treasury urgency to ReadinessSignal for major pending decisions (>10M ADA, <3 epochs)

## Impact
- **What changed**: Treasury intelligence is now ambient across the entire app via Compass panel
- **User-facing**: Yes — every route now includes treasury context in the intelligence panel
- **Risk**: Medium — touches context.ts (1139 lines) and governance-state.ts, but only adds highlights/actions
- **Scope**: 1 new component, 5 modified files (context.ts, governance-state.ts, PanelRouter, useIntelligencePanel, ReadinessSignal)

## Test plan
- [ ] Verify TreasuryPanel appears in Compass on /governance/treasury
- [ ] Verify treasury highlights appear in Compass on /governance/proposals, /drep/*, /workspace
- [ ] Verify ReadinessSignal shows treasury urgency for major pending proposals
- [ ] Verify DRep panel shows treasury stance (Growth/Conservative/Balanced)
- [ ] Verify Hub synthesis includes treasury health highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)