### PR TITLE
feat: SPO Score V3.2 attribution, methodology & versioning UI

### DIFF
--- a/app/help/methodology/page.tsx
+++ b/app/help/methodology/page.tsx
@@ -98,11 +98,12 @@ const SPO_PILLARS = [
     weight: SPO_PILLAR_WEIGHTS.deliberation,
     color: 'bg-emerald-500',
     description:
-      'Multi-signal measure of deliberation depth, including bot-detection via vote timing analysis.',
+      'Voting behavior signals that reward thoughtful, independent governance participation. Penalizes rubber-stamping and abstain-farming.',
     layers: [
-      'Rationale Provision (40%) — importance-weighted % with rationale',
-      'Vote Timing Distribution (30%) — stddev of time-to-vote (natural variation scores highest)',
-      'Proposal Coverage Entropy (30%) — Shannon entropy across proposal types',
+      'Vote Diversity (35%) — penalizes >85% same-direction voting with abstain penalty',
+      'Dissent Rate (30%) — 15-40% minority voting is the sweet spot for independent thinking',
+      'Type Breadth (20%) — fraction of distinct proposal types voted on',
+      'Coverage Entropy (15%) — Shannon entropy across proposal types',
     ],
   },
   {
@@ -124,10 +125,10 @@ const SPO_PILLARS = [
     weight: SPO_PILLAR_WEIGHTS.governanceIdentity,
     color: 'bg-violet-500',
     description:
-      'Evaluates pool identity quality and community trust. Governance statements are scored via a keyword quality checklist rather than pure character count.',
+      'Evaluates pool identity quality cross-validated against actual governance behavior. Metadata-only profiles score lower than profiles backed by voting activity. Pool size (delegator count) is excluded from governance scoring.',
     layers: [
-      'Pool Identity Quality (60%) — ticker, name, governance statement (keyword checklist), description, homepage, social links, hash verification',
-      'Delegation Responsiveness (40%) — delegator retention after governance activity (falls back to count percentile)',
+      'Pool Identity Quality (60%) — metadata fields cross-validated against voting activity (statement points gated behind vote counts)',
+      'Delegation Responsiveness (40%) — delegator retention after governance activity (neutral 50 default when insufficient data)',
     ],
   },
 ];

--- a/components/governada/identity/SPOScorecardView.tsx
+++ b/components/governada/identity/SPOScorecardView.tsx
@@ -6,6 +6,8 @@ import { useSPOPoolCompetitive, useSPOSummary } from '@/hooks/queries';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ExternalLink } from 'lucide-react';
+import { ScoreVersionBadge } from '@/components/ui/ScoreVersionBadge';
+import { CURRENT_SPO_SCORE_VERSION } from '@/lib/scoring/versioning';
 
 /**
  * SPOScorecardView — Your personal pool governance scorecard.
@@ -77,6 +79,7 @@ export function SPOScorecardView() {
             <div className="flex items-baseline gap-2">
               <span className="text-5xl font-bold tabular-nums text-foreground">{score}</span>
               <span className="text-sm text-muted-foreground">/100</span>
+              <ScoreVersionBadge version={CURRENT_SPO_SCORE_VERSION} entityType="spo" />
             </div>
           </div>
           <div className="text-right space-y-1">

--- a/components/ui/ScoreVersionBadge.tsx
+++ b/components/ui/ScoreVersionBadge.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import type { ScoredEntityType } from '@/lib/scoring/versioning';
+
+interface ScoreVersionBadgeProps {
+  version: string;
+  entityType: ScoredEntityType;
+}
+
+/**
+ * ScoreVersionBadge — Small mono badge showing the scoring methodology version.
+ * Links to the methodology page anchored to the relevant entity section.
+ */
+export function ScoreVersionBadge({ version, entityType }: ScoreVersionBadgeProps) {
+  return (
+    <Link
+      href={`/help/methodology#${entityType}-scoring`}
+      className="inline-flex items-center text-[10px] font-mono text-muted-foreground/60 border border-border/30 rounded px-1.5 py-0.5 hover:text-muted-foreground transition-colors"
+      title={`Scoring methodology V${version} — click to learn more`}
+    >
+      V{version}
+    </Link>
+  );
+}

--- a/docs/adr/006-spo-scoring-methodology.md
+++ b/docs/adr/006-spo-scoring-methodology.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — **V2 (current, Mar 2026)**. Supersedes V1 3-pillar model.
+Accepted — **V3.2 (current, Mar 2026)**. Supersedes V3.1.
 
 ## Context
 
@@ -86,6 +86,48 @@ Same tier system as DRep Score: Emerging (0-39), Bronze (40-54), Silver (55-69),
 - Shared: `lib/scoring/percentile.ts`, `lib/scoring/types.ts`
 - Pipeline: `inngest/functions/sync-spo-scores.ts`
 - Storage: `pools` table (current scores), `spo_score_snapshots` (history)
+
+## V3.2 Changes (Mar 2026)
+
+V3.2 is a methodology hardening release. Weights are unchanged; sub-component formulas are rewritten for robustness.
+
+### Deliberation Quality Rewrite
+
+Replaced the V3.1 three-layer model (Rationale Provision 40%, Vote Timing Distribution 30%, Proposal Coverage Entropy 30%) with a four-layer behavioral model:
+
+- **Vote Diversity (35%)** — penalizes >85% same-direction voting with an abstain penalty. Rubber-stamping and abstain-farming both score poorly.
+- **Dissent Rate (30%)** — 15-40% minority voting is the sweet spot. Too low = herd behavior; too high = contrarian noise.
+- **Type Breadth (20%)** — fraction of distinct proposal types voted on.
+- **Coverage Entropy (15%)** — Shannon entropy across proposal types (retained from V3.1 at lower weight).
+
+Rationale provision and vote timing were removed. SPOs rarely provide rationales (unlike DReps), making that signal noisy. Vote timing was intended for bot detection but produced false positives on pools that batch-vote.
+
+### Governance Identity Hardening
+
+- **Pool Identity Quality (60%)** now cross-validates metadata against voting activity. Governance statement points are gated behind minimum vote counts — a pool with a great statement but zero votes scores lower than one with a basic statement and active voting.
+- **Delegation Responsiveness (40%)** uses a neutral 50 default when insufficient data exists (was falling back to count percentile, which leaked pool size into governance scoring).
+- Pool size (delegator count) fully excluded from governance scoring.
+
+### Graduated Confidence System
+
+Tier caps based on vote count, mirroring DRep Score:
+
+- <3 votes: capped at Emerging
+- 3-5 votes: capped at Bronze
+- 6-9 votes: capped at Silver
+- 10+ votes: uncapped
+
+### Sybil/Gaming Penalty
+
+Pools with >95% same-direction votes AND abstain rate >40% receive a composite penalty (multiplier 0.7-0.9). Targets abstain-farming patterns.
+
+### Versioning Infrastructure
+
+Every score write now includes `score_version` column. Historical scores are traceable to the methodology version that produced them. UI displays version badge linking to methodology changelog.
+
+## V3.1 (Historical)
+
+V3.1 introduced the 4-pillar model (Participation 38%, Deliberation 24%, Reliability 23%, Identity 15%) with percentile normalization, importance weighting, and temporal decay. See the V2 section below for the original 4-pillar specification which V3.1 was based on.
 
 ## Consequences
 

--- a/lib/scoring/spoAttribution.ts
+++ b/lib/scoring/spoAttribution.ts
@@ -1,12 +1,14 @@
 /**
- * Per-vote attribution engine for SPO Score V3.
+ * Per-vote attribution engine for SPO Score V3.2.
  * Decomposes each pillar score into specific vote-level contributions,
  * producing actionable explanations like "Your reliability dropped 8 points
  * due to a 4-epoch gap in epochs 482-486."
  */
 
 import { DECAY_LAMBDA } from './types';
+import { SPO_ABSTAIN_PENALTY } from './calibration';
 import type { SpoVoteDataV3 } from './spoScore';
+import type { SpoDeliberationVoteData } from './spoDeliberationQuality';
 
 export interface AttributionEntry {
   proposalKey: string | null;
@@ -33,6 +35,7 @@ export interface SpoAttribution {
     identity: PillarAttribution;
   };
   recommendations: string[];
+  sybilFlagged?: boolean;
 }
 
 /**
@@ -79,8 +82,256 @@ export function computeParticipationAttribution(
   return { contributions };
 }
 
+// ---------------------------------------------------------------------------
+// Deliberation Attribution
+// ---------------------------------------------------------------------------
+
+/**
+ * Break down the V3.2 deliberation quality sub-components into
+ * human-readable attribution entries.
+ */
+export function computeDeliberationAttribution(
+  votes: SpoDeliberationVoteData[],
+  allProposalTypes: Set<string>,
+): { contributions: AttributionEntry[] } {
+  const contributions: AttributionEntry[] = [];
+
+  if (votes.length === 0) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 0,
+      reason: 'No votes cast — deliberation quality cannot be measured',
+    });
+    return { contributions };
+  }
+
+  // --- Vote Diversity ---
+  let yesCount = 0;
+  let noCount = 0;
+  let abstainCount = 0;
+  for (const v of votes) {
+    if (v.vote === 'Yes') yesCount++;
+    else if (v.vote === 'No') noCount++;
+    else abstainCount++;
+  }
+  const total = votes.length;
+  const abstainRate = abstainCount / total;
+  const nonAbstain = yesCount + noCount;
+  const dominantDir = yesCount >= noCount ? 'Yes' : 'No';
+  const dominantPct =
+    nonAbstain > 0 ? Math.round((Math.max(yesCount, noCount) / nonAbstain) * 100) : 0;
+  const abstainPenaltyApplied = abstainRate > SPO_ABSTAIN_PENALTY.threshold;
+
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: dominantPct <= 85 ? 10 : -10,
+    reason:
+      nonAbstain === 0
+        ? 'Vote Diversity: All votes are Abstain — no directional diversity'
+        : `Vote Diversity: ${dominantPct}% ${dominantDir} among non-abstain votes` +
+          (dominantPct > 85 ? ' (rubber-stamp penalty applied)' : ' (healthy mix)') +
+          (abstainPenaltyApplied
+            ? `. Abstain penalty active (${Math.round(abstainRate * 100)}% abstain rate > ${Math.round(SPO_ABSTAIN_PENALTY.threshold * 100)}% threshold)`
+            : ''),
+  });
+
+  // --- Dissent Rate ---
+  const eligibleVotes = votes.filter((v) => v.spoMajorityVote != null && v.vote !== 'Abstain');
+  let dissentCount = 0;
+  for (const v of eligibleVotes) {
+    if (v.vote !== v.spoMajorityVote) dissentCount++;
+  }
+  const dissentPct =
+    eligibleVotes.length > 0 ? Math.round((dissentCount / eligibleVotes.length) * 100) : 0;
+  const inSweetSpot = dissentPct >= 15 && dissentPct <= 40;
+
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: inSweetSpot ? 10 : dissentPct === 0 ? -10 : 0,
+    reason:
+      eligibleVotes.length < 3
+        ? `Dissent Rate: Insufficient majority data (${eligibleVotes.length} eligible votes, need 3) — neutral score applied`
+        : `Dissent Rate: ${dissentPct}% of votes against SPO majority` +
+          (inSweetSpot
+            ? ' (in 15-40% sweet spot — full score)'
+            : dissentPct < 15
+              ? ' (below 15% — consider voting independently more often)'
+              : ' (above 40% — high contrarian rate reduces score)'),
+  });
+
+  // --- Type Breadth ---
+  const votedTypes = new Set<string>();
+  for (const v of votes) votedTypes.add(v.proposalType);
+  const coveredTypes = [...votedTypes];
+  const missingTypes = [...allProposalTypes].filter((t) => !votedTypes.has(t));
+
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: missingTypes.length === 0 ? 10 : -Math.min(10, missingTypes.length * 3),
+    reason:
+      `Type Breadth: Voted on ${coveredTypes.length}/${allProposalTypes.size} proposal types` +
+      (coveredTypes.length > 0 ? ` (${coveredTypes.join(', ')})` : '') +
+      (missingTypes.length > 0 ? `. Missing: ${missingTypes.join(', ')}` : ' — full coverage'),
+  });
+
+  // --- Coverage Entropy ---
+  const typeCounts = new Map<string, number>();
+  for (const v of votes) {
+    typeCounts.set(v.proposalType, (typeCounts.get(v.proposalType) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of typeCounts.values()) {
+    const p = count / total;
+    if (p > 0) entropy -= p * Math.log2(p);
+  }
+  const maxEntropy = allProposalTypes.size > 1 ? Math.log2(allProposalTypes.size) : 1;
+  const entropyNormalized = Math.round((entropy / maxEntropy) * 100);
+
+  // Find the type that would most improve entropy if voted on more
+  let bestImprovementType: string | null = null;
+  if (missingTypes.length > 0) {
+    bestImprovementType = missingTypes[0];
+  } else {
+    // Find least-represented type
+    let minCount = Infinity;
+    for (const [t, c] of typeCounts) {
+      if (c < minCount) {
+        minCount = c;
+        bestImprovementType = t;
+      }
+    }
+  }
+
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: entropyNormalized >= 70 ? 5 : -5,
+    reason:
+      `Coverage Entropy: ${entropyNormalized}/100 (${entropyNormalized >= 70 ? 'well-balanced' : 'uneven'} distribution across types)` +
+      (bestImprovementType
+        ? `. Voting on more ${bestImprovementType} proposals would improve balance`
+        : ''),
+  });
+
+  return { contributions };
+}
+
+// ---------------------------------------------------------------------------
+// Identity Attribution
+// ---------------------------------------------------------------------------
+
+export interface IdentityFields {
+  hasGovernanceStatement: boolean;
+  governanceStatementLength: number;
+  socialLinkCount: number;
+  communityScore: number;
+  voteCount: number;
+}
+
+/**
+ * Report which identity fields contribute points and which are
+ * gated behind vote count thresholds.
+ */
+export function computeIdentityAttribution(fields: IdentityFields): {
+  contributions: AttributionEntry[];
+} {
+  const contributions: AttributionEntry[] = [];
+  const {
+    hasGovernanceStatement,
+    governanceStatementLength,
+    socialLinkCount,
+    communityScore,
+    voteCount,
+  } = fields;
+
+  // Governance statement presence: +5 pts, requires 1+ votes
+  if (hasGovernanceStatement && voteCount >= 1) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 5,
+      reason: 'Governance statement present: +5 pts (requires 1+ votes)',
+    });
+  } else if (hasGovernanceStatement && voteCount === 0) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 0,
+      reason: 'Governance statement: 0 pts (no votes cast — gated behind 1+ votes)',
+    });
+  } else {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 0,
+      reason: 'Governance statement: not set (0 pts)',
+    });
+  }
+
+  // Statement length >100 chars: +5 pts, requires 3+ votes
+  if (hasGovernanceStatement && governanceStatementLength > 100 && voteCount >= 3) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 5,
+      reason: `Statement length ${governanceStatementLength} chars (>100): +5 pts (requires 3+ votes)`,
+    });
+  } else if (hasGovernanceStatement && governanceStatementLength > 100 && voteCount < 3) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 0,
+      reason: `Statement length ${governanceStatementLength} chars (>100): 0 pts (need ${3 - voteCount} more votes to unlock)`,
+    });
+  } else if (hasGovernanceStatement) {
+    contributions.push({
+      proposalKey: null,
+      type: null,
+      contribution: 0,
+      reason: `Statement length ${governanceStatementLength} chars (≤100): expand to >100 chars for +5 pts`,
+    });
+  }
+
+  // Social links
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: Math.min(socialLinkCount, 3) * 10,
+    reason:
+      socialLinkCount > 0
+        ? `Social links (${socialLinkCount} valid): +${Math.min(socialLinkCount, 3) * 10} pts`
+        : 'Social links: none set (0 pts — add up to 3 for +30 pts)',
+  });
+
+  // Community score
+  contributions.push({
+    proposalKey: null,
+    type: null,
+    contribution: communityScore,
+    reason:
+      communityScore > 50
+        ? `Community score: ${communityScore} (above neutral — strong delegation retention)`
+        : communityScore < 50
+          ? `Community score: ${communityScore} (below neutral — delegation retention declining)`
+          : `Community score: ${communityScore} (neutral — delegation retention data insufficient)`,
+  });
+
+  return { contributions };
+}
+
+// ---------------------------------------------------------------------------
+// Recommendations (V3.2)
+// ---------------------------------------------------------------------------
+
 /**
  * Generate actionable recommendations based on pillar scores.
+ *
+ * V3.2: Replaces rationale-based recommendations with voting behavior signals.
+ * New params are optional for backward compatibility.
  */
 export function generateRecommendations(
   participationPct: number,
@@ -90,8 +341,20 @@ export function generateRecommendations(
   hasRationale: boolean,
   hasGovernanceStatement: boolean,
   hasSocialLinks: boolean,
+  voteDiversityPct: number = 50,
+  dissentPct: number = 20,
+  abstainRate: number = 0,
+  voteCount: number = 10,
+  hasSybilFlag: boolean = false,
 ): string[] {
   const recommendations: string[] = [];
+
+  // Sybil flag — always top priority
+  if (hasSybilFlag) {
+    recommendations.push(
+      'Your pool has been flagged for high vote correlation with another pool. This reduces your score confidence.',
+    );
+  }
 
   // Find weakest pillar (weighted by impact)
   const pillars = [
@@ -103,23 +366,46 @@ export function generateRecommendations(
 
   const weakest = pillars[0];
 
+  // Participation
   if (weakest.name === 'participation' || participationPct < 40) {
     recommendations.push('Vote on open governance proposals to improve your Participation score');
   }
+
+  // Deliberation — V3.2 behavior-based recommendations
   if (weakest.name === 'deliberation' || deliberationPct < 40) {
-    if (!hasRationale) {
+    if (voteDiversityPct > 85) {
       recommendations.push(
-        'Provide rationales when voting to unlock the Deliberation Quality pillar',
+        'Consider varying your votes — voting the same direction on every proposal reduces your Deliberation Quality score',
       );
-    } else {
+    }
+    if (dissentPct === 0) {
+      recommendations.push(
+        'Independent judgment is valued — voting against the majority when you disagree demonstrates governance maturity',
+      );
+    }
+    if (abstainRate > 0.6) {
+      recommendations.push(
+        'Taking positions strengthens your score — abstaining on most votes signals disengagement',
+      );
+    }
+    // Fallback if none of the specific deliberation issues apply
+    if (voteDiversityPct <= 85 && dissentPct > 0 && abstainRate <= 0.6) {
       recommendations.push('Vote across different proposal types to improve your coverage entropy');
     }
   }
+
+  // Reliability
   if (weakest.name === 'reliability' || reliabilityPct < 40) {
     recommendations.push('Vote consistently every epoch to build your reliability streak');
   }
+
+  // Identity
   if (weakest.name === 'identity' || identityPct < 40) {
-    if (!hasGovernanceStatement) {
+    if (!hasGovernanceStatement && voteCount < 1) {
+      recommendations.push(
+        'Add a governance statement AND start voting — identity points are gated behind voting activity',
+      );
+    } else if (!hasGovernanceStatement) {
       recommendations.push('Add a governance statement to your pool profile (+15 identity points)');
     }
     if (!hasSocialLinks) {


### PR DESCRIPTION
## Summary
- **Attribution expansion**: Deliberation attribution breaks down vote diversity, dissent rate, type breadth, and entropy contributions. Identity attribution explains vote-gated metadata points. Recommendations updated for V3.2 signals (rubber-stamping, abstain-farming, sybil flags).
- **ScoreVersionBadge**: Shared component showing "V3.2" linking to methodology changelog. Added to SPO scorecard.
- **Methodology page**: SPO pillar descriptions updated from V3.1 to V3.2 (deliberation rewrite, identity hardening).
- **ADR-006**: Updated to V3.2 with full change documentation and historical V3.1 note.

## Impact
- **What changed**: Attribution data richer and V3.2-aware, methodology page reflects actual scoring, version badge visible on SPO profiles
- **User-facing**: Yes — SPOs see version badge on scorecard, methodology page has accurate V3.2 descriptions
- **Risk**: Low — no scoring logic changes, purely attribution/display/documentation
- **Scope**: 5 files (attribution module, badge component, scorecard, methodology page, ADR)

## Test plan
- [x] 867 tests pass, 0 failures
- [x] Full preflight clean
- [x] Type check clean (0 errors)
- [ ] Verify version badge renders on `/you/spo`
- [ ] Verify methodology page shows V3.2 pillar descriptions
- [ ] Production health check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)