### PR TITLE
feat: community intelligence Phase A — signal collection, pulse dashboard

### DIFF
--- a/app/api/community/pulse/route.ts
+++ b/app/api/community/pulse/route.ts
@@ -1,0 +1,112 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { createClient } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+
+/**
+ * GET /api/community/pulse?epoch=620
+ *
+ * Serves aggregated matching intelligence — topic heatmap, archetype
+ * distribution, community centroid, and governance temperature.
+ * Feature-gated behind `community_intelligence`.
+ */
+export const GET = withRouteHandler(async (request: NextRequest) => {
+  const enabled = await getFeatureFlag('community_intelligence', false);
+  if (!enabled) {
+    return NextResponse.json({ error: 'Feature not enabled' }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const epochParam = searchParams.get('epoch');
+  const epoch = epochParam
+    ? parseInt(epochParam, 10)
+    : blockTimeToEpoch(Math.floor(Date.now() / 1000));
+
+  const supabase = createClient();
+
+  // Fetch match_preferences snapshot
+  const { data: prefsSnapshot } = await supabase
+    .from('community_intelligence_snapshots')
+    .select('data, computed_at')
+    .eq('snapshot_type', 'match_preferences')
+    .eq('epoch', epoch)
+    .single();
+
+  // Fetch temperature snapshot
+  const { data: tempSnapshot } = await supabase
+    .from('community_intelligence_snapshots')
+    .select('data')
+    .eq('snapshot_type', 'temperature')
+    .eq('epoch', epoch)
+    .single();
+
+  if (!prefsSnapshot?.data) {
+    return NextResponse.json(
+      {
+        epoch,
+        totalSessions: 0,
+        topicHeatmap: [],
+        archetypeDistribution: [],
+        communityCentroid: [50, 50, 50, 50, 50, 50],
+        temperature: { value: 0, band: 'cold' },
+        updatedAt: null,
+      },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60' } },
+    );
+  }
+
+  const prefs = prefsSnapshot.data as {
+    totalSessions: number;
+    topicFrequency: Record<string, number>;
+    topicTrends: Record<string, number>;
+    archetypeDistribution: Record<string, number>;
+    communityCentroid: number[];
+  };
+
+  // Build topic heatmap sorted by count descending
+  const topicHeatmap = Object.entries(prefs.topicFrequency ?? {})
+    .map(([topic, count]) => ({
+      topic,
+      count,
+      trend: prefs.topicTrends?.[topic] ?? 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  // Build archetype distribution with percentages
+  const totalArchetypes = Object.values(prefs.archetypeDistribution ?? {}).reduce(
+    (sum, n) => sum + n,
+    0,
+  );
+  const archetypeDistribution = Object.entries(prefs.archetypeDistribution ?? {})
+    .map(([archetype, count]) => ({
+      archetype,
+      count,
+      percentage: totalArchetypes > 0 ? Math.round((count / totalArchetypes) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  // Temperature
+  const tempData = tempSnapshot?.data as {
+    temperature?: number;
+    band?: string;
+  } | null;
+
+  return NextResponse.json(
+    {
+      epoch,
+      totalSessions: prefs.totalSessions ?? 0,
+      topicHeatmap,
+      archetypeDistribution,
+      communityCentroid: prefs.communityCentroid ?? [50, 50, 50, 50, 50, 50],
+      temperature: {
+        value: tempData?.temperature ?? 0,
+        band: tempData?.band ?? 'cold',
+      },
+      updatedAt: prefsSnapshot.computed_at,
+    },
+    { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60' } },
+  );
+});

--- a/app/api/governance/match-signals/route.ts
+++ b/app/api/governance/match-signals/route.ts
@@ -1,0 +1,101 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { blockTimeToEpoch } from '@/lib/koios';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/governance/match-signals
+ *
+ * Stores anonymous matching preference signals for community intelligence.
+ * Called fire-and-forget from the client after match completion.
+ * Data is stored in community_intelligence_snapshots as snapshot_type 'match_signal'.
+ */
+
+interface MatchSignalBody {
+  topicSelections: Record<string, boolean>;
+  importanceWeights?: Record<string, string>;
+  alignmentVector: number[];
+  archetype: string;
+  matchedDrepIds: string[];
+  expandedDrepIds?: string[];
+  freeformTopics?: string[];
+}
+
+function validateBody(body: unknown): body is MatchSignalBody {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+
+  // alignmentVector: must be array of 6 numbers 0-100
+  if (!Array.isArray(b.alignmentVector)) return false;
+  if (b.alignmentVector.length !== 6) return false;
+  if (!b.alignmentVector.every((v: unknown) => typeof v === 'number' && v >= 0 && v <= 100))
+    return false;
+
+  // archetype: non-empty string
+  if (typeof b.archetype !== 'string' || b.archetype.trim().length === 0) return false;
+
+  // topicSelections: must be object
+  if (!b.topicSelections || typeof b.topicSelections !== 'object') return false;
+
+  // matchedDrepIds: must be array of strings
+  if (!Array.isArray(b.matchedDrepIds)) return false;
+  if (!b.matchedDrepIds.every((v: unknown) => typeof v === 'string')) return false;
+
+  // Optional fields
+  if (b.importanceWeights !== undefined && typeof b.importanceWeights !== 'object') return false;
+  if (b.expandedDrepIds !== undefined) {
+    if (!Array.isArray(b.expandedDrepIds)) return false;
+    if (!b.expandedDrepIds.every((v: unknown) => typeof v === 'string')) return false;
+  }
+  if (b.freeformTopics !== undefined) {
+    if (!Array.isArray(b.freeformTopics)) return false;
+    if (!b.freeformTopics.every((v: unknown) => typeof v === 'string')) return false;
+  }
+
+  return true;
+}
+
+export const POST = withRouteHandler(
+  async (request: NextRequest) => {
+    const body = await request.json();
+
+    if (!validateBody(body)) {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const epoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
+    const supabase = getSupabaseAdmin();
+
+    const signalData = {
+      topicSelections: body.topicSelections,
+      importanceWeights: body.importanceWeights ?? null,
+      alignmentVector: body.alignmentVector,
+      archetype: body.archetype,
+      matchedDrepIds: body.matchedDrepIds,
+      expandedDrepIds: body.expandedDrepIds ?? [],
+      freeformTopics: body.freeformTopics ?? [],
+      timestamp: new Date().toISOString(),
+    };
+
+    // Insert as a new row (not upsert) — each match session is a unique signal
+    const { error } = await supabase.from('community_intelligence_snapshots').insert({
+      snapshot_type: 'match_signal',
+      epoch,
+      data: signalData,
+      computed_at: new Date().toISOString(),
+    });
+
+    if (error) {
+      logger.error('[MatchSignals] Failed to store signal', { error: error.message });
+      return NextResponse.json({ error: 'Failed to store signal' }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  },
+  {
+    rateLimit: { max: 10, window: 3600 }, // 10 signals per hour per IP
+  },
+);

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -7,9 +7,11 @@ import { Button } from '@/components/ui/button';
 import dynamic from 'next/dynamic';
 import { trackFunnel, FUNNEL_EVENTS } from '@/lib/funnel';
 import { useTranslation } from '@/lib/i18n/useTranslation';
+import { BarChart3 } from 'lucide-react';
 import { GovernanceConsequenceCard } from './GovernanceConsequenceCard';
 import { IntelligencePreview } from './IntelligencePreview';
 import { ConversationalMatchFlow } from '@/components/matching/ConversationalMatchFlow';
+import { CommunityPulse } from '@/components/intelligence/CommunityPulse';
 import { useFeatureFlag } from '@/components/FeatureGate';
 import { cn } from '@/lib/utils';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
@@ -43,6 +45,7 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
   const globeRef = useRef<ConstellationRef>(null);
   const [isMatching, setIsMatching] = useState(false);
   const conversationalMatchingEnabled = useFeatureFlag('conversational_matching');
+  const communityIntelligenceEnabled = useFeatureFlag('community_intelligence');
 
   useEffect(() => {
     trackFunnel(FUNNEL_EVENTS.LANDING_VIEWED);
@@ -170,6 +173,17 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
 
         {/* Intelligence preview — real AI headline from latest epoch briefing */}
         <IntelligencePreview />
+
+        {/* Community Pulse — what the Cardano community cares about */}
+        {communityIntelligenceEnabled && (
+          <div className="rounded-xl border border-white/[0.08] bg-card/60 backdrop-blur-sm p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-primary" />
+              <span className="text-sm font-semibold text-foreground">Community Pulse</span>
+            </div>
+            <CommunityPulse />
+          </div>
+        )}
       </section>
     </div>
   );

--- a/components/hub/CitizenHub.tsx
+++ b/components/hub/CitizenHub.tsx
@@ -52,10 +52,13 @@ import { useCheckin } from '@/hooks/useCheckin';
 import { useEpochHeadline } from '@/hooks/useEpochHeadline';
 import { useDepthConfig } from '@/hooks/useDepthConfig';
 import { DepthGate } from '@/components/providers/DepthGate';
+import { BarChart3 } from 'lucide-react';
 import { CommunityConsensus } from './CommunityConsensus';
 import { DelegationHealthSummary } from './DelegationHealthSummary';
 import { DepthDiscoveryFooter } from './DepthDiscoveryFooter';
 import { GovernancePulse } from './GovernancePulse';
+import { CommunityPulse } from '@/components/intelligence/CommunityPulse';
+import { useFeatureFlag } from '@/components/FeatureGate';
 import { WhatChanged } from '@/components/hub/WhatChanged';
 import { playMilestoneChime } from '@/lib/sounds';
 
@@ -1157,6 +1160,7 @@ function CoverageCelebration() {
 
 export function CitizenHub() {
   const { stakeAddress, delegatedDrep } = useSegment();
+  const communityIntelligenceEnabled = useFeatureFlag('community_intelligence');
 
   // Always-visible hooks: epoch headline + consequence for headline data + checkin
   const { aiHeadline } = useEpochHeadline(!!stakeAddress);
@@ -1264,6 +1268,19 @@ export function CitizenHub() {
       <DepthGate minDepth="engaged">
         <CommunityConsensus />
       </DepthGate>
+
+      {/* ── Community Pulse (engaged+, feature-flagged) ──── */}
+      {communityIntelligenceEnabled && (
+        <DepthGate minDepth="engaged">
+          <Section>
+            <div className="flex items-center gap-2 mb-3">
+              <BarChart3 className="h-4 w-4 text-primary" />
+              <span className="text-sm font-semibold text-foreground">Community Pulse</span>
+            </div>
+            <CommunityPulse />
+          </Section>
+        </DepthGate>
+      )}
 
       {/* ── Subtle depth upsell for users below Engaged ────── */}
       <DepthGate minDepth="engaged" fallback={<DepthDiscoveryFooter />} />

--- a/components/intelligence/CommunityPulse.tsx
+++ b/components/intelligence/CommunityPulse.tsx
@@ -1,0 +1,272 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/* ─── Types ─────────────────────────────────────────────── */
+
+interface TopicHeatmapEntry {
+  topic: string;
+  count: number;
+  trend: number;
+}
+
+interface ArchetypeEntry {
+  archetype: string;
+  count: number;
+  percentage: number;
+}
+
+interface PulseData {
+  epoch: number;
+  totalSessions: number;
+  topicHeatmap: TopicHeatmapEntry[];
+  archetypeDistribution: ArchetypeEntry[];
+  communityCentroid: number[];
+  temperature: { value: number; band: string };
+  updatedAt: string | null;
+}
+
+interface CommunityPulseProps {
+  className?: string;
+}
+
+/* ─── Topic label prettifier ───────────────────────────── */
+
+const TOPIC_LABELS: Record<string, string> = {
+  treasury: 'Treasury',
+  innovation: 'Innovation',
+  security: 'Security',
+  transparency: 'Transparency',
+  decentralization: 'Decentralization',
+  'developer-funding': 'Developer Funding',
+  'community-growth': 'Community Growth',
+  constitutional: 'Constitutional Compliance',
+};
+
+function topicLabel(key: string): string {
+  return TOPIC_LABELS[key] ?? key.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/* ─── Archetype color map ─────────────────────────────── */
+
+const ARCHETYPE_COLORS: Record<string, string> = {
+  'The Guardian': '#dc2626',
+  'The Fiscal Hawk': '#dc2626',
+  'The Prudent Steward': '#dc2626',
+  'The Moderate': '#94a3b8',
+  'The Builder': '#10b981',
+  'The Growth Architect': '#10b981',
+  'The Catalyst': '#10b981',
+  'The Pragmatist': '#94a3b8',
+  'The Federalist': '#a855f7',
+  'The Power Distributor': '#a855f7',
+  'The Decentralizer': '#a855f7',
+  'The Balanced Voice': '#94a3b8',
+  'The Sentinel': '#f59e0b',
+  'The Protocol Guardian': '#f59e0b',
+  'The Cautious Architect': '#f59e0b',
+  'The Measured Thinker': '#94a3b8',
+  'The Pioneer': '#06b6d4',
+  'The Changemaker': '#06b6d4',
+  'The Explorer': '#06b6d4',
+  'The Curious Mind': '#94a3b8',
+  'The Beacon': '#3b82f6',
+  'The Open Advocate': '#3b82f6',
+  'The Transparency Champion': '#3b82f6',
+  'The Thoughtful Observer': '#94a3b8',
+};
+
+function archetypeColor(name: string): string {
+  return ARCHETYPE_COLORS[name] ?? '#94a3b8';
+}
+
+/* ─── Fetcher ──────────────────────────────────────────── */
+
+async function fetchCommunityPulse(): Promise<PulseData> {
+  const res = await fetch('/api/community/pulse');
+  if (!res.ok) throw new Error(`Pulse fetch failed: ${res.status}`);
+  return res.json();
+}
+
+/* ─── Sub-components ───────────────────────────────────── */
+
+function TopicHeatmap({ topics }: { topics: TopicHeatmapEntry[] }) {
+  if (topics.length === 0) return null;
+  const maxCount = topics[0]?.count ?? 1;
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        What the community cares about
+      </p>
+      <div className="space-y-1">
+        {topics.slice(0, 8).map((entry, i) => {
+          const pct = maxCount > 0 ? (entry.count / maxCount) * 100 : 0;
+          const isTop3 = i < 3;
+
+          return (
+            <div key={entry.topic} className="flex items-center gap-2 h-7">
+              <span className="text-xs text-muted-foreground w-28 truncate shrink-0">
+                {topicLabel(entry.topic)}
+              </span>
+              <div className="flex-1 h-3 rounded-full bg-white/[0.06] overflow-hidden">
+                <div
+                  className={cn(
+                    'h-full rounded-full transition-all duration-500',
+                    isTop3 ? 'bg-primary' : 'bg-white/20',
+                  )}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span className="text-xs tabular-nums text-muted-foreground w-8 text-right shrink-0">
+                {entry.count}
+              </span>
+              <TrendIndicator trend={entry.trend} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TrendIndicator({ trend }: { trend: number }) {
+  if (trend > 0) {
+    return <TrendingUp className="h-3 w-3 text-emerald-400 shrink-0" />;
+  }
+  if (trend < 0) {
+    return <TrendingDown className="h-3 w-3 text-red-400 shrink-0" />;
+  }
+  return <Minus className="h-3 w-3 text-white/30 shrink-0" />;
+}
+
+function ArchetypeDistribution({ archetypes }: { archetypes: ArchetypeEntry[] }) {
+  if (archetypes.length === 0) return null;
+
+  // Show top 4, group rest as "Other"
+  const top4 = archetypes.slice(0, 4);
+  const otherCount = archetypes.slice(4).reduce((sum, a) => sum + a.count, 0);
+  const totalCount = archetypes.reduce((sum, a) => sum + a.count, 0);
+  const otherPct = totalCount > 0 ? Math.round((otherCount / totalCount) * 100) : 0;
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        Community archetypes
+      </p>
+      {/* Stacked bar */}
+      <div className="h-3 rounded-full overflow-hidden flex bg-white/[0.06]">
+        {top4.map((entry) => (
+          <div
+            key={entry.archetype}
+            className="h-full transition-all duration-500"
+            style={{
+              width: `${entry.percentage}%`,
+              backgroundColor: archetypeColor(entry.archetype),
+              opacity: 0.8,
+            }}
+          />
+        ))}
+        {otherCount > 0 && (
+          <div
+            className="h-full bg-white/20 transition-all duration-500"
+            style={{ width: `${otherPct}%` }}
+          />
+        )}
+      </div>
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+        {top4.map((entry) => (
+          <div key={entry.archetype} className="flex items-center gap-1">
+            <div
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ backgroundColor: archetypeColor(entry.archetype) }}
+            />
+            <span className="text-[11px] text-muted-foreground truncate">
+              {entry.archetype} {entry.percentage}%
+            </span>
+          </div>
+        ))}
+        {otherCount > 0 && (
+          <div className="flex items-center gap-1">
+            <div className="w-2 h-2 rounded-full bg-white/20 shrink-0" />
+            <span className="text-[11px] text-muted-foreground">Other {otherPct}%</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TemperatureGauge({ value, band }: { value: number; band: string }) {
+  const bandLabel =
+    band === 'cold' ? 'Cold' : band === 'cool' ? 'Cool' : band === 'warm' ? 'Warm' : 'Hot';
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Governance temperature
+        </p>
+        <span className="text-xs text-muted-foreground">{bandLabel}</span>
+      </div>
+      <div className="relative h-2 rounded-full overflow-hidden">
+        {/* Gradient background */}
+        <div
+          className="absolute inset-0 rounded-full"
+          style={{
+            background: 'linear-gradient(to right, #3b82f6, #06b6d4, #f59e0b, #ef4444)',
+          }}
+        />
+        {/* Value indicator */}
+        <div
+          className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full border-2 border-white shadow-md transition-all duration-500"
+          style={{
+            left: `calc(${Math.min(Math.max(value, 0), 100)}% - 6px)`,
+            backgroundColor: '#fff',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ─── Main component ───────────────────────────────────── */
+
+export function CommunityPulse({ className }: CommunityPulseProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['community-pulse'],
+    queryFn: fetchCommunityPulse,
+    staleTime: 300_000, // 5 min — matches server cache
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className={cn('space-y-3 animate-pulse', className)}>
+        <div className="h-3 bg-white/[0.06] rounded w-3/4" />
+        <div className="h-3 bg-white/[0.06] rounded w-1/2" />
+        <div className="h-3 bg-white/[0.06] rounded w-2/3" />
+      </div>
+    );
+  }
+
+  if (error || !data || data.totalSessions === 0) {
+    return null; // Don't render anything if no data
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <TopicHeatmap topics={data.topicHeatmap} />
+      <ArchetypeDistribution archetypes={data.archetypeDistribution} />
+      <TemperatureGauge value={data.temperature.value} band={data.temperature.band} />
+      {data.totalSessions > 0 && (
+        <p className="text-[10px] text-white/30 text-center">
+          Based on {data.totalSessions} citizen{data.totalSessions !== 1 ? 's' : ''} this epoch
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/matching/ConversationalMatchFlow.tsx
+++ b/components/matching/ConversationalMatchFlow.tsx
@@ -11,6 +11,7 @@ import { SemanticFastTrack } from './SemanticFastTrack';
 import { MatchResults } from './MatchResults';
 import { useConversationalMatch } from '@/hooks/useConversationalMatch';
 import { saveConversationalProfile } from '@/lib/matchStore';
+import { sendMatchSignals } from '@/lib/matchSignals';
 import { cn } from '@/lib/utils';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
 
@@ -163,6 +164,14 @@ export function ConversationalMatchFlow({
             matchResults: matches,
             timestamp: Date.now(),
           });
+
+          // Fire-and-forget: send anonymous match signals for community intelligence
+          sendMatchSignals({
+            selectedTopics,
+            userAlignments,
+            personalityLabel,
+            matches,
+          });
         }
       }
     }
@@ -175,6 +184,7 @@ export function ConversationalMatchFlow({
     personalityLabel,
     identityColor,
     userAlignments,
+    selectedTopics,
     onMatchComplete,
     getMatches,
   ]);

--- a/components/matching/GovernanceIdentityCard.tsx
+++ b/components/matching/GovernanceIdentityCard.tsx
@@ -2,10 +2,16 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import { Share2, ArrowRight } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { GovernanceRadar } from '@/components/GovernanceRadar';
 import type { AlignmentScores, AlignmentDimension } from '@/lib/drepIdentity';
-import { getDominantDimension, getDimensionLabel } from '@/lib/drepIdentity';
+import {
+  getDominantDimension,
+  getDimensionLabel,
+  getDimensionOrder,
+  alignmentsToArray,
+} from '@/lib/drepIdentity';
 import { cn } from '@/lib/utils';
 
 /* ─── Types ─────────────────────────────────────────────── */
@@ -66,6 +72,113 @@ function getArchetypeDescription(personalityLabel: string, alignments: Alignment
     transparency: 'You demand openness, accountability, and clear governance.',
   };
   return fallbacks[dominant];
+}
+
+/* ─── Where You Fit — community centroid comparison ───── */
+
+interface PulseResponse {
+  totalSessions: number;
+  communityCentroid: number[];
+}
+
+function WhereYouFit({
+  alignments,
+  identityColor,
+}: {
+  alignments: AlignmentScores;
+  identityColor: string;
+}) {
+  const { data } = useQuery<PulseResponse>({
+    queryKey: ['community-pulse-lite'],
+    queryFn: async () => {
+      const res = await fetch('/api/community/pulse');
+      if (!res.ok) throw new Error('Pulse fetch failed');
+      return res.json();
+    },
+    staleTime: 300_000,
+    refetchOnWindowFocus: false,
+  });
+
+  // Only show when we have community data
+  if (!data || data.totalSessions < 3) return null;
+
+  const userVector = alignmentsToArray(alignments);
+  const centroid = data.communityCentroid;
+  const dimensions = getDimensionOrder();
+
+  // Find the user's most distinctive dimension (largest positive deviation from centroid)
+  let topDim: AlignmentDimension = dimensions[0];
+  let topDeviation = 0;
+  for (let i = 0; i < 6; i++) {
+    const dev = Math.abs(userVector[i] - centroid[i]);
+    if (dev > topDeviation) {
+      topDeviation = dev;
+      topDim = dimensions[i];
+    }
+  }
+
+  // Compute percentile approximation: what % of the centroid is below this user's score
+  const userScore = userVector[dimensions.indexOf(topDim)];
+  const centroidScore = centroid[dimensions.indexOf(topDim)];
+  const isAbove = userScore > centroidScore;
+  // Simple approximation: distance from centroid mapped to a percentile
+  const pctDev = Math.min(99, Math.max(1, Math.round(50 + topDeviation / 2)));
+  const percentile = isAbove ? pctDev : 100 - pctDev;
+
+  return (
+    <div className="w-full rounded-lg border border-white/[0.08] bg-white/[0.04] p-3 text-center space-y-2">
+      <p className="text-xs text-white/60">Where you fit</p>
+      <p className="text-sm text-white/90">
+        You&apos;re in the{' '}
+        <span className="font-semibold" style={{ color: identityColor }}>
+          top {100 - percentile}%
+        </span>{' '}
+        of citizens who prioritize <span className="font-medium">{getDimensionLabel(topDim)}</span>
+      </p>
+      {/* Mini centroid comparison bars */}
+      <div className="flex gap-1 justify-center mt-1">
+        {dimensions.map((dim, i) => {
+          const userVal = userVector[i];
+          const centroidVal = centroid[i];
+          return (
+            <div key={dim} className="flex flex-col items-center gap-0.5 w-8">
+              <div className="w-full h-12 bg-white/[0.06] rounded-sm relative overflow-hidden">
+                {/* Centroid bar */}
+                <div
+                  className="absolute bottom-0 left-0 w-1/2 bg-white/20 rounded-sm"
+                  style={{ height: `${centroidVal}%` }}
+                />
+                {/* User bar */}
+                <div
+                  className="absolute bottom-0 right-0 w-1/2 rounded-sm"
+                  style={{
+                    height: `${userVal}%`,
+                    backgroundColor: identityColor,
+                    opacity: 0.7,
+                  }}
+                />
+              </div>
+              <span className="text-[8px] text-white/40 leading-none">
+                {getDimensionLabel(dim).slice(0, 3)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex items-center justify-center gap-3 text-[9px] text-white/40">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-2 h-2 rounded-sm bg-white/20" /> Community
+        </span>
+        <span className="flex items-center gap-1">
+          <span
+            className="inline-block w-2 h-2 rounded-sm"
+            style={{ backgroundColor: identityColor, opacity: 0.7 }}
+          />{' '}
+          You
+        </span>
+      </div>
+    </div>
+  );
 }
 
 /* ─── Component ─────────────────────────────────────────── */
@@ -146,6 +259,9 @@ export function GovernanceIdentityCard({
         <div className="my-2">
           <GovernanceRadar alignments={alignments} size="medium" animate={false} />
         </div>
+
+        {/* Where you fit — community context */}
+        <WhereYouFit alignments={alignments} identityColor={identityColor} />
 
         {/* Actions */}
         <div className="flex flex-col sm:flex-row items-center gap-3 w-full mt-2">

--- a/inngest/functions/compute-community-intelligence.ts
+++ b/inngest/functions/compute-community-intelligence.ts
@@ -81,11 +81,116 @@ export const computeCommunityIntelligence = inngest.createFunction(
       return { stored, temperature: temperature.temperature, band: temperature.band };
     });
 
+    // Step 4: Aggregate match preference signals into community pulse
+    const matchPreferencesResult = await step.run('aggregate-match-signals', async () => {
+      const { getSupabaseAdmin } = await import('@/lib/supabase');
+      const supabase = getSupabaseAdmin();
+
+      // Fetch all match_signal snapshots for this epoch
+      const { data: signals, error: fetchError } = await supabase
+        .from('community_intelligence_snapshots')
+        .select('data')
+        .eq('snapshot_type', 'match_signal')
+        .eq('epoch', epoch);
+
+      if (fetchError || !signals || signals.length === 0) {
+        return { stored: false, sessions: 0 };
+      }
+
+      // Aggregate topic frequency
+      const topicFrequency: Record<string, number> = {};
+      const archetypeDistribution: Record<string, number> = {};
+      const importanceProfile: Record<string, Record<string, number>> = {};
+      const alignmentSums = [0, 0, 0, 0, 0, 0];
+      let alignmentCount = 0;
+
+      for (const row of signals) {
+        const d = row.data as {
+          topicSelections?: Record<string, boolean>;
+          importanceWeights?: Record<string, string>;
+          alignmentVector?: number[];
+          archetype?: string;
+        };
+
+        // Topic selections
+        if (d.topicSelections) {
+          for (const [topic, selected] of Object.entries(d.topicSelections)) {
+            if (selected) {
+              topicFrequency[topic] = (topicFrequency[topic] || 0) + 1;
+            }
+          }
+        }
+
+        // Archetype
+        if (d.archetype) {
+          archetypeDistribution[d.archetype] = (archetypeDistribution[d.archetype] || 0) + 1;
+        }
+
+        // Alignment vector centroid
+        if (d.alignmentVector && d.alignmentVector.length === 6) {
+          for (let i = 0; i < 6; i++) {
+            alignmentSums[i] += d.alignmentVector[i];
+          }
+          alignmentCount++;
+        }
+
+        // Importance weights
+        if (d.importanceWeights) {
+          for (const [dim, level] of Object.entries(d.importanceWeights)) {
+            if (!importanceProfile[dim]) importanceProfile[dim] = {};
+            importanceProfile[dim][level] = (importanceProfile[dim][level] || 0) + 1;
+          }
+        }
+      }
+
+      // Compute community centroid
+      const communityCentroid =
+        alignmentCount > 0
+          ? alignmentSums.map((sum) => Math.round(sum / alignmentCount))
+          : [50, 50, 50, 50, 50, 50];
+
+      // Compute topic trends vs previous epoch
+      const { data: prevSnapshot } = await supabase
+        .from('community_intelligence_snapshots')
+        .select('data')
+        .eq('snapshot_type', 'match_preferences')
+        .eq('epoch', epoch - 1)
+        .single();
+
+      const prevTopicFreq =
+        (prevSnapshot?.data as { topicFrequency?: Record<string, number> } | null)
+          ?.topicFrequency ?? {};
+
+      const topicTrends: Record<string, number> = {};
+      for (const topic of Object.keys(topicFrequency)) {
+        topicTrends[topic] = topicFrequency[topic] - (prevTopicFreq[topic] ?? 0);
+      }
+
+      const aggregated = {
+        epoch,
+        totalSessions: signals.length,
+        topicFrequency,
+        topicTrends,
+        archetypeDistribution,
+        communityCentroid,
+        importanceProfile,
+      };
+
+      const stored = await storeCommunitySnapshot(
+        'match_preferences',
+        epoch,
+        aggregated as unknown as Record<string, unknown>,
+      );
+
+      return { stored, sessions: signals.length };
+    });
+
     logger.info('[CommunityIntelligence] Computation complete', {
       epoch,
       mandate: mandateResult,
       divergence: divergenceResult,
       temperature: temperatureResult,
+      matchPreferences: matchPreferencesResult,
     });
 
     return {
@@ -93,6 +198,7 @@ export const computeCommunityIntelligence = inngest.createFunction(
       mandate: mandateResult,
       divergence: divergenceResult,
       temperature: temperatureResult,
+      matchPreferences: matchPreferencesResult,
     };
   },
 );

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -38,6 +38,7 @@
  * mobile_gestures                  — Mobile gesture navigation, long-press peek, pull-to-refresh (Phase 10)
  * ai_composed_hub                  — AI-generated one-line insights on Hub cards with temporal ordering (Phase 7)
  * ambient_annotations              — Ambient AI annotations on proposal, DRep, and score pages (Phase 7)
+ * community_intelligence            — Community Pulse dashboard (aggregate preference intelligence from matching)
  *
  * ---------------------------------------------------------------------------
  * RETIRED FLAGS (code checks removed or hardcoded)

--- a/lib/matchSignals.ts
+++ b/lib/matchSignals.ts
@@ -1,0 +1,55 @@
+/**
+ * Match Signals — fire-and-forget POST to collect anonymous matching
+ * preference signals for community intelligence aggregation.
+ */
+
+import type { AlignmentScores } from '@/lib/drepIdentity';
+import { alignmentsToArray } from '@/lib/drepIdentity';
+
+interface MatchSignalInput {
+  selectedTopics: Set<string>;
+  userAlignments: AlignmentScores;
+  personalityLabel: string;
+  matches: Array<{
+    drepId: string;
+    drepName?: string | null;
+    score: number;
+  }>;
+  expandedDrepIds?: string[];
+  freeformTopics?: string[];
+}
+
+/**
+ * Send anonymous match signals to the community intelligence pipeline.
+ * Fire-and-forget — never blocks the UI.
+ */
+export function sendMatchSignals(input: MatchSignalInput): void {
+  try {
+    const topicSelections: Record<string, boolean> = {};
+    for (const topic of input.selectedTopics) {
+      // Strip the 'topic-' prefix from the pill IDs
+      const key = topic.replace(/^topic-/, '');
+      topicSelections[key] = true;
+    }
+
+    const body = {
+      topicSelections,
+      alignmentVector: alignmentsToArray(input.userAlignments),
+      archetype: input.personalityLabel,
+      matchedDrepIds: input.matches.map((m) => m.drepId),
+      expandedDrepIds: input.expandedDrepIds ?? [],
+      freeformTopics: input.freeformTopics ?? [],
+    };
+
+    // Fire and forget — no await, no error handling needed
+    fetch('/api/governance/match-signals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).catch(() => {
+      // Silently swallow — this is non-critical telemetry
+    });
+  } catch {
+    // Never throw from a fire-and-forget function
+  }
+}

--- a/supabase/migrations/064_add_community_intelligence_flag.sql
+++ b/supabase/migrations/064_add_community_intelligence_flag.sql
@@ -1,0 +1,14 @@
+-- Add community_intelligence feature flag
+INSERT INTO feature_flags (key, enabled, description, category, targeting, updated_at)
+VALUES (
+  'community_intelligence',
+  true,
+  'Community Pulse — aggregate governance preference intelligence from matching',
+  'Intelligence',
+  '{}',
+  now()
+)
+ON CONFLICT (key) DO UPDATE SET
+  description = EXCLUDED.description,
+  category = EXCLUDED.category,
+  updated_at = now();


### PR DESCRIPTION
## Summary
- **Match signal collection**: Anonymous POST endpoint stores governance preference signals after each matching session (topic selections, alignment vectors, archetypes, matched DRep IDs)
- **Aggregation pipeline**: New Inngest step `aggregate-match-signals` computes topic frequency, archetype distribution, and community alignment centroid per epoch
- **Community Pulse API + UI**: GET `/api/community/pulse` serves aggregated data; `CommunityPulse` component renders topic heatmap, archetype distribution bar, and governance temperature gauge
- **"Where You Fit" insight**: GovernanceIdentityCard now shows how the user's alignment compares to the community centroid with percentile ranking and mini comparison bars
- **Hub integration**: Community Pulse card appears for anonymous users (social proof below matching) and citizens (engaged+ depth gate)
- **Feature flag**: `community_intelligence` (migration 064, enabled by default)

## Impact
- **What changed**: Matching sessions now contribute to aggregate community intelligence, visible as a pulse dashboard
- **User-facing**: Yes — anonymous users see community pulse as social proof; citizens see it in their Hub feed; identity card shows "Where You Fit" comparison
- **Risk**: Low — all new code behind feature flag, fire-and-forget signal collection, existing Inngest function only gets an additive step
- **Scope**: 5 new files, 6 modified files, 1 migration

## Test plan
- [ ] Run matching flow end-to-end, verify signal POST fires (Network tab)
- [ ] Check `/api/governance/match-signals` rate limiting (10/hr/IP)
- [ ] Trigger `compute-community-intelligence` Inngest function, verify `match_preferences` snapshot created
- [ ] Load `/api/community/pulse` — verify JSON shape with topic heatmap, archetypes, centroid
- [ ] Anonymous landing: verify Community Pulse card renders below matching flow
- [ ] Citizen Hub: verify Community Pulse appears in engaged+ depth
- [ ] GovernanceIdentityCard: verify "Where You Fit" section appears when pulse data exists
- [ ] Toggle `community_intelligence` flag off, verify pulse cards hidden
- [ ] `npm run preflight` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)