### PR TITLE
fix: canonicalize proposal summary consumers

### DIFF
--- a/__tests__/api/proposals.test.ts
+++ b/__tests__/api/proposals.test.ts
@@ -150,4 +150,86 @@ describe('GET /api/proposals', () => {
       'current_epoch, treasury_balance_lovelace',
     );
   });
+
+  it('prefers the latest proposal_voting_summary epoch when duplicate rows are returned', async () => {
+    const proposalsQuery = makeProposalsQuery([
+      {
+        tx_hash: 'tx-1',
+        proposal_index: 0,
+        title: 'Treasury 1',
+        proposal_type: 'TreasuryWithdrawals',
+        expired_epoch: null,
+        ratified_epoch: null,
+        enacted_epoch: null,
+        dropped_epoch: null,
+        expiration_epoch: 400,
+        proposed_epoch: 399,
+        withdrawal_amount: 1_000_000_000,
+        treasury_tier: 'medium',
+        block_time: 1_000,
+        relevant_prefs: ['devex'],
+      },
+    ]);
+    const governanceStatsQuery = makeGovernanceStatsQuery({
+      current_epoch: 390,
+      treasury_balance_lovelace: 10_000_000_000,
+    });
+    const outcomesQuery = makeOutcomeQuery([]);
+    const summaryQuery = makeSummaryQuery([
+      {
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 111,
+        drep_yes_votes_cast: 1,
+        drep_no_votes_cast: 0,
+        drep_abstain_votes_cast: 0,
+        pool_yes_votes_cast: 0,
+        pool_no_votes_cast: 0,
+        pool_abstain_votes_cast: 0,
+        committee_yes_votes_cast: 0,
+        committee_no_votes_cast: 0,
+        committee_abstain_votes_cast: 0,
+      },
+      {
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 114,
+        drep_yes_votes_cast: 6,
+        drep_no_votes_cast: 2,
+        drep_abstain_votes_cast: 1,
+        pool_yes_votes_cast: 1,
+        pool_no_votes_cast: 0,
+        pool_abstain_votes_cast: 0,
+        committee_yes_votes_cast: 0,
+        committee_no_votes_cast: 1,
+        committee_abstain_votes_cast: 0,
+      },
+    ]);
+
+    const from = vi.fn((table: string) => {
+      if (table === 'proposals') return proposalsQuery;
+      if (table === 'governance_stats') return governanceStatsQuery;
+      if (table === 'proposal_outcomes') return outcomesQuery;
+      if (table === 'proposal_voting_summary') return summaryQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({ from });
+
+    const response = await GET(createRequest('/api/proposals?limit=1'));
+    const body = (await parseJson(response)) as {
+      proposals: Array<{
+        triBody: {
+          drep: { yes: number; no: number; abstain: number };
+        } | null;
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.proposals[0]?.triBody?.drep).toEqual({
+      yes: 6,
+      no: 2,
+      abstain: 1,
+    });
+  });
 });

--- a/__tests__/instrumentation.test.ts
+++ b/__tests__/instrumentation.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import * as jose from 'jose';
 
 const mockSetUser = vi.fn();
 const mockSetTag = vi.fn();
 const mockCaptureRequestError = vi.fn();
+const mockValidateSessionToken = vi.fn();
 
 vi.mock('@sentry/nextjs', () => ({
   withScope: (
@@ -12,24 +12,23 @@ vi.mock('@sentry/nextjs', () => ({
   captureRequestError: (...args: unknown[]) => mockCaptureRequestError(...args),
 }));
 
-import { onRequestError } from '@/instrumentation';
+vi.mock('@/lib/supabaseAuth', () => ({
+  validateSessionToken: (...args: unknown[]) => mockValidateSessionToken(...args),
+}));
 
-async function createToken(secret: string, walletAddress: string) {
-  return new jose.SignJWT({ userId: 'user-1', walletAddress, expiresAt: Date.now() + 60_000 })
-    .setProtectedHeader({ alg: 'HS256' })
-    .setIssuedAt()
-    .setExpirationTime('1m')
-    .sign(new TextEncoder().encode(secret));
-}
+import { onRequestError } from '@/instrumentation';
 
 describe('onRequestError', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.SESSION_SECRET = 'test-session-secret';
+    mockValidateSessionToken.mockResolvedValue(null);
   });
 
   it('tags Sentry with a verified session wallet hash', async () => {
-    const token = await createToken(process.env.SESSION_SECRET!, 'addr_test1verifiedwallet');
+    mockValidateSessionToken.mockResolvedValue({
+      walletAddress: 'addr_test1verifiedwallet',
+    });
+    const token = encodeURIComponent('verified.session.token');
 
     await onRequestError(
       new Error('boom') as Error & { digest: string },
@@ -46,13 +45,17 @@ describe('onRequestError', () => {
       },
     );
 
+    expect(mockValidateSessionToken).toHaveBeenCalledWith('verified.session.token');
     expect(mockSetUser).toHaveBeenCalledTimes(1);
     expect(mockSetTag).toHaveBeenCalledWith('hashedAddress', expect.any(String));
     expect(mockCaptureRequestError).toHaveBeenCalledTimes(1);
   });
 
   it('accepts the renamed governada session cookie', async () => {
-    const token = await createToken(process.env.SESSION_SECRET!, 'addr_test1renamedwallet');
+    mockValidateSessionToken.mockResolvedValue({
+      walletAddress: 'addr_test1renamedwallet',
+    });
+    const token = encodeURIComponent('renamed.session.token');
 
     await onRequestError(
       new Error('boom') as Error & { digest: string },
@@ -69,18 +72,19 @@ describe('onRequestError', () => {
       },
     );
 
+    expect(mockValidateSessionToken).toHaveBeenCalledWith('renamed.session.token');
     expect(mockSetUser).toHaveBeenCalledTimes(1);
     expect(mockSetTag).toHaveBeenCalledWith('hashedAddress', expect.any(String));
     expect(mockCaptureRequestError).toHaveBeenCalledTimes(1);
   });
 
-  it('does not trust unsigned or invalid session cookies', async () => {
+  it('does not trust sessions rejected by the canonical validator', async () => {
     await onRequestError(
       new Error('boom') as Error & { digest: string },
       {
         path: '/workspace',
         method: 'GET',
-        headers: { cookie: 'drepscore_session=forged.invalid.token' },
+        headers: { cookie: `drepscore_session=${encodeURIComponent('revoked.session.token')}` },
       },
       {
         routerKind: 'App Router',
@@ -90,6 +94,7 @@ describe('onRequestError', () => {
       },
     );
 
+    expect(mockValidateSessionToken).toHaveBeenCalledWith('revoked.session.token');
     expect(mockSetUser).not.toHaveBeenCalled();
     expect(mockSetTag).not.toHaveBeenCalledWith('hashedAddress', expect.any(String));
     expect(mockCaptureRequestError).toHaveBeenCalledTimes(1);

--- a/__tests__/lib/proposalVotingSummary.test.ts
+++ b/__tests__/lib/proposalVotingSummary.test.ts
@@ -58,6 +58,51 @@ describe('proposalVotingSummary helpers', () => {
     expect(query.in).toHaveBeenCalledWith('proposal_tx_hash', ['tx-1']);
   });
 
+  it('keeps only the latest epoch row per proposal when bulk-fetching summaries', async () => {
+    const query = makeInQuery([
+      {
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 111,
+        drep_yes_votes_cast: 1,
+        drep_no_votes_cast: 0,
+        drep_abstain_votes_cast: 0,
+        pool_yes_votes_cast: 0,
+        pool_no_votes_cast: 0,
+        pool_abstain_votes_cast: 0,
+        committee_yes_votes_cast: 0,
+        committee_no_votes_cast: 0,
+        committee_abstain_votes_cast: 0,
+      },
+      {
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 113,
+        drep_yes_votes_cast: 4,
+        drep_no_votes_cast: 2,
+        drep_abstain_votes_cast: 1,
+        pool_yes_votes_cast: 3,
+        pool_no_votes_cast: 1,
+        pool_abstain_votes_cast: 0,
+        committee_yes_votes_cast: 2,
+        committee_no_votes_cast: 0,
+        committee_abstain_votes_cast: 0,
+      },
+    ]);
+    const supabase = {
+      from: vi.fn(() => query),
+    };
+
+    await expect(fetchProposalVotingSummaries(supabase as any, ['tx-1'])).resolves.toEqual([
+      expect.objectContaining({
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 113,
+        drep_yes_votes_cast: 4,
+      }),
+    ]);
+  });
+
   it('returns the latest summary row and can fail closed or throw', async () => {
     const successQuery = makeLatestQuery([
       {
@@ -100,11 +145,26 @@ describe('proposalVotingSummary helpers', () => {
     ).rejects.toEqual({ message: 'boom' });
   });
 
-  it('indexes summary rows by proposal key and tri-body votes', () => {
+  it('indexes the latest summary row by proposal key and tri-body votes', () => {
     const rows = [
       {
         proposal_tx_hash: 'tx-1',
         proposal_index: 0,
+        epoch_no: 111,
+        drep_yes_votes_cast: 1,
+        drep_no_votes_cast: 0,
+        drep_abstain_votes_cast: 0,
+        pool_yes_votes_cast: 0,
+        pool_no_votes_cast: 0,
+        pool_abstain_votes_cast: 0,
+        committee_yes_votes_cast: 0,
+        committee_no_votes_cast: 0,
+        committee_abstain_votes_cast: 0,
+      },
+      {
+        proposal_tx_hash: 'tx-1',
+        proposal_index: 0,
+        epoch_no: 112,
         drep_yes_votes_cast: 3,
         drep_no_votes_cast: 1,
         drep_abstain_votes_cast: 0,
@@ -118,7 +178,7 @@ describe('proposalVotingSummary helpers', () => {
     ];
 
     expect(getProposalVotingSummaryKey('tx-1', 0)).toBe('tx-1-0');
-    expect(indexProposalVotingSummaries(rows as any).get('tx-1-0')).toMatchObject(rows[0]);
+    expect(indexProposalVotingSummaries(rows as any).get('tx-1-0')).toMatchObject(rows[1]);
     expect(indexProposalVotingSummaryTriBodies(rows as any).get('tx-1-0')).toEqual({
       drep: { yes: 3, no: 1, abstain: 0 },
       spo: { yes: 2, no: 1, abstain: 0 },

--- a/__tests__/lib/votingPowerSummary.test.ts
+++ b/__tests__/lib/votingPowerSummary.test.ts
@@ -18,29 +18,12 @@ async function loadVotingPowerSummaryModule({
     thresholdKey: threshold != null ? 'dvt_p_p_gov_group' : null,
     thresholdKeys: threshold != null ? ['dvt_p_p_gov_group'] : [],
   });
-
-  function makeResolvedQuery(
-    data: Record<string, unknown> | null,
-    terminal: 'single' | 'maybeSingle',
-  ) {
-    const chain = {
-      select: vi.fn(() => chain),
-      eq: vi.fn(() => chain),
-      single:
-        terminal === 'single'
-          ? vi.fn().mockResolvedValue({ data, error: null })
-          : vi.fn().mockResolvedValue({ data: null, error: null }),
-      maybeSingle:
-        terminal === 'maybeSingle'
-          ? vi.fn().mockResolvedValue({ data, error: null })
-          : vi.fn().mockResolvedValue({ data: null, error: null }),
-    };
-
-    return chain;
-  }
-
-  const canonicalQuery = makeResolvedQuery(canonical, 'single');
-  const proposalQuery = makeResolvedQuery(proposal, 'maybeSingle');
+  const fetchLatestProposalVotingSummary = vi.fn().mockResolvedValue(canonical);
+  const proposalQuery = {
+    select: vi.fn(() => proposalQuery),
+    eq: vi.fn(() => proposalQuery),
+    maybeSingle: vi.fn().mockResolvedValue({ data: proposal, error: null }),
+  };
   const votesQuery = {
     select: vi.fn(() => votesQuery),
     eq: vi.fn(() => votesQuery),
@@ -51,7 +34,6 @@ async function loadVotingPowerSummaryModule({
     eq: vi.fn().mockResolvedValue({ data: activeDreps, error: null }),
   };
   const from = vi.fn((table: string) => {
-    if (table === 'proposal_voting_summary') return canonicalQuery;
     if (table === 'proposals') return proposalQuery;
     if (table === 'drep_votes') return votesQuery;
     if (table === 'dreps') return drepsQuery;
@@ -64,6 +46,9 @@ async function loadVotingPowerSummaryModule({
   vi.doMock('@/lib/governanceThresholds', () => ({
     getGovernanceThresholdForProposal,
   }));
+  vi.doMock('@/lib/governance/proposalVotingSummary', () => ({
+    fetchLatestProposalVotingSummary,
+  }));
   vi.doMock('@/lib/logger', () => ({
     logger: {
       info: vi.fn(),
@@ -73,7 +58,11 @@ async function loadVotingPowerSummaryModule({
   }));
 
   const mod = await import('@/lib/governance/votingPowerSummary');
-  return { getVotingPowerSummary: mod.getVotingPowerSummary, getGovernanceThresholdForProposal };
+  return {
+    getVotingPowerSummary: mod.getVotingPowerSummary,
+    getGovernanceThresholdForProposal,
+    fetchLatestProposalVotingSummary,
+  };
 }
 
 describe('getVotingPowerSummary', () => {
@@ -96,7 +85,7 @@ describe('getVotingPowerSummary', () => {
       proposal_type: 'ParameterChange',
       param_changes: { govActionLifetime: 10 },
     };
-    const { getVotingPowerSummary, getGovernanceThresholdForProposal } =
+    const { getVotingPowerSummary, getGovernanceThresholdForProposal, fetchLatestProposalVotingSummary } =
       await loadVotingPowerSummaryModule({
         canonical,
         proposal,
@@ -107,6 +96,10 @@ describe('getVotingPowerSummary', () => {
     expect(getGovernanceThresholdForProposal).toHaveBeenCalledWith({
       proposalType: 'ParameterChange',
       paramChanges: { govActionLifetime: 10 },
+    });
+    expect(fetchLatestProposalVotingSummary).toHaveBeenCalledWith(expect.anything(), {
+      txHash: 'tx1',
+      proposalIndex: 0,
     });
     expect(result).toMatchObject({
       yesPower: 100,

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,4 +1,3 @@
-import * as jose from 'jose';
 import { findCookieValue } from './lib/persistence';
 
 export async function register() {
@@ -40,16 +39,10 @@ async function extractSessionPayload(
   const token = findCookieValue(cookieHeader);
   if (!token) return null;
 
-  const secret = process.env.SESSION_SECRET;
-  if (!secret) return null;
-
   try {
-    const { payload } = await jose.jwtVerify(
-      decodeURIComponent(token),
-      new TextEncoder().encode(secret),
-    );
-
-    if (typeof payload.walletAddress !== 'string' || payload.walletAddress.length === 0) {
+    const { validateSessionToken } = await import('@/lib/supabaseAuth');
+    const payload = await validateSessionToken(decodeURIComponent(token));
+    if (!payload?.walletAddress) {
       return null;
     }
 

--- a/lib/governance/proposalVotingSummary.ts
+++ b/lib/governance/proposalVotingSummary.ts
@@ -13,6 +13,7 @@ export interface ProposalVotingSummaryRow {
   drep_yes_vote_power?: number | null;
   drep_no_vote_power?: number | null;
   drep_abstain_vote_power?: number | null;
+  drep_always_abstain_power?: number | null;
   pool_yes_votes_cast: number | null;
   pool_no_votes_cast: number | null;
   pool_abstain_votes_cast: number | null;
@@ -26,6 +27,27 @@ export interface ProposalVotingSummaryRow {
 
 export function getProposalVotingSummaryKey(txHash: string, proposalIndex: number): string {
   return `${txHash}-${proposalIndex}`;
+}
+
+function getProposalVotingSummaryEpoch(row: ProposalVotingSummaryRow): number {
+  return row.epoch_no ?? Number.NEGATIVE_INFINITY;
+}
+
+function reduceLatestProposalVotingSummaryRows(
+  rows: ProposalVotingSummaryRow[],
+): Map<string, ProposalVotingSummaryRow> {
+  const latestRows = new Map<string, ProposalVotingSummaryRow>();
+
+  for (const row of rows) {
+    const key = getProposalVotingSummaryKey(row.proposal_tx_hash, row.proposal_index);
+    const current = latestRows.get(key);
+
+    if (!current || getProposalVotingSummaryEpoch(row) >= getProposalVotingSummaryEpoch(current)) {
+      latestRows.set(key, row);
+    }
+  }
+
+  return latestRows;
 }
 
 export async function fetchProposalVotingSummaries(
@@ -47,7 +69,9 @@ export async function fetchProposalVotingSummaries(
     return [];
   }
 
-  return data as unknown as ProposalVotingSummaryRow[];
+  return [
+    ...reduceLatestProposalVotingSummaryRows(data as unknown as ProposalVotingSummaryRow[]).values(),
+  ];
 }
 
 export async function fetchLatestProposalVotingSummary(
@@ -84,7 +108,7 @@ export function indexProposalVotingSummaryTriBodies(
 ): Map<string, TriBodyVotes> {
   const triBodyMap = new Map<string, TriBodyVotes>();
 
-  for (const row of rows) {
+  for (const row of reduceLatestProposalVotingSummaryRows(rows).values()) {
     triBodyMap.set(
       getProposalVotingSummaryKey(row.proposal_tx_hash, row.proposal_index),
       buildTriBodyVotes(row),
@@ -99,7 +123,7 @@ export function indexProposalVotingSummaries(
 ): Map<string, ProposalVotingSummaryRow> {
   const summaryMap = new Map<string, ProposalVotingSummaryRow>();
 
-  for (const row of rows) {
+  for (const row of reduceLatestProposalVotingSummaryRows(rows).values()) {
     summaryMap.set(getProposalVotingSummaryKey(row.proposal_tx_hash, row.proposal_index), row);
   }
 

--- a/lib/governance/votingPowerSummary.ts
+++ b/lib/governance/votingPowerSummary.ts
@@ -1,3 +1,4 @@
+import { fetchLatestProposalVotingSummary } from '@/lib/governance/proposalVotingSummary';
 import { getGovernanceThresholdForProposal } from '@/lib/governanceThresholds';
 import { logger } from '@/lib/logger';
 import { createClient } from '@/lib/supabase';
@@ -22,13 +23,8 @@ export async function getVotingPowerSummary(
   try {
     const supabase = createClient();
 
-    const [canonicalResult, proposalResult] = await Promise.all([
-      supabase
-        .from('proposal_voting_summary')
-        .select('*')
-        .eq('proposal_tx_hash', txHash)
-        .eq('proposal_index', proposalIndex)
-        .single(),
+    const [canonical, proposalResult] = await Promise.all([
+      fetchLatestProposalVotingSummary(supabase, { txHash, proposalIndex }),
       supabase
         .from('proposals')
         .select('proposal_type, param_changes')
@@ -37,7 +33,6 @@ export async function getVotingPowerSummary(
         .maybeSingle(),
     ]);
 
-    const canonical = canonicalResult.data;
     const proposalRow = proposalResult.data as {
       proposal_type?: string | null;
       param_changes?: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- make bulk proposal summary consumers collapse duplicate `proposal_voting_summary` rows to the latest epoch per proposal
- route `getVotingPowerSummary()` through the canonical latest-summary seam instead of treating `proposal_voting_summary` as single-row-per-proposal
- make Sentry request attribution defer to the canonical session validator so revoked sessions are not tagged as live users

## Existing Code Audit
- shared consumers such as proposal list, review queue, and API routes could receive multiple summary rows for the same proposal and keep whichever row happened to win iteration order
- `getVotingPowerSummary()` independently queried `proposal_voting_summary` with `.single()`, which broke once a proposal had multiple epoch snapshots and forced the code down a fallback path
- `instrumentation.ts` verified the session cookie JWT directly instead of reusing `validateSessionToken()`, so telemetry could still attribute revoked sessions

## Robustness
- the proposal summary seam now owns “latest row” semantics in one place and applies them defensively in the indexers used by downstream consumers
- voting-power surfaces reuse that same seam instead of encoding another table-shape assumption
- instrumentation now trusts the same auth boundary as the rest of the app, and the tests assert the canonical validator call instead of re-testing JWT mechanics locally

## Impact
- proposal tallies become deterministic across list and workspace surfaces once multiple epoch snapshots exist
- voting-power summaries keep using canonical aggregate fields such as `drep_always_abstain_power` instead of silently degrading to the fallback path
- Sentry attribution stops treating revoked sessions as valid request identities

## Verification
- `npm run test:unit -- __tests__/instrumentation.test.ts __tests__/lib/proposalVotingSummary.test.ts __tests__/lib/votingPowerSummary.test.ts __tests__/api/proposals.test.ts __tests__/lib/proposalList.test.ts __tests__/api/workspace-review-queue.test.ts`
- `npm run type-check`
- `npm run agent:validate`

## Notes
- this branch was rebased onto current `main` before opening the PR so the diff stays limited to the genuinely unfinished work from the earlier review thread