### PR TITLE
feat: DRep Score V3.2 methodology transparency

### DIFF
--- a/app/help/methodology/page.tsx
+++ b/app/help/methodology/page.tsx
@@ -34,11 +34,11 @@ const DREP_PILLARS = [
     weight: PILLAR_WEIGHTS.engagementQuality,
     color: 'bg-blue-500',
     description:
-      'Measures the depth of governance participation through three layers: rationale provision rate (40%), AI-assessed rationale quality (40%), and deliberation signal (20%) which captures vote diversity, dissent rate, and proposal type breadth.',
+      'Measures the depth of governance participation through three layers: rationale provision rate (40%), AI-assessed rationale quality with dissent-substance modifier (40%), and deliberation signal (20%) combining rationale diversity and coverage breadth.',
     layers: [
       'Provision Rate (40%) — importance-weighted % of votes with rationale',
-      'Rationale Quality (40%) — AI-scored reasoning quality, weighted by importance and recency',
-      'Deliberation Signal (20%) — vote diversity (40%), dissent rate (35%), type breadth (25%)',
+      'Rationale Quality (40%) — AI-scored across 5 dimensions (specificity, reasoning depth, constitutional grounding, coherence, proposal relevance). Outcome-blind: same quality earns the same score regardless of vote direction. DReps who vote against the majority AND provide quality rationale (score ≥60) receive a 1.2x bonus on that vote.',
+      'Deliberation Signal (20%) — rationale diversity (60%): penalizes copy-paste rationales across votes; coverage breadth (40%): governance surface coverage weighted by proposal availability',
     ],
   },
   {
@@ -72,10 +72,10 @@ const DREP_PILLARS = [
     weight: PILLAR_WEIGHTS.governanceIdentity,
     color: 'bg-violet-500',
     description:
-      "Rewards DReps who provide meaningful identity and intent information. Quality-tiered field scoring (not binary has/hasn't) across CIP-119 metadata fields, plus community trust signals.",
+      "Rewards DReps who provide meaningful identity and intent information. Quality-tiered field scoring (not binary has/hasn't) across CIP-119 metadata fields, with staleness decay for outdated profiles, plus delegation health signals.",
     layers: [
-      'Profile Quality (60%) — name, objectives, motivations, qualifications, bio, social links, hash verification',
-      'Community Presence (40%) — absolute delegator tiers (250+=100, 100+=95, 50+=80, 15+=60, 5+=40, 1+=20)',
+      'Profile Quality (60%) — name, objectives, motivations, qualifications, bio, social links, hash verification. Profiles not updated within 6 months start losing points (staleness decay, floor 50%)',
+      'Delegation Health (40%) — retention rate (33%): are delegators staying?; diversity (33%): is delegation power spread across many delegators?; organic growth (34%): is the DRep attracting new delegators? Falls back to delegator count tiers when insufficient snapshot history.',
     ],
   },
 ];
@@ -289,6 +289,7 @@ function TableOfContents() {
   const sections = [
     { id: 'philosophy', label: 'Philosophy' },
     { id: 'drep-scoring', label: 'DRep Scoring' },
+    { id: 'anti-gaming', label: 'Anti-Gaming Safeguards' },
     { id: 'tiers', label: 'Tier System' },
     { id: 'spo-scoring', label: 'SPO Governance Scoring' },
     { id: 'cc-transparency', label: 'CC Constitutional Fidelity' },
@@ -297,6 +298,7 @@ function TableOfContents() {
     { id: 'alignment', label: 'Alignment Dimensions' },
     { id: 'ghi', label: 'Governance Health Index' },
     { id: 'data-sources', label: 'Data Sources' },
+    { id: 'version-history', label: 'Version History' },
     { id: 'methodology-feedback', label: 'Challenge Our Methodology' },
     { id: 'citation', label: 'Citation Guide' },
   ];
@@ -376,6 +378,19 @@ export default function MethodologyPage() {
               recent score history reveals whether a DRep or SPO is improving or declining. DRep
               momentum uses a 14-day window; SPO momentum uses a 30-day window.
             </p>
+            <p>
+              <strong className="text-foreground">Outcome-blind assessment.</strong> Rationale
+              quality is assessed independently of vote direction. A well-reasoned &ldquo;No&rdquo;
+              scores the same as a well-reasoned &ldquo;Yes&rdquo;. The score never rewards or
+              penalizes political positions &mdash; only the quality of governance process.
+            </p>
+            <p>
+              <strong className="text-foreground">Honest about limitations.</strong> AI-based
+              rationale quality assessment is approximate. It evaluates reasoning structure, not
+              political correctness. Edge cases exist &mdash; a technically excellent rationale
+              referencing obscure domain knowledge may score lower than it deserves. We continuously
+              calibrate and welcome community feedback on scoring accuracy.
+            </p>
           </div>
         </section>
 
@@ -390,8 +405,8 @@ export default function MethodologyPage() {
           </p>
           <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4">
             <code className="block text-xs text-muted-foreground font-mono">
-              Score = (Engagement Quality x 0.35) + (Effective Participation x 0.25) + (Reliability
-              x 0.25) + (Governance Identity x 0.15)
+              Score = (Engagement Quality x 0.40) + (Effective Participation x 0.25) + (Reliability
+              x 0.25) + (Governance Identity x 0.10)
             </code>
           </div>
 
@@ -429,6 +444,65 @@ export default function MethodologyPage() {
                 </ul>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Anti-Gaming Safeguards */}
+        <section className="space-y-4">
+          <SectionAnchor id="anti-gaming" />
+          <h2 className="text-xl font-bold">Anti-Gaming Safeguards</h2>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Any public scoring system creates incentives. We design against known gaming vectors so
+            the score rewards genuine governance quality, not metric optimization.
+          </p>
+          <div className="space-y-3 text-sm text-muted-foreground leading-relaxed">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+              <p className="text-xs font-semibold text-foreground">
+                What the score does NOT incentivize
+              </p>
+              <ul className="space-y-1.5 text-[11px]">
+                <li className="pl-3 border-l-2 border-border">
+                  <strong className="text-foreground">Voting speed.</strong> Voting at any point
+                  within the governance window is equally valued. There is no bonus for voting
+                  first.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  <strong className="text-foreground">Strategic contrarianism.</strong> Dissent is
+                  not a standalone signal. The 1.2x quality modifier only applies when a minority
+                  vote is accompanied by a quality rationale (score 60+), and is capped at 40% of
+                  votes. Voting &ldquo;No&rdquo; without reasoning earns nothing extra.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  <strong className="text-foreground">Copy-paste rationales.</strong> Rationale
+                  diversity tracking uses CIP-100 metadata hashes to detect when the same rationale
+                  document is submitted across multiple votes. Unique, proposal-specific reasoning
+                  scores higher.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  <strong className="text-foreground">Rubber-stamping.</strong> Voting on every
+                  proposal with identical reasoning and no substantive engagement earns a low
+                  Engagement Quality score even if participation is high.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  <strong className="text-foreground">Profile set-and-forget.</strong> Governance
+                  Identity applies staleness decay to profiles not updated in 6+ months. A
+                  well-filled profile from registration day that&apos;s never maintained will
+                  gradually lose points.
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-3">
+              <p className="text-xs font-semibold text-foreground">
+                Proactive governance is naturally rewarded
+              </p>
+              <p className="text-[11px]">
+                DReps who proactively review proposals before voting tend to write more informed,
+                specific rationales. Our rationale quality assessment naturally rewards this
+                behavior &mdash; not because we measure the review, but because better preparation
+                produces better reasoning. The score measures the output (rationale quality), not
+                the input (whether you used any particular tool).
+              </p>
+            </div>
           </div>
         </section>
 
@@ -777,6 +851,70 @@ export default function MethodologyPage() {
               pipeline includes self-healing: failed syncs are retried with exponential backoff, and
               health is monitored via the System Stability GHI component.
             </p>
+          </div>
+        </section>
+
+        {/* Version History */}
+        <section className="space-y-4">
+          <SectionAnchor id="version-history" />
+          <h2 className="text-xl font-bold">Version History</h2>
+          <div className="space-y-2">
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
+              <p className="text-xs font-semibold text-foreground">
+                V3.2 (March 2026) &mdash; Defensibility Rebuild
+              </p>
+              <ul className="space-y-1 text-[11px] text-muted-foreground">
+                <li className="pl-3 border-l-2 border-border">
+                  Pillar weights rebalanced: EQ 35% &rarr; 40%, GI 15% &rarr; 10%. Engagement
+                  quality is the hardest pillar to game and the strongest signal of accountability.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Dissent removed as standalone signal. Replaced with dissent-with-substance
+                  modifier (1.2x quality bonus for minority votes with rationale quality 60+).
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Deliberation signal rebuilt: vote diversity &rarr; rationale diversity (catches
+                  copy-paste); type breadth &rarr; coverage breadth (weighted by proposal
+                  availability).
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Governance Identity: delegation health signals (retention, diversity, growth)
+                  replace raw delegator count. Profile staleness decay added.
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
+              <p className="text-xs font-semibold text-foreground">V3.1 (February 2026)</p>
+              <ul className="space-y-1 text-[11px] text-muted-foreground">
+                <li className="pl-3 border-l-2 border-border">
+                  Added AI rationale quality scoring (5-dimension assessment).
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Introduced importance weighting for proposals (3x critical, 2x important).
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Added confidence gating (vote count tiers cap achievable rank).
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border/50 bg-card/70 backdrop-blur-md p-4 space-y-2">
+              <p className="text-xs font-semibold text-foreground">
+                V3.0 (January 2026) &mdash; Four-Pillar Architecture
+              </p>
+              <ul className="space-y-1 text-[11px] text-muted-foreground">
+                <li className="pl-3 border-l-2 border-border">
+                  Initial four-pillar model: Engagement Quality, Effective Participation,
+                  Reliability, Governance Identity.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Absolute calibration curves (not percentile ranking). Temporal decay with{' '}
+                  {DECAY_HALF_LIFE_DAYS}-day half-life.
+                </li>
+                <li className="pl-3 border-l-2 border-border">
+                  Six-tier system (Emerging through Legendary) shared across DReps and SPOs.
+                </li>
+              </ul>
+            </div>
           </div>
         </section>
 

--- a/components/DRepQuickView.tsx
+++ b/components/DRepQuickView.tsx
@@ -57,9 +57,10 @@ export function DRepQuickView({
   const score = drep.drepScore ?? 0;
 
   const pillars = [
-    { label: 'Effective Participation', value: drep.effectiveParticipation, weight: '45%' },
-    { label: 'Rationale Quality', value: drep.rationaleRate, weight: '35%' },
-    { label: 'Reliability', value: drep.reliabilityScore, weight: '20%' },
+    { label: 'Engagement Quality', value: drep.rationaleRate, weight: '40%' },
+    { label: 'Effective Participation', value: drep.effectiveParticipation, weight: '25%' },
+    { label: 'Reliability', value: drep.reliabilityScore, weight: '25%' },
+    { label: 'Governance Identity', value: drep.profileCompleteness, weight: '10%' },
   ];
 
   return (

--- a/components/DRepTable.tsx
+++ b/components/DRepTable.tsx
@@ -140,7 +140,7 @@ export function DRepTable({
             <SortableHeader
               columnKey="drepScore"
               label="DRep Score"
-              tooltip="An objective 0-100 accountability score based on Effective Participation (45%), Rationale (35%), and Consistency (20%). Hover over the score for breakdown."
+              tooltip="An objective 0-100 accountability score based on Engagement Quality (40%), Effective Participation (25%), Reliability (25%), and Governance Identity (10%). Hover over the score for breakdown."
               align="center"
             />
 

--- a/components/InfoModal.tsx
+++ b/components/InfoModal.tsx
@@ -122,31 +122,41 @@ export function DRepScoreModal() {
       <p>
         Formula:{' '}
         <code className="bg-muted px-2 py-0.5 rounded">
-          Effective Participation (45%) + Rationale (35%) + Consistency (20%)
+          Engagement Quality (40%) + Effective Participation (25%) + Reliability (25%) + Governance
+          Identity (10%)
         </code>
       </p>
       <div className="bg-muted p-4 rounded-lg space-y-3">
         <div>
-          <p className="font-medium mb-1">Effective Participation (45%)</p>
+          <p className="font-medium mb-1">Engagement Quality (40%)</p>
           <p className="text-sm text-muted-foreground">
-            How often this DRep votes on available proposals, with a discount applied if they vote
-            uniformly (&gt;85% one direction), which suggests rubber-stamping.
+            How well this DRep explains their votes. Three layers: rationale provision rate,
+            AI-assessed rationale quality (outcome-blind), and deliberation signals including
+            rationale diversity and coverage breadth.
           </p>
         </div>
         <div>
-          <p className="font-medium mb-1">Rationale (35%)</p>
+          <p className="font-medium mb-1">Effective Participation (25%)</p>
           <p className="text-sm text-muted-foreground">
-            How often this DRep submits on-chain rationale metadata with their votes. This measures
-            governance transparency through the official CIP-100 standard. Some DReps share
-            reasoning through external channels (blogs, videos) that isn&apos;t captured by this
-            metric.
+            How often this DRep votes on available proposals, weighted by proposal importance.
+            Critical proposals (hard forks, constitutional changes) count 3x. Close-margin proposals
+            receive a 1.5x bonus.
           </p>
         </div>
         <div>
-          <p className="font-medium mb-1">Consistency (20%)</p>
+          <p className="font-medium mb-1">Reliability (25%)</p>
           <p className="text-sm text-muted-foreground">
-            How steadily this DRep participates over time. A DRep who votes consistently across
-            epochs scores higher than one who was active then disappeared.
+            How steadily this DRep participates over time. Active streak, recency, gap penalty, and
+            tenure. A DRep who votes consistently across epochs scores higher than one who was
+            active then disappeared.
+          </p>
+        </div>
+        <div>
+          <p className="font-medium mb-1">Governance Identity (10%)</p>
+          <p className="text-sm text-muted-foreground">
+            Profile quality (CIP-119 metadata completeness with staleness decay) and delegation
+            health (retention, diversity, growth). Well-documented DReps with healthy delegation
+            relationships score higher.
           </p>
         </div>
       </div>

--- a/components/MethodologyAccordion.tsx
+++ b/components/MethodologyAccordion.tsx
@@ -19,12 +19,44 @@ export function MethodologyAccordion() {
           <AccordionTrigger className="text-xs py-2">Overall Formula</AccordionTrigger>
           <AccordionContent className="text-xs text-muted-foreground space-y-2">
             <code className="block bg-muted p-2 rounded text-[11px]">
-              Score = (Participation × 0.30) + (Rationale × 0.35) + (Reliability × 0.20) + (Profile
-              × 0.15)
+              Score = (Engagement Quality × 0.40) + (Effective Participation × 0.25) + (Reliability
+              × 0.25) + (Governance Identity × 0.10)
             </code>
             <p>
-              Rationale is weighted highest because explaining votes is the best signal of
-              accountability.
+              Engagement Quality is weighted highest because explaining votes with quality reasoning
+              is the strongest signal of governance accountability.
+            </p>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="engagement">
+          <AccordionTrigger className="text-xs py-2">
+            <span className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-blue-500" />
+              Engagement Quality (40%)
+            </span>
+          </AccordionTrigger>
+          <AccordionContent className="text-xs text-muted-foreground space-y-2">
+            <p>
+              Three layers measuring depth of governance engagement: rationale provision,
+              AI-assessed rationale quality, and deliberation signals.
+            </p>
+            <ul className="list-disc pl-4 space-y-0.5">
+              <li>
+                <strong>Provision Rate (40%)</strong>: Importance-weighted % of votes with rationale
+              </li>
+              <li>
+                <strong>Rationale Quality (40%)</strong>: AI-scored reasoning quality. Outcome-blind
+                &mdash; same quality earns the same score regardless of vote direction
+              </li>
+              <li>
+                <strong>Deliberation Signal (20%)</strong>: Rationale diversity (60%) + coverage
+                breadth (40%)
+              </li>
+            </ul>
+            <p>
+              DReps who vote against the majority with quality rationale (score 60+) receive a 1.2x
+              quality bonus. Copy-paste rationales are detected and penalized.
             </p>
           </AccordionContent>
         </AccordionItem>
@@ -32,106 +64,78 @@ export function MethodologyAccordion() {
         <AccordionItem value="participation">
           <AccordionTrigger className="text-xs py-2">
             <span className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-blue-500" />
-              Effective Participation (30%)
+              <span className="h-2 w-2 rounded-full bg-emerald-500" />
+              Effective Participation (25%)
             </span>
           </AccordionTrigger>
           <AccordionContent className="text-xs text-muted-foreground space-y-2">
             <p>
-              Raw participation rate adjusted by a Deliberation Modifier that penalizes uniform
-              voting patterns.
+              Importance-weighted voting coverage with temporal decay. Critical proposals (hard
+              forks, constitutional changes) count 3x; important proposals 2x.
             </p>
             <ul className="list-disc pl-4 space-y-0.5">
-              <li>&gt;95% same direction: 30% penalty</li>
-              <li>&gt;90% same direction: 15% penalty</li>
-              <li>≤85% same direction: no penalty</li>
+              <li>Close-margin proposals (decided by &lt;20% margin) receive a 1.5x bonus</li>
+              <li>Older votes decay over time &mdash; current engagement matters most</li>
             </ul>
-            <p>
-              Rubber-stamping is penalized — thoughtful DReps engage with each proposal
-              individually.
-            </p>
-          </AccordionContent>
-        </AccordionItem>
-
-        <AccordionItem value="rationale">
-          <AccordionTrigger className="text-xs py-2">
-            <span className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-green-500" />
-              Rationale Quality (35%)
-            </span>
-          </AccordionTrigger>
-          <AccordionContent className="text-xs text-muted-foreground space-y-2">
-            <p>
-              Measures how often meaningful on-chain rationale is provided, weighted by proposal
-              importance.
-            </p>
-            <ul className="list-disc pl-4 space-y-0.5">
-              <li>
-                <strong>Critical (3×)</strong>: Hard forks, no confidence, committee changes
-              </li>
-              <li>
-                <strong>Important (2×)</strong>: Treasury withdrawals &gt;1M, parameter changes
-              </li>
-              <li>
-                <strong>Standard (1×)</strong>: Routine treasury withdrawals
-              </li>
-            </ul>
-            <p>
-              A forgiving curve rewards initial effort. Min 50 characters to count as rationale.
-            </p>
           </AccordionContent>
         </AccordionItem>
 
         <AccordionItem value="reliability">
           <AccordionTrigger className="text-xs py-2">
             <span className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-purple-500" />
-              Reliability (20%)
+              <span className="h-2 w-2 rounded-full bg-amber-500" />
+              Reliability (25%)
             </span>
           </AccordionTrigger>
           <AccordionContent className="text-xs text-muted-foreground space-y-2">
             <p>
-              Tracks the pattern of engagement over time — can you count on this DRep to show up?
+              Tracks the pattern of engagement over time &mdash; can you count on this DRep to show
+              up?
             </p>
             <ul className="list-disc pl-4 space-y-0.5">
               <li>
-                <strong>Active Streak (35%)</strong>: Consecutive epochs with votes
+                <strong>Active Streak (35%)</strong>: Consecutive proposal-active epochs with votes
               </li>
               <li>
                 <strong>Recency (30%)</strong>: Exponential decay since last vote
               </li>
               <li>
-                <strong>Gap Penalty (20%)</strong>: Penalizes longest inactivity stretch
+                <strong>Gap Penalty (25%)</strong>: Penalizes longest inactivity stretch
               </li>
               <li>
-                <strong>Tenure (15%)</strong>: Time since first vote (log curve)
+                <strong>Tenure (10%)</strong>: Time since first vote (log curve)
               </li>
             </ul>
           </AccordionContent>
         </AccordionItem>
 
-        <AccordionItem value="profile">
+        <AccordionItem value="identity">
           <AccordionTrigger className="text-xs py-2">
             <span className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-cyan-500" />
-              Profile Completeness (15%)
+              <span className="h-2 w-2 rounded-full bg-violet-500" />
+              Governance Identity (10%)
             </span>
           </AccordionTrigger>
           <AccordionContent className="text-xs text-muted-foreground space-y-2">
-            <p>Rewards DReps who provide useful identity and intent information:</p>
-            <ul className="list-disc pl-4 space-y-0.5">
-              <li>Name, bio/description, social links</li>
-              <li>Objectives, motivations, qualifications (CIP-119)</li>
-              <li>Payment address for accountability</li>
-            </ul>
             <p>
-              Well-documented profiles score higher since delegators can make informed decisions.
+              Rewards DReps who provide meaningful identity information and maintain healthy
+              delegation relationships.
             </p>
+            <ul className="list-disc pl-4 space-y-0.5">
+              <li>
+                <strong>Profile Quality (60%)</strong>: CIP-119 metadata completeness with staleness
+                decay for outdated profiles
+              </li>
+              <li>
+                <strong>Delegation Health (40%)</strong>: Retention, diversity, and organic growth
+                signals
+              </li>
+            </ul>
           </AccordionContent>
         </AccordionItem>
       </Accordion>
       <Link
-        href="/methodology"
+        href="/help/methodology"
         className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
       >
         See full methodology &rarr;

--- a/components/ScoreBreakdown.tsx
+++ b/components/ScoreBreakdown.tsx
@@ -3,7 +3,7 @@
 /**
  * Score Breakdown Component
  * Provides tooltip content for DRep Score breakdown
- * Shows: Rationale (35%), Effective Participation (30%), Reliability (20%), Profile (15%)
+ * Shows: Engagement Quality (40%), Effective Participation (25%), Reliability (25%), Governance Identity (10%)
  */
 
 import { EnrichedDRep } from '@/lib/koios';
@@ -17,10 +17,10 @@ interface ScoreBreakdownProps {
 }
 
 export const WEIGHTS = {
-  effectiveParticipation: 0.3,
-  rationale: 0.35,
-  reliability: 0.2,
-  profileCompleteness: 0.15,
+  engagementQuality: 0.4,
+  effectiveParticipation: 0.25,
+  reliability: 0.25,
+  governanceIdentity: 0.1,
 };
 
 export function ScoreBreakdownTooltip({ drep, children }: ScoreBreakdownProps) {
@@ -33,32 +33,32 @@ export function ScoreBreakdownTooltip({ drep, children }: ScoreBreakdownProps) {
 
   const components = [
     {
+      label: 'Engagement Quality',
+      value: applyRationaleCurve(safeRationale),
+      weight: WEIGHTS.engagementQuality,
+      description:
+        'Rationale provision, AI-assessed quality, and deliberation signals. Outcome-blind scoring rewards quality reasoning regardless of vote direction.',
+    },
+    {
       label: 'Effective Participation',
       value: safeEffectiveParticipation,
       weight: WEIGHTS.effectiveParticipation,
       description:
-        'How often this DRep votes on available proposals. Discounted if voting pattern suggests rubber-stamping.',
-    },
-    {
-      label: 'Rationale',
-      value: applyRationaleCurve(safeRationale),
-      weight: WEIGHTS.rationale,
-      description:
-        'Weighted by proposal importance. InfoActions excluded. Curve-adjusted to reward consistent effort.',
+        'Importance-weighted voting coverage. Critical proposals count 3x, close-margin proposals get a 1.5x bonus.',
     },
     {
       label: 'Reliability',
       value: safeReliability,
       weight: WEIGHTS.reliability,
       description:
-        'Can delegators count on this DRep to keep showing up? Measures voting streak, recency, and gaps.',
+        'Can delegators count on this DRep to keep showing up? Measures active streak, recency, gaps, and tenure.',
     },
     {
-      label: 'Profile Completeness',
+      label: 'Governance Identity',
       value: safeProfileCompleteness,
-      weight: WEIGHTS.profileCompleteness,
+      weight: WEIGHTS.governanceIdentity,
       description:
-        'CIP-119 metadata completeness: objectives, motivations, qualifications, and verified social links.',
+        'Profile quality (CIP-119 metadata with staleness decay) and delegation health (retention, diversity, growth).',
     },
   ];
 

--- a/components/governada/identity/DRepScorecardView.tsx
+++ b/components/governada/identity/DRepScorecardView.tsx
@@ -56,14 +56,14 @@ export function DRepScorecardView() {
 
   const { score } = data;
   const pillars = [
-    { label: 'Engagement Quality', value: score.pillars.engagementQuality, weight: '35%' },
+    { label: 'Engagement Quality', value: score.pillars.engagementQuality, weight: '40%' },
     {
       label: 'Effective Participation',
       value: score.pillars.effectiveParticipation,
       weight: '25%',
     },
     { label: 'Reliability', value: score.pillars.reliability, weight: '25%' },
-    { label: 'Governance Identity', value: score.pillars.governanceIdentity, weight: '15%' },
+    { label: 'Governance Identity', value: score.pillars.governanceIdentity, weight: '10%' },
   ];
 
   const TrendIcon = score.trend >= 0 ? TrendingUp : TrendingDown;

--- a/components/governada/mygov/DRepCommandCenter.tsx
+++ b/components/governada/mygov/DRepCommandCenter.tsx
@@ -57,10 +57,10 @@ import type {
 } from '@/types/api';
 
 const PILLAR_META = [
-  { key: 'engagementQuality', label: 'Engagement', icon: Zap, weight: '35%' },
+  { key: 'engagementQuality', label: 'Engagement', icon: Zap, weight: '40%' },
   { key: 'effectiveParticipation', label: 'Participation', icon: Vote, weight: '25%' },
   { key: 'reliability', label: 'Reliability', icon: Shield, weight: '25%' },
-  { key: 'governanceIdentity', label: 'Identity', icon: Fingerprint, weight: '15%' },
+  { key: 'governanceIdentity', label: 'Identity', icon: Fingerprint, weight: '10%' },
 ] as const;
 
 const ALIGNMENT_META = [

--- a/components/ui/ScoreExplainer.tsx
+++ b/components/ui/ScoreExplainer.tsx
@@ -9,9 +9,9 @@ type ScoreType = 'drep' | 'spo';
 const EXPLAINERS: Record<ScoreType, { pillars: string; summary: string }> = {
   drep: {
     pillars:
-      'Engagement Quality (35%) · Participation (25%) · Reliability (25%) · Governance Identity (15%)',
+      'Engagement Quality (40%) · Participation (25%) · Reliability (25%) · Governance Identity (10%)',
     summary:
-      'Higher scores mean this DRep votes consistently, explains their reasoning, and maintains an active governance presence.',
+      'Higher scores mean this DRep votes consistently, explains their reasoning with quality rationales, and maintains an active governance presence.',
   },
   spo: {
     pillars: 'Participation (35%) · Deliberation (25%) · Reliability (25%) · Identity (15%)',


### PR DESCRIPTION
## Summary
- Update all scoring documentation and UI components to reflect V3.2 pillar weights (EQ 40%, EP 25%, Reliability 25%, GI 10%)
- Add anti-gaming safeguards section, version history, calibration philosophy, and proactive governance explanation to methodology page
- Fix 9 component files with stale V1/V2 weight references (ScoreExplainer, MethodologyAccordion, InfoModal, DRepTable, DRepQuickView, ScoreBreakdown, DRepScorecardView, DRepCommandCenter)

## Impact
- **What changed**: All public-facing scoring methodology docs and UI tooltips now accurately reflect V3.2 scoring model
- **User-facing**: Yes — methodology page has new sections (anti-gaming, version history), all pillar weight displays corrected
- **Risk**: Low — documentation/UI only, no scoring function changes
- **Scope**: 9 files in app/help/ and components/

## Test plan
- [x] All 862 tests pass
- [x] Format, lint, type-check clean
- [ ] Verify methodology page renders correctly at /help/methodology
- [ ] Verify ScoreExplainer tooltip shows correct weights on DRep cards
- [ ] Verify MethodologyAccordion shows V3.2 formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)