### PR TITLE
fix: match score display, UX refinements, remove old quiz flow

### DIFF
--- a/app/match/page.tsx
+++ b/app/match/page.tsx
@@ -1,24 +1,7 @@
-import type { Metadata } from 'next';
-import { QuickMatchFlow } from '@/components/governada/match/QuickMatchFlow';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata: Metadata = {
-  title: 'Build Your Governance Team — Governada',
-  description:
-    'Answer 3 questions about what you care about and build your Cardano governance team. Find the DRep and Stake Pool that vote like you. No wallet required.',
-  openGraph: {
-    title: 'Build Your Governance Team — Governada',
-    description: 'Find who votes like you in Cardano governance. 60 seconds, no wallet needed.',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Build Your Governance Team — Governada',
-    description: 'Find who votes like you in Cardano governance. 60 seconds.',
-  },
-};
-
 export default function MatchPage() {
-  return <QuickMatchFlow />;
+  redirect('/');
 }

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -72,19 +72,26 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
 
         {/* Hero content */}
         <div className="relative z-10 text-center max-w-lg px-6 sm:pt-14">
-          <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-white leading-tight hero-text-shadow">
-            {t('Your ADA gives you')}
-            <br />
-            <span className="text-primary">{t('a voice.')}</span>
-          </h1>
-          <p
-            className="mt-4 text-lg sm:text-xl text-white/90 font-medium"
-            style={{
-              textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)',
-            }}
+          <div
+            className={cn(
+              'transition-all duration-500',
+              isMatching && 'opacity-0 h-0 overflow-hidden',
+            )}
           >
-            {t('Choose who votes for you. It takes 60 seconds.')}
-          </p>
+            <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-white leading-tight hero-text-shadow">
+              {t('Your ADA gives you')}
+              <br />
+              <span className="text-primary">{t('a voice.')}</span>
+            </h1>
+            <p
+              className="mt-4 text-lg sm:text-xl text-white/90 font-medium"
+              style={{
+                textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)',
+              }}
+            >
+              {t('Choose who votes for you. It takes 60 seconds.')}
+            </p>
+          </div>
 
           {/* Conversational matching pills — inline in hero when flag enabled */}
           {conversationalMatchingEnabled && (
@@ -128,21 +135,11 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
           </>
         )}
 
-        {/* Stake pool text link — always visible */}
-        {conversationalMatchingEnabled && (
-          <div className="text-center">
-            <Link
-              href="/match"
-              className="text-sm text-white/50 hover:text-white/80 transition-colors"
-              style={{ textShadow: '0 1px 6px rgba(0,0,0,0.6)' }}
-            >
-              {t('Looking for a stake pool?')}
-            </Link>
-          </div>
-        )}
+        {/* Spacer when conversational matching is enabled */}
+        {conversationalMatchingEnabled && <div />}
 
         {/* Governance consequence card — why governance matters to your ADA */}
-        {pulseData && (
+        {pulseData && !isMatching && (
           <GovernanceConsequenceCard
             activeProposals={pulseData.activeProposals}
             totalDelegators={pulseData.totalDelegators}

--- a/components/matching/ConversationalMatchFlow.tsx
+++ b/components/matching/ConversationalMatchFlow.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { ArrowRight, Loader2, RotateCcw, Sparkles } from 'lucide-react';
+import { ArrowRight, Loader2, RotateCcw } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
 import { Button } from '@/components/ui/button';
 import { PillCloud } from './PillCloud';
-import { ConfidenceRing } from './ConfidenceRing';
 import { ConversationalRound } from './ConversationalRound';
 import { SemanticFastTrack } from './SemanticFastTrack';
 import { MatchResults } from './MatchResults';
@@ -17,7 +16,7 @@ import type { ConstellationRef } from '@/components/GovernanceConstellation';
 
 /* ─── Types ─────────────────────────────────────────────── */
 
-type FlowState = 'idle' | 'matching' | 'ready' | 'results';
+type FlowState = 'idle' | 'matching' | 'results';
 
 interface ConversationalMatchFlowProps {
   globeRef: React.RefObject<ConstellationRef | null>;
@@ -119,17 +118,13 @@ export function ConversationalMatchFlow({
 
   const prefersReducedMotion = useReducedMotion();
   const motionTransition = prefersReducedMotion ? { duration: 0 } : { duration: 0.2 };
-  const springTransition = prefersReducedMotion
-    ? { duration: 0 }
-    : { type: 'spring' as const, stiffness: 300, damping: 20 };
-
   /* ─── URL popstate handler ─────────────────────────────── */
 
   useEffect(() => {
     function handlePopState(e: PopStateEvent) {
       if (e.state?.state === 'matching') {
         // Allow back to matching state — but we don't auto-restart
-      } else if (flowState === 'matching' || flowState === 'ready') {
+      } else if (flowState === 'matching') {
         // Back button during matching → reset to idle
         handleReset();
       }
@@ -142,9 +137,12 @@ export function ConversationalMatchFlow({
 
   /* ─── Sync hook status → flow state ────────────────────── */
 
+  // Auto-trigger match when ready — skip "ready" intermediate state
+  const hasAutoMatchedRef = useRef(false);
   useEffect(() => {
-    if (status === 'ready_to_match' && flowState === 'matching') {
-      // Don't auto-transition — let the user click "See your matches"
+    if (status === 'ready_to_match' && flowState === 'matching' && !hasAutoMatchedRef.current) {
+      hasAutoMatchedRef.current = true;
+      getMatches();
     }
     if (status === 'matched' && flowState !== 'results') {
       setFlowState('results');
@@ -178,6 +176,7 @@ export function ConversationalMatchFlow({
     identityColor,
     userAlignments,
     onMatchComplete,
+    getMatches,
   ]);
 
   /* ─── Update globe highlights after each answer ────────── */
@@ -291,29 +290,20 @@ export function ConversationalMatchFlow({
     [submitAnswer, pendingSemanticText, round],
   );
 
-  /* ─── See matches CTA ──────────────────────────────────── */
+  /* ─── Continue refining (restart session, go back to matching) ── */
 
-  const handleSeeMatches = useCallback(async () => {
-    setFlowState('ready');
-    await getMatches();
-  }, [getMatches]);
-
-  /* ─── Reset ────────────────────────────────────────────── */
-
-  const handleReset = useCallback(() => {
-    posthog.capture('match_reset');
+  const handleReset = useCallback(async () => {
+    posthog.capture('match_continue_refining');
     reset();
-    setFlowState('idle');
-    setSelectedTopics(new Set());
-    setFreeformText('');
-    setShowFastTrack(false);
+    hasAutoMatchedRef.current = false;
+    hasStartedRef.current = true;
+    setFlowState('matching');
     setPendingSemanticText(null);
-    hasStartedRef.current = false;
+    pushUrlState('matching', 'matching');
     globeRef.current?.clearMatches();
-    if (typeof window !== 'undefined') {
-      window.history.pushState({}, '', '/');
-    }
-  }, [reset, globeRef]);
+    // Start a fresh session to allow more rounds
+    await startSession();
+  }, [reset, globeRef, startSession]);
 
   /* ─── Render: Idle state ───────────────────────────────── */
 
@@ -415,7 +405,7 @@ export function ConversationalMatchFlow({
 
   if (flowState === 'matching') {
     return (
-      <div className="w-full space-y-4">
+      <div className="w-full space-y-3 max-md:fixed max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:z-30 max-md:bg-background/90 max-md:backdrop-blur-lg max-md:px-4 max-md:pb-[env(safe-area-inset-bottom,12px)] max-md:pt-3 max-md:border-t max-md:border-white/[0.06]">
         <AnimatePresence mode="wait">
           {/* Waiting for first question */}
           {isLoading && !question && (
@@ -454,50 +444,30 @@ export function ConversationalMatchFlow({
           )}
         </AnimatePresence>
 
-        {/* Confidence + ready CTA */}
-        <div className="flex items-center justify-between">
-          <ConfidenceRing confidence={confidence} size={48} label="Match confidence" />
+        {/* Thin confidence bar */}
+        {confidence > 0 && (
+          <div className="flex items-center gap-2">
+            <div className="flex-1 h-[3px] rounded-full bg-white/10 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-primary transition-all duration-500"
+                style={{ width: `${Math.min(confidence, 100)}%` }}
+              />
+            </div>
+            <span className="text-[11px] tabular-nums text-muted-foreground shrink-0">
+              {confidence}% match confidence
+            </span>
+          </div>
+        )}
 
-          {status === 'ready_to_match' && (
-            <motion.div
-              initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.9 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={springTransition}
-            >
-              <Button
-                onClick={handleSeeMatches}
-                size="lg"
-                className="gap-2 rounded-xl font-semibold"
-              >
-                <Sparkles className="h-4 w-4" />
-                See your matches
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            </motion.div>
-          )}
-        </div>
+        {/* Loading matches indicator (replaces old "ready" state) */}
+        {status === 'ready_to_match' && (
+          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground py-2">
+            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+            Finding your matches...
+          </div>
+        )}
 
         {error && <p className="text-center text-sm text-destructive">{error}</p>}
-      </div>
-    );
-  }
-
-  /* ─── Render: Ready state (loading matches) ────────────── */
-
-  if (flowState === 'ready') {
-    return (
-      <div className="flex flex-col items-center gap-4 py-8">
-        <motion.div
-          initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.8 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={
-            prefersReducedMotion ? { duration: 0 } : { type: 'spring', stiffness: 200, damping: 20 }
-          }
-        >
-          <ConfidenceRing confidence={confidence} size={80} />
-        </motion.div>
-        <p className="text-sm text-muted-foreground">Finding your matches...</p>
-        <Loader2 className="h-5 w-5 animate-spin text-primary" />
       </div>
     );
   }

--- a/components/matching/ConversationalRound.tsx
+++ b/components/matching/ConversationalRound.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { Loader2 } from 'lucide-react';
+import { ArrowRight, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { PillCloud } from './PillCloud';
@@ -55,7 +55,6 @@ const slideVariants = {
 
 export function ConversationalRound({
   question,
-  roundNumber,
   onAnswer,
   isLoading = false,
 }: ConversationalRoundProps) {
@@ -91,6 +90,16 @@ export function ConversationalRound({
     const trimmed = rawText.trim();
     onAnswer(Array.from(selected), trimmed.length > 0 ? trimmed : undefined);
   }, [canContinue, isLoading, rawText, selected, onAnswer]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canContinue && !isLoading) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [canContinue, isLoading, handleSubmit],
+  );
 
   // Auto-resize textarea
   useEffect(() => {
@@ -144,30 +153,52 @@ export function ConversationalRound({
           <div className="h-px flex-1 bg-white/10" />
         </div>
 
-        {/* Freeform text area */}
-        <div className="mb-6">
-          <textarea
-            ref={textareaRef}
-            value={rawText}
-            onChange={handleTextChange}
-            placeholder={placeholder}
-            aria-label="Share your governance values in your own words"
-            disabled={isLoading}
-            rows={3}
-            className={cn(
-              'w-full resize-none rounded-lg border border-white/10 bg-white/5 px-4 py-3',
-              'text-sm text-foreground placeholder:text-muted-foreground/50',
-              'backdrop-blur-sm transition-colors',
-              'focus:border-primary/40 focus:outline-none focus:ring-1 focus:ring-primary/20',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-            )}
-          />
+        {/* Freeform text area with inline Continue */}
+        <div className="mb-4">
+          <div className="relative">
+            <textarea
+              ref={textareaRef}
+              value={rawText}
+              onChange={handleTextChange}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              aria-label="Share your governance values in your own words"
+              disabled={isLoading}
+              rows={3}
+              className={cn(
+                'w-full resize-none rounded-lg border border-white/10 bg-white/5 px-4 py-3 pr-28',
+                'text-sm text-foreground placeholder:text-muted-foreground/50',
+                'backdrop-blur-sm transition-colors',
+                'focus:border-primary/40 focus:outline-none focus:ring-1 focus:ring-primary/20',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+            />
+            {/* Inline Continue button */}
+            <div className="absolute right-2 bottom-2">
+              <Button
+                onClick={handleSubmit}
+                disabled={!canContinue || isLoading}
+                size="sm"
+                className="gap-1.5 rounded-lg"
+              >
+                {isLoading ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <>
+                    Continue
+                    <ArrowRight className="size-3.5" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
           <div className="mt-1 flex justify-between">
             {rawText.trim().length >= 10 ? (
               <span className="text-xs text-primary/60">AI will analyze your response</span>
             ) : (
               <span className="text-xs text-muted-foreground">
-                Optional — share your thoughts in your own words
+                Optional — share your thoughts
+                <span className="hidden sm:inline"> (Ctrl+Enter to continue)</span>
               </span>
             )}
             <span
@@ -179,23 +210,6 @@ export function ConversationalRound({
               {rawText.length}/{MAX_CHARS}
             </span>
           </div>
-        </div>
-
-        {/* Continue button */}
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-muted-foreground" aria-label={`Round ${roundNumber}`}>
-            Round {roundNumber}
-          </span>
-          <Button onClick={handleSubmit} disabled={!canContinue || isLoading} size="default">
-            {isLoading ? (
-              <>
-                <Loader2 className="size-4 animate-spin" />
-                Processing...
-              </>
-            ) : (
-              'Continue'
-            )}
-          </Button>
         </div>
       </motion.div>
     </AnimatePresence>

--- a/components/matching/GovernanceIdentityCard.tsx
+++ b/components/matching/GovernanceIdentityCard.tsx
@@ -26,9 +26,38 @@ function hexToRgb(hex: string): [number, number, number] {
   return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
 }
 
-function getShortDescription(alignments: AlignmentScores): string {
+/** Map archetype labels to rich descriptions. Falls back to dimension-based. */
+function getArchetypeDescription(personalityLabel: string, alignments: AlignmentScores): string {
+  const archetypeDescriptions: Record<string, string> = {
+    'Treasury Guardian':
+      "You prioritize careful stewardship of Cardano's treasury and believe in sustainable growth over rapid spending.",
+    'Growth Catalyst':
+      "You champion strategic investment to accelerate Cardano's ecosystem, believing bold bets today create tomorrow's network effects.",
+    'Innovation Champion':
+      'You push for technical progress and believe Cardano should lead through bold protocol upgrades and experimentation.',
+    'Security Sentinel':
+      'You believe protocol safety and network resilience are non-negotiable foundations that everything else is built on.',
+    'Transparency Advocate':
+      'You demand openness in every governance decision and believe accountability is the bedrock of legitimate governance.',
+    'Decentralization Purist':
+      'You stand for distributed power and community autonomy, resisting any concentration of control.',
+    'Balanced Governor':
+      'You weigh multiple governance dimensions carefully, seeking pragmatic outcomes rather than ideological purity.',
+    'Fiscal Conservative':
+      'You believe the treasury should be preserved for only the most impactful investments, with rigorous oversight on spending.',
+    'Community Builder':
+      "You focus on growing Cardano's community and believe governance should empower participation from everyone.",
+    'Protocol Pioneer':
+      'You believe Cardano should be at the cutting edge, pushing boundaries on what blockchain governance can achieve.',
+  };
+
+  if (archetypeDescriptions[personalityLabel]) {
+    return archetypeDescriptions[personalityLabel];
+  }
+
+  // Fallback: use dominant dimension
   const dominant = getDominantDimension(alignments);
-  const descriptions: Record<AlignmentDimension, string> = {
+  const fallbacks: Record<AlignmentDimension, string> = {
     treasuryConservative: 'You prioritize fiscal responsibility and careful treasury stewardship.',
     treasuryGrowth: 'You champion strategic investment and ecosystem growth.',
     decentralization: 'You stand for distributed power and community autonomy.',
@@ -36,7 +65,7 @@ function getShortDescription(alignments: AlignmentScores): string {
     innovation: 'You push for progress, experimentation, and bold change.',
     transparency: 'You demand openness, accountability, and clear governance.',
   };
-  return descriptions[dominant];
+  return fallbacks[dominant];
 }
 
 /* ─── Component ─────────────────────────────────────────── */
@@ -49,7 +78,7 @@ export function GovernanceIdentityCard({
   onContinue,
 }: GovernanceIdentityCardProps) {
   const [r, g, b] = hexToRgb(identityColor);
-  const description = getShortDescription(alignments);
+  const description = getArchetypeDescription(personalityLabel, alignments);
   const dominantLabel = getDimensionLabel(getDominantDimension(alignments));
   const prefersReducedMotion = useReducedMotion();
 
@@ -87,18 +116,20 @@ export function GovernanceIdentityCard({
         aria-live="assertive"
       >
         {/* Preamble */}
-        <p className="text-sm text-muted-foreground uppercase tracking-widest">You&apos;re a</p>
+        <p className="text-xs text-muted-foreground uppercase tracking-[0.2em]">
+          Your Governance Identity
+        </p>
 
         {/* Archetype name */}
         <h2
-          className="font-display text-2xl md:text-4xl lg:text-5xl font-bold tracking-tight leading-tight"
+          className="font-display text-3xl md:text-5xl lg:text-6xl font-bold tracking-tight leading-tight"
           style={{ color: identityColor }}
         >
           {personalityLabel}
         </h2>
 
-        {/* Short description */}
-        <p className="text-sm md:text-base text-muted-foreground max-w-md">{description}</p>
+        {/* Rich description */}
+        <p className="text-sm md:text-base text-white/80 max-w-md leading-relaxed">{description}</p>
 
         {/* Dominant dimension badge */}
         <span

--- a/components/matching/MatchResultCard.tsx
+++ b/components/matching/MatchResultCard.tsx
@@ -82,12 +82,13 @@ export function MatchResultCard({
   const hasPulsed = useRef(false);
   const prefersReducedMotion = useReducedMotion();
   const displayName = match.drepName || match.drepId.slice(0, 16) + '...';
-  const scorePercent = Math.round(match.score * 100);
+  const scorePercent = Math.round(match.score);
   const [r, g, b] = hexToRgb(match.identityColor);
 
   const narrative = generateMatchNarrative({
     agreeDimensions: match.agreeDimensions,
     differDimensions: match.differDimensions,
+    isBridge,
   });
 
   // Pulse globe node when card first appears
@@ -98,10 +99,16 @@ export function MatchResultCard({
     }
   }, [globeRef, match.drepId]);
 
-  // Collapsed dimension badges: first 2 agree + first 1 differ
+  // Show differentiating dimensions: prioritize differ, then unique agree
+  // If this DRep differs on something, show that — it's what makes them distinctive
   const collapsedBadges = [
-    ...match.agreeDimensions.slice(0, 2).map((d) => ({ label: d, type: 'agree' as const })),
-    ...match.differDimensions.slice(0, 1).map((d) => ({ label: d, type: 'differ' as const })),
+    ...match.differDimensions.slice(0, 2).map((d) => ({ label: d, type: 'differ' as const })),
+    ...(match.differDimensions.length < 2
+      ? match.agreeDimensions.slice(0, 2 - match.differDimensions.length).map((d) => ({
+          label: d,
+          type: 'agree' as const,
+        }))
+      : []),
   ];
 
   const perDimension = computePerDimensionAgreement(userAlignments, match.alignments);
@@ -125,7 +132,9 @@ export function MatchResultCard({
       {/* Bridge header */}
       {isBridge && (
         <div className="px-4 py-1.5 bg-violet-500/10 text-violet-400 text-xs font-medium">
-          A different perspective
+          {match.differDimensions.length > 0
+            ? `A different perspective on ${match.differDimensions[0]}`
+            : 'A different perspective'}
         </div>
       )}
 

--- a/components/matching/MatchResults.tsx
+++ b/components/matching/MatchResults.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
-import { RotateCcw, ArrowRight } from 'lucide-react';
+import { RotateCcw } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
 import { Button } from '@/components/ui/button';
 import { GovernanceIdentityCard } from './GovernanceIdentityCard';
@@ -10,7 +10,6 @@ import { MatchResultCard } from './MatchResultCard';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import type { MatchResult } from '@/lib/matching/conversationalMatch';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
-import Link from 'next/link';
 
 /* ─── Types ─────────────────────────────────────────────── */
 
@@ -168,16 +167,8 @@ export function MatchResults({
           <div className="flex flex-col items-center gap-3 pt-4">
             <Button variant="outline" onClick={onReset} className="gap-2 min-h-[44px]">
               <RotateCcw className="h-4 w-4" />
-              Start over
+              Continue refining
             </Button>
-
-            <Link
-              href="/match?type=spo"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1"
-            >
-              Looking for a stake pool? Complete your governance team
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Link>
           </div>
         </motion.div>
       )}

--- a/components/matching/SemanticFastTrack.tsx
+++ b/components/matching/SemanticFastTrack.tsx
@@ -17,10 +17,10 @@ interface SemanticFastTrackProps {
 /* ─── Example prompts ───────────────────────────────────── */
 
 const EXAMPLE_PROMPTS = [
-  'I believe the treasury should prioritize developer tooling...',
-  'DReps should be transparent about every vote...',
-  'Cardano needs to move faster on protocol upgrades...',
-  'Security and stability matter more than speed...',
+  'I believe the treasury should prioritize developer tooling',
+  'DReps should be transparent about every vote',
+  'Cardano needs to move faster on protocol upgrades',
+  'Security and stability matter more than speed',
 ] as const;
 
 const MAX_CHARS = 500;
@@ -164,7 +164,7 @@ export function SemanticFastTrack({ onSubmit, isProcessing, className }: Semanti
                     i === activePromptIndex && 'border-primary/20 text-foreground/70',
                   )}
                 >
-                  {prompt.slice(0, 40)}...
+                  {prompt}
                 </button>
               ))}
             </div>

--- a/lib/matching/matchNarrative.ts
+++ b/lib/matching/matchNarrative.ts
@@ -71,6 +71,8 @@ export interface MatchNarrativeInput {
   differDimensions: string[];
   /** Optional confidence breakdown for the confidence sentence. */
   confidence?: ConfidenceBreakdown;
+  /** Whether this is a bridge match (emphasize contrast). */
+  isBridge?: boolean;
 }
 
 /**
@@ -78,10 +80,15 @@ export interface MatchNarrativeInput {
  *
  * Returns 1-2 sentences: an alignment summary + a confidence qualifier.
  */
+/**
+ * Narrative openers vary by pattern to avoid cookie-cutter feel.
+ * Uses agree/differ dimensions to pick the best frame.
+ */
 export function generateMatchNarrative({
   agreeDimensions,
   differDimensions,
   confidence,
+  isBridge,
 }: MatchNarrativeInput): string {
   const agreeNames = toDisplayNames(agreeDimensions);
   const differNames = toDisplayNames(differDimensions);
@@ -89,21 +96,32 @@ export function generateMatchNarrative({
 
   let alignmentSentence: string;
 
-  if (agreeDimensions.length >= 3 && differDimensions.length === 0) {
-    // Strong alignment
-    alignmentSentence = `Strong alignment \u2014 you share views on ${naturalList(agreeNames)}.`;
+  if (isBridge && differDimensions.length >= 1) {
+    // Bridge match: emphasize the contrast
+    const mainDiffer = differNames[0];
+    if (agreeDimensions.length >= 1) {
+      alignmentSentence = `Disagrees with you on ${mainDiffer} but strongly aligned on ${naturalList(agreeNames)} \u2014 worth considering for balance.`;
+    } else {
+      alignmentSentence = `Takes a different stance on ${mainDiffer} \u2014 a contrasting perspective to broaden your view.`;
+    }
+  } else if (agreeDimensions.length >= 4 && differDimensions.length === 0) {
+    // Very strong alignment
+    alignmentSentence = `Closely mirrors your governance values across ${naturalList(agreeNames)}.`;
+  } else if (agreeDimensions.length >= 3 && differDimensions.length === 0) {
+    // Strong alignment — vary openers
+    alignmentSentence = `Shares your priorities on ${naturalList(agreeNames)}.`;
   } else if (agreeDimensions.length >= 2 && differDimensions.length >= 1) {
-    // Mixed: agree on some, differ on others
-    alignmentSentence = `You align on ${naturalList(agreeNames)} but see ${naturalList(differNames)} differently.`;
+    // Mixed: emphasize the interesting contrast
+    alignmentSentence = `Shares your ${naturalList(agreeNames)} values but brings a different perspective on ${naturalList(differNames)}.`;
   } else if (agreeDimensions.length >= 1 && differDimensions.length === 0) {
     // Some agreement, no disagreement
-    alignmentSentence = `You share common ground on ${naturalList(agreeNames)}.`;
+    alignmentSentence = `Common ground on ${naturalList(agreeNames)}.`;
   } else if (agreeDimensions.length >= 1 && differDimensions.length >= 1) {
     // 1 agree, 1+ differ
-    alignmentSentence = `You align on ${naturalList(agreeNames)} but see ${naturalList(differNames)} differently.`;
+    alignmentSentence = `Aligned on ${naturalList(agreeNames)} with a different take on ${naturalList(differNames)}.`;
   } else if (differDimensions.length >= 1) {
     // No agreement, some differences
-    alignmentSentence = 'This DRep takes a different approach to governance than you.';
+    alignmentSentence = 'Offers a contrasting governance philosophy to yours.';
   } else {
     // Neutral across the board
     alignmentSentence = 'A moderate alignment across your governance values.';


### PR DESCRIPTION
## Summary
- Fix match scores showing 8800-9000% (double multiplication bug in display)
- Remove Round N display, move Continue into text input, add Ctrl+Enter shortcut
- Replace confidence ring with thin horizontal progress bar
- Hide hero text during matching flow, skip "ready" state (auto-fetch matches)
- Richer identity card with archetype descriptions
- Unique match narratives per DRep (context-aware, not cookie-cutter)
- Clearer bridge match explanation with specific differ dimension
- "Continue refining" replaces "Start over"
- Redirect /match to / (remove old QuickMatchFlow)
- Full text in semantic fast-track example pills
- Mobile: anchor questions to bottom, hide below-fold content

## Impact
- **What changed**: Score bug fixed, major UX polish across matching flow, old quiz removed
- **User-facing**: Yes — all anonymous visitors see improved matching experience
- **Risk**: Medium — significant UX changes, old match route now redirects
- **Scope**: 9 files modified (matching components, landing page, match page, narrative engine)

## Test plan
- [x] Match scores display as 0-100% (not 8800%)
- [x] TypeScript strict compiles
- [x] All 55 test files pass
- [x] /match redirects to /
- [x] Ctrl+Enter submits answer
- [x] Bridge match shows specific differ dimension
- [x] Preflight passes (format + lint + types + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)