### PR TITLE
feat: Proposer Score — identity resolution, 4-pillar scoring, contextual track record

### DIFF
--- a/app/api/governance/proposers/route.ts
+++ b/app/api/governance/proposers/route.ts
@@ -1,0 +1,31 @@
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { withRouteHandler } from '@/lib/api/withRouteHandler';
+import { getProposalProposers } from '@/lib/scoring/proposer/data';
+
+export const GET = withRouteHandler(
+  async (request) => {
+    const txHash = request.nextUrl.searchParams.get('txHash');
+    const indexStr = request.nextUrl.searchParams.get('index');
+
+    if (!txHash || !indexStr) {
+      return NextResponse.json(
+        { error: 'txHash and index query parameters required' },
+        { status: 400 },
+      );
+    }
+
+    const proposalIndex = parseInt(indexStr, 10);
+    if (isNaN(proposalIndex)) {
+      return NextResponse.json({ error: 'Invalid index' }, { status: 400 });
+    }
+
+    const proposers = await getProposalProposers(txHash, proposalIndex);
+
+    return NextResponse.json(proposers, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=600' },
+    });
+  },
+  { rateLimit: { max: 120, window: 60 } },
+);

--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -53,6 +53,7 @@ import { generateUserEmbedding } from '@/inngest/functions/generate-user-embeddi
 import { computeAiQuality } from '@/inngest/functions/compute-ai-quality';
 import { detectGamingSignals } from '@/inngest/functions/detect-gaming-signals';
 import { extractMatchingTopics } from '@/inngest/functions/extract-matching-topics';
+import { scoreProposers } from '@/inngest/functions/score-proposers';
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [
@@ -107,5 +108,6 @@ export const { GET, POST, PUT } = serve({
     computeAiQuality,
     detectGamingSignals,
     extractMatchingTopics,
+    scoreProposers,
   ],
 });

--- a/app/proposal/[txHash]/[index]/page.tsx
+++ b/app/proposal/[txHash]/[index]/page.tsx
@@ -43,6 +43,7 @@ import { YourRepresentativeCard } from '@/components/governada/proposals/YourRep
 import { CitizenProposalSummary } from '@/components/governada/proposals/CitizenProposalSummary';
 import { ProposalVerdictStrip } from '@/components/governada/proposals/ProposalVerdictStrip';
 import { MobileStickyAction } from '@/components/governada/proposals/MobileStickyAction';
+import { ProposerTrackRecord } from '@/components/governada/proposals/ProposerTrackRecord';
 import { generateEditorialHeadline } from '@/lib/editorialHeadline';
 import { getVerdict } from '@/components/governada/proposals/proposal-theme';
 // Legacy layout uses ProposalHeroV2 (see else branch below)
@@ -363,6 +364,9 @@ export default async function ProposalDetailPage({ params }: PageProps) {
         currentYesPct={voteProjection?.currentYesPct ?? null}
       />
 
+      {/* Proposer track record — contextual trust signal */}
+      <ProposerTrackRecord txHash={txHash} proposalIndex={proposalIndex} />
+
       {/* Citizen context — accessible explanation for non-experts */}
       <CitizenProposalSummary
         title={title}
@@ -520,6 +524,8 @@ export default async function ProposalDetailPage({ params }: PageProps) {
 
       {/* Your Representative — shows citizen's DRep and their vote */}
       <YourRepresentativeCard txHash={txHash} proposalIndex={proposalIndex} />
+      {/* Proposer track record — contextual trust signal */}
+      <ProposerTrackRecord txHash={txHash} proposalIndex={proposalIndex} />
       {/* Citizen-friendly expanded summary — richer context for non-experts */}
       <CitizenProposalSummary
         title={title}

--- a/components/governada/proposals/ProposerTrackRecord.tsx
+++ b/components/governada/proposals/ProposerTrackRecord.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { CheckCircle2, XCircle, Clock, Building2, User, Landmark } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ProposerSummary {
+  id: string;
+  displayName: string;
+  type: 'individual' | 'organization' | 'institutional';
+  proposalCount: number;
+  enactedCount: number;
+  droppedCount: number;
+  compositeScore: number | null;
+  tier: string;
+  confidence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Tier badge colors
+// ---------------------------------------------------------------------------
+
+const TIER_COLORS: Record<string, string> = {
+  Emerging: 'bg-white/10 text-white/50',
+  Bronze: 'bg-amber-900/30 text-amber-400',
+  Silver: 'bg-slate-400/20 text-slate-300',
+  Gold: 'bg-yellow-500/20 text-yellow-400',
+  Diamond: 'bg-cyan-500/20 text-cyan-300',
+  Legendary: 'bg-purple-500/20 text-purple-300',
+};
+
+const TYPE_ICONS = {
+  individual: User,
+  organization: Building2,
+  institutional: Landmark,
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface ProposerTrackRecordProps {
+  txHash: string;
+  proposalIndex: number;
+}
+
+export function ProposerTrackRecord({ txHash, proposalIndex }: ProposerTrackRecordProps) {
+  const { data: proposers, isLoading } = useQuery<ProposerSummary[]>({
+    queryKey: ['proposal-proposers', txHash, proposalIndex],
+    queryFn: async () => {
+      const res = await fetch(`/api/governance/proposers?txHash=${txHash}&index=${proposalIndex}`);
+      if (!res.ok) return [];
+      return res.json();
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes
+  });
+
+  if (isLoading || !proposers?.length) return null;
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-wrap gap-3">
+        {proposers.map((proposer) => (
+          <ProposerChip key={proposer.id} proposer={proposer} />
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function ProposerChip({ proposer }: { proposer: ProposerSummary }) {
+  const TypeIcon = TYPE_ICONS[proposer.type] ?? User;
+  const total = proposer.proposalCount;
+  const enacted = proposer.enactedCount;
+  const dropped = proposer.droppedCount;
+  const inProgress = total - enacted - dropped;
+  const approvalRate = total > 0 ? Math.round((enacted / total) * 100) : 0;
+
+  const tierColor = TIER_COLORS[proposer.tier] ?? TIER_COLORS.Emerging;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-2 rounded-lg border border-white/5 bg-white/[0.02] px-3 py-2 text-sm">
+          <TypeIcon className="h-3.5 w-3.5 text-white/40" />
+          <span className="font-medium text-white/70">{proposer.displayName}</span>
+
+          {/* Track record mini-stats */}
+          <div className="flex items-center gap-1.5 text-xs text-white/40">
+            <span className="flex items-center gap-0.5">
+              <CheckCircle2 className="h-3 w-3 text-emerald-400/70" />
+              {enacted}
+            </span>
+            {dropped > 0 && (
+              <span className="flex items-center gap-0.5">
+                <XCircle className="h-3 w-3 text-red-400/70" />
+                {dropped}
+              </span>
+            )}
+            {inProgress > 0 && (
+              <span className="flex items-center gap-0.5">
+                <Clock className="h-3 w-3 text-amber-400/70" />
+                {inProgress}
+              </span>
+            )}
+          </div>
+
+          {/* Tier badge */}
+          {proposer.compositeScore !== null && (
+            <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${tierColor}`}>
+              {proposer.tier}
+            </span>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs">
+        <div className="space-y-1.5">
+          <p className="font-medium">{proposer.displayName}</p>
+          <p className="text-xs text-muted-foreground">
+            {total} proposal{total !== 1 ? 's' : ''} submitted · {approvalRate}% approval rate
+          </p>
+          <div className="flex gap-3 text-xs">
+            <span className="text-emerald-400">{enacted} enacted</span>
+            <span className="text-red-400">{dropped} dropped</span>
+            {inProgress > 0 && <span className="text-amber-400">{inProgress} in progress</span>}
+          </div>
+          {proposer.compositeScore !== null && (
+            <p className="text-xs text-muted-foreground">
+              Proposer Score: {proposer.compositeScore}/100 ({proposer.tier})
+            </p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/inngest/functions/score-proposers.ts
+++ b/inngest/functions/score-proposers.ts
@@ -1,0 +1,35 @@
+/**
+ * Inngest: Score Proposers
+ *
+ * Resolves proposer identities from CIP-100 metadata, then computes
+ * scores for all proposers. Runs daily after proposal sync completes.
+ */
+
+import { inngest } from '@/lib/inngest';
+import { resolveAllProposers, scoreAllProposers } from '@/lib/scoring/proposer';
+import { logger } from '@/lib/logger';
+
+export const scoreProposers = inngest.createFunction(
+  {
+    id: 'score-proposers',
+    name: 'Score Proposers',
+    retries: 2,
+  },
+  [{ cron: '0 3 * * *' }, { event: 'drepscore/sync.proposers' }],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Inngest dual-trigger type inference
+  async ({ step }: any) => {
+    const resolution = await step.run('resolve-identities', async () => {
+      const result = await resolveAllProposers();
+      logger.info('[ScoreProposers] Identity resolution complete', result);
+      return result;
+    });
+
+    const scoring = await step.run('score-proposers', async () => {
+      const result = await scoreAllProposers();
+      logger.info('[ScoreProposers] Scoring complete', result);
+      return result;
+    });
+
+    return { resolution, scoring };
+  },
+);

--- a/lib/scoring/proposer/data.ts
+++ b/lib/scoring/proposer/data.ts
@@ -1,0 +1,141 @@
+/**
+ * Proposer Score — Data Access Layer
+ *
+ * Read functions for proposer scores, used by UI components.
+ * All reads use the public Supabase client (RLS-protected).
+ */
+
+import { createClient } from '@/lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProposerSummary {
+  id: string;
+  displayName: string;
+  type: 'individual' | 'organization' | 'institutional';
+  proposalCount: number;
+  enactedCount: number;
+  droppedCount: number;
+  compositeScore: number | null;
+  trackRecordScore: number | null;
+  proposalQualityScore: number | null;
+  fiscalResponsibilityScore: number | null;
+  governanceCitizenshipScore: number | null;
+  confidence: number;
+  tier: string;
+}
+
+// ---------------------------------------------------------------------------
+// Read functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the proposer(s) for a specific proposal.
+ * Returns null if no proposer is linked (proposal has no author metadata).
+ */
+export async function getProposalProposers(
+  txHash: string,
+  proposalIndex: number,
+): Promise<ProposerSummary[]> {
+  const supabase = createClient();
+
+  const { data: links } = await supabase
+    .from('proposal_proposers')
+    .select('proposer_id')
+    .eq('proposal_tx_hash', txHash)
+    .eq('proposal_index', proposalIndex);
+
+  if (!links?.length) return [];
+
+  const proposerIds = links.map((l) => l.proposer_id);
+
+  const { data: proposers } = await supabase.from('proposers').select('*').in('id', proposerIds);
+
+  if (!proposers?.length) return [];
+
+  return proposers.map(mapProposer);
+}
+
+/**
+ * Get a single proposer by ID.
+ */
+export async function getProposer(proposerId: string): Promise<ProposerSummary | null> {
+  const supabase = createClient();
+
+  const { data } = await supabase.from('proposers').select('*').eq('id', proposerId).single();
+
+  if (!data) return null;
+  return mapProposer(data);
+}
+
+/**
+ * Get all proposals by a specific proposer, for showing their track record.
+ */
+export async function getProposerProposals(proposerId: string): Promise<
+  {
+    txHash: string;
+    proposalIndex: number;
+    title: string | null;
+    proposalType: string;
+    proposedEpoch: number | null;
+    enacted: boolean;
+    dropped: boolean;
+    withdrawalAmount: number | null;
+  }[]
+> {
+  const supabase = createClient();
+
+  const { data: links } = await supabase
+    .from('proposal_proposers')
+    .select('proposal_tx_hash, proposal_index')
+    .eq('proposer_id', proposerId);
+
+  if (!links?.length) return [];
+
+  const txHashes = links.map((l) => l.proposal_tx_hash);
+
+  const { data: proposals } = await supabase
+    .from('proposals')
+    .select(
+      'tx_hash, proposal_index, title, proposal_type, proposed_epoch, enacted_epoch, dropped_epoch, expired_epoch, ratified_epoch, withdrawal_amount',
+    )
+    .in('tx_hash', txHashes)
+    .order('proposed_epoch', { ascending: false });
+
+  if (!proposals?.length) return [];
+
+  return proposals.map((p) => ({
+    txHash: p.tx_hash,
+    proposalIndex: p.proposal_index,
+    title: p.title,
+    proposalType: p.proposal_type,
+    proposedEpoch: p.proposed_epoch,
+    enacted: !!(p.enacted_epoch || p.ratified_epoch),
+    dropped: !!(p.dropped_epoch || (p.expired_epoch && !p.enacted_epoch && !p.ratified_epoch)),
+    withdrawalAmount: p.withdrawal_amount ? Number(p.withdrawal_amount) : null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mapProposer(row: Record<string, unknown>): ProposerSummary {
+  return {
+    id: row.id as string,
+    displayName: row.display_name as string,
+    type: row.type as 'individual' | 'organization' | 'institutional',
+    proposalCount: row.proposal_count as number,
+    enactedCount: row.enacted_count as number,
+    droppedCount: row.dropped_count as number,
+    compositeScore: row.composite_score as number | null,
+    trackRecordScore: row.track_record_score as number | null,
+    proposalQualityScore: row.proposal_quality_score as number | null,
+    fiscalResponsibilityScore: row.fiscal_responsibility_score as number | null,
+    governanceCitizenshipScore: row.governance_citizenship_score as number | null,
+    confidence: row.confidence as number,
+    tier: row.tier as string,
+  };
+}

--- a/lib/scoring/proposer/identity.ts
+++ b/lib/scoring/proposer/identity.ts
@@ -1,0 +1,265 @@
+/**
+ * Proposer Identity Resolution
+ *
+ * Resolves CIP-100 author metadata from proposals into canonical proposer
+ * entities. Handles alias deduplication (e.g. "KtorZ" and
+ * "KtorZ <matthias.benkort@...>" map to the same proposer).
+ *
+ * Called by the sync pipeline after proposal metadata is fetched.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { logger } from '@/lib/logger';
+import { createHash } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CIP100Author {
+  name?: string;
+  witness?: {
+    publicKey?: string;
+    witnessAlgorithm?: string;
+  };
+}
+
+/** Known institutional/organizational proposers for type classification. */
+const INSTITUTIONAL_NAMES = new Set([
+  'intersect',
+  'cardano foundation',
+  'input output global',
+  'iog',
+  'emurgo',
+]);
+
+const ORGANIZATION_PATTERNS = [
+  /foundation$/i,
+  /council$/i,
+  /network$/i,
+  /alliance$/i,
+  /committee$/i,
+  /holdings/i,
+];
+
+// ---------------------------------------------------------------------------
+// Identity resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an author name for deduplication.
+ * Strips email addresses, trims whitespace, lowercases.
+ * "KtorZ <matthias.benkort@cardanofoundation.org>" → "ktorz"
+ */
+function normalizeName(name: string): string {
+  return name
+    .replace(/<[^>]+>/g, '') // strip email/angle-bracket content
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Generate a stable proposer ID from a normalized name + optional public key.
+ * Uses a hash to ensure IDs are URL-safe and consistent.
+ */
+function generateProposerId(normalizedName: string, publicKey?: string): string {
+  const input = publicKey ? `${normalizedName}:${publicKey}` : normalizedName;
+  return createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Classify proposer type based on name patterns.
+ */
+function classifyProposerType(name: string): 'individual' | 'organization' | 'institutional' {
+  const lower = name.toLowerCase();
+  if (INSTITUTIONAL_NAMES.has(lower)) return 'institutional';
+  if (ORGANIZATION_PATTERNS.some((p) => p.test(name))) return 'organization';
+  // Names with spaces and no org patterns are likely individuals
+  // Single-word names could be either, default to individual
+  return 'individual';
+}
+
+/**
+ * Extract the display name from a CIP-100 author entry.
+ * Prefers the name field, strips email suffixes for cleaner display.
+ */
+function extractDisplayName(author: CIP100Author): string {
+  if (!author.name) return 'Unknown';
+  // Keep the full name for display but clean up formatting
+  return author.name.replace(/<[^>]+>/g, '').trim();
+}
+
+// ---------------------------------------------------------------------------
+// Main resolution function
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve all proposers from the proposals table.
+ * Idempotent — safe to run repeatedly. Creates new proposers, updates
+ * aliases, and links proposals to proposers.
+ *
+ * Returns the number of proposers created/updated.
+ */
+export async function resolveAllProposers(): Promise<{
+  proposersCreated: number;
+  proposersUpdated: number;
+  proposalsLinked: number;
+}> {
+  const supabase = getSupabaseAdmin();
+
+  // 1. Fetch all proposals with author metadata
+  const { data: proposals, error: fetchErr } = await supabase
+    .from('proposals')
+    .select(
+      'tx_hash, proposal_index, meta_json, proposed_epoch, enacted_epoch, dropped_epoch, expired_epoch, ratified_epoch',
+    );
+
+  if (fetchErr || !proposals) {
+    logger.error('[ProposerIdentity] Failed to fetch proposals', { error: fetchErr });
+    return { proposersCreated: 0, proposersUpdated: 0, proposalsLinked: 0 };
+  }
+
+  // 2. Build a map of normalized name → proposer data
+  const proposerMap = new Map<
+    string,
+    {
+      id: string;
+      displayName: string;
+      type: 'individual' | 'organization' | 'institutional';
+      aliases: { name: string; key: string }[];
+      proposals: {
+        txHash: string;
+        index: number;
+        proposedEpoch: number | null;
+        enacted: boolean;
+        dropped: boolean;
+      }[];
+    }
+  >();
+
+  for (const p of proposals) {
+    const meta = p.meta_json as Record<string, unknown> | null;
+    if (!meta) continue;
+
+    const authors = meta.authors as CIP100Author[] | undefined;
+    if (!authors || !Array.isArray(authors) || authors.length === 0) continue;
+
+    for (const author of authors) {
+      if (!author.name || author.name.trim() === '') continue;
+
+      const normalized = normalizeName(author.name);
+      const publicKey = author.witness?.publicKey ?? '';
+      const proposerId = generateProposerId(normalized, publicKey || undefined);
+
+      let entry = proposerMap.get(proposerId);
+      if (!entry) {
+        entry = {
+          id: proposerId,
+          displayName: extractDisplayName(author),
+          type: classifyProposerType(author.name),
+          aliases: [],
+          proposals: [],
+        };
+        proposerMap.set(proposerId, entry);
+      }
+
+      // Add alias if not already present
+      const aliasKey = publicKey || '';
+      const hasAlias = entry.aliases.some((a) => a.name === author.name && a.key === aliasKey);
+      if (!hasAlias) {
+        entry.aliases.push({ name: author.name, key: aliasKey });
+      }
+
+      // Add proposal link
+      entry.proposals.push({
+        txHash: p.tx_hash,
+        index: p.proposal_index,
+        proposedEpoch: p.proposed_epoch,
+        enacted: !!(p.enacted_epoch || p.ratified_epoch),
+        dropped: !!(p.dropped_epoch || (p.expired_epoch && !p.enacted_epoch && !p.ratified_epoch)),
+      });
+    }
+  }
+
+  // 3. Upsert proposers
+  let created = 0;
+  let updated = 0;
+  let linked = 0;
+
+  for (const entry of proposerMap.values()) {
+    const firstEpoch =
+      entry.proposals
+        .map((p) => p.proposedEpoch)
+        .filter((e): e is number => e !== null)
+        .sort((a, b) => a - b)[0] ?? null;
+
+    const proposalCount = entry.proposals.length;
+    const enactedCount = entry.proposals.filter((p) => p.enacted).length;
+    const droppedCount = entry.proposals.filter((p) => p.dropped).length;
+
+    const { error: upsertErr, data: upsertData } = await supabase
+      .from('proposers')
+      .upsert(
+        {
+          id: entry.id,
+          display_name: entry.displayName,
+          type: entry.type,
+          first_proposal_epoch: firstEpoch,
+          proposal_count: proposalCount,
+          enacted_count: enactedCount,
+          dropped_count: droppedCount,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'id' },
+      )
+      .select('id');
+
+    if (upsertErr) {
+      logger.error('[ProposerIdentity] Failed to upsert proposer', {
+        proposerId: entry.id,
+        error: upsertErr,
+      });
+      continue;
+    }
+
+    if (upsertData?.length) {
+      // Check if this was a create or update (approximation)
+      created++;
+    }
+
+    // 4. Upsert aliases
+    for (const alias of entry.aliases) {
+      await supabase.from('proposer_aliases').upsert(
+        {
+          alias_name: alias.name,
+          alias_key: alias.key,
+          proposer_id: entry.id,
+        },
+        { onConflict: 'alias_name,alias_key' },
+      );
+    }
+
+    // 5. Link proposals
+    for (const p of entry.proposals) {
+      const { error: linkErr } = await supabase.from('proposal_proposers').upsert(
+        {
+          proposal_tx_hash: p.txHash,
+          proposal_index: p.index,
+          proposer_id: entry.id,
+        },
+        { onConflict: 'proposal_tx_hash,proposal_index,proposer_id' },
+      );
+      if (!linkErr) linked++;
+    }
+  }
+
+  updated = created; // all are upserts in this batch model
+
+  logger.info('[ProposerIdentity] Resolution complete', {
+    proposers: proposerMap.size,
+    proposalsLinked: linked,
+  });
+
+  return { proposersCreated: proposerMap.size, proposersUpdated: updated, proposalsLinked: linked };
+}

--- a/lib/scoring/proposer/index.ts
+++ b/lib/scoring/proposer/index.ts
@@ -1,0 +1,2 @@
+export { resolveAllProposers } from './identity';
+export { scoreAllProposers, PROPOSER_PILLAR_WEIGHTS, PROPOSER_CALIBRATION } from './score';

--- a/lib/scoring/proposer/score.ts
+++ b/lib/scoring/proposer/score.ts
@@ -1,0 +1,356 @@
+/**
+ * Proposer Score Engine
+ *
+ * 4-pillar scoring model for governance proposers:
+ *   1. Track Record (35%)  — approval rate + delivery + trajectory
+ *   2. Proposal Quality (30%) — specification completeness + community engagement
+ *   3. Fiscal Responsibility (20%) — request reasonableness + efficiency
+ *   4. Governance Citizenship (15%) — responsiveness + transparency
+ *
+ * Uses absolute calibration curves (same as DRep/SPO/CC scores).
+ * Confidence-gated: 1 proposal = max Emerging, 2-3 = max Bronze, 4+ = full.
+ */
+
+import { getSupabaseAdmin } from '@/lib/supabase';
+import { calibrate, type CalibrationCurve } from '@/lib/scoring/calibration';
+import { logger } from '@/lib/logger';
+
+// ---------------------------------------------------------------------------
+// Weights & Calibration
+// ---------------------------------------------------------------------------
+
+export const PROPOSER_PILLAR_WEIGHTS = {
+  trackRecord: 0.35,
+  proposalQuality: 0.3,
+  fiscalResponsibility: 0.2,
+  governanceCitizenship: 0.15,
+} as const;
+
+/**
+ * Calibration curves for proposer score pillars.
+ *
+ * Track Record:
+ * - floor (15): ~15% approval rate, 1 enacted out of many.
+ * - targetLow (40): ~40% approval rate, some enacted, no delivery data yet.
+ * - targetHigh (70): ~70% approval rate, good track record.
+ * - ceiling (90): 90%+ approval with delivery evidence.
+ */
+export const PROPOSER_CALIBRATION: Record<string, CalibrationCurve> = {
+  trackRecord: { floor: 15, targetLow: 40, targetHigh: 70, ceiling: 90 },
+  proposalQuality: { floor: 20, targetLow: 40, targetHigh: 65, ceiling: 85 },
+  fiscalResponsibility: { floor: 15, targetLow: 35, targetHigh: 65, ceiling: 85 },
+  governanceCitizenship: { floor: 10, targetLow: 30, targetHigh: 60, ceiling: 80 },
+};
+
+/** Confidence tiers based on proposal count. */
+const CONFIDENCE_TIERS = [
+  { maxProposals: 1, confidence: 40, maxTier: 'Emerging' },
+  { maxProposals: 3, confidence: 70, maxTier: 'Bronze' },
+] as const;
+
+const FULL_CONFIDENCE_PROPOSALS = 4;
+
+const TIER_BOUNDARIES = [
+  { name: 'Emerging', min: 0, max: 39 },
+  { name: 'Bronze', min: 40, max: 54 },
+  { name: 'Silver', min: 55, max: 69 },
+  { name: 'Gold', min: 70, max: 84 },
+  { name: 'Diamond', min: 85, max: 94 },
+  { name: 'Legendary', min: 95, max: 100 },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Pillar computations
+// ---------------------------------------------------------------------------
+
+interface ProposerData {
+  id: string;
+  proposalCount: number;
+  enactedCount: number;
+  droppedCount: number;
+  proposals: {
+    txHash: string;
+    proposalIndex: number;
+    proposalType: string;
+    withdrawalAmount: number | null;
+    hasAbstract: boolean;
+    hasBody: boolean;
+    proposedEpoch: number | null;
+    enacted: boolean;
+    dropped: boolean;
+    voteCount: number;
+    deliveryScore: number | null;
+  }[];
+}
+
+function computeTrackRecord(data: ProposerData): number {
+  if (data.proposalCount === 0) return 0;
+
+  // Exclude InfoActions from approval rate (non-binding)
+  const actionable = data.proposals.filter((p) => p.proposalType !== 'InfoAction');
+  if (actionable.length === 0) return 50; // InfoAction-only proposer gets neutral
+
+  // Sub-signal 1: Approval rate (60%)
+  const enacted = actionable.filter((p) => p.enacted).length;
+  const approvalRate = (enacted / actionable.length) * 100;
+
+  // Sub-signal 2: Delivery score (25%) — from proposal_outcomes
+  const withDelivery = data.proposals.filter((p) => p.deliveryScore !== null);
+  let deliveryScore = 50; // neutral when no data
+  if (withDelivery.length > 0) {
+    deliveryScore =
+      withDelivery.reduce((s, p) => s + (p.deliveryScore ?? 0), 0) / withDelivery.length;
+  }
+
+  // Sub-signal 3: Volume bonus (15%) — more proposals = more experience
+  // 1 proposal = 20, 3 = 50, 5 = 70, 10+ = 100
+  const volumeScore = Math.min(100, 20 + (data.proposalCount - 1) * 13);
+
+  return approvalRate * 0.6 + deliveryScore * 0.25 + volumeScore * 0.15;
+}
+
+function computeProposalQuality(data: ProposerData): number {
+  if (data.proposals.length === 0) return 0;
+
+  // Sub-signal 1: Specification completeness (50%)
+  // Does the proposal have: title (assumed yes), abstract, body, author metadata?
+  let completenessTotal = 0;
+  for (const p of data.proposals) {
+    let score = 30; // base: has title + author (they're in the system)
+    if (p.hasAbstract) score += 35;
+    if (p.hasBody) score += 35;
+    completenessTotal += score;
+  }
+  const completeness = completenessTotal / data.proposals.length;
+
+  // Sub-signal 2: Community engagement (50%)
+  // Did their proposals generate votes and discussion?
+  let engagementTotal = 0;
+  for (const p of data.proposals) {
+    // Vote count scoring: 0 votes = 0, 10 = 40, 30 = 70, 50+ = 100
+    const voteScore = Math.min(100, p.voteCount * 2);
+    engagementTotal += voteScore;
+  }
+  const engagement = engagementTotal / data.proposals.length;
+
+  return completeness * 0.5 + engagement * 0.5;
+}
+
+function computeFiscalResponsibility(data: ProposerData): number {
+  const treasuryProposals = data.proposals.filter((p) => p.proposalType === 'TreasuryWithdrawals');
+
+  // Non-treasury proposers get neutral score
+  if (treasuryProposals.length === 0) return 50;
+
+  // Sub-signal 1: Enacted rate for treasury asks (60%)
+  const enacted = treasuryProposals.filter((p) => p.enacted).length;
+  const enactedRate = (enacted / treasuryProposals.length) * 100;
+
+  // Sub-signal 2: Delivery on funded proposals (40%)
+  const funded = treasuryProposals.filter((p) => p.enacted);
+  const withDelivery = funded.filter((p) => p.deliveryScore !== null);
+  let deliveryScore = 50; // neutral when no delivery data
+  if (withDelivery.length > 0) {
+    deliveryScore =
+      withDelivery.reduce((s, p) => s + (p.deliveryScore ?? 0), 0) / withDelivery.length;
+  }
+
+  return enactedRate * 0.6 + deliveryScore * 0.4;
+}
+
+function computeGovernanceCitizenship(data: ProposerData): number {
+  // This pillar is the hardest to measure with current data.
+  // For Phase A, we use proxy signals:
+
+  // Sub-signal 1: Proposal type diversity (40%)
+  // Proposers who engage across multiple governance areas show broader citizenship
+  const types = new Set(data.proposals.map((p) => p.proposalType));
+  const diversityScore = Math.min(100, types.size * 30); // 1 type=30, 2=60, 3+=90
+
+  // Sub-signal 2: Proposal completeness (30%)
+  // Treating specification quality as a citizenship signal — putting effort in
+  const withBody = data.proposals.filter((p) => p.hasBody).length;
+  const bodyRate = (withBody / data.proposals.length) * 100;
+
+  // Sub-signal 3: Sustained engagement (30%)
+  // Proposers who submit across multiple epochs show commitment
+  const uniqueEpochs = new Set(
+    data.proposals.map((p) => p.proposedEpoch).filter((e): e is number => e !== null),
+  );
+  const sustainedScore = Math.min(100, uniqueEpochs.size * 25); // 1 epoch=25, 2=50, 4+=100
+
+  return diversityScore * 0.4 + bodyRate * 0.3 + sustainedScore * 0.3;
+}
+
+// ---------------------------------------------------------------------------
+// Confidence & Tier
+// ---------------------------------------------------------------------------
+
+function computeConfidence(proposalCount: number): number {
+  for (const tier of CONFIDENCE_TIERS) {
+    if (proposalCount <= tier.maxProposals) return tier.confidence;
+  }
+  return 100;
+}
+
+function getTier(score: number, proposalCount: number): string {
+  // Apply confidence cap
+  for (const cap of CONFIDENCE_TIERS) {
+    if (proposalCount <= cap.maxProposals) {
+      const maxTierBoundary = TIER_BOUNDARIES.find((t) => t.name === cap.maxTier);
+      if (maxTierBoundary) {
+        // Find the tier for the actual score, but cap it
+        const actualTier = TIER_BOUNDARIES.find((t) => score >= t.min && score <= t.max);
+        const actualIdx = TIER_BOUNDARIES.findIndex((t) => t.name === actualTier?.name);
+        const capIdx = TIER_BOUNDARIES.findIndex((t) => t.name === cap.maxTier);
+        if (actualIdx > capIdx) return cap.maxTier;
+      }
+    }
+  }
+  return TIER_BOUNDARIES.find((t) => score >= t.min && score <= t.max)?.name ?? 'Emerging';
+}
+
+// ---------------------------------------------------------------------------
+// Main scoring function
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute scores for all proposers and update the database.
+ * Called by the Inngest sync pipeline.
+ */
+export async function scoreAllProposers(): Promise<{ scored: number }> {
+  const supabase = getSupabaseAdmin();
+
+  // 1. Fetch all proposers with their proposal links
+  const { data: proposers, error: propErr } = await supabase
+    .from('proposers')
+    .select('id, proposal_count, enacted_count, dropped_count');
+
+  if (propErr || !proposers?.length) {
+    logger.error('[ProposerScore] Failed to fetch proposers', { error: propErr });
+    return { scored: 0 };
+  }
+
+  let scored = 0;
+
+  for (const proposer of proposers) {
+    // 2. Fetch linked proposals with their data
+    const { data: links } = await supabase
+      .from('proposal_proposers')
+      .select('proposal_tx_hash, proposal_index')
+      .eq('proposer_id', proposer.id);
+
+    if (!links?.length) continue;
+
+    const txHashes = links.map((l) => l.proposal_tx_hash);
+
+    const { data: proposals } = await supabase
+      .from('proposals')
+      .select(
+        'tx_hash, proposal_index, proposal_type, withdrawal_amount, abstract, proposed_epoch, enacted_epoch, dropped_epoch, expired_epoch, ratified_epoch, meta_json',
+      )
+      .in('tx_hash', txHashes);
+
+    if (!proposals?.length) continue;
+
+    // 3. Get vote counts per proposal
+    const { data: votes } = await supabase
+      .from('drep_votes')
+      .select('proposal_tx_hash, proposal_index')
+      .in('proposal_tx_hash', txHashes);
+
+    const voteCounts = new Map<string, number>();
+    for (const v of votes ?? []) {
+      const key = `${v.proposal_tx_hash}-${v.proposal_index}`;
+      voteCounts.set(key, (voteCounts.get(key) ?? 0) + 1);
+    }
+
+    // 4. Get delivery scores
+    const { data: outcomes } = await supabase
+      .from('proposal_outcomes')
+      .select('proposal_tx_hash, proposal_index, delivery_score')
+      .in('proposal_tx_hash', txHashes);
+
+    const deliveryScores = new Map<string, number | null>();
+    for (const o of outcomes ?? []) {
+      deliveryScores.set(`${o.proposal_tx_hash}-${o.proposal_index}`, o.delivery_score);
+    }
+
+    // 5. Build proposer data
+    const proposerData: ProposerData = {
+      id: proposer.id,
+      proposalCount: proposer.proposal_count,
+      enactedCount: proposer.enacted_count,
+      droppedCount: proposer.dropped_count,
+      proposals: proposals.map((p) => {
+        const key = `${p.tx_hash}-${p.proposal_index}`;
+        const meta = p.meta_json as Record<string, unknown> | null;
+        return {
+          txHash: p.tx_hash,
+          proposalIndex: p.proposal_index,
+          proposalType: p.proposal_type,
+          withdrawalAmount: p.withdrawal_amount ? Number(p.withdrawal_amount) : null,
+          hasAbstract: !!(p.abstract && (p.abstract as string).length > 10),
+          hasBody: !!(meta && typeof meta.body === 'object' && meta.body !== null),
+          proposedEpoch: p.proposed_epoch,
+          enacted: !!(p.enacted_epoch || p.ratified_epoch),
+          dropped: !!(
+            p.dropped_epoch ||
+            (p.expired_epoch && !p.enacted_epoch && !p.ratified_epoch)
+          ),
+          voteCount: voteCounts.get(key) ?? 0,
+          deliveryScore: deliveryScores.get(key) ?? null,
+        };
+      }),
+    };
+
+    // 6. Compute pillars
+    const rawTrackRecord = computeTrackRecord(proposerData);
+    const rawQuality = computeProposalQuality(proposerData);
+    const rawFiscal = computeFiscalResponsibility(proposerData);
+    const rawCitizenship = computeGovernanceCitizenship(proposerData);
+
+    // 7. Calibrate
+    const calTrackRecord = calibrate(rawTrackRecord, PROPOSER_CALIBRATION.trackRecord);
+    const calQuality = calibrate(rawQuality, PROPOSER_CALIBRATION.proposalQuality);
+    const calFiscal = calibrate(rawFiscal, PROPOSER_CALIBRATION.fiscalResponsibility);
+    const calCitizenship = calibrate(rawCitizenship, PROPOSER_CALIBRATION.governanceCitizenship);
+
+    // 8. Composite
+    const composite = Math.min(
+      100,
+      Math.max(
+        0,
+        Math.round(
+          calTrackRecord * PROPOSER_PILLAR_WEIGHTS.trackRecord +
+            calQuality * PROPOSER_PILLAR_WEIGHTS.proposalQuality +
+            calFiscal * PROPOSER_PILLAR_WEIGHTS.fiscalResponsibility +
+            calCitizenship * PROPOSER_PILLAR_WEIGHTS.governanceCitizenship,
+        ),
+      ),
+    );
+
+    const confidence = computeConfidence(proposer.proposal_count);
+    const tier = getTier(composite, proposer.proposal_count);
+
+    // 9. Update
+    await supabase
+      .from('proposers')
+      .update({
+        composite_score: composite,
+        track_record_score: Math.round(calTrackRecord),
+        proposal_quality_score: Math.round(calQuality),
+        fiscal_responsibility_score: Math.round(calFiscal),
+        governance_citizenship_score: Math.round(calCitizenship),
+        confidence,
+        tier,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', proposer.id);
+
+    scored++;
+  }
+
+  logger.info('[ProposerScore] Scoring complete', { scored });
+  return { scored };
+}

--- a/supabase/migrations/066_proposer_score_foundation.sql
+++ b/supabase/migrations/066_proposer_score_foundation.sql
@@ -1,0 +1,58 @@
+-- Proposer Score Foundation
+-- Canonical proposer entities resolved from CIP-100 author metadata.
+
+-- 1. Proposers table — one row per canonical proposer entity
+CREATE TABLE proposers (
+  id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  type TEXT NOT NULL DEFAULT 'individual'
+    CHECK (type IN ('individual', 'organization', 'institutional')),
+  first_proposal_epoch INTEGER,
+  proposal_count INTEGER NOT NULL DEFAULT 0,
+  enacted_count INTEGER NOT NULL DEFAULT 0,
+  dropped_count INTEGER NOT NULL DEFAULT 0,
+  composite_score REAL,
+  track_record_score REAL,
+  proposal_quality_score REAL,
+  fiscal_responsibility_score REAL,
+  governance_citizenship_score REAL,
+  confidence INTEGER NOT NULL DEFAULT 0,
+  tier TEXT NOT NULL DEFAULT 'Emerging',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 2. Alias mapping — CIP-100 author entries → canonical proposer
+CREATE TABLE proposer_aliases (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  alias_name TEXT NOT NULL,
+  alias_key TEXT NOT NULL DEFAULT '',
+  proposer_id TEXT NOT NULL REFERENCES proposers(id) ON DELETE CASCADE,
+  UNIQUE (alias_name, alias_key)
+);
+
+CREATE INDEX idx_proposer_aliases_name ON proposer_aliases (alias_name);
+CREATE INDEX idx_proposer_aliases_proposer ON proposer_aliases (proposer_id);
+
+-- 3. Link proposals to proposers for fast lookups
+CREATE TABLE proposal_proposers (
+  proposal_tx_hash TEXT NOT NULL,
+  proposal_index INTEGER NOT NULL,
+  proposer_id TEXT NOT NULL REFERENCES proposers(id) ON DELETE CASCADE,
+  PRIMARY KEY (proposal_tx_hash, proposal_index, proposer_id)
+);
+
+CREATE INDEX idx_proposal_proposers_proposer ON proposal_proposers (proposer_id);
+
+-- 4. RLS — public read, service role write
+ALTER TABLE proposers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE proposer_aliases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE proposal_proposers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read proposers" ON proposers FOR SELECT USING (true);
+CREATE POLICY "Service write proposers" ON proposers FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Public read proposer_aliases" ON proposer_aliases FOR SELECT USING (true);
+CREATE POLICY "Service write proposer_aliases" ON proposer_aliases FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY "Public read proposal_proposers" ON proposal_proposers FOR SELECT USING (true);
+CREATE POLICY "Service write proposal_proposers" ON proposal_proposers FOR ALL USING (auth.role() = 'service_role');

--- a/types/database.ts
+++ b/types/database.ts
@@ -4629,6 +4629,32 @@ export type Database = {
           },
         ];
       };
+      proposal_proposers: {
+        Row: {
+          proposal_index: number;
+          proposal_tx_hash: string;
+          proposer_id: string;
+        };
+        Insert: {
+          proposal_index: number;
+          proposal_tx_hash: string;
+          proposer_id: string;
+        };
+        Update: {
+          proposal_index?: number;
+          proposal_tx_hash?: string;
+          proposer_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'proposal_proposers_proposer_id_fkey';
+            columns: ['proposer_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposers';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       proposal_revision_notifications: {
         Row: {
           created_at: string;
@@ -5075,6 +5101,89 @@ export type Database = {
           tx_hash?: string;
           updated_at?: string | null;
           withdrawal_amount?: number | null;
+        };
+        Relationships: [];
+      };
+      proposer_aliases: {
+        Row: {
+          alias_key: string;
+          alias_name: string;
+          id: number;
+          proposer_id: string;
+        };
+        Insert: {
+          alias_key?: string;
+          alias_name: string;
+          id?: never;
+          proposer_id: string;
+        };
+        Update: {
+          alias_key?: string;
+          alias_name?: string;
+          id?: never;
+          proposer_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'proposer_aliases_proposer_id_fkey';
+            columns: ['proposer_id'];
+            isOneToOne: false;
+            referencedRelation: 'proposers';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      proposers: {
+        Row: {
+          composite_score: number | null;
+          confidence: number;
+          display_name: string;
+          dropped_count: number;
+          enacted_count: number;
+          first_proposal_epoch: number | null;
+          fiscal_responsibility_score: number | null;
+          governance_citizenship_score: number | null;
+          id: string;
+          proposal_count: number;
+          proposal_quality_score: number | null;
+          tier: string;
+          track_record_score: number | null;
+          type: string;
+          updated_at: string;
+        };
+        Insert: {
+          composite_score?: number | null;
+          confidence?: number;
+          display_name: string;
+          dropped_count?: number;
+          enacted_count?: number;
+          first_proposal_epoch?: number | null;
+          fiscal_responsibility_score?: number | null;
+          governance_citizenship_score?: number | null;
+          id: string;
+          proposal_count?: number;
+          proposal_quality_score?: number | null;
+          tier?: string;
+          track_record_score?: number | null;
+          type?: string;
+          updated_at?: string;
+        };
+        Update: {
+          composite_score?: number | null;
+          confidence?: number;
+          display_name?: string;
+          dropped_count?: number;
+          enacted_count?: number;
+          first_proposal_epoch?: number | null;
+          fiscal_responsibility_score?: number | null;
+          governance_citizenship_score?: number | null;
+          id?: string;
+          proposal_count?: number;
+          proposal_quality_score?: number | null;
+          tier?: string;
+          track_record_score?: number | null;
+          type?: string;
+          updated_at?: string;
         };
         Relationships: [];
       };


### PR DESCRIPTION
## Summary
- Introduces a **Proposer Score** system — the 4th scored governance role alongside DReps, SPOs, and CC members
- Resolves CIP-100 author metadata from 67 proposals into canonical proposer entities with alias deduplication and type classification (individual/organization/institutional)
- 4-pillar scoring model: Track Record (35%), Proposal Quality (30%), Fiscal Responsibility (20%), Governance Citizenship (15%)
- Contextual display only (option 3) — proposer track record shown on proposal detail pages, not as a standalone leaderboard
- Daily Inngest pipeline at 03:00 UTC: identity resolution → scoring → database update

## Impact
- **What changed**: New scoring dimension for governance proposers, surfaced contextually on proposal pages
- **User-facing**: Yes — proposal detail pages now show proposer name, approval rate, enacted/dropped counts, and tier badge
- **Risk**: Low — new tables (no existing schema changes), additive UI component (renders nothing if no proposer data), Inngest function is additive
- **Scope**: New `lib/scoring/proposer/` module (4 files), migration, Inngest function, UI component, API route

## Architecture
```
CIP-100 author metadata → Identity Resolution → proposers table
                                                    ↓
proposals table → proposal_proposers links → Scoring Engine → 4-pillar scores
                                                    ↓
ProposerTrackRecord component ← API route ← proposers table
```

## Test plan
- [x] All 887 tests pass
- [x] Type-check clean
- [x] Format clean  
- [x] Lint clean (0 errors, 15 pre-existing warnings)
- [x] Migration applied to production Supabase
- [ ] Trigger `drepscore/sync.proposers` event in Inngest to seed initial data
- [ ] Verify proposer chips appear on proposal pages after seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)