### PR TITLE
fix: revalidate governance thresholds cache

### DIFF
--- a/__tests__/lib/governanceThresholds.test.ts
+++ b/__tests__/lib/governanceThresholds.test.ts
@@ -1,7 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-function mockEpochParamsRow(row: Record<string, unknown> | null) {
-  const maybeSingle = vi.fn().mockResolvedValue({ data: row, error: null });
+function mockEpochParamsRows(
+  responses: Array<{ data: Record<string, unknown> | null; error?: unknown }>,
+) {
+  let responseIndex = 0;
+  const maybeSingle = vi.fn().mockImplementation(async () => {
+    const nextResponse = responses[Math.min(responseIndex, responses.length - 1)];
+    responseIndex += 1;
+    return {
+      data: nextResponse?.data ?? null,
+      error: nextResponse?.error ?? null,
+    };
+  });
   const limit = vi.fn(() => ({ maybeSingle }));
   const order = vi.fn(() => ({ limit }));
   const select = vi.fn(() => ({ order }));
@@ -12,7 +22,7 @@ function mockEpochParamsRow(row: Record<string, unknown> | null) {
     return { select };
   });
 
-  return { from };
+  return { client: { from }, maybeSingle };
 }
 
 describe('governance threshold resolver', () => {
@@ -21,16 +31,24 @@ describe('governance threshold resolver', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('uses Supabase epoch_params and the maximum threshold for mixed parameter groups', async () => {
     const fetchGovernanceThresholds = vi.fn();
-
-    vi.doMock('@/lib/supabase', () => ({
-      createClient: () =>
-        mockEpochParamsRow({
+    const epochParams = mockEpochParamsRows([
+      {
+        data: {
           epoch_no: 551,
           dvt_p_p_network_group: 0.51,
           dvt_p_p_gov_group: 0.67,
-        }),
+        },
+      },
+    ]);
+
+    vi.doMock('@/lib/supabase', () => ({
+      createClient: () => epochParams.client,
     }));
     vi.doMock('@/utils/koios', () => ({
       fetchGovernanceThresholds,
@@ -54,13 +72,18 @@ describe('governance threshold resolver', () => {
   });
 
   it('supports legacy parameter aliases when resolving parameter-change groups', async () => {
-    vi.doMock('@/lib/supabase', () => ({
-      createClient: () =>
-        mockEpochParamsRow({
+    const epochParams = mockEpochParamsRows([
+      {
+        data: {
           epoch_no: 551,
           dvt_p_p_economic_group: 0.6,
           dvt_p_p_technical_group: 0.72,
-        }),
+        },
+      },
+    ]);
+
+    vi.doMock('@/lib/supabase', () => ({
+      createClient: () => epochParams.client,
     }));
     vi.doMock('@/utils/koios', () => ({
       fetchGovernanceThresholds: vi.fn(),
@@ -88,7 +111,7 @@ describe('governance threshold resolver', () => {
     });
 
     vi.doMock('@/lib/supabase', () => ({
-      createClient: () => mockEpochParamsRow(null),
+      createClient: () => mockEpochParamsRows([{ data: null }]).client,
     }));
     vi.doMock('@/utils/koios', () => ({
       fetchGovernanceThresholds,
@@ -105,5 +128,82 @@ describe('governance threshold resolver', () => {
       thresholdKeys: ['dvt_treasury_withdrawal'],
     });
     expect(fetchGovernanceThresholds).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses cached Supabase thresholds inside the revalidation window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-09T12:00:00Z'));
+
+    const epochParams = mockEpochParamsRows([
+      {
+        data: {
+          epoch_no: 551,
+          dvt_treasury_withdrawal: 0.75,
+        },
+      },
+    ]);
+
+    vi.doMock('@/lib/supabase', () => ({
+      createClient: () => epochParams.client,
+    }));
+    vi.doMock('@/utils/koios', () => ({
+      fetchGovernanceThresholds: vi.fn(),
+    }));
+
+    const mod = await import('@/lib/governanceThresholds');
+
+    const first = await mod.getGovernanceThresholdForProposal({
+      proposalType: 'TreasuryWithdrawals',
+    });
+    const second = await mod.getGovernanceThresholdForProposal({
+      proposalType: 'TreasuryWithdrawals',
+    });
+
+    expect(first.threshold).toBe(0.75);
+    expect(second.threshold).toBe(0.75);
+    expect(epochParams.maybeSingle).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes cached Supabase thresholds when epoch_params changes before the long TTL expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-09T12:00:00Z'));
+
+    const epochParams = mockEpochParamsRows([
+      {
+        data: {
+          epoch_no: 551,
+          dvt_treasury_withdrawal: 0.75,
+        },
+      },
+      {
+        data: {
+          epoch_no: 551,
+          dvt_treasury_withdrawal: 0.82,
+        },
+      },
+    ]);
+
+    vi.doMock('@/lib/supabase', () => ({
+      createClient: () => epochParams.client,
+    }));
+    vi.doMock('@/utils/koios', () => ({
+      fetchGovernanceThresholds: vi.fn(),
+    }));
+
+    const mod = await import('@/lib/governanceThresholds');
+
+    const first = await mod.getGovernanceThresholdForProposal({
+      proposalType: 'TreasuryWithdrawals',
+    });
+
+    vi.setSystemTime(new Date('2026-04-09T12:01:01Z'));
+
+    const second = await mod.getGovernanceThresholdForProposal({
+      proposalType: 'TreasuryWithdrawals',
+    });
+
+    expect(first.threshold).toBe(0.75);
+    expect(second.threshold).toBe(0.82);
+    expect(epochParams.maybeSingle).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/governanceThresholds.ts
+++ b/lib/governanceThresholds.ts
@@ -15,6 +15,19 @@ export type GovernanceThresholdKey =
 type GovernanceThresholdMap = Partial<Record<GovernanceThresholdKey, number>>;
 export type ParameterGroup = 'network' | 'economic' | 'technical' | 'governance';
 
+interface GovernanceThresholdSnapshot {
+  data: GovernanceThresholdMap;
+  epochNo: number | null;
+}
+
+interface GovernanceThresholdCacheEntry {
+  data: GovernanceThresholdMap;
+  epochNo: number | null;
+  fetchedAt: number;
+  revalidatedAt: number;
+  source: 'supabase' | 'koios';
+}
+
 export interface GovernanceThresholdResolution {
   threshold: number | null;
   thresholdKey: GovernanceThresholdKey | null;
@@ -40,6 +53,7 @@ const GOVERNANCE_THRESHOLD_COLUMNS = [
 ] as const satisfies readonly GovernanceThresholdKey[];
 
 const THRESHOLD_CACHE_MS = 24 * 60 * 60 * 1000;
+const SUPABASE_THRESHOLD_REVALIDATE_MS = 60 * 1000;
 
 const PROPOSAL_TYPE_THRESHOLD_KEY_MAP: Record<string, GovernanceThresholdKey> = {
   TreasuryWithdrawals: 'dvt_treasury_withdrawal',
@@ -134,7 +148,7 @@ const SPO_SECURITY_PARAMETER_ALIASES = [
   'minFeeRefScriptCoinsPerByte',
 ].map(normalizeParamKey);
 
-let cachedThresholds: { data: GovernanceThresholdMap; fetchedAt: number } | null = null;
+let cachedThresholds: GovernanceThresholdCacheEntry | null = null;
 
 function normalizeParamKey(paramKey: string): string {
   return paramKey
@@ -241,7 +255,46 @@ export function resolveGovernanceThresholdKeys(
   return thresholdKey ? [thresholdKey] : [];
 }
 
-async function loadThresholdsFromSupabase(): Promise<GovernanceThresholdMap | null> {
+function mapGovernanceThresholdRow(
+  thresholdRow: Record<string, unknown>,
+): GovernanceThresholdSnapshot | null {
+  const thresholds: GovernanceThresholdMap = {};
+  for (const key of GOVERNANCE_THRESHOLD_COLUMNS) {
+    const value = Number(thresholdRow[key]);
+    if (Number.isFinite(value)) {
+      thresholds[key] = value;
+    }
+  }
+
+  if (Object.keys(thresholds).length === 0) {
+    return null;
+  }
+
+  const epochNo = Number(thresholdRow.epoch_no);
+  return {
+    data: thresholds,
+    epochNo: Number.isFinite(epochNo) ? epochNo : null,
+  };
+}
+
+function hasGovernanceThresholdSnapshotChanged(
+  cacheEntry: GovernanceThresholdCacheEntry,
+  snapshot: GovernanceThresholdSnapshot,
+): boolean {
+  if (cacheEntry.epochNo !== snapshot.epochNo) {
+    return true;
+  }
+
+  for (const key of GOVERNANCE_THRESHOLD_COLUMNS) {
+    if ((cacheEntry.data[key] ?? null) !== (snapshot.data[key] ?? null)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function loadThresholdsFromSupabase(): Promise<GovernanceThresholdSnapshot | null> {
   const supabase = createClient();
   const { data } = await supabase
     .from('epoch_params')
@@ -254,33 +307,65 @@ async function loadThresholdsFromSupabase(): Promise<GovernanceThresholdMap | nu
     return null;
   }
 
-  const thresholds: GovernanceThresholdMap = {};
-  const thresholdRow = data as unknown as Record<string, unknown>;
-  for (const key of GOVERNANCE_THRESHOLD_COLUMNS) {
-    const value = Number(thresholdRow[key]);
-    if (Number.isFinite(value)) {
-      thresholds[key] = value;
-    }
-  }
-
-  return Object.keys(thresholds).length > 0 ? thresholds : null;
+  return mapGovernanceThresholdRow(data as unknown as Record<string, unknown>);
 }
 
 async function loadGovernanceThresholds(): Promise<GovernanceThresholdMap | null> {
-  if (cachedThresholds && Date.now() - cachedThresholds.fetchedAt < THRESHOLD_CACHE_MS) {
-    return cachedThresholds.data;
+  const now = Date.now();
+
+  if (cachedThresholds) {
+    if (now - cachedThresholds.fetchedAt >= THRESHOLD_CACHE_MS) {
+      cachedThresholds = null;
+    } else if (
+      cachedThresholds.source !== 'supabase' ||
+      now - cachedThresholds.revalidatedAt < SUPABASE_THRESHOLD_REVALIDATE_MS
+    ) {
+      return cachedThresholds.data;
+    } else {
+      const latestSupabaseThresholds = await loadThresholdsFromSupabase().catch(() => null);
+      if (!latestSupabaseThresholds) {
+        cachedThresholds = { ...cachedThresholds, revalidatedAt: now };
+        return cachedThresholds.data;
+      }
+
+      if (hasGovernanceThresholdSnapshotChanged(cachedThresholds, latestSupabaseThresholds)) {
+        cachedThresholds = {
+          data: latestSupabaseThresholds.data,
+          epochNo: latestSupabaseThresholds.epochNo,
+          fetchedAt: now,
+          revalidatedAt: now,
+          source: 'supabase',
+        };
+        return latestSupabaseThresholds.data;
+      }
+
+      cachedThresholds = { ...cachedThresholds, revalidatedAt: now };
+      return cachedThresholds.data;
+    }
   }
 
   const supabaseThresholds = await loadThresholdsFromSupabase().catch(() => null);
   if (supabaseThresholds) {
-    cachedThresholds = { data: supabaseThresholds, fetchedAt: Date.now() };
-    return supabaseThresholds;
+    cachedThresholds = {
+      data: supabaseThresholds.data,
+      epochNo: supabaseThresholds.epochNo,
+      fetchedAt: now,
+      revalidatedAt: now,
+      source: 'supabase',
+    };
+    return supabaseThresholds.data;
   }
 
   const { fetchGovernanceThresholds } = await import('@/utils/koios');
   const koiosThresholds = await fetchGovernanceThresholds();
   if (koiosThresholds) {
-    cachedThresholds = { data: koiosThresholds, fetchedAt: Date.now() };
+    cachedThresholds = {
+      data: koiosThresholds,
+      epochNo: null,
+      fetchedAt: now,
+      revalidatedAt: now,
+      source: 'koios',
+    };
     return koiosThresholds;
   }
 


### PR DESCRIPTION
## Summary
- rework `lib/governanceThresholds.ts` so Supabase-backed threshold cache entries carry both epoch metadata and a short revalidation timestamp
- revalidate the latest `epoch_params` snapshot every minute while preserving the long-lived cache for hot-path proposal loops
- refresh cached thresholds when the latest row changes, including same-epoch corrective backfills, and keep focused regression coverage around the new cache contract

## Existing Code Audit
- the previous implementation cached the first successful `epoch_params` read for 24 hours with no revalidation
- that meant proposal monitor, voting-power, and passage-prediction consumers could keep serving stale thresholds after a new epoch landed or after the current epoch row was corrected
- an epoch-only cache key would still miss same-epoch backfills, so the cache now compares the full latest snapshot on a short revalidation interval instead

## Robustness
- repeated threshold lookups inside a request still stay cheap because the cache is only revalidated once per short interval, not on every call
- if a short-interval Supabase revalidation misses, the branch keeps serving the last known cached Supabase thresholds instead of degrading immediately
- regression tests cover mixed parameter-group resolution, hot-path cache reuse, Koios fallback, and same-epoch row updates before the long TTL expires

## Impact
- workspace proposal monitoring and passage prediction stop drifting behind freshly synced governance thresholds
- corrective `epoch_params` updates within the same epoch now propagate without waiting for a 24-hour cache expiry
- the threshold resolver stays performant under repeated proposal reads while behaving more like a canonical cache boundary

## Verification
- `npm run test:unit -- __tests__/lib/governanceThresholds.test.ts`
- `npm run type-check`
- `npm run agent:validate`

## Notes
- `AGENTS.md` documents `npm run codex:verify`, but that script is not present on this branch, so verification used the nearest repo-native baseline wrapper (`npm run agent:validate`) plus targeted tests and type-checking.