### PR TITLE
feat: DRep Score V3.2 engine core — defensible deliberation signals

### DIFF
--- a/__tests__/fixtures/scoring.ts
+++ b/__tests__/fixtures/scoring.ts
@@ -31,6 +31,7 @@ export function makeVoteData(overrides: Partial<VoteData> = {}): VoteData {
     proposalType: 'TreasuryWithdrawals',
     rationaleQuality: 70,
     importanceWeight: 2,
+    rationaleMetaHash: null,
     ...overrides,
   };
 }
@@ -136,6 +137,7 @@ export function makeRealisticScenario(drepCount: number, proposalCount: number) 
   ];
 
   const allProposalTypes = new Set(proposalTypes);
+  const proposalTypeCounts = new Map<string, number>();
 
   // Create proposals
   const proposals = Array.from({ length: proposalCount }, (_, i) => {
@@ -147,6 +149,11 @@ export function makeRealisticScenario(drepCount: number, proposalCount: number) 
       importanceWeight: pType === 'HardForkInitiation' ? 3 : pType === 'ParameterChange' ? 2 : 1,
     });
   });
+
+  // Build proposal type counts (V3.2)
+  for (const p of proposals) {
+    proposalTypeCounts.set(p.proposalType, (proposalTypeCounts.get(p.proposalType) || 0) + 1);
+  }
 
   // Create voting summaries (varied margins)
   const votingSummaries = new Map<string, ProposalVotingSummary>();
@@ -198,6 +205,7 @@ export function makeRealisticScenario(drepCount: number, proposalCount: number) 
   return {
     proposals,
     allProposalTypes,
+    proposalTypeCounts,
     votingSummaries,
     drepVotes,
     allProposals: new Map(proposals.map((p) => [p.proposalKey, p])),

--- a/__tests__/scoring/drepScore.test.ts
+++ b/__tests__/scoring/drepScore.test.ts
@@ -94,16 +94,16 @@ describe('computeDRepScores', () => {
     expect(result.effectiveParticipationCalibrated).toBe(76);
     expect(result.reliabilityCalibrated).toBe(91);
     expect(result.governanceIdentityCalibrated).toBe(65);
-    expect(result.composite).toBe(83);
+    expect(result.composite).toBe(84);
   });
 
   // ── Pillar weight verification ──
 
-  it('uses correct pillar weights (35/25/25/15)', () => {
-    expect(PILLAR_WEIGHTS.engagementQuality).toBe(0.35);
+  it('uses correct pillar weights (40/25/25/10)', () => {
+    expect(PILLAR_WEIGHTS.engagementQuality).toBe(0.4);
     expect(PILLAR_WEIGHTS.effectiveParticipation).toBe(0.25);
     expect(PILLAR_WEIGHTS.reliability).toBe(0.25);
-    expect(PILLAR_WEIGHTS.governanceIdentity).toBe(0.15);
+    expect(PILLAR_WEIGHTS.governanceIdentity).toBe(0.1);
 
     const total = Object.values(PILLAR_WEIGHTS).reduce((s, w) => s + w, 0);
     expect(total).toBeCloseTo(1.0, 10);
@@ -262,11 +262,12 @@ describe('computeDRepScores', () => {
 
     // With absolute calibration (not percentile), scores are determined solely by raw values:
     //   a (90/85/80/75): high raws → high calibrated → composite ~93
-    //   b (60/55/50/45): mid raws → mid calibrated → composite ~72
+    //   b (60/55/50/45): mid raws → mid calibrated → composite ~73
     //   c (30/25/20/15): low raws → low calibrated → composite ~43
+    // V3.2 weights: EQ 40%, EP 25%, Rel 25%, GI 10%
     expect(results.get('a')!.composite).toBe(93);
-    expect(results.get('b')!.composite).toBe(72);
-    expect(results.get('c')!.composite).toBe(43);
+    expect(results.get('b')!.composite).toBe(73);
+    expect(results.get('c')!.composite).toBe(44);
   });
 
   // ── Confidence field ──
@@ -316,7 +317,7 @@ describe('computeDRepScores', () => {
 
   // ── Zero-activity override ──
 
-  it('caps zero-activity DReps to GI-only composite (~15% of GI calibrated)', () => {
+  it('caps zero-activity DReps to GI-only composite (~10% of GI calibrated)', () => {
     // DRep with zero activity on all 3 activity pillars but high GI
     // should NOT score from dampened-to-median activity scores.
     // Instead, activity calibrated scores should be forced to 0.

--- a/__tests__/scoring/engagementQuality.test.ts
+++ b/__tests__/scoring/engagementQuality.test.ts
@@ -33,11 +33,12 @@ function makeSummaries(keys: string[], yesRatios: number[]): Map<string, Proposa
   return map;
 }
 
-const ALL_TYPES = new Set([
-  'TreasuryWithdrawals',
-  'ParameterChange',
-  'HardForkInitiation',
-  'InfoAction',
+/** V3.2: proposalTypeCounts replaces allProposalTypes Set */
+const TYPE_COUNTS = new Map([
+  ['TreasuryWithdrawals', 10],
+  ['ParameterChange', 5],
+  ['HardForkInitiation', 2],
+  ['InfoAction', 3],
 ]);
 
 // ── Tests ──
@@ -59,6 +60,7 @@ describe('computeEngagementQuality', () => {
             blockTime: NOW - p * 5 * ONE_DAY,
             proposalBlockTime: NOW - (p * 5 + 2) * ONE_DAY,
             rationaleQuality: d < 7 ? 50 + d * 5 : null,
+            rationaleMetaHash: d < 7 ? `hash_${d}_${p}` : null,
             proposalType: [
               'TreasuryWithdrawals',
               'ParameterChange',
@@ -76,7 +78,7 @@ describe('computeEngagementQuality', () => {
       Array.from({ length: 20 }, (_, i) => 0.3 + (i / 20) * 0.4),
     );
 
-    const scores = computeEngagementQuality(drepVotes, summaries, ALL_TYPES, NOW);
+    const scores = computeEngagementQuality(drepVotes, summaries, TYPE_COUNTS, NOW);
     expect(scores.size).toBe(10);
     for (const [, score] of scores) {
       expect(score).toBeGreaterThanOrEqual(0);
@@ -90,7 +92,7 @@ describe('computeEngagementQuality', () => {
     const scores = computeEngagementQuality(
       new Map([['drep_empty', []]]),
       emptySummaries(),
-      ALL_TYPES,
+      TYPE_COUNTS,
       NOW,
     );
     expect(scores.get('drep_empty')).toBe(0);
@@ -109,45 +111,10 @@ describe('computeEngagementQuality', () => {
         },
       ]),
       emptySummaries(),
-      ALL_TYPES,
+      TYPE_COUNTS,
       NOW,
     );
     expect(scores.get('d1')).toBeGreaterThan(0);
-  });
-
-  // ── Edge: All votes same direction (rubber-stamp) ──
-
-  it('penalizes rubber-stamping (>95% same vote direction)', () => {
-    const diverseVotes = makeVotes(
-      'diverse',
-      Array.from({ length: 10 }, (_, i) => ({
-        proposalKey: `tx_${i}-0`,
-        vote: (i % 3 === 0 ? 'No' : i % 3 === 1 ? 'Abstain' : 'Yes') as VoteData['vote'],
-        blockTime: NOW - i * ONE_DAY,
-        rationaleQuality: 60,
-      })),
-    );
-
-    const rubberStamp = makeVotes(
-      'stamp',
-      Array.from({ length: 10 }, (_, i) => ({
-        proposalKey: `tx_${i}-0`,
-        vote: 'Yes' as const,
-        blockTime: NOW - i * ONE_DAY,
-        rationaleQuality: 60,
-      })),
-    );
-
-    const summaries = makeSummaries(
-      Array.from({ length: 10 }, (_, i) => `tx_${i}-0`),
-      Array.from({ length: 10 }, () => 0.7),
-    );
-
-    const diverseScores = computeEngagementQuality(diverseVotes, summaries, ALL_TYPES, NOW);
-    const stampScores = computeEngagementQuality(rubberStamp, summaries, ALL_TYPES, NOW);
-
-    // Diverse voter should score higher on deliberation signal
-    expect(diverseScores.get('diverse')!).toBeGreaterThan(stampScores.get('stamp')!);
   });
 
   // ── Edge: All rationales scored 0 ──
@@ -163,7 +130,7 @@ describe('computeEngagementQuality', () => {
         })),
       ),
       emptySummaries(),
-      ALL_TYPES,
+      TYPE_COUNTS,
       NOW,
     );
     // With all quality=0, quality layer = 0 but provision and deliberation can still contribute
@@ -181,13 +148,14 @@ describe('computeEngagementQuality', () => {
         Array.from({ length: 8 }, (_, i) => ({
           proposalKey: `tx_${i}-0`,
           rationaleQuality: 100,
+          rationaleMetaHash: `unique_hash_${i}`,
           blockTime: NOW - i * ONE_DAY,
           vote: (i % 3 === 0 ? 'No' : 'Yes') as VoteData['vote'],
           proposalType: ['TreasuryWithdrawals', 'ParameterChange', 'HardForkInitiation'][i % 3],
         })),
       ),
       emptySummaries(),
-      ALL_TYPES,
+      TYPE_COUNTS,
       NOW,
     );
     expect(scores.get('d1')!).toBeGreaterThan(60);
@@ -214,12 +182,10 @@ describe('computeEngagementQuality', () => {
       },
     ]);
 
-    const recentScores = computeEngagementQuality(recentVotes, emptySummaries(), ALL_TYPES, NOW);
-    const oldScores = computeEngagementQuality(oldVotes, emptySummaries(), ALL_TYPES, NOW);
+    const recentScores = computeEngagementQuality(recentVotes, emptySummaries(), TYPE_COUNTS, NOW);
+    const oldScores = computeEngagementQuality(oldVotes, emptySummaries(), TYPE_COUNTS, NOW);
 
     // Both have same quality but old vote is decayed
-    // The provision rate is binary (has quality > 0 = yes), but the quality layer uses decay
-    // The 180-day-old vote should contribute ~50% weight
     expect(recentScores.get('recent')!).toBeGreaterThanOrEqual(oldScores.get('old')!);
   });
 
@@ -242,68 +208,10 @@ describe('computeEngagementQuality', () => {
       })),
     );
 
-    const scores = computeEngagementQuality(onlyInfoActions, emptySummaries(), ALL_TYPES, NOW);
+    const scores = computeEngagementQuality(onlyInfoActions, emptySummaries(), TYPE_COUNTS, NOW);
     // InfoActions are excluded from provision and quality layers
-    // Only deliberation signal contributes (and it returns 50 for ≤5 votes)
     const score = scores.get('d1')!;
     expect(score).toBeLessThanOrEqual(30); // mostly zeros from provision+quality
-  });
-
-  // ── Dissent scoring ──
-
-  it('scores dissent sweet spot (15-40%) highest', () => {
-    // DRep who votes against majority 25% of the time (sweet spot)
-    const sweetSpotVotes: VoteData[] = [];
-    const summaries = new Map<string, ProposalVotingSummary>();
-    for (let i = 0; i < 20; i++) {
-      const key = `tx_d${i}-0`;
-      // Majority is Yes on all proposals
-      summaries.set(key, {
-        proposalKey: key,
-        drepYesVotePower: 7000,
-        drepNoVotePower: 3000,
-        drepAbstainVotePower: 0,
-      });
-      sweetSpotVotes.push(
-        makeVoteData({
-          drepId: 'moderate',
-          proposalKey: key,
-          // 25% dissent (vote No when majority is Yes)
-          vote: i < 5 ? 'No' : 'Yes',
-          blockTime: NOW - i * ONE_DAY,
-          rationaleQuality: 60,
-        }),
-      );
-    }
-
-    const zeroDissentVotes: VoteData[] = [];
-    for (let i = 0; i < 20; i++) {
-      const key = `tx_d${i}-0`;
-      zeroDissentVotes.push(
-        makeVoteData({
-          drepId: 'conformist',
-          proposalKey: key,
-          vote: 'Yes', // always agrees with majority
-          blockTime: NOW - i * ONE_DAY,
-          rationaleQuality: 60,
-        }),
-      );
-    }
-
-    const moderateScores = computeEngagementQuality(
-      new Map([['moderate', sweetSpotVotes]]),
-      summaries,
-      ALL_TYPES,
-      NOW,
-    );
-    const conformistScores = computeEngagementQuality(
-      new Map([['conformist', zeroDissentVotes]]),
-      summaries,
-      ALL_TYPES,
-      NOW,
-    );
-
-    expect(moderateScores.get('moderate')!).toBeGreaterThan(conformistScores.get('conformist')!);
   });
 
   // ── Scores bounded 0-100 ──
@@ -325,7 +233,7 @@ describe('computeEngagementQuality', () => {
       );
     }
 
-    const scores = computeEngagementQuality(drepVotes, emptySummaries(), ALL_TYPES, NOW);
+    const scores = computeEngagementQuality(drepVotes, emptySummaries(), TYPE_COUNTS, NOW);
     for (const [, score] of scores) {
       expect(score).toBeGreaterThanOrEqual(0);
       expect(score).toBeLessThanOrEqual(100);

--- a/__tests__/scoring/engagementQualityV32.test.ts
+++ b/__tests__/scoring/engagementQualityV32.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/utils/display', () => ({
+  isValidatedSocialLink: () => true,
+}));
+
+import {
+  computeEngagementQuality,
+  computeRationaleDiversity,
+  computeCoverageBreadth,
+} from '@/lib/scoring/engagementQuality';
+import type { VoteData, ProposalVotingSummary } from '@/lib/scoring/types';
+import { makeVoteData, NOW, ONE_DAY } from '../fixtures/scoring';
+
+// ── Helpers ──
+
+function makeVotes(drepId: string, configs: Partial<VoteData>[]): Map<string, VoteData[]> {
+  return new Map([[drepId, configs.map((c) => makeVoteData({ drepId, ...c }))]]);
+}
+
+function emptySummaries(): Map<string, ProposalVotingSummary> {
+  return new Map();
+}
+
+function makeSummaries(keys: string[], yesRatios: number[]): Map<string, ProposalVotingSummary> {
+  const map = new Map<string, ProposalVotingSummary>();
+  for (let i = 0; i < keys.length; i++) {
+    const total = 10000;
+    map.set(keys[i], {
+      proposalKey: keys[i],
+      drepYesVotePower: Math.round(total * yesRatios[i]),
+      drepNoVotePower: Math.round(total * (1 - yesRatios[i])),
+      drepAbstainVotePower: 0,
+    });
+  }
+  return map;
+}
+
+const TYPE_COUNTS = new Map([
+  ['TreasuryWithdrawals', 10],
+  ['ParameterChange', 5],
+  ['HardForkInitiation', 2],
+  ['InfoAction', 3],
+]);
+
+// ── Rationale Diversity Tests ──
+
+describe('computeRationaleDiversity', () => {
+  it('returns 100 for 10 unique meta_hashes out of 10 votes', () => {
+    const votes = Array.from({ length: 10 }, (_, i) =>
+      makeVoteData({
+        rationaleMetaHash: `hash_${i}`,
+        proposalKey: `tx_${i}-0`,
+      }),
+    );
+    expect(computeRationaleDiversity(votes)).toBe(100);
+  });
+
+  it('returns 20 for 2 unique meta_hashes out of 10 votes', () => {
+    const votes = Array.from({ length: 10 }, (_, i) =>
+      makeVoteData({
+        rationaleMetaHash: i < 5 ? 'hash_a' : 'hash_b',
+        proposalKey: `tx_${i}-0`,
+      }),
+    );
+    expect(computeRationaleDiversity(votes)).toBe(20);
+  });
+
+  it('returns neutral 50 when fewer than 3 rationales have meta_hash', () => {
+    const votes = [
+      makeVoteData({ rationaleMetaHash: 'hash_1', proposalKey: 'tx_0-0' }),
+      makeVoteData({ rationaleMetaHash: 'hash_2', proposalKey: 'tx_1-0' }),
+      makeVoteData({ rationaleMetaHash: null, proposalKey: 'tx_2-0' }),
+    ];
+    expect(computeRationaleDiversity(votes)).toBe(50);
+  });
+
+  it('returns neutral 50 for 0 votes', () => {
+    expect(computeRationaleDiversity([])).toBe(50);
+  });
+
+  it('returns 10 when 1 hash is reused across 10 votes (extreme copy-paste)', () => {
+    const votes = Array.from({ length: 10 }, (_, i) =>
+      makeVoteData({
+        rationaleMetaHash: 'same_hash',
+        proposalKey: `tx_${i}-0`,
+      }),
+    );
+    expect(computeRationaleDiversity(votes)).toBe(10);
+  });
+
+  it('ignores votes without meta_hash (null) in both numerator and denominator', () => {
+    const votes = [
+      makeVoteData({ rationaleMetaHash: 'a', proposalKey: 'tx_0-0' }),
+      makeVoteData({ rationaleMetaHash: 'b', proposalKey: 'tx_1-0' }),
+      makeVoteData({ rationaleMetaHash: 'c', proposalKey: 'tx_2-0' }),
+      makeVoteData({ rationaleMetaHash: null, proposalKey: 'tx_3-0' }),
+      makeVoteData({ rationaleMetaHash: null, proposalKey: 'tx_4-0' }),
+    ];
+    // 3 unique out of 3 with hashes = 100
+    expect(computeRationaleDiversity(votes)).toBe(100);
+  });
+});
+
+// ── Coverage Breadth Tests ──
+
+describe('computeCoverageBreadth', () => {
+  it('treasury specialist scores ~90 in treasury-heavy epoch', () => {
+    // 90% treasury, 10% other
+    const heavyTreasury = new Map([
+      ['TreasuryWithdrawals', 90],
+      ['HardForkInitiation', 10],
+    ]);
+
+    const votes = Array.from({ length: 5 }, (_, i) =>
+      makeVoteData({
+        proposalType: 'TreasuryWithdrawals',
+        proposalKey: `tx_${i}-0`,
+      }),
+    );
+
+    const score = computeCoverageBreadth(votes, heavyTreasury);
+    expect(score).toBe(90);
+  });
+
+  it('DRep covering all types scores 100', () => {
+    const votes = [
+      makeVoteData({ proposalType: 'TreasuryWithdrawals', proposalKey: 'tx_0-0' }),
+      makeVoteData({ proposalType: 'ParameterChange', proposalKey: 'tx_1-0' }),
+      makeVoteData({ proposalType: 'HardForkInitiation', proposalKey: 'tx_2-0' }),
+      makeVoteData({ proposalType: 'InfoAction', proposalKey: 'tx_3-0' }),
+    ];
+
+    expect(computeCoverageBreadth(votes, TYPE_COUNTS)).toBe(100);
+  });
+
+  it('returns 50 for empty proposal type counts', () => {
+    const votes = [makeVoteData({ proposalType: 'TreasuryWithdrawals', proposalKey: 'tx_0-0' })];
+    expect(computeCoverageBreadth(votes, new Map())).toBe(50);
+  });
+
+  it('DRep voting only on rare type scores low', () => {
+    // 1 HardFork out of 100 total proposals
+    const typeCounts = new Map([
+      ['TreasuryWithdrawals', 90],
+      ['ParameterChange', 9],
+      ['HardForkInitiation', 1],
+    ]);
+
+    const votes = [makeVoteData({ proposalType: 'HardForkInitiation', proposalKey: 'tx_0-0' })];
+
+    const score = computeCoverageBreadth(votes, typeCounts);
+    expect(score).toBe(1); // 1/100 = 1%
+  });
+});
+
+// ── Dissent with Substance Tests ──
+
+describe('dissent with substance modifier', () => {
+  it('boosts quality for minority vote with quality >= 60', () => {
+    const keys = Array.from({ length: 10 }, (_, i) => `tx_ds${i}-0`);
+    const summaries = makeSummaries(
+      keys,
+      Array.from({ length: 10 }, () => 0.8), // majority is Yes
+    );
+
+    // DRep A: votes No (dissent) with quality 80 on some proposals
+    const dissentVotes = makeVotes(
+      'dissenter',
+      keys.map((key, i) => ({
+        proposalKey: key,
+        vote: i < 3 ? ('No' as const) : ('Yes' as const),
+        rationaleQuality: 80,
+        rationaleMetaHash: `hash_${i}`,
+        blockTime: NOW - i * ONE_DAY,
+        proposalType: 'TreasuryWithdrawals',
+      })),
+    );
+
+    // DRep B: always votes Yes (conformist) with same quality
+    const conformistVotes = makeVotes(
+      'conformist',
+      keys.map((key, i) => ({
+        proposalKey: key,
+        vote: 'Yes' as const,
+        rationaleQuality: 80,
+        rationaleMetaHash: `hash_c${i}`,
+        blockTime: NOW - i * ONE_DAY,
+        proposalType: 'TreasuryWithdrawals',
+      })),
+    );
+
+    const dissentScores = computeEngagementQuality(dissentVotes, summaries, TYPE_COUNTS, NOW);
+    const conformistScores = computeEngagementQuality(conformistVotes, summaries, TYPE_COUNTS, NOW);
+
+    // Dissenter should score slightly higher due to quality multiplier
+    expect(dissentScores.get('dissenter')!).toBeGreaterThan(conformistScores.get('conformist')!);
+  });
+
+  it('does NOT boost dissent without sufficient rationale quality', () => {
+    const keys = Array.from({ length: 10 }, (_, i) => `tx_nq${i}-0`);
+    const summaries = makeSummaries(
+      keys,
+      Array.from({ length: 10 }, () => 0.8),
+    );
+
+    // DRep votes No (dissent) but quality is only 30 (below minQuality of 60)
+    const lowQualityDissent = makeVotes(
+      'lowq',
+      keys.map((key, i) => ({
+        proposalKey: key,
+        vote: i < 3 ? ('No' as const) : ('Yes' as const),
+        rationaleQuality: 30,
+        rationaleMetaHash: `hash_${i}`,
+        blockTime: NOW - i * ONE_DAY,
+        proposalType: 'TreasuryWithdrawals',
+      })),
+    );
+
+    // Same DRep but always Yes
+    const conformistLowQ = makeVotes(
+      'conf',
+      keys.map((key, i) => ({
+        proposalKey: key,
+        vote: 'Yes' as const,
+        rationaleQuality: 30,
+        rationaleMetaHash: `hash_c${i}`,
+        blockTime: NOW - i * ONE_DAY,
+        proposalType: 'TreasuryWithdrawals',
+      })),
+    );
+
+    const dissentScores = computeEngagementQuality(lowQualityDissent, summaries, TYPE_COUNTS, NOW);
+    const conformistScores = computeEngagementQuality(conformistLowQ, summaries, TYPE_COUNTS, NOW);
+
+    // Without quality >= 60, no modifier applies — scores should be equal
+    expect(dissentScores.get('lowq')!).toBe(conformistScores.get('conf')!);
+  });
+
+  it('caps dissent modifier to maxVoteFraction (40%) of votes', () => {
+    // All 10 votes are dissent with quality 80 — but only 4 (40%) should get bonus
+    const keys = Array.from({ length: 10 }, (_, i) => `tx_cap${i}-0`);
+    const summaries = makeSummaries(
+      keys,
+      Array.from({ length: 10 }, () => 0.8), // majority is Yes
+    );
+
+    const allDissent = makeVotes(
+      'alldissent',
+      keys.map((key, i) => ({
+        proposalKey: key,
+        vote: 'No' as const, // all against majority
+        rationaleQuality: 80,
+        rationaleMetaHash: `hash_${i}`,
+        blockTime: NOW - i * ONE_DAY,
+        proposalType: 'TreasuryWithdrawals',
+      })),
+    );
+
+    const scores = computeEngagementQuality(allDissent, summaries, TYPE_COUNTS, NOW);
+    // Should not crash and score should be bounded
+    const score = scores.get('alldissent')!;
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── Edge Cases ──
+
+describe('V3.2 edge cases', () => {
+  it('handles 0 votes', () => {
+    const scores = computeEngagementQuality(
+      new Map([['empty', []]]),
+      emptySummaries(),
+      TYPE_COUNTS,
+      NOW,
+    );
+    expect(scores.get('empty')).toBe(0);
+  });
+
+  it('handles 1 vote', () => {
+    const scores = computeEngagementQuality(
+      makeVotes('one', [
+        {
+          proposalKey: 'tx_solo-0',
+          rationaleQuality: 75,
+          rationaleMetaHash: 'hash_solo',
+          blockTime: NOW - ONE_DAY,
+          proposalType: 'TreasuryWithdrawals',
+        },
+      ]),
+      emptySummaries(),
+      TYPE_COUNTS,
+      NOW,
+    );
+    const score = scores.get('one')!;
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('handles all abstains', () => {
+    const scores = computeEngagementQuality(
+      makeVotes(
+        'abstainer',
+        Array.from({ length: 5 }, (_, i) => ({
+          proposalKey: `tx_abs${i}-0`,
+          vote: 'Abstain' as const,
+          rationaleQuality: 50,
+          rationaleMetaHash: `hash_${i}`,
+          blockTime: NOW - i * ONE_DAY,
+          proposalType: 'TreasuryWithdrawals',
+        })),
+      ),
+      emptySummaries(),
+      TYPE_COUNTS,
+      NOW,
+    );
+    const score = scores.get('abstainer')!;
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it('handles no rationales (all null quality)', () => {
+    const scores = computeEngagementQuality(
+      makeVotes(
+        'norationale',
+        Array.from({ length: 8 }, (_, i) => ({
+          proposalKey: `tx_nr${i}-0`,
+          rationaleQuality: null,
+          rationaleMetaHash: null,
+          blockTime: NOW - i * ONE_DAY,
+          proposalType: 'TreasuryWithdrawals',
+        })),
+      ),
+      emptySummaries(),
+      TYPE_COUNTS,
+      NOW,
+    );
+    const score = scores.get('norationale')!;
+    // Provision = 0, Quality = 0, Deliberation = neutral-ish
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(20);
+  });
+});

--- a/inngest/functions/sync-drep-scores.ts
+++ b/inngest/functions/sync-drep-scores.ts
@@ -89,6 +89,7 @@ export const syncDrepScores = inngest.createFunction(
           block_time: number;
           epoch_no: number | null;
           rationale_quality: number | null;
+          meta_hash: string | null;
         }> = [];
         {
           const VOTE_PAGE = 1000;
@@ -97,7 +98,7 @@ export const syncDrepScores = inngest.createFunction(
             const { data, error } = await supabase
               .from('drep_votes')
               .select(
-                'drep_id, proposal_tx_hash, proposal_index, vote, block_time, epoch_no, rationale_quality',
+                'drep_id, proposal_tx_hash, proposal_index, vote, block_time, epoch_no, rationale_quality, meta_hash',
               )
               .range(vPage * VOTE_PAGE, (vPage + 1) * VOTE_PAGE - 1);
             if (error) throw new Error(`drep_votes page ${vPage}: ${JSON.stringify(error)}`);
@@ -124,6 +125,7 @@ export const syncDrepScores = inngest.createFunction(
         // Proposal context map
         const proposalContexts = new Map<string, ProposalScoringContext>();
         const allProposalTypes = new Set<string>();
+        const proposalTypeCounts = new Map<string, number>();
         const proposalBlockTimes = new Map<string, number>();
 
         for (const p of proposalRows || []) {
@@ -142,6 +144,10 @@ export const syncDrepScores = inngest.createFunction(
             importanceWeight: weight,
           });
           allProposalTypes.add(p.proposal_type);
+          proposalTypeCounts.set(
+            p.proposal_type,
+            (proposalTypeCounts.get(p.proposal_type) || 0) + 1,
+          );
           proposalBlockTimes.set(key, p.block_time || 0);
         }
 
@@ -192,6 +198,7 @@ export const syncDrepScores = inngest.createFunction(
             proposalType: ctx?.proposalType || 'InfoAction',
             rationaleQuality: v.rationale_quality,
             importanceWeight: ctx?.importanceWeight || 1,
+            rationaleMetaHash: v.meta_hash,
           };
 
           if (!drepVotes.has(v.drep_id)) drepVotes.set(v.drep_id, []);
@@ -247,7 +254,7 @@ export const syncDrepScores = inngest.createFunction(
         const rawEngagement = computeEngagementQuality(
           drepVotes,
           votingSummaries,
-          allProposalTypes,
+          proposalTypeCounts,
           nowSeconds,
         );
 

--- a/lib/scoring/calibration.ts
+++ b/lib/scoring/calibration.ts
@@ -17,16 +17,16 @@
 /**
  * DRep pillar weights (must sum to 1.0).
  *
- * Rationale: Engagement Quality (35%) is weighted highest because rationale
- * provision and quality are the strongest signals of governance diligence.
- * Participation and Reliability (25% each) reward showing up consistently.
- * Identity (15%) is the baseline — important but not dominant.
+ * V3.2: EQ raised to 40% (hardest pillar to game — requires actual governance
+ * substance), GI reduced to 10% (easiest to game — fill out a form).
+ * Shifting weight from gameable to non-gameable pillars makes the composite
+ * more resistant to manipulation and more meaningful under public scrutiny.
  */
 export const DREP_PILLAR_WEIGHTS = {
-  engagementQuality: 0.35,
+  engagementQuality: 0.4,
   effectiveParticipation: 0.25,
   reliability: 0.25,
-  governanceIdentity: 0.15,
+  governanceIdentity: 0.1,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -48,42 +48,42 @@ export const ENGAGEMENT_LAYER_WEIGHTS = {
 
 /**
  * Deliberation sub-signal weights (must sum to 1.0).
+ *
+ * V3.2: Dissent removed as standalone signal (incentivized strategic contrarianism).
+ * Vote diversity replaced by rationale diversity (catches copy-paste, not vote direction).
+ * Coverage breadth replaces type breadth (weighted by proposal frequency).
  */
 export const DELIBERATION_WEIGHTS = {
-  voteDiversity: 0.4,
-  dissent: 0.35,
-  typeBreadth: 0.25,
+  rationaleDiversity: 0.6,
+  coverageBreadth: 0.4,
 } as const;
 
 /**
- * Vote diversity thresholds — penalizes rubber-stamping.
- * Maps dominant vote ratio → score.
- * >95% same direction = 15 (severe penalty), >90% = 35, etc.
+ * Rationale diversity config.
+ * Measures unique meta_hashes vs total rationales — detects copy-paste rationales.
+ * Below minRationales → neutral 50 (insufficient data).
  */
-export const VOTE_DIVERSITY_THRESHOLDS = [
-  { maxRatio: 0.75, score: 100 },
-  { maxRatio: 0.85, score: 75 },
-  { maxRatio: 0.9, score: 55 },
-  { maxRatio: 0.95, score: 35 },
-  { maxRatio: 1.0, score: 15 },
-] as const;
-
-/** Minimum votes needed to evaluate diversity (below this → neutral 50). */
-export const VOTE_DIVERSITY_MIN_VOTES = 5;
+export const RATIONALE_DIVERSITY_CONFIG = {
+  /** Minimum rationales with meta_hash to evaluate diversity. */
+  minRationales: 3,
+  /** Score when below minRationales (neutral). */
+  neutralScore: 50,
+} as const;
 
 /**
- * Dissent scoring curve breakpoints.
- * Sweet spot: 15-40% dissent = maximum score (independent thinking).
- * 0% = rubber-stamper (25), >40% = contrarian (decays to 15).
+ * Dissent-with-substance modifier config.
+ * V3.2: Instead of a standalone dissent signal, dissent is a quality multiplier.
+ * When a DRep votes against the majority AND provides a quality rationale (≥ minQuality),
+ * their rationale quality contribution for that vote gets a bonus multiplier.
+ * Capped to maxVoteFraction of total votes to prevent always-dissent gaming.
  */
-export const DISSENT_CURVE = {
-  zeroRate: 25,
-  sweetSpotStart: 0.15,
-  sweetSpotEnd: 0.4,
-  sweetSpotScore: 100,
-  minScore: 15,
-  /** Minimum eligible votes to evaluate dissent. */
-  minVotes: 5,
+export const DISSENT_SUBSTANCE_MODIFIER = {
+  /** Multiplier applied to rationale quality for substantive dissent votes. */
+  multiplier: 1.2,
+  /** Minimum rationale quality score to qualify for the modifier. */
+  minQuality: 60,
+  /** Maximum fraction of votes that can receive the modifier (prevents gaming). */
+  maxVoteFraction: 0.4,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/lib/scoring/engagementQuality.ts
+++ b/lib/scoring/engagementQuality.ts
@@ -1,16 +1,22 @@
 /**
- * Engagement Quality pillar (35% of DRep Score).
- * Three layers: Provision Rate, Rationale Quality, Deliberation Signal.
- * Replaces the old binary rationale rate.
+ * Engagement Quality pillar (40% of DRep Score V3.2).
+ * Three layers: Provision Rate, Rationale Quality (with dissent-with-substance modifier),
+ * Deliberation Signal (rationale diversity + coverage breadth).
+ *
+ * V3.2 changes:
+ * - Vote diversity removed (penalized honest voting patterns)
+ * - Dissent rate removed as standalone signal (incentivized strategic contrarianism)
+ * - Added: rationale diversity via meta_hash uniqueness (catches copy-paste)
+ * - Added: coverage breadth weighted by proposal frequency (doesn't penalize specialization)
+ * - Added: dissent-with-substance modifier on rationale quality layer
  */
 
 import { DECAY_LAMBDA, type VoteData, type ProposalVotingSummary } from './types';
 import {
   ENGAGEMENT_LAYER_WEIGHTS,
   DELIBERATION_WEIGHTS,
-  VOTE_DIVERSITY_THRESHOLDS,
-  VOTE_DIVERSITY_MIN_VOTES,
-  DISSENT_CURVE,
+  RATIONALE_DIVERSITY_CONFIG,
+  DISSENT_SUBSTANCE_MODIFIER,
 } from './calibration';
 
 const LAYER_WEIGHTS = ENGAGEMENT_LAYER_WEIGHTS;
@@ -22,13 +28,13 @@ const INFO_ACTION = 'InfoAction';
  *
  * @param drepVotes Map of drepId → their votes (enriched with rationale quality & importance)
  * @param votingSummaries Map of proposalKey → voting power summary (for majority determination)
- * @param allProposalTypes Set of all distinct proposal types in the system
+ * @param proposalTypeCounts Map of proposalType → count of proposals of that type
  * @param nowSeconds Current unix timestamp
  */
 export function computeEngagementQuality(
   drepVotes: Map<string, VoteData[]>,
   votingSummaries: Map<string, ProposalVotingSummary>,
-  allProposalTypes: Set<string>,
+  proposalTypeCounts: Map<string, number>,
   nowSeconds: number,
 ): Map<string, number> {
   const scores = new Map<string, number>();
@@ -40,8 +46,8 @@ export function computeEngagementQuality(
     }
 
     const provision = computeProvisionRate(votes, nowSeconds);
-    const quality = computeRationaleQuality(votes, nowSeconds);
-    const deliberation = computeDeliberationSignal(votes, votingSummaries, allProposalTypes);
+    const quality = computeRationaleQuality(votes, votingSummaries, nowSeconds);
+    const deliberation = computeDeliberationSignal(votes, proposalTypeCounts);
 
     const raw =
       provision * LAYER_WEIGHTS.provision +
@@ -83,10 +89,26 @@ function computeProvisionRate(votes: VoteData[], nowSeconds: number): number {
  * Layer 2 — Rationale Quality (40% of pillar).
  * Weighted average of AI quality scores across votes, with importance and decay.
  * DReps with 0 rationales get 0. DReps with few but excellent rationales can score high.
+ *
+ * V3.2: Includes "dissent with substance" modifier — when a DRep votes against
+ * the majority AND provides a quality rationale (≥ minQuality), the quality
+ * contribution for that vote is boosted by the multiplier. Capped to maxVoteFraction
+ * of total eligible votes to prevent always-dissent gaming.
  */
-function computeRationaleQuality(votes: VoteData[], nowSeconds: number): number {
+function computeRationaleQuality(
+  votes: VoteData[],
+  votingSummaries: Map<string, ProposalVotingSummary>,
+  nowSeconds: number,
+): number {
   let weightedQuality = 0;
   let totalWeight = 0;
+
+  // Determine how many votes can receive the dissent modifier
+  const eligibleVotes = votes.filter((v) => v.proposalType !== INFO_ACTION);
+  const maxDissentBonuses = Math.floor(
+    eligibleVotes.length * DISSENT_SUBSTANCE_MODIFIER.maxVoteFraction,
+  );
+  let dissentBonusesApplied = 0;
 
   for (const v of votes) {
     if (v.proposalType === INFO_ACTION) continue;
@@ -96,8 +118,26 @@ function computeRationaleQuality(votes: VoteData[], nowSeconds: number): number 
     const decay = Math.exp(-DECAY_LAMBDA * ageDays);
     const w = v.importanceWeight * decay;
 
+    let qualityScore = v.rationaleQuality;
+
+    // Apply dissent-with-substance modifier
+    if (
+      dissentBonusesApplied < maxDissentBonuses &&
+      v.rationaleQuality >= DISSENT_SUBSTANCE_MODIFIER.minQuality &&
+      v.vote !== 'Abstain'
+    ) {
+      const summary = votingSummaries.get(v.proposalKey);
+      if (summary) {
+        const majority = summary.drepYesVotePower >= summary.drepNoVotePower ? 'Yes' : 'No';
+        if (v.vote !== majority) {
+          qualityScore = Math.min(100, v.rationaleQuality * DISSENT_SUBSTANCE_MODIFIER.multiplier);
+          dissentBonusesApplied++;
+        }
+      }
+    }
+
     totalWeight += w;
-    weightedQuality += v.rationaleQuality * w;
+    weightedQuality += qualityScore * w;
   }
 
   return totalWeight === 0 ? 0 : weightedQuality / totalWeight;
@@ -105,102 +145,70 @@ function computeRationaleQuality(votes: VoteData[], nowSeconds: number): number 
 
 /**
  * Layer 3 — Deliberation Signal (20% of pillar).
- * Sub-components: vote diversity, dissent rate, proposal type breadth.
+ * V3.2 sub-components: rationale diversity (60%) + coverage breadth (40%).
  */
 function computeDeliberationSignal(
   votes: VoteData[],
-  votingSummaries: Map<string, ProposalVotingSummary>,
-  allProposalTypes: Set<string>,
+  proposalTypeCounts: Map<string, number>,
 ): number {
-  const diversity = computeVoteDiversity(votes);
-  const dissent = computeDissentRate(votes, votingSummaries);
-  const breadth = computeTypeBreadth(votes, allProposalTypes);
+  const diversity = computeRationaleDiversity(votes);
+  const breadth = computeCoverageBreadth(votes, proposalTypeCounts);
 
-  return (
-    diversity * DELIB_WEIGHTS.voteDiversity +
-    dissent * DELIB_WEIGHTS.dissent +
-    breadth * DELIB_WEIGHTS.typeBreadth
-  );
+  return diversity * DELIB_WEIGHTS.rationaleDiversity + breadth * DELIB_WEIGHTS.coverageBreadth;
 }
 
 /**
- * Vote diversity: rescale the existing deliberation modifier concept to 0-100.
- * Penalizes rubber-stamping (>85% same vote direction).
+ * Rationale diversity: measures unique meta_hashes vs total votes with rationale.
+ * Catches copy-paste rationales (same meta_hash reused across votes) without
+ * penalizing vote direction. Below minRationales → neutral 50.
+ *
+ * Score = (unique meta_hashes / total votes with meta_hash) × 100
  */
-function computeVoteDiversity(votes: VoteData[]): number {
-  if (votes.length <= VOTE_DIVERSITY_MIN_VOTES) return 50; // too few votes to judge
-
-  const counts = { Yes: 0, No: 0, Abstain: 0 };
-  for (const v of votes) counts[v.vote]++;
-
-  const dominant = Math.max(counts.Yes, counts.No, counts.Abstain);
-  const dominantRatio = dominant / votes.length;
-
-  // Thresholds sorted ascending by maxRatio — first match wins
-  for (const t of VOTE_DIVERSITY_THRESHOLDS) {
-    if (dominantRatio <= t.maxRatio) return t.score;
+export function computeRationaleDiversity(votes: VoteData[]): number {
+  const hashVotes = votes.filter((v) => v.rationaleMetaHash != null);
+  if (hashVotes.length < RATIONALE_DIVERSITY_CONFIG.minRationales) {
+    return RATIONALE_DIVERSITY_CONFIG.neutralScore;
   }
-  return VOTE_DIVERSITY_THRESHOLDS[VOTE_DIVERSITY_THRESHOLDS.length - 1].score;
+
+  const uniqueHashes = new Set(hashVotes.map((v) => v.rationaleMetaHash));
+  return (uniqueHashes.size / hashVotes.length) * 100;
 }
 
 /**
- * Dissent rate: percentage of votes against the eventual majority outcome.
- * Moderate dissent (15-40%) scores highest (independent thinking).
- * Zero = rubber-stamper, very high = contrarian.
+ * Coverage breadth: what fraction of governance surface area has this DRep covered,
+ * weighted by proposal frequency. A DRep who votes on all treasury proposals
+ * (90% of proposals) scores ~90 even if they miss the one HardFork.
+ *
+ * For each proposal type T:
+ *   typeWeight[T] = count of proposals of type T / total proposals
+ *   covered[T] = 1 if DRep voted on at least one T, else 0
+ *
+ * coverageScore = sum(covered[T] * typeWeight[T]) / sum(typeWeight[T]) * 100
  */
-function computeDissentRate(
+export function computeCoverageBreadth(
   votes: VoteData[],
-  votingSummaries: Map<string, ProposalVotingSummary>,
+  proposalTypeCounts: Map<string, number>,
 ): number {
-  let dissentCount = 0;
-  let eligibleCount = 0;
+  if (proposalTypeCounts.size === 0) return 50;
 
-  for (const v of votes) {
-    if (v.vote === 'Abstain') continue;
-
-    const summary = votingSummaries.get(v.proposalKey);
-    if (!summary) continue;
-
-    eligibleCount++;
-    const majority = summary.drepYesVotePower >= summary.drepNoVotePower ? 'Yes' : 'No';
-
-    if (v.vote !== majority) dissentCount++;
-  }
-
-  if (eligibleCount < DISSENT_CURVE.minVotes) return 50; // too few data points
-
-  const rate = dissentCount / eligibleCount;
-  return scoreDissentCurve(rate);
-}
-
-/**
- * Dissent scoring curve: sweet spot at 15-40%.
- */
-function scoreDissentCurve(rate: number): number {
-  const { zeroRate, sweetSpotStart, sweetSpotEnd, sweetSpotScore, minScore } = DISSENT_CURVE;
-  if (rate <= 0) return zeroRate;
-  if (rate < sweetSpotStart)
-    return zeroRate + (rate / sweetSpotStart) * (sweetSpotScore - zeroRate);
-  if (rate <= sweetSpotEnd) return sweetSpotScore;
-  if (rate < 1.0)
-    return Math.max(
-      minScore,
-      sweetSpotScore - ((rate - sweetSpotEnd) / (1 - sweetSpotEnd)) * (sweetSpotScore - minScore),
-    );
-  return minScore;
-}
-
-/**
- * Proposal type breadth: what fraction of distinct proposal types
- * has this DRep voted on? Rewards governance surface area coverage.
- */
-function computeTypeBreadth(votes: VoteData[], allProposalTypes: Set<string>): number {
-  if (allProposalTypes.size === 0) return 50;
+  const totalProposals = [...proposalTypeCounts.values()].reduce((a, b) => a + b, 0);
+  if (totalProposals === 0) return 50;
 
   const votedTypes = new Set<string>();
   for (const v of votes) votedTypes.add(v.proposalType);
 
-  return (votedTypes.size / allProposalTypes.size) * 100;
+  let coveredWeight = 0;
+  let totalWeight = 0;
+
+  for (const [pType, count] of proposalTypeCounts) {
+    const typeWeight = count / totalProposals;
+    totalWeight += typeWeight;
+    if (votedTypes.has(pType)) {
+      coveredWeight += typeWeight;
+    }
+  }
+
+  return totalWeight === 0 ? 50 : (coveredWeight / totalWeight) * 100;
 }
 
 function clamp(v: number): number {

--- a/lib/scoring/types.ts
+++ b/lib/scoring/types.ts
@@ -19,6 +19,8 @@ export interface VoteData {
   proposalType: string;
   rationaleQuality: number | null;
   importanceWeight: number;
+  /** CIP-100 metadata hash — unique per rationale document. Used for diversity detection. */
+  rationaleMetaHash: string | null;
 }
 
 export interface ProposalScoringContext {

--- a/scripts/calibration-analysis.ts
+++ b/scripts/calibration-analysis.ts
@@ -25,7 +25,7 @@ import {
   RELIABILITY_WEIGHTS,
   IDENTITY_WEIGHTS,
   CLOSE_MARGIN,
-  DISSENT_CURVE,
+  DISSENT_SUBSTANCE_MODIFIER,
   TIER_BOUNDARIES,
 } from '../lib/scoring/calibration';
 import { calibrate, type CalibrationCurve } from '../lib/ghi/calibration';
@@ -377,7 +377,7 @@ async function main() {
     reliabilityWeights: RELIABILITY_WEIGHTS,
     identityWeights: IDENTITY_WEIGHTS,
     closeMargin: CLOSE_MARGIN,
-    dissentCurve: DISSENT_CURVE,
+    dissentSubstanceModifier: DISSENT_SUBSTANCE_MODIFIER,
     tierBoundaries: TIER_BOUNDARIES,
     ghiCalibration: GHI_CALIBRATION,
     ghiComponentWeights: GHI_COMPONENT_WEIGHTS,


### PR DESCRIPTION
## Summary

Overhauls the DRep scoring engine's deliberation methodology to be defensible under public scrutiny:

- **Removes dissent rate as standalone signal** — replaced with "dissent with substance" modifier on rationale quality (1.2x when minority vote + quality >= 60, capped at 40% of votes)
- **Replaces vote diversity with rationale diversity** — detects copy-paste rationales via `meta_hash` uniqueness instead of penalizing honest voting patterns
- **Replaces type breadth with coverage breadth** — weighted by proposal frequency so treasury specialists aren't penalized for missing rare proposal types
- **Rebalances pillar weights** — EQ 35% -> 40% (hardest to game), GI 15% -> 10% (easiest to game)

## Impact
- **What changed**: Scoring methodology V3.2 — 5 deliberation signal changes + pillar weight rebalance
- **User-facing**: Yes — DRep scores will shift slightly. DReps with genuine engagement rewarded more; copy-paste rationales and strategic contrarianism penalized
- **Risk**: Medium — scoring methodology change affects all DRep scores. No data migration needed. All changes are in computation logic only.
- **Scope**: `lib/scoring/` (calibration, engagementQuality, types), `inngest/functions/sync-drep-scores.ts`, `scripts/calibration-analysis.ts`, test files

## Test plan
- [x] 17 new V3.2-specific tests covering rationale diversity, coverage breadth, dissent-with-substance modifier, and edge cases
- [x] 9 existing engagement quality tests updated for new API (Map instead of Set)
- [x] 3 drepScore regression tests updated for new weight expectations
- [x] All 847 tests pass (`npm run preflight` clean)
- [ ] Verify scores recalculate correctly on next sync cycle in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)