### PR TITLE
feat: Spotlight Theater — theatrical entity discovery

### DIFF
--- a/app/api/spotlight/narrative/route.ts
+++ b/app/api/spotlight/narrative/route.ts
@@ -1,0 +1,143 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getCachedNarrative,
+  cacheNarrative,
+  generateDRepNarrative,
+  generateSPONarrative,
+} from '@/lib/spotlight/narratives';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { logger } from '@/lib/logger';
+import {
+  extractAlignments,
+  getDominantDimension,
+  getCompoundArchetype,
+  getDimensionLabel,
+} from '@/lib/drepIdentity';
+import { computeTier } from '@/lib/scoring/tiers';
+import { getPoolStrengths } from '@/components/governada/cards/GovernadaSPOCard';
+
+// Rate limit: 5/min/IP (simple in-memory counter)
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT = 5;
+const RATE_WINDOW = 60_000;
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_WINDOW });
+    return true;
+  }
+  if (entry.count >= RATE_LIMIT) return false;
+  entry.count++;
+  return true;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const enabled = await getFeatureFlag('spotlight_narratives');
+    if (!enabled) {
+      return NextResponse.json({ narrative: null, source: 'disabled' });
+    }
+
+    const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+    if (!checkRateLimit(ip)) {
+      return NextResponse.json({ error: 'Rate limited' }, { status: 429 });
+    }
+
+    const { entityType, entityId } = await req.json();
+    if (!entityType || !entityId) {
+      return NextResponse.json({ error: 'Missing entityType or entityId' }, { status: 400 });
+    }
+
+    // Check cache first
+    const cached = await getCachedNarrative(entityType, entityId);
+    if (cached) {
+      return NextResponse.json({ narrative: cached, source: 'cache' });
+    }
+
+    // Generate based on entity type
+    let narrative: string | null = null;
+
+    const supabase = getSupabaseAdmin();
+
+    if (entityType === 'drep') {
+      const { data: drep } = await supabase
+        .from('dreps')
+        .select('*')
+        .eq('drep_id', entityId)
+        .single();
+
+      if (!drep) return NextResponse.json({ narrative: null, source: 'not_found' });
+
+      const info = drep.info as Record<string, unknown> | null;
+      const alignments = extractAlignments(drep);
+      const dominant = getDominantDimension(alignments);
+      const archetype = getCompoundArchetype(alignments);
+      const score = drep.score ?? 0;
+
+      // Get pillar strengths
+      const pillars: [string, number][] = [
+        ['Explains votes', (drep.engagement_quality as number) ?? 0],
+        ['Active voter', (drep.effective_participation_v3 as number) ?? 0],
+        ['Reliable', (drep.reliability_v3 as number) ?? 0],
+        ['Clear identity', (drep.governance_identity as number) ?? 0],
+      ];
+      const strengths = pillars
+        .filter(([, v]) => v >= 65)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 2)
+        .map(([label]) => label);
+
+      narrative = await generateDRepNarrative({
+        name: (info?.name as string) ?? (info?.ticker as string) ?? entityId.slice(0, 16),
+        score,
+        tier: computeTier(score),
+        archetype,
+        participationRate: (drep.participation_rate as number) ?? 0,
+        totalVotes: (drep.total_votes as number) ?? 0,
+        delegatorCount: (drep.delegator_count as number) ?? 0,
+        strengths,
+        alignmentSummary: `Dominant: ${getDimensionLabel(dominant)}`,
+        momentum: (drep.score_momentum as number) ?? 0,
+      });
+    } else if (entityType === 'spo') {
+      const { data: pool } = await supabase
+        .from('pools')
+        .select('*')
+        .eq('pool_id', entityId)
+        .single();
+
+      if (!pool) return NextResponse.json({ narrative: null, source: 'not_found' });
+
+      narrative = await generateSPONarrative({
+        name: (pool.ticker as string) ?? (pool.pool_name as string) ?? entityId.slice(0, 16),
+        score: (pool.governance_score as number) ?? 0,
+        tier: computeTier((pool.governance_score as number) ?? 0),
+        participationPct: (pool.participation_pct as number) ?? 0,
+        voteCount: (pool.vote_count as number) ?? 0,
+        delegatorCount: (pool.delegator_count as number) ?? 0,
+        liveStakeAda: (pool.live_stake_ada as number) ?? 0,
+        strengths: [],
+        governanceStatement: (pool.governance_statement as string) ?? null,
+      });
+    }
+
+    // Cache the generated narrative
+    if (narrative) {
+      await cacheNarrative(entityType, entityId, narrative);
+    }
+
+    return NextResponse.json({
+      narrative,
+      source: narrative ? 'generated' : 'unavailable',
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.error('[Spotlight Narrative] Error', { error: err });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/app/api/spotlight/narratives/batch/route.ts
+++ b/app/api/spotlight/narratives/batch/route.ts
@@ -1,0 +1,57 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { getFeatureFlag } from '@/lib/featureFlags';
+import { logger } from '@/lib/logger';
+
+const MAX_BATCH = 10;
+
+/**
+ * Batch fetch cached narratives for pre-loading the spotlight queue.
+ * Does NOT generate on demand — only returns what's cached.
+ * This keeps the batch endpoint fast and predictable.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const enabled = await getFeatureFlag('spotlight_narratives');
+    if (!enabled) {
+      return NextResponse.json({ narratives: {} });
+    }
+
+    const { entityType, entityIds } = await req.json();
+    if (!entityType || !Array.isArray(entityIds)) {
+      return NextResponse.json({ error: 'Missing entityType or entityIds' }, { status: 400 });
+    }
+
+    const ids = entityIds.slice(0, MAX_BATCH);
+    const table = entityType === 'drep' ? 'dreps' : 'pools';
+    const idCol = entityType === 'drep' ? 'drep_id' : 'pool_id';
+
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from(table)
+      .select(`${idCol}, spotlight_narrative`)
+      .in(idCol, ids)
+      .not('spotlight_narrative', 'is', null);
+
+    if (error) {
+      logger.error('[Spotlight Batch] Query error', { error });
+      return NextResponse.json({ narratives: {} });
+    }
+
+    const narratives: Record<string, string> = {};
+    for (const row of data ?? []) {
+      const id = (row as Record<string, unknown>)[idCol] as string;
+      const narrative = (row as Record<string, unknown>).spotlight_narrative as string;
+      if (id && narrative) {
+        narratives[id] = narrative;
+      }
+    }
+
+    return NextResponse.json({ narratives });
+  } catch (err) {
+    logger.error('[Spotlight Batch] Error', { error: err });
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/components/governada/discover/GovernadaDRepBrowse.tsx
+++ b/components/governada/discover/GovernadaDRepBrowse.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useMemo, useRef, useCallback, useDeferredValue } from 'react';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useFeatureFlag } from '@/components/FeatureGate';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -57,6 +58,15 @@ import {
   getIdentityColor,
 } from '@/lib/drepIdentity';
 import type { AlignmentScores } from '@/lib/drepIdentity';
+import { SpotlightTheater } from '@/components/spotlight/SpotlightTheater';
+import { SpotlightDRepCard } from '@/components/spotlight/SpotlightDRepCard';
+import { ViewModeToggle } from '@/components/spotlight/ViewModeToggle';
+import { SolonDiscoveryPanel } from '@/components/spotlight/SolonDiscoveryPanel';
+import { ConstellationCTA } from '@/components/spotlight/ConstellationCTA';
+import { ConstellationBrowse } from '@/components/spotlight/ConstellationBrowse';
+import { useSpotlightTracking, useSpotlightViewMode } from '@/hooks/useSpotlightTracking';
+import { useSpotlightNarrative } from '@/hooks/useSpotlightNarratives';
+import type { SpotlightEntity } from '@/components/spotlight/types';
 
 const TIER_CHIPS: { value: string; label: string; tooltip?: string }[] = [
   { value: 'All', label: 'All' },
@@ -580,6 +590,37 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
     };
   }, [matchProfile, filtered]);
 
+  // ── Spotlight mode integration ──────────────────────────────────────
+  const spotlightEnabled = useFeatureFlag('spotlight_browse');
+  const solonEnabled = useFeatureFlag('solon_discovery');
+  const constellationEnabled = useFeatureFlag('constellation_browse');
+  const [spotlightViewMode, setSpotlightViewMode] = useSpotlightViewMode();
+  const spotlightTracking = useSpotlightTracking('drep');
+  const [showConstellation, setShowConstellation] = useState(false);
+  const router = useRouter();
+
+  // Build spotlight queue from filtered DReps
+  const spotlightQueue: SpotlightEntity[] = useMemo(() => {
+    const sorted = [...filtered].sort((a, b) => (b.drepScore ?? 0) - (a.drepScore ?? 0));
+    return sorted.map((d) => ({
+      entityType: 'drep' as const,
+      id: d.drepId,
+      data: d,
+    }));
+  }, [filtered]);
+
+  const renderSpotlightCard = useCallback((entity: SpotlightEntity, isTracked: boolean) => {
+    if (entity.entityType !== 'drep') return null;
+    return <SpotlightDRepCard drep={entity.data} isTracked={isTracked} />;
+  }, []);
+
+  const handleSpotlightDetails = useCallback(
+    (entity: SpotlightEntity) => {
+      router.push(`/drep/${entity.id}`);
+    },
+    [router],
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-2 pt-4">
@@ -590,13 +631,50 @@ export function GovernadaDRepBrowse(_props: GovernadaDRepBrowseProps) {
     );
   }
 
-  // ── Hands-Off: match-aware discovery or delegation summary ──────────
+  // ── Spotlight mode for anonymous/hands-off users ────────────────────
   if (!isAtLeast('informed')) {
-    // Wallet-connected users with a delegation: show their DRep summary
+    if (spotlightEnabled && spotlightViewMode === 'spotlight') {
+      return (
+        <div className="space-y-4 pt-2">
+          <div className="flex items-center justify-between">
+            <h1 className="text-xl font-bold tracking-tight">Explore Representatives</h1>
+            <ViewModeToggle mode={spotlightViewMode} onChange={setSpotlightViewMode} hideTable />
+          </div>
+
+          {solonEnabled && <SolonDiscoveryPanel entityType="drep" entityCount={dreps.length} />}
+
+          {showConstellation && constellationEnabled ? (
+            <ConstellationBrowse
+              trackedIds={spotlightTracking.trackedIds}
+              onNodeSelect={(id) => router.push(`/drep/${id}`)}
+              onClose={() => setShowConstellation(false)}
+            />
+          ) : (
+            <>
+              <SpotlightTheater
+                queue={spotlightQueue}
+                entityType="drep"
+                sort="score"
+                renderCard={renderSpotlightCard}
+                onDetails={handleSpotlightDetails}
+              />
+
+              {constellationEnabled && spotlightTracking.trackedCount >= 3 && (
+                <ConstellationCTA
+                  trackedCount={spotlightTracking.trackedCount}
+                  onClick={() => setShowConstellation(true)}
+                />
+              )}
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // Fallback: existing hands-off experience
     if (delegatedDrepId) {
       return <YourDRepSummary dreps={dreps} />;
     }
-    // Anonymous / no delegation: show match-aware hero
     const drepEntities = dreps.map((d) => ({
       id: d.drepId,
       name: d.name || d.ticker || d.handle || `${d.drepId.slice(0, 16)}\u2026`,

--- a/components/governada/discover/GovernadaSPOBrowse.tsx
+++ b/components/governada/discover/GovernadaSPOBrowse.tsx
@@ -36,6 +36,16 @@ import { CompassGuide } from '@/components/governada/shared/CompassGuide';
 import { InsightCard } from '@/components/governada/shared/InsightCard';
 import { PersonalTeaser } from '@/components/governada/shared/PersonalTeaser';
 import { AdvisorPanel } from '@/components/governada/shared/AdvisorPanel';
+import { useRouter } from 'next/navigation';
+import { useFeatureFlag } from '@/components/FeatureGate';
+import { SpotlightTheater } from '@/components/spotlight/SpotlightTheater';
+import { SpotlightSPOCard } from '@/components/spotlight/SpotlightSPOCard';
+import { ViewModeToggle } from '@/components/spotlight/ViewModeToggle';
+import { SolonDiscoveryPanel } from '@/components/spotlight/SolonDiscoveryPanel';
+import { ConstellationCTA } from '@/components/spotlight/ConstellationCTA';
+import { ConstellationBrowse } from '@/components/spotlight/ConstellationBrowse';
+import { useSpotlightTracking, useSpotlightViewMode } from '@/hooks/useSpotlightTracking';
+import type { SpotlightEntity } from '@/components/spotlight/types';
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -304,6 +314,38 @@ export function GovernadaSPOBrowse() {
   // Determine if search hit the "governance-active only" boundary
   const searchHasResults = !deferredSearch.trim() || filtered.length > 0;
 
+  // ── Spotlight mode ──────────────────────────────────────────────────
+  const spotlightEnabled = useFeatureFlag('spotlight_browse');
+  const solonEnabled = useFeatureFlag('solon_discovery');
+  const constellationEnabled = useFeatureFlag('constellation_browse');
+  const [spotlightViewMode, setSpotlightViewMode] = useSpotlightViewMode();
+  const spotlightTracking = useSpotlightTracking('spo');
+  const [showConstellation, setShowConstellation] = useState(false);
+  const router = useRouter();
+
+  const spotlightQueue: SpotlightEntity[] = useMemo(() => {
+    const sorted = [...filtered].sort(
+      (a, b) => (b.governanceScore ?? 0) - (a.governanceScore ?? 0),
+    );
+    return sorted.map((p) => ({
+      entityType: 'spo' as const,
+      id: p.poolId,
+      data: p,
+    }));
+  }, [filtered]);
+
+  const renderSpotlightCard = useCallback((entity: SpotlightEntity, isTracked: boolean) => {
+    if (entity.entityType !== 'spo') return null;
+    return <SpotlightSPOCard pool={entity.data} isTracked={isTracked} />;
+  }, []);
+
+  const handleSpotlightDetails = useCallback(
+    (entity: SpotlightEntity) => {
+      router.push(`/pool/${entity.id}`);
+    },
+    [router],
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-4 pt-4">
@@ -318,8 +360,44 @@ export function GovernadaSPOBrowse() {
     );
   }
 
-  // ── Hands-Off: match-aware discovery hero ──────────────────────────
+  // ── Spotlight for anonymous/hands-off users ────────────────────────
   if (!isAtLeast('informed')) {
+    if (spotlightEnabled && spotlightViewMode === 'spotlight') {
+      return (
+        <div className="space-y-4 pt-2">
+          <div className="flex items-center justify-between">
+            <h1 className="text-xl font-bold tracking-tight">Explore Stake Pools</h1>
+            <ViewModeToggle mode={spotlightViewMode} onChange={setSpotlightViewMode} hideTable />
+          </div>
+          {solonEnabled && <SolonDiscoveryPanel entityType="spo" entityCount={pools.length} />}
+          {showConstellation && constellationEnabled ? (
+            <ConstellationBrowse
+              trackedIds={spotlightTracking.trackedIds}
+              onNodeSelect={(id) => router.push(`/pool/${id}`)}
+              onClose={() => setShowConstellation(false)}
+            />
+          ) : (
+            <>
+              <SpotlightTheater
+                queue={spotlightQueue}
+                entityType="spo"
+                sort="score"
+                renderCard={renderSpotlightCard}
+                onDetails={handleSpotlightDetails}
+              />
+              {constellationEnabled && spotlightTracking.trackedCount >= 3 && (
+                <ConstellationCTA
+                  trackedCount={spotlightTracking.trackedCount}
+                  onClick={() => setShowConstellation(true)}
+                />
+              )}
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // Fallback: existing hands-off
     const poolEntities = pools.map((p) => ({
       id: p.poolId,
       name: p.ticker || p.poolName || `${p.poolId.slice(0, 16)}\u2026`,

--- a/components/governada/discover/ProposalsBrowse.tsx
+++ b/components/governada/discover/ProposalsBrowse.tsx
@@ -23,6 +23,14 @@ import type { BrowseProposal } from './ProposalCard';
 import { DiscoverFilterBar } from './DiscoverFilterBar';
 import { DiscoverPagination } from './DiscoverPagination';
 import { usePeekTrigger } from '@/components/governada/peeks/PeekDrawerProvider';
+import { useRouter } from 'next/navigation';
+import { useFeatureFlag } from '@/components/FeatureGate';
+import { SpotlightTheater } from '@/components/spotlight/SpotlightTheater';
+import { SpotlightProposalCard } from '@/components/spotlight/SpotlightProposalCard';
+import { ViewModeToggle } from '@/components/spotlight/ViewModeToggle';
+import { SolonDiscoveryPanel } from '@/components/spotlight/SolonDiscoveryPanel';
+import { useSpotlightTracking, useSpotlightViewMode } from '@/hooks/useSpotlightTracking';
+import type { SpotlightEntity } from '@/components/spotlight/types';
 
 const STATUS_FILTERS = ['All', 'Open', 'Ratified', 'Enacted', 'Expired', 'Dropped'];
 const TYPE_FILTERS = [
@@ -254,6 +262,43 @@ export function ProposalsBrowse() {
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
   const pageItems = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
+  // ── Spotlight mode ──────────────────────────────────────────────────
+  const spotlightEnabled = useFeatureFlag('spotlight_browse');
+  const solonEnabled = useFeatureFlag('solon_discovery');
+  const [spotlightViewMode, setSpotlightViewMode] = useSpotlightViewMode();
+  const spotlightTracking = useSpotlightTracking('proposal');
+  const router = useRouter();
+
+  const spotlightQueue: SpotlightEntity[] = useMemo(() => {
+    return filtered.map((p) => ({
+      entityType: 'proposal' as const,
+      id: `${p.txHash}-${p.index}`,
+      data: p,
+    }));
+  }, [filtered]);
+
+  const renderSpotlightCard = useCallback(
+    (entity: SpotlightEntity, isTracked: boolean) => {
+      if (entity.entityType !== 'proposal') return null;
+      return (
+        <SpotlightProposalCard
+          proposal={entity.data}
+          currentEpoch={currentEpoch}
+          isTracked={isTracked}
+        />
+      );
+    },
+    [currentEpoch],
+  );
+
+  const handleSpotlightDetails = useCallback(
+    (entity: SpotlightEntity) => {
+      if (entity.entityType !== 'proposal') return;
+      router.push(`/proposal/${entity.data.txHash}/${entity.data.index}`);
+    },
+    [router],
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-3 pt-4">
@@ -264,8 +309,28 @@ export function ProposalsBrowse() {
     );
   }
 
-  // ── Hands-Off: compact status summary only ──────────────────────────────
+  // ── Spotlight for hands-off users ──────────────────────────────────
   if (depthConfig.proposalDetail === 'headline' && !isAtLeast('informed')) {
+    if (spotlightEnabled && spotlightViewMode === 'spotlight') {
+      return (
+        <div className="space-y-4 pt-2">
+          <div className="flex items-center justify-between">
+            <h1 className="text-xl font-bold tracking-tight">Explore Proposals</h1>
+            <ViewModeToggle mode={spotlightViewMode} onChange={setSpotlightViewMode} hideTable />
+          </div>
+          {solonEnabled && (
+            <SolonDiscoveryPanel entityType="proposal" entityCount={proposals.length} />
+          )}
+          <SpotlightTheater
+            queue={spotlightQueue}
+            entityType="proposal"
+            sort="score"
+            renderCard={renderSpotlightCard}
+            onDetails={handleSpotlightDetails}
+          />
+        </div>
+      );
+    }
     return <ProposalStatusSummary proposals={proposals} />;
   }
 

--- a/components/spotlight/AnimatedAlignmentRing.tsx
+++ b/components/spotlight/AnimatedAlignmentRing.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import {
+  type AlignmentScores,
+  getDimensionOrder,
+  getIdentityColor,
+  getDimensionLabel,
+  alignmentsToArray,
+} from '@/lib/drepIdentity';
+import { spring } from '@/lib/animations';
+
+interface AnimatedAlignmentRingProps {
+  alignments: AlignmentScores;
+  size?: number;
+  /** Delay before first segment begins animating (ms) */
+  delay?: number;
+  /** If true, show ring at full values immediately */
+  immediate?: boolean;
+}
+
+/**
+ * SVG ring that fills with alignment dimension colors in sequence.
+ * Each of 6 segments fills proportionally to its alignment score.
+ */
+export function AnimatedAlignmentRing({
+  alignments,
+  size = 120,
+  delay = 0,
+  immediate = false,
+}: AnimatedAlignmentRingProps) {
+  const reducedMotion = useReducedMotion();
+  const shouldAnimate = !immediate && !reducedMotion;
+
+  const dimensions = getDimensionOrder();
+  const scores = alignmentsToArray(alignments);
+  const center = size / 2;
+  const radius = size / 2 - 8;
+  const strokeWidth = 6;
+  const circumference = 2 * Math.PI * radius;
+  const segmentLength = circumference / 6;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      className="shrink-0"
+      role="img"
+      aria-label="Alignment dimensions ring"
+    >
+      {/* Background ring */}
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        className="text-white/5"
+      />
+
+      {/* Dimension segments */}
+      {dimensions.map((dim, i) => {
+        const score = scores[i];
+        const normalizedScore = score / 100;
+        const color = getIdentityColor(dim);
+        const offset = segmentLength * i;
+        // Each segment fills proportionally to its score
+        const fillLength = segmentLength * normalizedScore;
+        const gapLength = circumference - fillLength;
+        const segDelay = delay / 1000 + i * 0.1;
+
+        return (
+          <motion.circle
+            key={dim}
+            cx={center}
+            cy={center}
+            r={radius}
+            fill="none"
+            stroke={color.hex}
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={`${fillLength} ${gapLength}`}
+            strokeDashoffset={-offset}
+            initial={shouldAnimate ? { strokeDasharray: `0 ${circumference}` } : undefined}
+            animate={{ strokeDasharray: `${fillLength} ${gapLength}` }}
+            transition={shouldAnimate ? { ...spring.bouncy, delay: segDelay } : { duration: 0 }}
+            style={{
+              transform: 'rotate(-90deg)',
+              transformOrigin: `${center}px ${center}px`,
+            }}
+          >
+            <title>{`${getDimensionLabel(dim)}: ${score}`}</title>
+          </motion.circle>
+        );
+      })}
+
+      {/* Center score area (left empty for composability) */}
+    </svg>
+  );
+}

--- a/components/spotlight/AnimatedScore.tsx
+++ b/components/spotlight/AnimatedScore.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface AnimatedScoreProps {
+  value: number;
+  /** Duration in ms (default 800) */
+  duration?: number;
+  className?: string;
+  /** If true, skip animation and show value immediately */
+  immediate?: boolean;
+}
+
+/**
+ * Animated counter that counts from 0 to target value with an ease-out curve.
+ * The visual counter is `aria-hidden`; a screen-reader-only span holds the real value.
+ */
+export function AnimatedScore({
+  value,
+  duration = 800,
+  className,
+  immediate = false,
+}: AnimatedScoreProps) {
+  const [display, setDisplay] = useState(immediate ? value : 0);
+  const rafRef = useRef<number>(0);
+  const startRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (immediate) {
+      setDisplay(value);
+      return;
+    }
+
+    // Reset to 0 and animate up
+    setDisplay(0);
+    startRef.current = 0;
+
+    const animate = (timestamp: number) => {
+      if (!startRef.current) startRef.current = timestamp;
+      const elapsed = timestamp - startRef.current;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // Ease-out curve: 1 - (1 - t)^3
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplay(Math.round(eased * value));
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [value, duration, immediate]);
+
+  return (
+    <>
+      <span aria-hidden="true" className={cn('tabular-nums', className)}>
+        {display}
+      </span>
+      <span className="sr-only">{value}</span>
+    </>
+  );
+}

--- a/components/spotlight/ConstellationBrowse.tsx
+++ b/components/spotlight/ConstellationBrowse.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useRef, useState, useCallback, useEffect } from 'react';
+import dynamic from 'next/dynamic';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { X, ArrowLeft } from 'lucide-react';
+import { fadeInUp } from '@/lib/animations';
+import { ConstellationLegend } from './ConstellationLegend';
+import type { ConstellationRef } from '@/components/GovernanceConstellation';
+import type { ConstellationNode3D } from '@/lib/constellation/types';
+
+const ConstellationScene = dynamic(
+  () => import('@/components/ConstellationScene').then((m) => ({ default: m.ConstellationScene })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[60vh] w-full items-center justify-center bg-background text-sm text-muted-foreground">
+        Loading constellation...
+      </div>
+    ),
+  },
+);
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ConstellationBrowseProps {
+  trackedIds: Set<string>;
+  /** Called when user clicks a node to see its spotlight card */
+  onNodeSelect: (nodeId: string, nodeType: string) => void;
+  /** Called when user exits constellation view */
+  onClose: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Interactive constellation globe as a browse surface.
+ * Tracked entities pulse, others are dimmed.
+ * Click a node to open its spotlight card.
+ */
+export function ConstellationBrowse({
+  trackedIds,
+  onNodeSelect,
+  onClose,
+}: ConstellationBrowseProps) {
+  const reducedMotion = useReducedMotion();
+  const constellationRef = useRef<ConstellationRef>(null);
+  const [selectedNode, setSelectedNode] = useState<ConstellationNode3D | null>(null);
+  const [ready, setReady] = useState(false);
+
+  // Pulse tracked nodes once constellation is ready
+  useEffect(() => {
+    if (!ready || !constellationRef.current) return;
+
+    // Pulse each tracked node
+    for (const id of trackedIds) {
+      constellationRef.current.pulseNode(id);
+    }
+  }, [ready, trackedIds]);
+
+  const handleNodeSelect = useCallback(
+    (node: ConstellationNode3D) => {
+      setSelectedNode(node);
+      onNodeSelect(node.fullId ?? node.id, node.nodeType);
+    },
+    [onNodeSelect],
+  );
+
+  const handleReady = useCallback(() => {
+    setReady(true);
+  }, []);
+
+  return (
+    <motion.div
+      className="relative flex flex-col"
+      variants={reducedMotion ? undefined : fadeInUp}
+      initial={reducedMotion ? undefined : 'hidden'}
+      animate="visible"
+    >
+      {/* Back button */}
+      <div className="flex items-center justify-between px-2 py-3">
+        <button
+          onClick={onClose}
+          className="flex items-center gap-1.5 rounded-lg border border-border/40 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to Spotlight
+        </button>
+
+        <ConstellationLegend />
+      </div>
+
+      {/* Globe container */}
+      <div className="relative h-[60vh] min-h-[400px] w-full overflow-hidden rounded-xl border border-border/20">
+        <ConstellationScene
+          ref={constellationRef}
+          interactive={true}
+          onNodeSelect={(node: ConstellationNode3D) => handleNodeSelect(node)}
+          onReady={handleReady}
+        />
+
+        {/* Selected node detail overlay */}
+        <AnimatePresence>
+          {selectedNode && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 20 }}
+              className="absolute bottom-4 left-4 right-4 z-10 rounded-xl border border-border/40 bg-card/90 p-4 backdrop-blur-md sm:left-auto sm:w-80"
+            >
+              <div className="flex items-start justify-between">
+                <div>
+                  <p className="text-sm font-semibold">{selectedNode.name ?? selectedNode.id}</p>
+                  <p className="text-xs text-muted-foreground capitalize">
+                    {selectedNode.nodeType} · Score: {Math.round(selectedNode.score)}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setSelectedNode(null)}
+                  className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <button
+                onClick={() => {
+                  onNodeSelect(selectedNode.fullId ?? selectedNode.id, selectedNode.nodeType);
+                }}
+                className="mt-3 w-full rounded-lg bg-primary/10 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+              >
+                View in Spotlight
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Tracked count overlay */}
+        {trackedIds.size > 0 && (
+          <div className="absolute left-4 top-4 rounded-lg border border-amber-500/20 bg-card/80 px-3 py-1.5 text-xs backdrop-blur-sm">
+            <span className="tabular-nums font-medium text-amber-400">{trackedIds.size}</span>{' '}
+            <span className="text-muted-foreground">tracked — pulsing on globe</span>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/spotlight/ConstellationCTA.tsx
+++ b/components/spotlight/ConstellationCTA.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Globe2, ArrowRight } from 'lucide-react';
+import { fadeInUp } from '@/lib/animations';
+
+interface ConstellationCTAProps {
+  trackedCount: number;
+  onClick: () => void;
+}
+
+/**
+ * "See where your picks sit in the governance universe →"
+ * Appears after tracking 3+ entities in spotlight mode.
+ */
+export function ConstellationCTA({ trackedCount, onClick }: ConstellationCTAProps) {
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <motion.button
+      onClick={onClick}
+      className="group flex w-full items-center gap-3 rounded-xl border border-primary/20 bg-primary/5 px-5 py-4 text-left transition-colors hover:border-primary/40 hover:bg-primary/10"
+      variants={reducedMotion ? undefined : fadeInUp}
+      initial={reducedMotion ? undefined : 'hidden'}
+      animate="visible"
+    >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
+        <Globe2 className="h-5 w-5 text-primary" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-foreground">
+          See where your {trackedCount} picks sit in the governance universe
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Explore the 3D constellation — your tracked representatives will pulse
+        </p>
+      </div>
+
+      <ArrowRight className="h-4 w-4 shrink-0 text-primary/60 transition-transform group-hover:translate-x-0.5" />
+    </motion.button>
+  );
+}

--- a/components/spotlight/ConstellationLegend.tsx
+++ b/components/spotlight/ConstellationLegend.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { getDimensionOrder, getIdentityColor, getDimensionLabel } from '@/lib/drepIdentity';
+
+/**
+ * Color legend overlay for the constellation browse.
+ * Shows which color corresponds to which alignment dimension.
+ */
+export function ConstellationLegend() {
+  const dimensions = getDimensionOrder();
+
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1.5 rounded-lg border border-border/20 bg-card/60 px-3 py-2 backdrop-blur-sm">
+      {dimensions.map((dim) => {
+        const color = getIdentityColor(dim);
+        return (
+          <div key={dim} className="flex items-center gap-1.5">
+            <div className="h-2 w-2 rounded-full" style={{ backgroundColor: color.hex }} />
+            <span className="text-[10px] text-muted-foreground">{getDimensionLabel(dim)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/spotlight/SolonDiscoveryPanel.tsx
+++ b/components/spotlight/SolonDiscoveryPanel.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { Send, X, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fadeInUp } from '@/lib/animations';
+import { useAdvisor } from '@/hooks/useAdvisor';
+import { SolonSuggestedPrompts } from './SolonSuggestedPrompts';
+import type { SpotlightEntityType } from './types';
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface SolonDiscoveryPanelProps {
+  entityType: SpotlightEntityType;
+  entityCount: number;
+  /** Called when Solon wants to curate the spotlight queue */
+  onQueryResults?: (query: string) => void;
+}
+
+// ─── Entity Labels ────────────────────────────────────────────────────────────
+
+const ENTITY_LABELS: Record<SpotlightEntityType, string> = {
+  drep: 'representatives',
+  spo: 'stake pools',
+  proposal: 'proposals',
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SolonDiscoveryPanel({
+  entityType,
+  entityCount,
+  onQueryResults,
+}: SolonDiscoveryPanelProps) {
+  const reducedMotion = useReducedMotion();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const { messages, sendMessage, isStreaming, error, clearMessages } = useAdvisor({
+    pageContext: `spotlight_discovery_${entityType}`,
+  });
+
+  // Auto-scroll messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed || isStreaming) return;
+
+    sendMessage(trimmed);
+    setInputValue('');
+    setIsExpanded(true);
+    onQueryResults?.(trimmed);
+  }, [inputValue, isStreaming, sendMessage, onQueryResults]);
+
+  const handlePromptSelect = useCallback(
+    (prompt: string) => {
+      sendMessage(prompt);
+      setIsExpanded(true);
+      onQueryResults?.(prompt);
+    },
+    [sendMessage, onQueryResults],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend],
+  );
+
+  const handleClear = useCallback(() => {
+    clearMessages();
+    setIsExpanded(false);
+  }, [clearMessages]);
+
+  const hasMessages = messages.length > 0;
+
+  return (
+    <motion.div
+      className="overflow-hidden rounded-xl border border-primary/10 bg-card/40 backdrop-blur-md"
+      variants={reducedMotion ? undefined : fadeInUp}
+      initial={reducedMotion ? undefined : 'hidden'}
+      animate="visible"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        {/* Solon avatar */}
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+          S
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-muted-foreground">
+            Cardano has{' '}
+            <span className="tabular-nums font-medium text-foreground">{entityCount}</span> active{' '}
+            {ENTITY_LABELS[entityType]}.{' '}
+            <span className="text-primary/80">What matters to you in governance?</span>
+          </p>
+        </div>
+
+        {hasMessages && (
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="shrink-0 rounded-md p-1 text-muted-foreground hover:text-foreground"
+          >
+            {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </button>
+        )}
+      </div>
+
+      {/* Suggested prompts (only when no messages) */}
+      {!hasMessages && (
+        <div className="border-t border-border/10 px-4 py-3">
+          <SolonSuggestedPrompts entityType={entityType} onSelect={handlePromptSelect} />
+        </div>
+      )}
+
+      {/* Messages (expandable) */}
+      <AnimatePresence>
+        {isExpanded && hasMessages && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="max-h-60 space-y-3 overflow-y-auto border-t border-border/10 px-4 py-3">
+              {messages.map((msg, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    'text-sm',
+                    msg.role === 'user' ? 'text-right text-primary/90' : 'text-muted-foreground',
+                  )}
+                >
+                  {msg.role === 'user' ? (
+                    <span className="inline-block rounded-lg bg-primary/10 px-3 py-1.5">
+                      {msg.content}
+                    </span>
+                  ) : (
+                    <span>
+                      {msg.content}
+                      {isStreaming && i === messages.length - 1 && (
+                        <span className="ml-1 inline-flex gap-0.5">
+                          <span className="animate-pulse">·</span>
+                          <span className="animate-pulse" style={{ animationDelay: '0.15s' }}>
+                            ·
+                          </span>
+                          <span className="animate-pulse" style={{ animationDelay: '0.3s' }}>
+                            ·
+                          </span>
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </div>
+              ))}
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Clear button */}
+            <div className="flex justify-end border-t border-border/10 px-4 py-2">
+              <button
+                onClick={handleClear}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+                Clear
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Input */}
+      <div className="flex items-center gap-2 border-t border-border/10 px-4 py-2.5">
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={`Ask about ${ENTITY_LABELS[entityType]}...`}
+          className="min-w-0 flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+          disabled={isStreaming}
+        />
+        <button
+          onClick={handleSend}
+          disabled={!inputValue.trim() || isStreaming}
+          className="shrink-0 rounded-lg bg-primary/10 p-2 text-primary transition-colors hover:bg-primary/20 disabled:opacity-30"
+        >
+          {isStreaming ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Send className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="border-t border-red-500/20 bg-red-500/5 px-4 py-2 text-xs text-red-400">
+          {error}
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/components/spotlight/SolonSuggestedPrompts.tsx
+++ b/components/spotlight/SolonSuggestedPrompts.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import type { SpotlightEntityType } from './types';
+
+interface SolonSuggestedPromptsProps {
+  entityType: SpotlightEntityType;
+  onSelect: (prompt: string) => void;
+}
+
+const PROMPTS: Record<SpotlightEntityType, string[]> = {
+  drep: [
+    'Who votes on every proposal?',
+    'DReps focused on developer funding',
+    'Most active newcomers',
+    'Representatives who explain their votes',
+  ],
+  spo: [
+    'Most active governance pools',
+    'Pools with strong deliberation',
+    'Large pools that participate in governance',
+    'Pools focused on decentralization',
+  ],
+  proposal: [
+    "What's being decided right now?",
+    'Treasury spending proposals',
+    'Most contested proposals',
+    'Proposals closing soon',
+  ],
+};
+
+export function SolonSuggestedPrompts({ entityType, onSelect }: SolonSuggestedPromptsProps) {
+  const prompts = PROMPTS[entityType];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {prompts.map((prompt) => (
+        <button
+          key={prompt}
+          onClick={() => onSelect(prompt)}
+          className="flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+        >
+          <Sparkles className="h-3 w-3" />
+          {prompt}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/spotlight/SpotlightBackground.tsx
+++ b/components/spotlight/SpotlightBackground.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { type AlignmentDimension, getIdentityColor } from '@/lib/drepIdentity';
+
+interface SpotlightBackgroundProps {
+  dimension: AlignmentDimension | null;
+}
+
+/**
+ * Full-viewport background that transitions to the entity's dominant alignment color.
+ * Uses a CSS transition for smooth 600ms color shifts.
+ */
+export function SpotlightBackground({ dimension }: SpotlightBackgroundProps) {
+  const color = dimension ? getIdentityColor(dimension) : null;
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 -z-10 transition-all duration-[600ms] ease-out"
+      style={{
+        background: color
+          ? `radial-gradient(ellipse at 50% 30%, rgba(${color.rgb.join(',')}, 0.08) 0%, transparent 70%)`
+          : 'transparent',
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/components/spotlight/SpotlightBreathe.tsx
+++ b/components/spotlight/SpotlightBreathe.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Sparkles, ArrowRight } from 'lucide-react';
+import { fadeInUp } from '@/lib/animations';
+
+interface SpotlightBreatheProps {
+  trackedCount: number;
+  onCompare: () => void;
+  onContinue: () => void;
+}
+
+/**
+ * Breathe point shown every N entities in the spotlight queue.
+ * "You've tracked 4 DReps. Want to compare them?"
+ */
+export function SpotlightBreathe({ trackedCount, onCompare, onContinue }: SpotlightBreatheProps) {
+  const reducedMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className="mx-auto flex max-w-lg flex-col items-center gap-5 rounded-2xl border border-primary/10 bg-card/60 px-8 py-10 text-center backdrop-blur-md"
+      variants={reducedMotion ? undefined : fadeInUp}
+      initial="hidden"
+      animate="visible"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+        <Sparkles className="h-6 w-6 text-primary" />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">Nice work exploring!</h3>
+        {trackedCount > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            You&apos;ve tracked {trackedCount}{' '}
+            {trackedCount === 1 ? 'representative' : 'representatives'}.
+            {trackedCount >= 2
+              ? ' Want to compare them side by side?'
+              : ' Keep exploring to find more.'}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Take a moment to breathe. Track the ones that interest you to build your shortlist.
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3">
+        {trackedCount >= 2 && (
+          <button
+            onClick={onCompare}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Compare tracked
+          </button>
+        )}
+        <button
+          onClick={onContinue}
+          className="flex items-center gap-1.5 rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+        >
+          Keep exploring
+          <ArrowRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/components/spotlight/SpotlightControls.tsx
+++ b/components/spotlight/SpotlightControls.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Star, SkipForward, ChevronRight, StarOff } from 'lucide-react';
+import { hapticSuccess, hapticLight } from '@/lib/haptics';
+import { staggerContainer, fadeInUp } from '@/lib/animations';
+import type { SpotlightAction } from './types';
+
+interface SpotlightControlsProps {
+  onAction: (action: SpotlightAction) => void;
+  isTracked: boolean;
+  /** Delay before buttons stagger in (seconds) */
+  delay?: number;
+  /** Skip entrance animation */
+  immediate?: boolean;
+}
+
+/**
+ * Quick action buttons for the spotlight card.
+ * Desktop: visible buttons with keyboard shortcut hints.
+ * Mobile: same buttons, swipe handling is in the parent SwipeHandler.
+ */
+export function SpotlightControls({
+  onAction,
+  isTracked,
+  delay = 0,
+  immediate = false,
+}: SpotlightControlsProps) {
+  const reducedMotion = useReducedMotion();
+  const shouldAnimate = !immediate && !reducedMotion;
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Don't capture if user is typing in an input
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault();
+          hapticLight();
+          onAction('skip');
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          hapticSuccess();
+          onAction('track');
+          break;
+        case 'Enter':
+          e.preventDefault();
+          onAction('details');
+          break;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onAction]);
+
+  const buttons = [
+    {
+      action: 'track' as SpotlightAction,
+      icon: isTracked ? StarOff : Star,
+      label: isTracked ? 'Untrack' : 'Track',
+      shortcut: '↑',
+      variant: isTracked
+        ? 'border-amber-500/30 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20'
+        : 'border-border/50 text-muted-foreground hover:border-amber-500/30 hover:text-amber-400',
+    },
+    {
+      action: 'skip' as SpotlightAction,
+      icon: SkipForward,
+      label: 'Skip',
+      shortcut: '→',
+      variant: 'border-border/50 text-muted-foreground hover:border-border hover:text-foreground',
+    },
+    {
+      action: 'details' as SpotlightAction,
+      icon: ChevronRight,
+      label: 'Details',
+      shortcut: 'Enter',
+      variant: 'border-primary/30 bg-primary/5 text-primary hover:bg-primary/10',
+    },
+  ];
+
+  return (
+    <motion.div
+      className="flex items-center justify-center gap-3"
+      variants={shouldAnimate ? staggerContainer : undefined}
+      initial={shouldAnimate ? 'hidden' : undefined}
+      animate={shouldAnimate ? 'visible' : undefined}
+      transition={shouldAnimate ? { delayChildren: delay } : undefined}
+    >
+      {buttons.map(({ action, icon: Icon, label, shortcut, variant }) => (
+        <motion.button
+          key={action}
+          variants={shouldAnimate ? fadeInUp : undefined}
+          onClick={() => {
+            if (action === 'track') hapticSuccess();
+            else hapticLight();
+            onAction(action);
+          }}
+          className={`flex items-center gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition-colors ${variant}`}
+        >
+          <Icon className="h-4 w-4" />
+          <span>{label}</span>
+          <kbd className="hidden rounded bg-white/5 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/60 lg:inline">
+            {shortcut}
+          </kbd>
+        </motion.button>
+      ))}
+    </motion.div>
+  );
+}

--- a/components/spotlight/SpotlightDRepCard.tsx
+++ b/components/spotlight/SpotlightDRepCard.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Users, Coins, TrendingUp, TrendingDown, Minus, Star } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fadeIn, spring } from '@/lib/animations';
+import { AnimatedScore } from './AnimatedScore';
+import { AnimatedAlignmentRing } from './AnimatedAlignmentRing';
+import { TierStamp } from './TierStamp';
+import type { EnrichedDRep } from '@/lib/koios';
+import {
+  extractAlignments,
+  getDominantDimension,
+  getIdentityColor,
+  getIdentityGradient,
+  getCompoundArchetype,
+  getDimensionLabel,
+} from '@/lib/drepIdentity';
+import { TIER_SCORE_COLOR, tierKey } from '@/components/governada/cards/tierStyles';
+import { computeTier } from '@/lib/scoring/tiers';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getPillarStrengths(drep: EnrichedDRep): string[] {
+  const pillars: [string, number][] = [
+    ['Explains votes', drep.engagementQuality ?? 0],
+    ['Active voter', drep.effectiveParticipationV3 ?? 0],
+    ['Reliable', drep.reliabilityV3 ?? 0],
+    ['Clear identity', drep.governanceIdentity ?? 0],
+  ];
+  return pillars
+    .filter(([, v]) => v >= 65)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([label]) => label);
+}
+
+function formatAda(lovelace: string): string {
+  const ada = parseInt(lovelace, 10) / 1_000_000;
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${Math.round(ada / 1_000)}K`;
+  return String(Math.round(ada));
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface SpotlightDRepCardProps {
+  drep: EnrichedDRep;
+  isTracked: boolean;
+  /** AI-generated narrative (null = use template fallback) */
+  narrative?: string | null;
+}
+
+export function SpotlightDRepCard({ drep, isTracked, narrative }: SpotlightDRepCardProps) {
+  const reducedMotion = useReducedMotion();
+  const immediate = !!reducedMotion;
+
+  const alignments = extractAlignments(drep);
+  const dominant = getDominantDimension(alignments);
+  const identityColor = getIdentityColor(dominant);
+  const archetype = getCompoundArchetype(alignments);
+  const strengths = getPillarStrengths(drep);
+  const tier = tierKey(computeTier(drep.drepScore));
+  const momentum = drep.scoreMomentum ?? 0;
+
+  // Template fallback narrative
+  const displayNarrative = narrative ?? buildTemplateNarrative(drep, archetype, strengths);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/70 backdrop-blur-md"
+      style={{ background: getIdentityGradient(dominant) }}
+    >
+      {/* Tracked indicator */}
+      {isTracked && (
+        <div className="absolute right-4 top-4 z-10">
+          <Star className="h-5 w-5 fill-amber-400 text-amber-400" />
+        </div>
+      )}
+
+      {/* Identity accent bar */}
+      <div
+        className="h-1 w-full"
+        style={{ background: `linear-gradient(90deg, ${identityColor.hex}, transparent)` }}
+      />
+
+      <div className="flex flex-col gap-6 p-6 sm:p-8">
+        {/* Header: Score + Name + Tier */}
+        <div className="flex items-start gap-5">
+          {/* Score circle */}
+          <div className="flex flex-col items-center gap-1">
+            <div className="relative">
+              <AnimatedAlignmentRing
+                alignments={alignments}
+                size={100}
+                delay={500}
+                immediate={immediate}
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className={cn('text-2xl font-bold tabular-nums', TIER_SCORE_COLOR[tier])}>
+                  <AnimatedScore value={drep.drepScore} immediate={immediate} />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Name + archetype */}
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className="flex items-center gap-3">
+              <h2 className="truncate text-xl font-semibold sm:text-2xl">
+                {drep.name || drep.ticker || drep.drepId.slice(0, 16)}
+              </h2>
+              <TierStamp score={drep.drepScore} delay={0.35} immediate={immediate} />
+            </div>
+
+            {/* Personality archetype */}
+            <div className="flex items-center gap-2">
+              <span
+                className="rounded-full px-2.5 py-0.5 text-xs font-medium"
+                style={{
+                  color: identityColor.hex,
+                  backgroundColor: `rgba(${identityColor.rgb.join(',')}, 0.1)`,
+                  border: `1px solid rgba(${identityColor.rgb.join(',')}, 0.2)`,
+                }}
+              >
+                {archetype}
+              </span>
+              <span className="text-xs text-muted-foreground">{getDimensionLabel(dominant)}</span>
+            </div>
+
+            {/* Strengths */}
+            {strengths.length > 0 && (
+              <div className="flex gap-1.5">
+                {strengths.map((s) => (
+                  <span
+                    key={s}
+                    className="rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400"
+                  >
+                    {s}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* AI Narrative */}
+        <motion.p
+          className="text-sm leading-relaxed text-muted-foreground"
+          variants={immediate ? undefined : fadeIn}
+          initial={immediate ? undefined : 'hidden'}
+          animate="visible"
+          transition={immediate ? undefined : { delay: 0.8 }}
+        >
+          {displayNarrative}
+        </motion.p>
+
+        {/* Stats row */}
+        <div className="flex flex-wrap items-center gap-4 border-t border-border/20 pt-4 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <Users className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{drep.delegatorCount.toLocaleString()}</span>
+            <span>delegators</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Coins className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{formatAda(drep.votingPowerLovelace)}</span>
+            <span>ADA</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="tabular-nums">{drep.totalVotes}</span>
+            <span>votes</span>
+          </div>
+          {momentum !== 0 && (
+            <div className="flex items-center gap-1">
+              {momentum > 0 ? (
+                <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
+              ) : (
+                <TrendingDown className="h-3.5 w-3.5 text-red-400" />
+              )}
+              <span
+                className={cn('tabular-nums', momentum > 0 ? 'text-emerald-400' : 'text-red-400')}
+              >
+                {momentum > 0 ? '+' : ''}
+                {momentum.toFixed(1)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Template Narrative (Zero API Cost Fallback) ──────────────────────────────
+
+function buildTemplateNarrative(
+  drep: EnrichedDRep,
+  archetype: string,
+  strengths: string[],
+): string {
+  const parts: string[] = [];
+
+  // Participation sentence
+  const partRate = drep.participationRate ?? 0;
+  if (partRate >= 90) {
+    parts.push(`Votes on ${Math.round(partRate)}% of proposals.`);
+  } else if (partRate >= 70) {
+    parts.push(`Active voter with ${Math.round(partRate)}% participation.`);
+  } else if (partRate >= 40) {
+    parts.push(`Participates in ${Math.round(partRate)}% of governance votes.`);
+  } else {
+    parts.push(`Selective voter — participates in ${Math.round(partRate)}% of proposals.`);
+  }
+
+  // Strength sentence
+  if (strengths.length > 0) {
+    parts.push(`Known for: ${strengths.join(' and ').toLowerCase()}.`);
+  }
+
+  // Momentum sentence
+  const momentum = drep.scoreMomentum ?? 0;
+  if (momentum > 0.5) {
+    parts.push('Score trending upward.');
+  } else if (momentum < -0.5) {
+    parts.push('Score trending downward recently.');
+  }
+
+  return parts.join(' ');
+}

--- a/components/spotlight/SpotlightProgress.tsx
+++ b/components/spotlight/SpotlightProgress.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { SpotlightEntityType, QueueSort } from './types';
+
+interface SpotlightProgressProps {
+  current: number;
+  total: number;
+  entityType: SpotlightEntityType;
+  sort: QueueSort;
+}
+
+const ENTITY_LABELS: Record<SpotlightEntityType, string> = {
+  drep: 'DReps',
+  spo: 'Stake Pools',
+  proposal: 'Proposals',
+};
+
+const SORT_LABELS: Record<QueueSort, string> = {
+  score: 'Highest scoring first',
+  match: 'Best match first',
+};
+
+/**
+ * Progress indicator: "3 of 247 DReps · Highest scoring first"
+ */
+export function SpotlightProgress({ current, total, entityType, sort }: SpotlightProgressProps) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <span className="tabular-nums font-medium">
+        {current + 1} of {total} {ENTITY_LABELS[entityType]}
+      </span>
+      <span className="text-border">·</span>
+      <span>{SORT_LABELS[sort]}</span>
+    </div>
+  );
+}

--- a/components/spotlight/SpotlightProposalCard.tsx
+++ b/components/spotlight/SpotlightProposalCard.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Clock, Landmark, AlertTriangle, Star } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fadeIn, spring } from '@/lib/animations';
+import { AnimatedScore } from './AnimatedScore';
+import type { BrowseProposal } from '@/components/governada/discover/ProposalCard';
+import { getProposalTheme, getVerdict } from '@/components/governada/proposals/proposal-theme';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface VoteBarProps {
+  label: string;
+  yes: number;
+  no: number;
+  abstain: number;
+  delay: number;
+  immediate: boolean;
+}
+
+function VoteBar({ label, yes, no, abstain, delay, immediate }: VoteBarProps) {
+  const total = yes + no + abstain;
+  if (total === 0) return null;
+
+  const yesPct = (yes / total) * 100;
+  const noPct = (no / total) * 100;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {Math.round(yesPct)}% / {Math.round(noPct)}%
+        </span>
+      </div>
+      <div className="flex h-2 w-full overflow-hidden rounded-full bg-white/5">
+        <motion.div
+          className="h-full bg-emerald-500/80"
+          initial={immediate ? { width: `${yesPct}%` } : { width: '0%' }}
+          animate={{ width: `${yesPct}%` }}
+          transition={immediate ? { duration: 0 } : { ...spring.smooth, delay }}
+        />
+        <motion.div
+          className="h-full bg-red-500/80"
+          initial={immediate ? { width: `${noPct}%` } : { width: '0%' }}
+          animate={{ width: `${noPct}%` }}
+          transition={immediate ? { duration: 0 } : { ...spring.smooth, delay: delay + 0.1 }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface SpotlightProposalCardProps {
+  proposal: BrowseProposal;
+  currentEpoch: number | null;
+  isTracked: boolean;
+}
+
+export function SpotlightProposalCard({
+  proposal,
+  currentEpoch,
+  isTracked,
+}: SpotlightProposalCardProps) {
+  const reducedMotion = useReducedMotion();
+  const immediate = !!reducedMotion;
+
+  const theme = getProposalTheme(proposal.type ?? '');
+  const verdict = getVerdict(proposal.status ?? 'open', proposal.triBody);
+  const isOpen = proposal.status === 'open' || proposal.status === 'active';
+
+  // Urgency
+  const epochsRemaining =
+    proposal.expirationEpoch && currentEpoch ? proposal.expirationEpoch - currentEpoch : null;
+  const isUrgent = epochsRemaining != null && epochsRemaining <= 1;
+
+  // Status color
+  const statusColors: Record<string, string> = {
+    open: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    active: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+    ratified: 'bg-primary/10 text-primary border-primary/20',
+    enacted: 'bg-primary/10 text-primary border-primary/20',
+    expired: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
+    dropped: 'bg-red-500/10 text-red-400 border-red-500/20',
+  };
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/70 backdrop-blur-md">
+      {isTracked && (
+        <div className="absolute right-4 top-4 z-10">
+          <Star className="h-5 w-5 fill-amber-400 text-amber-400" />
+        </div>
+      )}
+
+      {/* Type color accent */}
+      <div className="h-1 w-full" style={{ backgroundColor: theme.accent }} />
+
+      <div className="flex flex-col gap-5 p-6 sm:p-8">
+        {/* Header: Type + Status + Urgency */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              'rounded-full border px-2.5 py-0.5 text-xs font-medium',
+              theme.browseBadgeClass,
+            )}
+          >
+            {theme.label}
+          </span>
+
+          {proposal.status && (
+            <span
+              className={cn(
+                'rounded-full border px-2.5 py-0.5 text-xs font-medium capitalize',
+                statusColors[proposal.status] ?? statusColors.open,
+              )}
+            >
+              {proposal.status}
+            </span>
+          )}
+
+          {isUrgent && (
+            <span className="flex items-center gap-1 rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-0.5 text-xs font-medium text-amber-400">
+              <AlertTriangle className="h-3 w-3" />
+              {epochsRemaining === 0 ? 'Last epoch!' : `${epochsRemaining} epoch left`}
+            </span>
+          )}
+
+          {epochsRemaining != null && !isUrgent && epochsRemaining > 0 && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              {epochsRemaining} epochs remaining
+            </span>
+          )}
+        </div>
+
+        {/* Title */}
+        <h2 className="text-lg font-semibold leading-snug sm:text-xl">
+          {proposal.title || `Proposal ${proposal.txHash.slice(0, 8)}...#${proposal.index}`}
+        </h2>
+
+        {/* Treasury Amount */}
+        {proposal.withdrawalAmount != null && proposal.withdrawalAmount > 0 && (
+          <motion.div
+            className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-2.5"
+            variants={immediate ? undefined : fadeIn}
+            initial={immediate ? undefined : 'hidden'}
+            animate="visible"
+            transition={immediate ? undefined : { delay: 0.3 }}
+          >
+            <Landmark className="h-4 w-4 text-amber-400" />
+            <span className="text-sm font-medium text-amber-400">
+              <AnimatedScore
+                value={Math.round(proposal.withdrawalAmount / 1_000_000)}
+                duration={600}
+                immediate={immediate}
+              />
+              M ADA
+            </span>
+            {proposal.treasuryPct != null && (
+              <span className="text-xs text-muted-foreground">
+                ({proposal.treasuryPct.toFixed(1)}% of treasury)
+              </span>
+            )}
+          </motion.div>
+        )}
+
+        {/* Vote Bars */}
+        {proposal.triBody && isOpen && (
+          <motion.div
+            className="space-y-3"
+            variants={immediate ? undefined : fadeIn}
+            initial={immediate ? undefined : 'hidden'}
+            animate="visible"
+            transition={immediate ? undefined : { delay: 0.4 }}
+          >
+            <VoteBar
+              label="DReps"
+              yes={proposal.triBody.drep.yes}
+              no={proposal.triBody.drep.no}
+              abstain={proposal.triBody.drep.abstain}
+              delay={0.5}
+              immediate={immediate}
+            />
+            <VoteBar
+              label="Stake Pools"
+              yes={proposal.triBody.spo.yes}
+              no={proposal.triBody.spo.no}
+              abstain={proposal.triBody.spo.abstain}
+              delay={0.6}
+              immediate={immediate}
+            />
+            <VoteBar
+              label="Committee"
+              yes={proposal.triBody.cc.yes}
+              no={proposal.triBody.cc.no}
+              abstain={proposal.triBody.cc.abstain}
+              delay={0.7}
+              immediate={immediate}
+            />
+          </motion.div>
+        )}
+
+        {/* Verdict */}
+        {verdict && (
+          <motion.div
+            className="text-sm font-medium"
+            variants={immediate ? undefined : fadeIn}
+            initial={immediate ? undefined : 'hidden'}
+            animate="visible"
+            transition={immediate ? undefined : { delay: 0.8 }}
+          >
+            <span
+              className={cn(
+                'rounded-full border px-3 py-1',
+                verdict.type === 'passing' || verdict.type === 'passed'
+                  ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400'
+                  : verdict.type === 'failing' || verdict.type === 'rejected'
+                    ? 'border-red-500/20 bg-red-500/10 text-red-400'
+                    : 'border-amber-500/20 bg-amber-500/10 text-amber-400',
+              )}
+            >
+              {verdict.label}
+            </span>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/spotlight/SpotlightSPOCard.tsx
+++ b/components/spotlight/SpotlightSPOCard.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { Users, Coins, TrendingUp, TrendingDown, Star, Vote } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fadeIn } from '@/lib/animations';
+import { AnimatedScore } from './AnimatedScore';
+import { AnimatedAlignmentRing } from './AnimatedAlignmentRing';
+import { TierStamp } from './TierStamp';
+import type { GovernadaSPOData } from '@/components/governada/cards/GovernadaSPOCard';
+import { getPoolStrengths } from '@/components/governada/cards/GovernadaSPOCard';
+import {
+  extractAlignments,
+  getDominantDimension,
+  getIdentityColor,
+  getIdentityGradient,
+  getDimensionLabel,
+  getPersonalityLabel,
+} from '@/lib/drepIdentity';
+import { TIER_SCORE_COLOR, tierKey } from '@/components/governada/cards/tierStyles';
+import { computeTier } from '@/lib/scoring/tiers';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatAda(ada: number): string {
+  if (ada >= 1_000_000_000) return `${(ada / 1_000_000_000).toFixed(1)}B`;
+  if (ada >= 1_000_000) return `${(ada / 1_000_000).toFixed(1)}M`;
+  if (ada >= 1_000) return `${Math.round(ada / 1_000)}K`;
+  return String(ada);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface SpotlightSPOCardProps {
+  pool: GovernadaSPOData;
+  isTracked: boolean;
+  narrative?: string | null;
+}
+
+export function SpotlightSPOCard({ pool, isTracked, narrative }: SpotlightSPOCardProps) {
+  const reducedMotion = useReducedMotion();
+  const immediate = !!reducedMotion;
+
+  const alignments = extractAlignments({
+    alignmentTreasuryConservative: pool.alignmentTreasuryConservative ?? null,
+    alignmentTreasuryGrowth: pool.alignmentTreasuryGrowth ?? null,
+    alignmentDecentralization: pool.alignmentDecentralization ?? null,
+    alignmentSecurity: pool.alignmentSecurity ?? null,
+    alignmentInnovation: pool.alignmentInnovation ?? null,
+    alignmentTransparency: pool.alignmentTransparency ?? null,
+  });
+  const dominant = getDominantDimension(alignments);
+  const identityColor = getIdentityColor(dominant);
+  const score = pool.governanceScore ?? 0;
+  const tier = tierKey(computeTier(score));
+  const strengths = getPoolStrengths(pool);
+  const momentum = pool.scoreMomentum ?? 0;
+  const archetype = getPersonalityLabel(alignments);
+
+  const displayNarrative = narrative ?? buildTemplateNarrative(pool, strengths);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/70 backdrop-blur-md"
+      style={{ background: getIdentityGradient(dominant) }}
+    >
+      {isTracked && (
+        <div className="absolute right-4 top-4 z-10">
+          <Star className="h-5 w-5 fill-amber-400 text-amber-400" />
+        </div>
+      )}
+
+      <div
+        className="h-1 w-full"
+        style={{ background: `linear-gradient(90deg, ${identityColor.hex}, transparent)` }}
+      />
+
+      <div className="flex flex-col gap-6 p-6 sm:p-8">
+        {/* Header */}
+        <div className="flex items-start gap-5">
+          <div className="flex flex-col items-center gap-1">
+            <div className="relative">
+              <AnimatedAlignmentRing
+                alignments={alignments}
+                size={100}
+                delay={500}
+                immediate={immediate}
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className={cn('text-2xl font-bold tabular-nums', TIER_SCORE_COLOR[tier])}>
+                  <AnimatedScore value={score} immediate={immediate} />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className="flex items-center gap-3">
+              <h2 className="truncate text-xl font-semibold sm:text-2xl">
+                {pool.ticker ?? pool.poolName ?? pool.poolId.slice(0, 16)}
+              </h2>
+              <TierStamp score={score} delay={0.35} immediate={immediate} />
+            </div>
+
+            {pool.poolName && pool.ticker && (
+              <p className="truncate text-sm text-muted-foreground">{pool.poolName}</p>
+            )}
+
+            <div className="flex items-center gap-2">
+              <span
+                className="rounded-full px-2.5 py-0.5 text-xs font-medium"
+                style={{
+                  color: identityColor.hex,
+                  backgroundColor: `rgba(${identityColor.rgb.join(',')}, 0.1)`,
+                  border: `1px solid rgba(${identityColor.rgb.join(',')}, 0.2)`,
+                }}
+              >
+                {archetype}
+              </span>
+              <span className="text-xs text-muted-foreground">{getDimensionLabel(dominant)}</span>
+            </div>
+
+            {strengths.length > 0 && (
+              <div className="flex gap-1.5">
+                {strengths.map((s) => (
+                  <span
+                    key={s}
+                    className="rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400"
+                  >
+                    {s}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Governance Statement Preview */}
+        {pool.governanceStatement && (
+          <motion.div
+            className="rounded-lg border border-border/20 bg-white/[0.02] px-4 py-3"
+            variants={immediate ? undefined : fadeIn}
+            initial={immediate ? undefined : 'hidden'}
+            animate="visible"
+            transition={immediate ? undefined : { delay: 0.6 }}
+          >
+            <p className="line-clamp-2 text-sm italic text-muted-foreground">
+              &ldquo;{pool.governanceStatement}&rdquo;
+            </p>
+          </motion.div>
+        )}
+
+        {/* Narrative */}
+        <motion.p
+          className="text-sm leading-relaxed text-muted-foreground"
+          variants={immediate ? undefined : fadeIn}
+          initial={immediate ? undefined : 'hidden'}
+          animate="visible"
+          transition={immediate ? undefined : { delay: 0.8 }}
+        >
+          {displayNarrative}
+        </motion.p>
+
+        {/* Stats */}
+        <div className="flex flex-wrap items-center gap-4 border-t border-border/20 pt-4 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <Vote className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{pool.voteCount}</span>
+            <span>votes</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Users className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{pool.delegatorCount.toLocaleString()}</span>
+            <span>delegators</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Coins className="h-3.5 w-3.5" />
+            <span className="tabular-nums">{formatAda(pool.liveStakeAda)}</span>
+            <span>ADA</span>
+          </div>
+          {pool.participationPct != null && (
+            <div className="flex items-center gap-1.5">
+              <span className="tabular-nums">{Math.round(pool.participationPct)}%</span>
+              <span>participation</span>
+            </div>
+          )}
+          {momentum !== 0 && (
+            <div className="flex items-center gap-1">
+              {momentum > 0 ? (
+                <TrendingUp className="h-3.5 w-3.5 text-emerald-400" />
+              ) : (
+                <TrendingDown className="h-3.5 w-3.5 text-red-400" />
+              )}
+              <span
+                className={cn('tabular-nums', momentum > 0 ? 'text-emerald-400' : 'text-red-400')}
+              >
+                {momentum > 0 ? '+' : ''}
+                {momentum.toFixed(1)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildTemplateNarrative(pool: GovernadaSPOData, strengths: string[]): string {
+  const parts: string[] = [];
+
+  const participation = pool.participationPct ?? 0;
+  if (participation >= 90) {
+    parts.push(`Votes on ${Math.round(participation)}% of governance proposals.`);
+  } else if (participation >= 60) {
+    parts.push(`Active governance participant with ${Math.round(participation)}% vote rate.`);
+  } else {
+    parts.push(`Participates in ${Math.round(participation)}% of governance votes.`);
+  }
+
+  if (strengths.length > 0) {
+    parts.push(`Strengths: ${strengths.join(' and ').toLowerCase()}.`);
+  }
+
+  if (pool.liveStakeAda >= 50_000_000) {
+    parts.push('Large pool with significant delegator trust.');
+  }
+
+  return parts.join(' ');
+}

--- a/components/spotlight/SpotlightTheater.tsx
+++ b/components/spotlight/SpotlightTheater.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { spring } from '@/lib/animations';
+import { useSpotlightTracking } from '@/hooks/useSpotlightTracking';
+import { SpotlightBackground } from './SpotlightBackground';
+import { SpotlightControls } from './SpotlightControls';
+import { SpotlightProgress } from './SpotlightProgress';
+import { SpotlightBreathe } from './SpotlightBreathe';
+import { SwipeHandler } from './SwipeHandler';
+import type { SpotlightEntity, SpotlightEntityType, SpotlightAction, QueueSort } from './types';
+import {
+  getDominantDimension,
+  extractAlignments,
+  type AlignmentDimension,
+} from '@/lib/drepIdentity';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const BREATHE_INTERVAL = 10;
+
+// ─── Animation Variants ───────────────────────────────────────────────────────
+
+const cardVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 200 : -200,
+    opacity: 0,
+    scale: 0.95,
+  }),
+  center: {
+    x: 0,
+    opacity: 1,
+    scale: 1,
+    transition: spring.smooth,
+  },
+  exit: (direction: number) => ({
+    x: direction > 0 ? -200 : 200,
+    opacity: 0,
+    scale: 0.95,
+    transition: { ...spring.snappy, duration: 0.2 },
+  }),
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface SpotlightTheaterProps {
+  /** The full sorted queue of entities */
+  queue: SpotlightEntity[];
+  entityType: SpotlightEntityType;
+  sort: QueueSort;
+  /** Render function for entity-specific card content */
+  renderCard: (entity: SpotlightEntity, isTracked: boolean) => React.ReactNode;
+  /** Called when user clicks "Details" */
+  onDetails: (entity: SpotlightEntity) => void;
+  /** Called when user wants to compare tracked entities */
+  onCompare?: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SpotlightTheater({
+  queue,
+  entityType,
+  sort,
+  renderCard,
+  onDetails,
+  onCompare,
+}: SpotlightTheaterProps) {
+  const reducedMotion = useReducedMotion();
+  const tracking = useSpotlightTracking(entityType);
+
+  const [currentIndex, setCurrentIndex] = useState(() => tracking.currentIndex);
+  const [direction, setDirection] = useState(1); // 1 = forward, -1 = backward
+  const [showBreathe, setShowBreathe] = useState(false);
+  const [entitiesSinceBreathe, setEntitiesSinceBreathe] = useState(0);
+
+  // Current entity
+  const entity = queue[currentIndex] ?? null;
+
+  // Get dominant dimension for background color
+  const dominantDimension = useMemo<AlignmentDimension | null>(() => {
+    if (!entity) return null;
+
+    if (entity.entityType === 'drep') {
+      const alignments = extractAlignments(entity.data);
+      return getDominantDimension(alignments);
+    }
+    if (entity.entityType === 'spo') {
+      const spo = entity.data;
+      const alignments = extractAlignments({
+        alignmentTreasuryConservative: spo.alignmentTreasuryConservative ?? null,
+        alignmentTreasuryGrowth: spo.alignmentTreasuryGrowth ?? null,
+        alignmentDecentralization: spo.alignmentDecentralization ?? null,
+        alignmentSecurity: spo.alignmentSecurity ?? null,
+        alignmentInnovation: spo.alignmentInnovation ?? null,
+        alignmentTransparency: spo.alignmentTransparency ?? null,
+      });
+      return getDominantDimension(alignments);
+    }
+    // Proposals don't have alignment — use null (no background tint)
+    return null;
+  }, [entity]);
+
+  const advance = useCallback(
+    (dir: 1 | -1 = 1) => {
+      const newSinceBreathe = entitiesSinceBreathe + 1;
+
+      // Check for breathe point
+      if (newSinceBreathe >= BREATHE_INTERVAL && dir === 1) {
+        setShowBreathe(true);
+        setEntitiesSinceBreathe(0);
+        return;
+      }
+
+      setDirection(dir);
+      const nextIndex = currentIndex + dir;
+      if (nextIndex >= 0 && nextIndex < queue.length) {
+        setCurrentIndex(nextIndex);
+        tracking.setIndex(nextIndex);
+        setEntitiesSinceBreathe(newSinceBreathe);
+      }
+    },
+    [currentIndex, queue.length, entitiesSinceBreathe, tracking],
+  );
+
+  const handleAction = useCallback(
+    (action: SpotlightAction) => {
+      if (!entity) return;
+
+      switch (action) {
+        case 'track':
+          if (tracking.isTracked(entity.id)) {
+            tracking.untrack(entity.id);
+          } else {
+            tracking.track(entity.id);
+          }
+          break;
+        case 'skip':
+          tracking.skip(entity.id);
+          advance(1);
+          break;
+        case 'details':
+          onDetails(entity);
+          break;
+      }
+    },
+    [entity, tracking, advance, onDetails],
+  );
+
+  const handleSwipeRight = useCallback(() => {
+    if (!entity) return;
+    // Swipe right = Track + advance
+    tracking.track(entity.id);
+    advance(1);
+  }, [entity, tracking, advance]);
+
+  const handleSwipeLeft = useCallback(() => {
+    if (!entity) return;
+    // Swipe left = Skip
+    tracking.skip(entity.id);
+    advance(1);
+  }, [entity, tracking, advance]);
+
+  const handleBreatheCompare = useCallback(() => {
+    setShowBreathe(false);
+    onCompare?.();
+  }, [onCompare]);
+
+  const handleBreatheContinue = useCallback(() => {
+    setShowBreathe(false);
+    advance(1);
+  }, [advance]);
+
+  if (!entity) {
+    return (
+      <div className="flex items-center justify-center py-20 text-muted-foreground">
+        No entities to display.
+      </div>
+    );
+  }
+
+  if (showBreathe) {
+    return (
+      <div className="py-8">
+        <SpotlightBreathe
+          trackedCount={tracking.trackedCount}
+          onCompare={handleBreatheCompare}
+          onContinue={handleBreatheContinue}
+        />
+      </div>
+    );
+  }
+
+  const isTracked = tracking.isTracked(entity.id);
+
+  return (
+    <div className="relative flex flex-col items-center gap-6 py-4">
+      <SpotlightBackground dimension={dominantDimension} />
+
+      {/* Progress */}
+      <SpotlightProgress
+        current={currentIndex}
+        total={queue.length}
+        entityType={entityType}
+        sort={sort}
+      />
+
+      {/* Card with swipe handling */}
+      <SwipeHandler
+        onSwipeLeft={handleSwipeLeft}
+        onSwipeRight={handleSwipeRight}
+        className="w-full max-w-2xl"
+      >
+        <AnimatePresence mode="wait" custom={direction}>
+          <motion.div
+            key={entity.id}
+            custom={direction}
+            variants={reducedMotion ? undefined : cardVariants}
+            initial={reducedMotion ? undefined : 'enter'}
+            animate="center"
+            exit={reducedMotion ? undefined : 'exit'}
+            className="w-full"
+          >
+            {renderCard(entity, isTracked)}
+          </motion.div>
+        </AnimatePresence>
+      </SwipeHandler>
+
+      {/* Controls */}
+      <SpotlightControls
+        onAction={handleAction}
+        isTracked={isTracked}
+        delay={reducedMotion ? 0 : 1}
+        immediate={!!reducedMotion}
+      />
+
+      {/* Tracked count indicator */}
+      {tracking.trackedCount > 0 && (
+        <div className="text-xs text-muted-foreground">
+          <span className="tabular-nums font-medium text-amber-400">{tracking.trackedCount}</span>{' '}
+          tracked
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/spotlight/SwipeHandler.tsx
+++ b/components/spotlight/SwipeHandler.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useRef, useCallback, type ReactNode, type PointerEvent } from 'react';
+
+interface SwipeHandlerProps {
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  /** Minimum horizontal distance to trigger swipe (px, default 50) */
+  threshold?: number;
+  /** Enable visual drag feedback via CSS transform */
+  visualFeedback?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Pointer-event-based swipe handler. No external dependencies.
+ * Distinguishes horizontal swipes from vertical scrolls.
+ * Provides optional visual drag feedback during swipe.
+ */
+export function SwipeHandler({
+  onSwipeLeft,
+  onSwipeRight,
+  threshold = 50,
+  visualFeedback = true,
+  children,
+  className,
+}: SwipeHandlerProps) {
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const currentX = useRef(0);
+  const isTracking = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
+    // Only track primary pointer (not right-click or multi-touch)
+    if (e.button !== 0) return;
+
+    startX.current = e.clientX;
+    startY.current = e.clientY;
+    currentX.current = e.clientX;
+    isTracking.current = true;
+
+    // Capture pointer for reliable tracking
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (!isTracking.current) return;
+
+      currentX.current = e.clientX;
+      const dx = currentX.current - startX.current;
+      const dy = e.clientY - startY.current;
+
+      // If vertical movement exceeds horizontal, stop tracking (user is scrolling)
+      if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 10) {
+        isTracking.current = false;
+        if (containerRef.current && visualFeedback) {
+          containerRef.current.style.transform = '';
+          containerRef.current.style.transition = 'transform 0.2s ease-out';
+        }
+        return;
+      }
+
+      // Visual feedback: translate the container
+      if (visualFeedback && containerRef.current && Math.abs(dx) > 5) {
+        // Dampen the movement slightly
+        const dampened = dx * 0.6;
+        containerRef.current.style.transform = `translateX(${dampened}px)`;
+        containerRef.current.style.transition = 'none';
+      }
+    },
+    [visualFeedback],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (!isTracking.current) return;
+      isTracking.current = false;
+
+      const dx = currentX.current - startX.current;
+
+      // Reset visual transform
+      if (visualFeedback && containerRef.current) {
+        containerRef.current.style.transform = '';
+        containerRef.current.style.transition = 'transform 0.2s ease-out';
+      }
+
+      // Release pointer capture
+      (e.target as HTMLElement).releasePointerCapture?.(e.pointerId);
+
+      // Check threshold
+      if (Math.abs(dx) < threshold) return;
+
+      if (dx > 0) {
+        onSwipeRight?.();
+      } else {
+        onSwipeLeft?.();
+      }
+    },
+    [threshold, onSwipeLeft, onSwipeRight, visualFeedback],
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    isTracking.current = false;
+    if (visualFeedback && containerRef.current) {
+      containerRef.current.style.transform = '';
+      containerRef.current.style.transition = 'transform 0.2s ease-out';
+    }
+  }, [visualFeedback]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      style={{ touchAction: 'pan-y' }} // Allow vertical scroll, capture horizontal
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/spotlight/TierStamp.tsx
+++ b/components/spotlight/TierStamp.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+import { computeTier } from '@/lib/scoring/tiers';
+import { TierBadge } from '@/components/governada/cards/TierBadge';
+import { hapticMedium } from '@/lib/haptics';
+import { spring } from '@/lib/animations';
+
+interface TierStampProps {
+  score: number;
+  /** Delay before stamp animation (seconds) */
+  delay?: number;
+  /** Skip animation */
+  immediate?: boolean;
+  className?: string;
+}
+
+/**
+ * Tier badge that stamps in with a scale-bounce animation + haptic feedback.
+ */
+export function TierStamp({ score, delay = 0, immediate = false, className }: TierStampProps) {
+  const reducedMotion = useReducedMotion();
+  const shouldAnimate = !immediate && !reducedMotion;
+  const hapticFired = useRef(false);
+
+  const tier = computeTier(score);
+
+  // Fire haptic when animation reaches peak
+  useEffect(() => {
+    if (!shouldAnimate || hapticFired.current) return;
+
+    const timeout = setTimeout(
+      () => {
+        hapticMedium();
+        hapticFired.current = true;
+      },
+      delay * 1000 + 200,
+    ); // ~200ms is when spring.bouncy overshoots to scale=1
+
+    return () => clearTimeout(timeout);
+  }, [shouldAnimate, delay]);
+
+  // Reset haptic ref when score changes
+  useEffect(() => {
+    hapticFired.current = false;
+  }, [score]);
+
+  if (!shouldAnimate) {
+    return (
+      <div className={className}>
+        <TierBadge tier={tier} />
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, scale: 0.3 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ ...spring.bouncy, delay }}
+    >
+      <TierBadge tier={tier} />
+    </motion.div>
+  );
+}

--- a/components/spotlight/ViewModeToggle.tsx
+++ b/components/spotlight/ViewModeToggle.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Spotlight, LayoutGrid, TableProperties } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { SpotlightViewMode } from './types';
+
+interface ViewModeToggleProps {
+  mode: SpotlightViewMode;
+  onChange: (mode: SpotlightViewMode) => void;
+  /** Hide table option (e.g., for proposals which don't have table view) */
+  hideTable?: boolean;
+}
+
+const MODES: { value: SpotlightViewMode; icon: typeof Spotlight; label: string }[] = [
+  { value: 'spotlight', icon: Spotlight, label: 'Spotlight' },
+  { value: 'cards', icon: LayoutGrid, label: 'Grid' },
+  { value: 'table', icon: TableProperties, label: 'Table' },
+];
+
+/**
+ * Toggle between Spotlight / Grid / Table view modes.
+ */
+export function ViewModeToggle({ mode, onChange, hideTable = false }: ViewModeToggleProps) {
+  const modes = hideTable ? MODES.filter((m) => m.value !== 'table') : MODES;
+
+  return (
+    <div className="flex items-center rounded-lg border border-border/40 bg-card/40 p-0.5">
+      {modes.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          onClick={() => onChange(value)}
+          className={cn(
+            'flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors',
+            mode === value
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          aria-pressed={mode === value}
+          title={`${label} view`}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/spotlight/index.ts
+++ b/components/spotlight/index.ts
@@ -1,0 +1,20 @@
+// Spotlight Theater — barrel export
+export { SpotlightTheater } from './SpotlightTheater';
+export { SpotlightDRepCard } from './SpotlightDRepCard';
+export { SpotlightSPOCard } from './SpotlightSPOCard';
+export { SpotlightProposalCard } from './SpotlightProposalCard';
+export { ViewModeToggle } from './ViewModeToggle';
+export { AnimatedScore } from './AnimatedScore';
+export { AnimatedAlignmentRing } from './AnimatedAlignmentRing';
+export { TierStamp } from './TierStamp';
+export { SwipeHandler } from './SwipeHandler';
+export { SpotlightBackground } from './SpotlightBackground';
+export { SpotlightControls } from './SpotlightControls';
+export { SpotlightProgress } from './SpotlightProgress';
+export { SpotlightBreathe } from './SpotlightBreathe';
+export { SolonDiscoveryPanel } from './SolonDiscoveryPanel';
+export { SolonSuggestedPrompts } from './SolonSuggestedPrompts';
+export { ConstellationBrowse } from './ConstellationBrowse';
+export { ConstellationCTA } from './ConstellationCTA';
+export { ConstellationLegend } from './ConstellationLegend';
+export * from './types';

--- a/components/spotlight/types.ts
+++ b/components/spotlight/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Spotlight Theater — shared types for the entity discovery experience.
+ */
+
+import type { EnrichedDRep } from '@/lib/koios';
+import type { GovernadaSPOData } from '@/components/governada/cards/GovernadaSPOCard';
+import type { BrowseProposal } from '@/components/governada/discover/ProposalCard';
+
+// ─── Entity Union ─────────────────────────────────────────────────────────────
+
+export type SpotlightEntityType = 'drep' | 'spo' | 'proposal';
+
+export interface SpotlightDRep {
+  entityType: 'drep';
+  id: string;
+  data: EnrichedDRep;
+}
+
+export interface SpotlightSPO {
+  entityType: 'spo';
+  id: string;
+  data: GovernadaSPOData;
+}
+
+export interface SpotlightProposal {
+  entityType: 'proposal';
+  id: string; // txHash-index
+  data: BrowseProposal;
+}
+
+export type SpotlightEntity = SpotlightDRep | SpotlightSPO | SpotlightProposal;
+
+// ─── View Mode ────────────────────────────────────────────────────────────────
+
+export type SpotlightViewMode = 'spotlight' | 'cards' | 'table';
+
+// ─── Spotlight Action ─────────────────────────────────────────────────────────
+
+export type SpotlightAction = 'track' | 'skip' | 'details';
+
+// ─── Queue Sorting ────────────────────────────────────────────────────────────
+
+export type QueueSort = 'score' | 'match';

--- a/hooks/useSpotlightNarratives.ts
+++ b/hooks/useSpotlightNarratives.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * Fetch a single spotlight narrative for an entity.
+ * Falls back gracefully — if the API returns null, the card uses template narrative.
+ */
+export function useSpotlightNarrative(entityType: 'drep' | 'spo' | null, entityId: string | null) {
+  return useQuery({
+    queryKey: ['spotlight-narrative', entityType, entityId],
+    queryFn: async () => {
+      if (!entityType || !entityId) return null;
+      const res = await fetch('/api/spotlight/narrative', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entityType, entityId }),
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return (data.narrative as string) ?? null;
+    },
+    enabled: !!entityType && !!entityId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: false,
+  });
+}
+
+/**
+ * Batch-fetch cached narratives for the next N entities in the spotlight queue.
+ * Used for pre-loading to eliminate latency during browsing.
+ */
+export function useSpotlightNarrativesBatch(
+  entityType: 'drep' | 'spo' | null,
+  entityIds: string[],
+) {
+  return useQuery({
+    queryKey: ['spotlight-narratives-batch', entityType, entityIds.join(',')],
+    queryFn: async () => {
+      if (!entityType || entityIds.length === 0) return {};
+      const res = await fetch('/api/spotlight/narratives/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entityType, entityIds }),
+      });
+      if (!res.ok) return {};
+      const data = await res.json();
+      return (data.narratives as Record<string, string>) ?? {};
+    },
+    enabled: !!entityType && entityIds.length > 0,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/hooks/useSpotlightTracking.ts
+++ b/hooks/useSpotlightTracking.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCallback, useSyncExternalStore } from 'react';
+import type { SpotlightEntityType, SpotlightViewMode } from '@/components/spotlight/types';
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+const TRACKED_KEY = (t: SpotlightEntityType) => `governada_spotlight_tracked_${t}`;
+const SKIPPED_KEY = (t: SpotlightEntityType) => `governada_spotlight_skipped_${t}`;
+const INDEX_KEY = (t: SpotlightEntityType) => `governada_spotlight_index_${t}`;
+const VIEW_MODE_KEY = 'governada_spotlight_view_mode';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function readSet(key: string): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeSet(key: string, set: Set<string>): void {
+  localStorage.setItem(key, JSON.stringify([...set]));
+}
+
+function readNumber(key: string, fallback: number): number {
+  if (typeof window === 'undefined') return fallback;
+  const raw = localStorage.getItem(key);
+  return raw ? parseInt(raw, 10) || fallback : fallback;
+}
+
+// ─── External Store for Tracked IDs ───────────────────────────────────────────
+// This lets multiple components subscribe to tracked ID changes across the app.
+
+const listeners = new Set<() => void>();
+let snapshotVersion = 0;
+
+function emitChange() {
+  snapshotVersion++;
+  listeners.forEach((l) => l());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot() {
+  return snapshotVersion;
+}
+
+function getServerSnapshot() {
+  return 0;
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useSpotlightTracking(entityType: SpotlightEntityType) {
+  // Subscribe to changes so React re-renders when tracking state changes
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const trackedKey = TRACKED_KEY(entityType);
+  const skippedKey = SKIPPED_KEY(entityType);
+  const indexKey = INDEX_KEY(entityType);
+
+  const trackedIds = readSet(trackedKey);
+  const skippedIds = readSet(skippedKey);
+  const currentIndex = readNumber(indexKey, 0);
+
+  const track = useCallback(
+    (id: string) => {
+      const set = readSet(trackedKey);
+      set.add(id);
+      writeSet(trackedKey, set);
+      // Remove from skipped if it was there
+      const skip = readSet(skippedKey);
+      if (skip.has(id)) {
+        skip.delete(id);
+        writeSet(skippedKey, skip);
+      }
+      emitChange();
+    },
+    [trackedKey, skippedKey],
+  );
+
+  const untrack = useCallback(
+    (id: string) => {
+      const set = readSet(trackedKey);
+      set.delete(id);
+      writeSet(trackedKey, set);
+      emitChange();
+    },
+    [trackedKey],
+  );
+
+  const skip = useCallback(
+    (id: string) => {
+      const set = readSet(skippedKey);
+      set.add(id);
+      writeSet(skippedKey, set);
+      emitChange();
+    },
+    [skippedKey],
+  );
+
+  const isTracked = useCallback((id: string) => readSet(trackedKey).has(id), [trackedKey]);
+
+  const setIndex = useCallback(
+    (index: number) => {
+      localStorage.setItem(indexKey, String(index));
+      emitChange();
+    },
+    [indexKey],
+  );
+
+  const clearAll = useCallback(() => {
+    localStorage.removeItem(trackedKey);
+    localStorage.removeItem(skippedKey);
+    localStorage.removeItem(indexKey);
+    emitChange();
+  }, [trackedKey, skippedKey, indexKey]);
+
+  return {
+    trackedIds,
+    skippedIds,
+    currentIndex,
+    trackedCount: trackedIds.size,
+    track,
+    untrack,
+    skip,
+    isTracked,
+    setIndex,
+    clearAll,
+  };
+}
+
+// ─── View Mode ────────────────────────────────────────────────────────────────
+
+export function useSpotlightViewMode(): [SpotlightViewMode, (mode: SpotlightViewMode) => void] {
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const mode =
+    (typeof window !== 'undefined'
+      ? (localStorage.getItem(VIEW_MODE_KEY) as SpotlightViewMode | null)
+      : null) ?? 'spotlight';
+
+  const setMode = useCallback((m: SpotlightViewMode) => {
+    localStorage.setItem(VIEW_MODE_KEY, m);
+    emitChange();
+  }, []);
+
+  return [mode, setMode];
+}

--- a/lib/haptics.ts
+++ b/lib/haptics.ts
@@ -15,3 +15,10 @@ export function hapticSuccess(): void {
     navigator.vibrate([10, 50, 10]);
   }
 }
+
+/** Short double-tap for tier badge stamp-in */
+export function hapticStamp(): void {
+  if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+    navigator.vibrate([8, 30, 15]);
+  }
+}

--- a/lib/spotlight/narratives.ts
+++ b/lib/spotlight/narratives.ts
@@ -1,0 +1,138 @@
+/**
+ * Spotlight Narrative Generation
+ *
+ * Generates 2-3 sentence personality narratives for DReps and SPOs.
+ * Uses Claude for AI narratives, with a template fallback for zero-cost operation.
+ */
+
+import { generateText } from '@/lib/ai';
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { logger } from '@/lib/logger';
+
+// ─── System Prompt ────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a governance analyst writing brief personality narratives for Cardano governance participants.
+
+Rules:
+- Write exactly 2-3 sentences.
+- Be specific about their governance behavior (participation, voting patterns, strengths).
+- Use warm but factual tone. No marketing language, no superlatives, no emojis.
+- Write in third person ("Votes on..." not "They vote on...").
+- Reference concrete data: participation rate, vote count, alignment strengths.
+- If participation is low, be honest but encouraging.
+- Never fabricate data — only reference what's provided in the context.`;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DRepNarrativeContext {
+  name: string;
+  score: number;
+  tier: string;
+  archetype: string;
+  participationRate: number;
+  totalVotes: number;
+  delegatorCount: number;
+  strengths: string[];
+  alignmentSummary: string;
+  momentum: number;
+}
+
+interface SPONarrativeContext {
+  name: string;
+  score: number;
+  tier: string;
+  participationPct: number;
+  voteCount: number;
+  delegatorCount: number;
+  liveStakeAda: number;
+  strengths: string[];
+  governanceStatement: string | null;
+}
+
+// ─── Generator ────────────────────────────────────────────────────────────────
+
+export async function generateDRepNarrative(ctx: DRepNarrativeContext): Promise<string | null> {
+  const prompt = `Write a 2-3 sentence governance personality narrative for this DRep:
+
+Name: ${ctx.name}
+Governance Score: ${ctx.score}/100 (${ctx.tier})
+Archetype: ${ctx.archetype}
+Participation: ${Math.round(ctx.participationRate)}% of proposals voted on
+Total Votes: ${ctx.totalVotes}
+Delegators: ${ctx.delegatorCount}
+Strengths: ${ctx.strengths.join(', ') || 'None yet'}
+Alignment: ${ctx.alignmentSummary}
+Score Momentum: ${ctx.momentum > 0 ? 'trending up' : ctx.momentum < 0 ? 'trending down' : 'stable'}
+
+Focus on what makes this DRep distinctive as a governance participant.`;
+
+  return generateText(prompt, {
+    model: 'FAST',
+    maxTokens: 200,
+    temperature: 0.4,
+    system: SYSTEM_PROMPT,
+  });
+}
+
+export async function generateSPONarrative(ctx: SPONarrativeContext): Promise<string | null> {
+  const prompt = `Write a 2-3 sentence governance personality narrative for this Stake Pool Operator:
+
+Pool: ${ctx.name}
+Governance Score: ${ctx.score}/100 (${ctx.tier})
+Participation: ${Math.round(ctx.participationPct)}% of proposals voted on
+Total Votes: ${ctx.voteCount}
+Delegators: ${ctx.delegatorCount}
+Live Stake: ${(ctx.liveStakeAda / 1_000_000).toFixed(1)}M ADA
+Strengths: ${ctx.strengths.join(', ') || 'None yet'}
+${ctx.governanceStatement ? `Governance Statement: "${ctx.governanceStatement.slice(0, 200)}"` : ''}
+
+Focus on their governance engagement and reliability.`;
+
+  return generateText(prompt, {
+    model: 'FAST',
+    maxTokens: 200,
+    temperature: 0.4,
+    system: SYSTEM_PROMPT,
+  });
+}
+
+// ─── Cache Layer ──────────────────────────────────────────────────────────────
+
+export async function getCachedNarrative(
+  entityType: 'drep' | 'spo',
+  entityId: string,
+): Promise<string | null> {
+  const table = entityType === 'drep' ? 'dreps' : 'pools';
+  const idCol = entityType === 'drep' ? 'drep_id' : 'pool_id';
+
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from(table)
+    .select('spotlight_narrative')
+    .eq(idCol, entityId)
+    .single();
+
+  return (data as { spotlight_narrative?: string | null } | null)?.spotlight_narrative ?? null;
+}
+
+export async function cacheNarrative(
+  entityType: 'drep' | 'spo',
+  entityId: string,
+  narrative: string,
+): Promise<void> {
+  const table = entityType === 'drep' ? 'dreps' : 'pools';
+  const idCol = entityType === 'drep' ? 'drep_id' : 'pool_id';
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from(table)
+    .update({
+      spotlight_narrative: narrative,
+      spotlight_narrative_generated_at: new Date().toISOString(),
+    })
+    .eq(idCol, entityId);
+
+  if (error) {
+    logger.error('[Spotlight] Failed to cache narrative', { entityType, entityId, error });
+  }
+}

--- a/types/database.ts
+++ b/types/database.ts
@@ -2091,6 +2091,7 @@ export type Database = {
           feedback_themes: string[];
           id: string;
           impact_score: number | null;
+          reviewed_at_version: number | null;
           reviewer_stake_address: string;
           reviewer_user_id: string | null;
           value_score: number | null;
@@ -2104,6 +2105,7 @@ export type Database = {
           feedback_themes?: string[];
           id?: string;
           impact_score?: number | null;
+          reviewed_at_version?: number | null;
           reviewer_stake_address: string;
           reviewer_user_id?: string | null;
           value_score?: number | null;
@@ -2117,6 +2119,7 @@ export type Database = {
           feedback_themes?: string[];
           id?: string;
           impact_score?: number | null;
+          reviewed_at_version?: number | null;
           reviewer_stake_address?: string;
           reviewer_user_id?: string | null;
           value_score?: number | null;
@@ -2540,6 +2543,8 @@ export type Database = {
           score: number | null;
           score_momentum: number | null;
           size_tier: string | null;
+          spotlight_narrative: string | null;
+          spotlight_narrative_generated_at: string | null;
           updated_at: string | null;
           votes: Json[] | null;
         };
@@ -2588,6 +2593,8 @@ export type Database = {
           score?: number | null;
           score_momentum?: number | null;
           size_tier?: string | null;
+          spotlight_narrative?: string | null;
+          spotlight_narrative_generated_at?: string | null;
           updated_at?: string | null;
           votes?: Json[] | null;
         };
@@ -2636,6 +2643,8 @@ export type Database = {
           score?: number | null;
           score_momentum?: number | null;
           size_tier?: string | null;
+          spotlight_narrative?: string | null;
+          spotlight_narrative_generated_at?: string | null;
           updated_at?: string | null;
           votes?: Json[] | null;
         };
@@ -3329,6 +3338,48 @@ export type Database = {
         };
         Relationships: [];
       };
+      matching_topics: {
+        Row: {
+          alignment_hints: Json | null;
+          created_at: string | null;
+          display_text: string;
+          enabled: boolean | null;
+          epoch_introduced: number | null;
+          id: string;
+          selection_count: number | null;
+          slug: string;
+          source: string;
+          trending: boolean | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          alignment_hints?: Json | null;
+          created_at?: string | null;
+          display_text: string;
+          enabled?: boolean | null;
+          epoch_introduced?: number | null;
+          id?: string;
+          selection_count?: number | null;
+          slug: string;
+          source?: string;
+          trending?: boolean | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          alignment_hints?: Json | null;
+          created_at?: string | null;
+          display_text?: string;
+          enabled?: boolean | null;
+          epoch_introduced?: number | null;
+          id?: string;
+          selection_count?: number | null;
+          slug?: string;
+          source?: string;
+          trending?: boolean | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       metadata_archive: {
         Row: {
           cip_standard: string | null;
@@ -3682,6 +3733,8 @@ export type Database = {
           retiring_epoch: number | null;
           score_momentum: number | null;
           social_links: Json | null;
+          spotlight_narrative: string | null;
+          spotlight_narrative_generated_at: string | null;
           ticker: string | null;
           updated_at: string | null;
           vote_count: number | null;
@@ -3726,6 +3779,8 @@ export type Database = {
           retiring_epoch?: number | null;
           score_momentum?: number | null;
           social_links?: Json | null;
+          spotlight_narrative?: string | null;
+          spotlight_narrative_generated_at?: string | null;
           ticker?: string | null;
           updated_at?: string | null;
           vote_count?: number | null;
@@ -3770,6 +3825,8 @@ export type Database = {
           retiring_epoch?: number | null;
           score_momentum?: number | null;
           social_links?: Json | null;
+          spotlight_narrative?: string | null;
+          spotlight_narrative_generated_at?: string | null;
           ticker?: string | null;
           updated_at?: string | null;
           vote_count?: number | null;
@@ -4581,6 +4638,42 @@ export type Database = {
         };
         Relationships: [];
       };
+      proposal_team_approvals: {
+        Row: {
+          approved_at: string | null;
+          draft_id: string;
+          id: string;
+          team_member_id: string;
+        };
+        Insert: {
+          approved_at?: string | null;
+          draft_id: string;
+          id?: string;
+          team_member_id: string;
+        };
+        Update: {
+          approved_at?: string | null;
+          draft_id?: string;
+          id?: string;
+          team_member_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'proposal_team_approvals_draft_id_fkey';
+            columns: ['draft_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposal_drafts';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'proposal_team_approvals_team_member_id_fkey';
+            columns: ['team_member_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposal_team_members';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       proposal_team_invites: {
         Row: {
           created_at: string;
@@ -4621,42 +4714,6 @@ export type Database = {
             columns: ['team_id'];
             isOneToOne: false;
             referencedRelation: 'proposal_teams';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
-      proposal_team_approvals: {
-        Row: {
-          id: string;
-          draft_id: string;
-          team_member_id: string;
-          approved_at: string;
-        };
-        Insert: {
-          id?: string;
-          draft_id: string;
-          team_member_id: string;
-          approved_at?: string;
-        };
-        Update: {
-          id?: string;
-          draft_id?: string;
-          team_member_id?: string;
-          approved_at?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'proposal_team_approvals_draft_id_fkey';
-            columns: ['draft_id'];
-            isOneToOne: false;
-            referencedRelation: 'proposal_drafts';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'proposal_team_approvals_team_member_id_fkey';
-            columns: ['team_member_id'];
-            isOneToOne: false;
-            referencedRelation: 'proposal_team_members';
             referencedColumns: ['id'];
           },
         ];


### PR DESCRIPTION
## Summary

- **Spotlight Mode**: One-at-a-time theatrical presentation of DReps, SPOs, and proposals with animated score reveals, alignment ring fills, personality archetypes, AI narratives, and swipe-to-track mechanics
- **Solon Discovery**: Conversational AI panel ("Tell me what you care about in governance") replaces filter bars for anonymous users
- **Constellation Browse**: After tracking 3+ entities, interactive 3D globe reveals where tracked entities cluster in governance space

## Impact
- **What changed**: Complete new browse experience layer for /governance pages (proposals, representatives, pools). 22 new components, 2 new API endpoints, 2 new hooks, 1 migration
- **User-facing**: Yes — but all feature-flagged OFF by default. Zero visual change until flags are enabled via /admin/flags
- **Risk**: Low — all 4 feature flags (`spotlight_browse`, `solon_discovery`, `constellation_browse`, `spotlight_narratives`) default to disabled. Current grid/table views completely untouched behind toggle. Instant rollback by disabling flags
- **Scope**: 30 files changed (+3017 lines). New `components/spotlight/` directory, `lib/spotlight/`, `hooks/useSpotlight*`, `app/api/spotlight/`, migration for `spotlight_narrative` columns on dreps/pools tables

## Test plan
- [ ] Verify `/governance/representatives` renders normally with flags OFF (zero regression)
- [ ] Enable `spotlight_browse` flag → anonymous user sees Spotlight mode with DRep theatrical cards
- [ ] Enable `solon_discovery` → Solon panel appears with suggested prompts
- [ ] Track 3+ DReps → Constellation CTA appears (requires `constellation_browse` flag)
- [ ] Keyboard navigation: → Skip, ↑ Track, Enter Details
- [ ] Toggle between Spotlight ⇄ Grid views
- [ ] Mobile: swipe right to track, left to skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)