### PR TITLE
feat: Cerebro reveal — immersive /match, hero match card, no inline flow

### DIFF
--- a/components/GlobeConstellation.tsx
+++ b/components/GlobeConstellation.tsx
@@ -306,15 +306,17 @@ export const GlobeConstellation = forwardRef<
         true,
       );
 
-      // Hold the dramatic lock — give user time to register the "found you" moment
-      await sleep(2500);
+      // Hold the dramatic lock — the "Cerebro found you" moment
+      // Keep the node highlighted and rotation stopped — results will render over this
+      await sleep(3000);
       setSceneState((prev) => ({
         ...prev,
         pulseId: null,
         animating: false,
         flyToActive: false,
-        flyToTarget: null,
+        // Keep flyToTarget set so the globe stays focused on the match
       }));
+      // Don't restore rotation — let the globe stay locked during results
     },
 
     clearMatches: () => {
@@ -409,7 +411,7 @@ export const GlobeConstellation = forwardRef<
                 matchIntensities={sceneState.matchIntensities}
               />
             )}
-            {quality !== 'low' && (
+            {quality !== 'low' && sceneState.scanProgress < 0.5 && (
               <ScanningRing
                 active={sceneState.matchedNodeIds.size > 0}
                 progress={sceneState.scanProgress}

--- a/components/hub/AnonymousLanding.tsx
+++ b/components/hub/AnonymousLanding.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import Link from 'next/link';
-import { ArrowRight, Users, Wallet } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { ArrowRight, Users, Wallet, TrendingUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import dynamic from 'next/dynamic';
 import { trackFunnel, FUNNEL_EVENTS } from '@/lib/funnel';
@@ -10,11 +11,11 @@ import { useTranslation } from '@/lib/i18n/useTranslation';
 import { BarChart3 } from 'lucide-react';
 import { GovernanceConsequenceCard } from './GovernanceConsequenceCard';
 import { IntelligencePreview } from './IntelligencePreview';
-import { ConversationalMatchFlow } from '@/components/matching/ConversationalMatchFlow';
+import { PillCloud } from '@/components/matching/PillCloud';
 import { CommunityPulse } from '@/components/intelligence/CommunityPulse';
 import { useFeatureFlag } from '@/components/FeatureGate';
+import { useQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
-import type { ConstellationRef } from '@/components/GovernanceConstellation';
 
 const ConstellationScene = dynamic(
   () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
@@ -29,142 +30,161 @@ interface AnonymousLandingProps {
   };
 }
 
+interface MatchingTopicResponse {
+  topics: Array<{
+    id: string;
+    slug: string;
+    displayText: string;
+    source: string;
+    trending: boolean;
+    selectionCount: number;
+  }>;
+}
+
+const FALLBACK_TOPICS = [
+  { id: 'topic-treasury', text: 'Treasury', trending: false },
+  { id: 'topic-innovation', text: 'Innovation', trending: false },
+  { id: 'topic-security', text: 'Security', trending: false },
+  { id: 'topic-transparency', text: 'Transparency', trending: false },
+  { id: 'topic-decentralization', text: 'Decentralization', trending: false },
+  { id: 'topic-developer-funding', text: 'Developer Funding', trending: false },
+  { id: 'topic-community-growth', text: 'Community Growth', trending: false },
+  { id: 'topic-constitutional', text: 'Constitutional Compliance', trending: false },
+] as const;
+
 /**
  * Anonymous Landing — Optimized conversion page.
  *
- * Two modes:
- * 1. Feature flag OFF: Original CTA cards (Choose Representative + Get Started)
- * 2. Feature flag ON: Conversational matching pills embedded in hero with globe convergence
- *
- * Enhanced social proof: live DRep, proposal, and participation counts.
- * Glass-window peek at governance health pulse to demonstrate value.
- * PostHog funnel instrumented at every interaction.
+ * When conversational matching is enabled, topic pills navigate to the
+ * dedicated /match page (Xavier's Room) instead of running the flow inline.
  */
 export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
   const { t } = useTranslation();
-  const globeRef = useRef<ConstellationRef>(null);
-  const [isMatching, setIsMatching] = useState(false);
+  const router = useRouter();
   const conversationalMatchingEnabled = useFeatureFlag('conversational_matching');
   const communityIntelligenceEnabled = useFeatureFlag('community_intelligence');
+
+  const { data: topicsData } = useQuery<MatchingTopicResponse>({
+    queryKey: ['matching-topics'],
+    queryFn: async () => {
+      const res = await fetch('/api/governance/matching-topics');
+      if (!res.ok) throw new Error('Failed to fetch topics');
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+    enabled: conversationalMatchingEnabled === true,
+  });
+
+  const topicPills = topicsData?.topics?.length
+    ? topicsData.topics.map((t) => ({
+        id: `topic-${t.slug}`,
+        text: t.displayText,
+        trending: t.trending,
+      }))
+    : FALLBACK_TOPICS.map((t) => ({ id: t.id, text: t.text, trending: t.trending }));
 
   useEffect(() => {
     trackFunnel(FUNNEL_EVENTS.LANDING_VIEWED);
   }, []);
 
-  const handleMatchStart = () => {
-    setIsMatching(true);
-    trackFunnel(FUNNEL_EVENTS.MATCH_STARTED, { source: 'landing_conversational' });
+  /** Navigate to /match with the tapped topic as a query param */
+  const handleTopicTap = (topicId: string) => {
+    trackFunnel(FUNNEL_EVENTS.MATCH_STARTED, { source: 'landing_pill', topic: topicId });
+    router.push(`/match?topic=${encodeURIComponent(topicId)}`);
   };
 
   return (
     <div className="relative flex flex-col min-h-[calc(100vh-4rem)]">
-      {/* Constellation hero — fills viewport on mobile during matching */}
-      <section
-        className={cn(
-          'force-dark relative sm:-mt-14 overflow-visible flex items-start sm:items-center justify-center',
-          'transition-all duration-700',
-          isMatching
-            ? 'min-h-[calc(100vh-4rem)] max-md:min-h-[calc(100dvh-4rem)]'
-            : 'flex-1 min-h-[50vh]',
-        )}
-      >
+      {/* Constellation hero */}
+      <section className="force-dark relative sm:-mt-14 overflow-visible flex items-start sm:items-center justify-center flex-1 min-h-[50vh]">
         <div className="absolute inset-0 overflow-hidden">
-          <ConstellationScene ref={globeRef} className="w-full h-full" interactive={false} />
+          <ConstellationScene className="w-full h-full" interactive={false} />
         </div>
 
-        {/* Gradient fade — only when not matching on mobile */}
-        <div
-          className={cn(
-            'absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-background to-transparent pointer-events-none',
-            'transition-opacity duration-500',
-            isMatching && 'max-md:opacity-0',
-          )}
-        />
+        {/* Gradient fade */}
+        <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-background to-transparent pointer-events-none" />
 
-        {/* Hero content — text lives in flow, matching flow anchored to bottom on mobile */}
-        <div
-          className={cn(
-            'relative z-10 text-center px-6 pt-16 sm:pt-14 w-full flex flex-col',
-            isMatching
-              ? 'max-w-lg max-md:h-full max-md:justify-between max-md:pt-20 max-md:pb-0'
-              : 'max-w-lg',
-          )}
-        >
-          <div
-            className={cn(
-              'transition-all duration-500',
-              isMatching && 'opacity-0 max-md:h-0 max-md:overflow-hidden md:h-0 md:overflow-hidden',
-            )}
+        {/* Hero content */}
+        <div className="relative z-10 text-center px-6 pt-16 sm:pt-14 w-full flex flex-col max-w-lg">
+          <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-white leading-tight hero-text-shadow">
+            {t('Your ADA gives you')}
+            <br />
+            <span className="text-primary">{t('a voice.')}</span>
+          </h1>
+          <p
+            className="mt-4 text-lg sm:text-xl text-white/90 font-medium"
+            style={{
+              textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)',
+            }}
           >
-            <h1 className="font-display text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight text-white leading-tight hero-text-shadow">
-              {t('Your ADA gives you')}
-              <br />
-              <span className="text-primary">{t('a voice.')}</span>
-            </h1>
-            <p
-              className="mt-4 text-lg sm:text-xl text-white/90 font-medium"
-              style={{
-                textShadow: '0 2px 12px rgba(0,0,0,0.8), 0 0 40px rgba(0,0,0,0.5)',
-              }}
-            >
-              {t('Choose who votes for you. It takes 60 seconds.')}
-            </p>
-          </div>
+            {t('Choose who votes for you. It takes 60 seconds.')}
+          </p>
 
-          {/* Conversational matching flow */}
+          {/* Topic pills — tapping navigates to /match */}
           {conversationalMatchingEnabled && (
-            <div className={cn('mt-8', isMatching && 'max-md:mt-auto')}>
-              <ConversationalMatchFlow globeRef={globeRef} onMatchStart={handleMatchStart} />
+            <div className="mt-8 space-y-4 rounded-2xl bg-black/40 backdrop-blur-md p-5 border border-white/[0.06]">
+              <p className="text-center text-sm text-white/70 font-medium">
+                What matters to you in governance?
+              </p>
+              <PillCloud
+                pills={topicPills.map((t) => ({
+                  id: t.id,
+                  text: t.trending ? t.text : t.text,
+                  icon: t.trending ? <TrendingUp className="h-3 w-3 text-orange-400" /> : undefined,
+                }))}
+                selected={new Set()}
+                onToggle={handleTopicTap}
+                multiSelect={false}
+                layout="cloud"
+                size="md"
+              />
+              {/* Direct CTA for impatient users */}
+              <Button
+                asChild
+                variant="ghost"
+                className="w-full gap-2 text-primary/80 hover:text-primary"
+              >
+                <Link href="/match">
+                  Just find my match
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
             </div>
           )}
         </div>
       </section>
 
-      {/* CTAs + social proof — dims when matching starts */}
-      <section
-        className={cn(
-          'relative z-10 mx-auto w-full max-w-lg px-6 -mt-8 pb-12 space-y-6',
-          'transition-all duration-700',
-          isMatching &&
-            'opacity-20 translate-y-10 pointer-events-none md:opacity-20 md:translate-y-10',
-          isMatching && 'max-md:hidden',
-        )}
-      >
-        {/* Original CTA cards — shown when conversational matching is disabled */}
+      {/* CTAs + social proof */}
+      <section className="relative z-10 mx-auto w-full max-w-lg px-6 -mt-8 pb-12 space-y-6">
         {!conversationalMatchingEnabled && (
-          <>
-            {/* Primary CTA — Choose your representative */}
-            <div className="flex flex-col gap-3">
-              <Button
-                asChild
-                size="lg"
-                className="w-full gap-2 text-base py-6 rounded-xl font-semibold"
-                onClick={() =>
-                  trackFunnel(FUNNEL_EVENTS.MATCH_STARTED, { source: 'landing_primary' })
-                }
-              >
-                <Link href="/match">
-                  <Users className="h-5 w-5" />
-                  {t('Choose Your Representative')}
-                  <ArrowRight className="h-5 w-5" />
-                </Link>
-              </Button>
-            </div>
-          </>
+          <div className="flex flex-col gap-3">
+            <Button
+              asChild
+              size="lg"
+              className="w-full gap-2 text-base py-6 rounded-xl font-semibold"
+              onClick={() =>
+                trackFunnel(FUNNEL_EVENTS.MATCH_STARTED, { source: 'landing_primary' })
+              }
+            >
+              <Link href="/match">
+                <Users className="h-5 w-5" />
+                {t('Choose Your Representative')}
+                <ArrowRight className="h-5 w-5" />
+              </Link>
+            </Button>
+          </div>
         )}
 
-        {/* Spacer when conversational matching is enabled */}
         {conversationalMatchingEnabled && <div />}
 
-        {/* Governance consequence card — why governance matters to your ADA */}
-        {pulseData && !isMatching && (
+        {pulseData && (
           <GovernanceConsequenceCard
             activeProposals={pulseData.activeProposals}
             totalDelegators={pulseData.totalDelegators}
           />
         )}
 
-        {/* Get Started card — encourage wallet connection */}
         <Link
           href="/get-started"
           className="block rounded-xl border border-white/[0.08] bg-card/60 backdrop-blur-xl p-4 space-y-2 transition-all duration-200 hover:border-primary/60 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
@@ -186,10 +206,8 @@ export function AnonymousLanding({ pulseData }: AnonymousLandingProps) {
           </span>
         </Link>
 
-        {/* Intelligence preview — real AI headline from latest epoch briefing */}
         <IntelligencePreview />
 
-        {/* Community Pulse — what the Cardano community cares about */}
         {communityIntelligenceEnabled && (
           <div className="rounded-xl border border-white/[0.08] bg-card/60 backdrop-blur-sm p-4 space-y-3">
             <div className="flex items-center gap-2">

--- a/components/matching/ConversationalMatchFlow.tsx
+++ b/components/matching/ConversationalMatchFlow.tsx
@@ -25,6 +25,10 @@ interface ConversationalMatchFlowProps {
   globeRef: React.RefObject<ConstellationRef | null>;
   onMatchStart?: () => void;
   onMatchComplete?: (matches: unknown[]) => void;
+  /** Pre-selected topic hints (from URL params) */
+  initialTopics?: string[];
+  /** Auto-start the session immediately (when arriving from homepage pill tap) */
+  autoStart?: boolean;
 }
 
 /* ─── Fallback topic pills (used when API is unavailable) ── */
@@ -137,9 +141,13 @@ export function ConversationalMatchFlow({
   globeRef,
   onMatchStart,
   onMatchComplete,
+  initialTopics,
+  autoStart,
 }: ConversationalMatchFlowProps) {
   const [flowState, setFlowState] = useState<FlowState>('idle');
-  const [selectedTopics, setSelectedTopics] = useState<Set<string>>(new Set());
+  const [selectedTopics, setSelectedTopics] = useState<Set<string>>(
+    () => new Set(initialTopics ?? []),
+  );
   const [freeformText, setFreeformText] = useState('');
   const [showFastTrack, setShowFastTrack] = useState(false);
   const [pendingSemanticText, setPendingSemanticText] = useState<string | null>(null);
@@ -312,6 +320,16 @@ export function ConversationalMatchFlow({
     },
     [onMatchStart, startSession, selectedTopics],
   );
+
+  /* ─── Auto-start when arriving from homepage with topic ── */
+
+  useEffect(() => {
+    if (autoStart && !hasStartedRef.current) {
+      handleInitialInteraction(initialTopics);
+    }
+    // Only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /* ─── Topic pill toggle ────────────────────────────────── */
 

--- a/components/matching/ImmersiveMatchPage.tsx
+++ b/components/matching/ImmersiveMatchPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRef, useState, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { X } from 'lucide-react';
 import { ConversationalMatchFlow } from '@/components/matching/ConversationalMatchFlow';
@@ -15,16 +15,22 @@ const ConstellationScene = dynamic(
 );
 
 /**
- * Immersive matching page — "Xavier's Room."
+ * Immersive matching page — "Xavier's Room / Cerebro."
  *
  * Full-screen globe + conversational matching flow.
  * No distractions, no scrolling — just the globe and the questions.
+ *
+ * Accepts ?topic=topic-treasury to auto-start with a topic hint.
  */
 export function ImmersiveMatchPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const globeRef = useRef<ConstellationRef>(null);
   const [isMatching, setIsMatching] = useState(false);
   const conversationalEnabled = useFeatureFlag('conversational_matching');
+
+  // Extract topic from URL params (set by homepage pill tap)
+  const initialTopic = searchParams.get('topic');
 
   const handleClose = useCallback(() => {
     router.push('/');
@@ -34,6 +40,15 @@ export function ImmersiveMatchPage() {
     setIsMatching(true);
   }, []);
 
+  // Auto-trigger start when arriving with a topic param
+  const autoStartedRef = useRef(false);
+  useEffect(() => {
+    if (initialTopic && !autoStartedRef.current) {
+      autoStartedRef.current = true;
+      setIsMatching(true);
+    }
+  }, [initialTopic]);
+
   // Redirect if conversational matching is disabled
   if (conversationalEnabled === false) {
     router.replace('/');
@@ -41,12 +56,12 @@ export function ImmersiveMatchPage() {
   }
 
   return (
-    <div className="fixed inset-0 z-50 bg-black flex flex-col">
-      {/* Close button — top right, above the globe */}
+    <div className="fixed inset-0 z-50 bg-black flex flex-col overflow-y-auto">
+      {/* Close button */}
       <button
         onClick={handleClose}
         className={cn(
-          'absolute top-4 right-4 z-50 rounded-full p-2',
+          'fixed top-4 right-4 z-[60] rounded-full p-2',
           'bg-white/10 backdrop-blur-sm border border-white/10',
           'text-white/70 hover:text-white hover:bg-white/20',
           'transition-all duration-200',
@@ -56,24 +71,24 @@ export function ImmersiveMatchPage() {
         <X className="h-5 w-5" />
       </button>
 
-      {/* Globe — fills entire viewport */}
-      <div className="absolute inset-0">
+      {/* Globe — fills viewport, stays behind content */}
+      <div className="fixed inset-0 z-0">
         <ConstellationScene ref={globeRef} className="w-full h-full" interactive={false} />
       </div>
 
-      {/* Gradient overlay for readability */}
-      <div className="absolute inset-x-0 bottom-0 h-[60%] bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
+      {/* Gradient overlay */}
+      <div className="fixed inset-x-0 bottom-0 h-[70%] bg-gradient-to-t from-black/90 via-black/50 to-transparent pointer-events-none z-[1]" />
 
-      {/* Matching flow — anchored to bottom center */}
+      {/* Matching flow — scrollable content on top of globe */}
       <div
         className={cn(
-          'relative z-10 mt-auto w-full flex flex-col items-center',
+          'relative z-10 min-h-screen flex flex-col items-center justify-end',
           'px-6 pb-[calc(env(safe-area-inset-bottom,16px)+16px)]',
         )}
       >
         {/* Title — only before matching starts */}
         {!isMatching && (
-          <div className="text-center mb-6 max-w-lg">
+          <div className="text-center mb-6 max-w-lg mt-auto">
             <h1 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight">
               Find your governance match
             </h1>
@@ -84,7 +99,12 @@ export function ImmersiveMatchPage() {
         )}
 
         <div className="w-full max-w-lg">
-          <ConversationalMatchFlow globeRef={globeRef} onMatchStart={handleMatchStart} />
+          <ConversationalMatchFlow
+            globeRef={globeRef}
+            onMatchStart={handleMatchStart}
+            initialTopics={initialTopic ? [initialTopic] : undefined}
+            autoStart={!!initialTopic}
+          />
         </div>
       </div>
     </div>

--- a/components/matching/MatchResults.tsx
+++ b/components/matching/MatchResults.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { motion, useReducedMotion } from 'framer-motion';
-import { RotateCcw, ExternalLink } from 'lucide-react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { RotateCcw, ExternalLink, Vote, ChevronDown } from 'lucide-react';
 import { posthog } from '@/lib/posthog';
 import { Button } from '@/components/ui/button';
 import { GovernanceIdentityCard } from './GovernanceIdentityCard';
 import { MatchResultCard } from './MatchResultCard';
+import { generateMatchNarrative } from '@/lib/matching/matchNarrative';
 import type { AlignmentScores } from '@/lib/drepIdentity';
 import type { MatchResult, SpoMatchResult } from '@/lib/matching/conversationalMatch';
 import type { ConstellationRef } from '@/components/GovernanceConstellation';
@@ -27,6 +28,12 @@ interface MatchResultsProps {
 
 /* ─── Helpers ───────────────────────────────────────────── */
 
+function hexToRgb(hex: string): [number, number, number] {
+  const cleaned = hex.replace('#', '');
+  const num = parseInt(cleaned, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}
+
 function pickBridgeMatch(matches: MatchResult[]): MatchResult | null {
   if (matches.length < 4) return null;
   const candidates = matches.slice(3);
@@ -36,6 +43,129 @@ function pickBridgeMatch(matches: MatchResult[]): MatchResult | null {
     return a.score - b.score;
   });
   return sorted[0] ?? null;
+}
+
+/* ─── Hero Match Card — the #1 "found you" moment ──────── */
+
+function HeroMatchCard({
+  match,
+  identityColor,
+  onDelegate,
+}: {
+  match: MatchResult;
+  identityColor: string;
+  onDelegate?: (drepId: string) => void;
+}) {
+  const [r, g, b] = hexToRgb(match.identityColor);
+  const displayName = match.drepName || match.drepId.slice(0, 16) + '...';
+  const narrative = generateMatchNarrative({
+    agreeDimensions: match.agreeDimensions,
+    differDimensions: match.differDimensions,
+    isBridge: false,
+  });
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: 'spring', stiffness: 200, damping: 20, delay: 0.3 }}
+      className="relative rounded-2xl border bg-black/70 backdrop-blur-xl overflow-hidden"
+      style={{
+        borderColor: `rgba(${r}, ${g}, ${b}, 0.5)`,
+        boxShadow: `0 0 40px rgba(${r}, ${g}, ${b}, 0.25), 0 0 80px rgba(${r}, ${g}, ${b}, 0.1)`,
+      }}
+    >
+      {/* Glow pulse on entrance */}
+      <motion.div
+        className="pointer-events-none absolute inset-0 rounded-2xl"
+        initial={{ opacity: 0.8 }}
+        animate={{ opacity: 0 }}
+        transition={{ duration: 2, ease: 'easeOut' }}
+        style={{ boxShadow: `inset 0 0 80px rgba(${r}, ${g}, ${b}, 0.3)` }}
+      />
+
+      <div className="relative z-10 p-6 text-center space-y-4">
+        {/* "Match Found" preamble */}
+        <motion.p
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="text-[10px] uppercase tracking-[0.3em] text-white/50"
+        >
+          Match found
+        </motion.p>
+
+        {/* Giant score */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.5 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ type: 'spring', stiffness: 150, damping: 15, delay: 0.6 }}
+          className="font-display text-6xl sm:text-7xl font-bold tabular-nums"
+          style={{ color: match.identityColor }}
+        >
+          {Math.round(match.score)}%
+        </motion.div>
+
+        {/* DRep name */}
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.8 }}>
+          <h2 className="font-display text-xl sm:text-2xl font-bold text-white">{displayName}</h2>
+          {match.tier && <span className="text-xs text-muted-foreground">{match.tier}</span>}
+        </motion.div>
+
+        {/* Narrative */}
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.0 }}
+          className="text-sm text-white/70 max-w-sm mx-auto leading-relaxed"
+        >
+          {narrative}
+        </motion.p>
+
+        {/* Agree dimension pills */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.1 }}
+          className="flex flex-wrap justify-center gap-2"
+        >
+          {match.agreeDimensions.slice(0, 3).map((dim) => (
+            <span
+              key={dim}
+              className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-400"
+            >
+              {dim} &#x2713;
+            </span>
+          ))}
+        </motion.div>
+
+        {/* CTAs */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 1.2 }}
+          className="flex flex-col sm:flex-row gap-2 pt-2"
+        >
+          {onDelegate && (
+            <Button
+              onClick={() => onDelegate(match.drepId)}
+              className="gap-2 flex-1 min-h-[44px]"
+              style={{ backgroundColor: match.identityColor, color: '#fff' }}
+            >
+              <Vote className="h-4 w-4" />
+              Delegate to {displayName}
+            </Button>
+          )}
+          <Button variant="outline" asChild className="gap-2 flex-1 min-h-[44px]">
+            <a href={`/drep/${encodeURIComponent(match.drepId)}`}>
+              View profile
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
 }
 
 /* ─── SPO Match Card (compact) ──────────────────────────── */
@@ -53,15 +183,12 @@ function SpoMatchCard({ spo, rank }: { spo: SpoMatchResult; rank: number }) {
         'px-4 py-3 transition-colors hover:border-violet-500/30',
       )}
     >
-      {/* Rank */}
       <span
         className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white shrink-0"
         style={{ backgroundColor: spo.identityColor }}
       >
         {rank}
       </span>
-
-      {/* Name + vote count */}
       <div className="flex-1 min-w-0">
         <span className="font-medium text-sm text-foreground truncate block">{displayName}</span>
         {spo.voteCount > 0 && (
@@ -70,15 +197,12 @@ function SpoMatchCard({ spo, rank }: { spo: SpoMatchResult; rank: number }) {
           </span>
         )}
       </div>
-
-      {/* Score */}
       <span
         className="font-display text-lg font-bold tabular-nums shrink-0"
         style={{ color: spo.identityColor }}
       >
         {Math.round(spo.score)}%
       </span>
-
       <ExternalLink className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
     </a>
   );
@@ -96,10 +220,12 @@ export function MatchResults({
   onDelegate,
   globeRef,
 }: MatchResultsProps) {
+  const [showMore, setShowMore] = useState(false);
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
   const prefersReducedMotion = useReducedMotion();
 
-  const topMatches = useMemo(() => matches.slice(0, 3), [matches]);
+  const topMatch = matches[0] ?? null;
+  const runnerUps = useMemo(() => matches.slice(1, 3), [matches]);
   const bridgeMatch = useMemo(() => pickBridgeMatch(matches), [matches]);
 
   // Fire identity viewed event once on mount
@@ -110,13 +236,10 @@ export function MatchResults({
       posthog.capture('match_identity_viewed', {
         personality: personalityLabel,
         identityColor,
+        topMatchScore: topMatch?.score,
       });
     }
-  }, [personalityLabel, identityColor]);
-
-  const handleShare = useCallback(() => {
-    posthog.capture('match_identity_shared');
-  }, []);
+  }, [personalityLabel, identityColor, topMatch?.score]);
 
   const handleExpand = useCallback(
     (index: number, isBridge: boolean) => {
@@ -140,79 +263,125 @@ export function MatchResults({
     [onDelegate],
   );
 
+  if (!topMatch) {
+    return (
+      <div className="w-full text-center space-y-4 py-8">
+        <p className="text-sm text-muted-foreground">
+          No strong matches found. Try again with different priorities.
+        </p>
+        <Button variant="outline" onClick={onReset} className="gap-2">
+          <RotateCcw className="h-4 w-4" />
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <div className="w-full space-y-5">
-      {/* Identity card — compact */}
-      <GovernanceIdentityCard
-        personalityLabel={personalityLabel}
+    <div className="w-full space-y-6">
+      {/* ── THE CEREBRO REVEAL ─────────────────────────── */}
+
+      {/* Hero: #1 Match — the dramatic "found you" card */}
+      <HeroMatchCard
+        match={topMatch}
         identityColor={identityColor}
-        alignments={userAlignments}
-        onShare={handleShare}
+        onDelegate={onDelegate ? (id) => handleDelegate(id, 1) : undefined}
       />
 
-      {/* DRep match result cards — immediately visible */}
+      {/* Identity badge — compact inline, not a full card */}
       <motion.div
-        initial={prefersReducedMotion ? false : { opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.4, delay: 0.2 }}
-        className="space-y-4"
+        initial={prefersReducedMotion ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.4 }}
+        className="text-center"
       >
-        <h3 className="text-sm font-medium text-muted-foreground">Your DRep matches</h3>
-
-        {topMatches.map((match, i) => (
-          <MatchResultCard
-            key={match.drepId}
-            match={match}
-            rank={i + 1}
-            userAlignments={userAlignments}
-            expanded={expandedIndex === i}
-            onExpand={() => handleExpand(i, false)}
-            onDelegate={onDelegate ? (drepId) => handleDelegate(drepId, i + 1) : undefined}
-            globeRef={globeRef}
-          />
-        ))}
-
-        {bridgeMatch && (
-          <MatchResultCard
-            key={`bridge-${bridgeMatch.drepId}`}
-            match={bridgeMatch}
-            rank={4}
-            isBridge
-            userAlignments={userAlignments}
-            expanded={expandedIndex === 99}
-            onExpand={() => handleExpand(99, true)}
-            onDelegate={onDelegate ? (drepId) => handleDelegate(drepId, 4) : undefined}
-            globeRef={globeRef}
-          />
-        )}
-
-        {matches.length === 0 && (
-          <p className="text-center text-sm text-muted-foreground py-4">
-            No strong DRep matches found. Try again with different priorities.
-          </p>
-        )}
+        <p className="text-[10px] text-white/40 uppercase tracking-widest mb-1">
+          Your governance identity
+        </p>
+        <p className="font-display text-lg font-bold" style={{ color: identityColor }}>
+          {personalityLabel}
+        </p>
       </motion.div>
 
-      {/* SPO matches — separate section */}
-      {spoMatches && spoMatches.length > 0 && (
-        <motion.div
-          initial={prefersReducedMotion ? false : { opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.4, delay: 0.4 }}
-          className="space-y-3"
-        >
-          <div>
-            <h3 className="text-sm font-medium text-muted-foreground">Your stake pool matches</h3>
-            <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-              SPOs aligned with your governance values
-            </p>
-          </div>
+      {/* ── MORE MATCHES (expandable) ─────────────────── */}
 
-          {spoMatches.map((spo, i) => (
-            <SpoMatchCard key={spo.poolId} spo={spo} rank={i + 1} />
-          ))}
-        </motion.div>
-      )}
+      <motion.div
+        initial={prefersReducedMotion ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.5 }}
+        className="space-y-3"
+      >
+        <button
+          onClick={() => setShowMore(!showMore)}
+          className="flex items-center justify-center gap-1 w-full text-xs text-white/50 hover:text-white/80 transition-colors py-2"
+        >
+          {showMore
+            ? 'Hide other matches'
+            : `${runnerUps.length + (bridgeMatch ? 1 : 0)} more matches`}
+          <ChevronDown className={cn('h-3 w-3 transition-transform', showMore && 'rotate-180')} />
+        </button>
+
+        <AnimatePresence>
+          {showMore && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.3 }}
+              className="space-y-3 overflow-hidden"
+            >
+              {/* Runner-up DRep matches */}
+              {runnerUps.map((match, i) => (
+                <MatchResultCard
+                  key={match.drepId}
+                  match={match}
+                  rank={i + 2}
+                  userAlignments={userAlignments}
+                  expanded={expandedIndex === i + 1}
+                  onExpand={() => handleExpand(i + 1, false)}
+                  onDelegate={onDelegate ? (drepId) => handleDelegate(drepId, i + 2) : undefined}
+                  globeRef={globeRef}
+                />
+              ))}
+
+              {/* Bridge match */}
+              {bridgeMatch && (
+                <MatchResultCard
+                  key={`bridge-${bridgeMatch.drepId}`}
+                  match={bridgeMatch}
+                  rank={4}
+                  isBridge
+                  userAlignments={userAlignments}
+                  expanded={expandedIndex === 99}
+                  onExpand={() => handleExpand(99, true)}
+                  onDelegate={onDelegate ? (drepId) => handleDelegate(drepId, 4) : undefined}
+                  globeRef={globeRef}
+                />
+              )}
+
+              {/* SPO matches */}
+              {spoMatches && spoMatches.length > 0 && (
+                <div className="space-y-2 pt-2">
+                  <h4 className="text-xs font-medium text-muted-foreground">Stake pool matches</h4>
+                  {spoMatches.map((spo, i) => (
+                    <SpoMatchCard key={spo.poolId} spo={spo} rank={i + 1} />
+                  ))}
+                </div>
+              )}
+
+              {/* Full identity card */}
+              <div className="pt-2">
+                <GovernanceIdentityCard
+                  personalityLabel={personalityLabel}
+                  identityColor={identityColor}
+                  alignments={userAlignments}
+                  onShare={() => posthog.capture('match_identity_shared')}
+                />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </motion.div>
 
       {/* Bottom CTAs */}
       <div className="flex flex-col items-center gap-3 pt-2">


### PR DESCRIPTION
## Summary
- **Scanning ring fix**: Completely unmounted at scanProgress > 0.5 — no more curved line at close zoom
- **Homepage → /match**: Topic pills navigate to `/match?topic=X` instead of running inline. No dimmed homepage content visible below results
- **Cerebro reveal**: Post-match redesigned with dramatic hero card for #1 match (giant score animation, staggered reveals, glow pulse), identity as compact inline badge, runner-ups/SPOs behind expandable toggle
- **Globe stays locked**: Rotation frozen on match node during results, 3s hold for the "found you" moment

## Impact
- **What changed**: Matching now happens exclusively on /match (full-screen), results are dramatically redesigned
- **User-facing**: Yes — the entire post-match experience is reimagined as a cinematic "Cerebro found you" moment
- **Risk**: Low — same matching engine, UX/presentation changes only
- **Scope**: 5 files (AnonymousLanding, ImmersiveMatchPage, ConversationalMatchFlow, MatchResults, GlobeConstellation)

## Test plan
- [ ] Visit homepage — verify topic pills link to /match, NOT run inline flow
- [ ] Visit /match — verify full-screen immersive experience, no homepage content
- [ ] Visit /match?topic=topic-treasury — verify auto-starts with treasury question
- [ ] Complete matching — verify hero card with giant score + name + glow
- [ ] Verify globe stays locked on match node (no rotation)
- [ ] Verify "more matches" toggle reveals runner-ups + SPOs + identity card
- [ ] Verify no scanning ring line visible during rounds 2-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)