### PR TITLE
fix: harden local hygiene guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ PR_BODY*.md
 .claude/perf-snapshots/
 .claude/infra-snapshots/
 .claude/worktrees/
+/.gh-cache/
+/.codex-*
+/.codex-next-start.*
+/.tmp-*
 
 # Founder-only docs (not for agents/repo)
 docs/strategy/operations-guide.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,15 @@ These constraints are enforced by `npm run agent:validate`. Run it before shippi
 
 1. If the task is feature work, create a fresh worktree first with `powershell -ExecutionPolicy Bypass -File scripts/new-worktree.ps1 <name>`. Do not start feature work in the shared checkout. `npm run worktree:new -- <name>` is a convenience wrapper, but on Windows Codex Desktop the direct PowerShell entrypoint is more reliable because it matches persistent approval prefixes cleanly.
 2. Start from fresh `origin/main`. When resuming an existing worktree or when session diagnostics show drift/setup gaps, run `npm run worktree:sync`.
-3. Read only the minimal context needed. Use the strategy registry and manifest before diving into the full vision docs.
-4. Make the most elegant change that cleanly solves the actual problem within scope. Do not choose a shortcut or merely minimal patch when a more coherent fix is clear and practical.
-5. Run `npm run agent:validate` and the relevant local verification for the scope.
-6. Communicate impact explicitly in updates, handoffs, and reviews: what changed, why it matters, which surfaces or constraints it affects, and any real tradeoffs or risks.
-7. For feature work, open a PR with `Summary`, `Existing Code Audit`, `Robustness`, and `Impact` sections.
-8. Before merging, run `npm run pre-merge-check -- <PR#>`.
-9. After merge, verify deploy health and smoke tests with `npm run deploy:verify`.
+3. Run `npm run session:guard` at the start and end of each local session. Treat a failing guard as a blocker, not a suggestion.
+4. End each local session with exactly one outcome for every change set: committed, intentionally exported, or discarded. Do not leave anonymous stashes or dirty merged worktrees behind.
+5. Read only the minimal context needed. Use the strategy registry and manifest before diving into the full vision docs.
+6. Make the most elegant change that cleanly solves the actual problem within scope. Do not choose a shortcut or merely minimal patch when a more coherent fix is clear and practical.
+7. Run `npm run agent:validate` and the relevant local verification for the scope.
+8. Communicate impact explicitly in updates, handoffs, and reviews: what changed, why it matters, which surfaces or constraints it affects, and any real tradeoffs or risks.
+9. For feature work, open a PR with `Summary`, `Existing Code Audit`, `Robustness`, and `Impact` sections.
+10. Before merging, run `npm run pre-merge-check -- <PR#>`.
+11. After merge, verify deploy health and smoke tests with `npm run deploy:verify`.
 
 ## Autonomy Boundary
 
@@ -49,8 +51,9 @@ Keep Codex Desktop in `workspace-write`. The goal is not removing the sandbox; i
 - Preferred writable root: the shared repo root that also contains `.claude/worktrees/`, so worktree metadata stays inside the writable area.
 - Open Codex on the shared repo root only. Do not open separate Codex projects rooted at `.claude/worktrees/<name>` or other external worktree directories for this repo.
 - Prefer stable `npm run ...` wrappers for diagnostics, CI, deploy, and GitHub operations. For mutating Git/worktree setup on Windows Codex Desktop, prefer direct approved entrypoints such as `powershell -ExecutionPolicy Bypass -File scripts/new-worktree.ps1 <name>`, `git fetch origin main`, and `git worktree add`.
+- When local hygiene is in question, use `npm run session:guard` as the blocking gate and `npm run session:doctor` for the human-readable breakdown.
 - For repo orientation, prefer `npm run session:doctor` over one-off `git branch`, `git worktree`, or `git stash` reads when it gives enough context.
-- Persist approvals for safe recurring prefixes such as `powershell -ExecutionPolicy Bypass -File scripts/new-worktree.ps1`, `npm run worktree:new`, `npm run worktree:sync`, `npm run session:doctor`, `npm run gh:auth-status`, `npm run auth:repair`, `npm run ci:watch`, `npm run ci:failed`, `npm run pre-merge-check`, `npm run deploy:verify`, `npm run inngest:register`, `git add`, `git commit -m`, `git push`, `git fetch origin main`, `git worktree add`, and `gh api repos/governada/governada-app/pulls`.
+- Persist approvals for safe recurring prefixes such as `powershell -ExecutionPolicy Bypass -File scripts/new-worktree.ps1`, `npm run worktree:new`, `npm run worktree:sync`, `npm run session:doctor`, `npm run session:guard`, `npm run gh:auth-status`, `npm run auth:repair`, `npm run ci:watch`, `npm run ci:failed`, `npm run pre-merge-check`, `npm run deploy:verify`, `npm run inngest:register`, `git add`, `git commit -m`, `git push`, `git fetch origin main`, `git worktree add`, and `gh api repos/governada/governada-app/pulls`.
 - Do not persist approvals for broad shells or interpreters such as bare `powershell`, `cmd`, `node`, `python`, `git`, or `gh`.
 - On Windows Codex Desktop, if a mutating Git/worktree command or an `npm` wrapper that shells out to Git fails in `workspace-write` with `EPERM`, access denied, or a likely sandbox error, rerun it immediately with `sandbox_permissions=require_escalated` using an already-approved prefix. Do not stop to ask first unless the prefix itself is missing.
 - Repo-local GH context is provided by `npm run gh:auth-status` and the scripts in `scripts/lib/runtime.js`; do not rely on `gh` inferring the repo from a remote alias or unrelated global state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -727,6 +727,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@cardano-ogmios/client/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@cardano-ogmios/client/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -23543,6 +23558,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -28479,6 +28495,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "migration:test": "node scripts/test-migration.js",
     "codex:sync-windows-rules": "node scripts/codex-sync-windows-rules.js",
     "session:doctor": "powershell -ExecutionPolicy Bypass -File scripts/session-doctor.ps1",
+    "session:guard": "powershell -ExecutionPolicy Bypass -File scripts/session-doctor.ps1 --strict",
     "worktree:new": "powershell -ExecutionPolicy Bypass -File scripts/new-worktree.ps1",
     "worktree:sync": "powershell -ExecutionPolicy Bypass -File scripts/sync-worktree.ps1",
     "inngest:register": "node scripts/register-inngest.js",

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -68,7 +68,57 @@ function slugify(value) {
 }
 
 function git(args, options = {}) {
-  return commandOutput('git', args, { cwd: options.cwd ?? repoRoot });
+  return commandOutput('git', args, {
+    allowFailure: options.allowFailure ?? false,
+    cwd: options.cwd ?? repoRoot,
+  });
+}
+
+function getLines(value) {
+  return value
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function revCount(range) {
+  const value = Number.parseInt(git(['rev-list', '--count', range], { allowFailure: true }), 10);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function ensureSharedCheckoutReady(repoTopLevel) {
+  if (path.resolve(repoTopLevel) !== path.resolve(repoRoot)) {
+    throw new Error(`Run this script from the shared checkout at ${repoRoot}.`);
+  }
+
+  const gitDir = git(['rev-parse', '--path-format=absolute', '--git-dir'], { allowFailure: true });
+  const commonDir = git(['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+    allowFailure: true,
+  });
+  if (!gitDir || !commonDir || path.resolve(gitDir) !== path.resolve(commonDir)) {
+    throw new Error('Run this script from the shared checkout, not from an existing worktree.');
+  }
+
+  const branch = git(['branch', '--show-current'], { allowFailure: true }) || '(detached)';
+  if (!['main', 'master'].includes(branch)) {
+    throw new Error(
+      `Shared checkout must stay on main/master before creating a new worktree. Current branch: ${branch}.`,
+    );
+  }
+
+  const statusLines = getLines(git(['status', '--short'], { allowFailure: true }));
+  if (statusLines.length > 0) {
+    throw new Error(
+      'Shared checkout is dirty. Clean it before creating another worktree. Run npm run session:doctor.',
+    );
+  }
+
+  const stashCount = getLines(git(['stash', 'list'], { allowFailure: true })).length;
+  if (stashCount > 0) {
+    throw new Error(
+      `Repo has ${stashCount} stash(es). Clear or export them before creating another worktree. Run npm run session:doctor.`,
+    );
+  }
 }
 
 function ensureNodeModulesLink(worktreePath, noNodeModulesLink) {
@@ -112,10 +162,7 @@ const { repoRoot } = getScriptContext(import.meta.url);
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const repoTopLevel = git(['rev-parse', '--show-toplevel']);
-
-  if (path.resolve(repoTopLevel) !== path.resolve(repoRoot)) {
-    throw new Error(`Run this script from the shared checkout at ${repoRoot}.`);
-  }
+  ensureSharedCheckoutReady(repoTopLevel);
 
   const slug = slugify(options.name);
   const branchName = options.branch || `feat/${slug}`;
@@ -130,6 +177,13 @@ function main() {
 
   console.log('Fetching origin/main...');
   git(['fetch', 'origin', 'main']);
+
+  const ahead = revCount('origin/main..HEAD');
+  if (ahead > 0) {
+    throw new Error(
+      `Shared checkout has ${ahead} local commit(s) ahead of origin/main. Reconcile them before creating another worktree.`,
+    );
+  }
 
   console.log(`Creating worktree ${worktreePath} on branch ${branchName}...`);
   git(['worktree', 'add', worktreePath, '-b', branchName, 'origin/main']);

--- a/scripts/new-worktree.ps1
+++ b/scripts/new-worktree.ps1
@@ -18,6 +18,24 @@ function Get-Slug([string]$Value) {
   return $slug
 }
 
+function Get-Lines([string]$Text) {
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  return $Text -split "\r?\n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Get-RevCount([string]$Range) {
+  $value = (git rev-list --count $Range).Trim()
+  $count = 0
+  if ([int]::TryParse($value, [ref]$count)) {
+    return $count
+  }
+
+  return 0
+}
+
 function Copy-LocalBootstrapFile([string]$SourceRoot, [string]$WorktreeRoot, [string]$RelativePath) {
   $sourcePath = Join-Path $SourceRoot $RelativePath
   $destinationPath = Join-Path $WorktreeRoot $RelativePath
@@ -35,55 +53,93 @@ function Copy-LocalBootstrapFile([string]$SourceRoot, [string]$WorktreeRoot, [st
   Write-Host "$RelativePath copied."
 }
 
-$repoRoot = (git rev-parse --show-toplevel).Trim()
-if (-not $repoRoot) {
-  throw "Run this script from inside the repository."
+try {
+  $repoRoot = (git rev-parse --show-toplevel).Trim()
+  if (-not $repoRoot) {
+    throw "Run this script from inside the repository."
+  }
+
+  $gitDir = (git rev-parse --path-format=absolute --git-dir).Trim()
+  $commonDir = (git rev-parse --path-format=absolute --git-common-dir).Trim()
+  if (-not $gitDir -or -not $commonDir -or -not [System.StringComparer]::OrdinalIgnoreCase.Equals(
+    [System.IO.Path]::GetFullPath($gitDir),
+    [System.IO.Path]::GetFullPath($commonDir)
+  )) {
+    throw 'Run this script from the shared checkout, not from an existing worktree.'
+  }
+
+  $currentBranch = (git branch --show-current).Trim()
+  if (-not $currentBranch) {
+    $currentBranch = '(detached)'
+  }
+
+  if ($currentBranch -notin @('main', 'master')) {
+    throw "Shared checkout must stay on main/master before creating a new worktree. Current branch: $currentBranch."
+  }
+
+  $statusLines = Get-Lines (git status --short)
+  if ($statusLines.Count -gt 0) {
+    throw 'Shared checkout is dirty. Clean it before creating another worktree. Run npm run session:doctor.'
+  }
+
+  $stashCount = (Get-Lines (git stash list)).Count
+  if ($stashCount -gt 0) {
+    throw "Repo has $stashCount stash(es). Clear or export them before creating another worktree. Run npm run session:doctor."
+  }
+
+  $slug = Get-Slug $Name
+  $branchName = if ($Branch) { $Branch } else { "feat/$slug" }
+  $worktreesRoot = Join-Path $repoRoot '.claude\worktrees'
+  $worktreePath = Join-Path $worktreesRoot $slug
+
+  if (Test-Path $worktreePath) {
+    throw "Target worktree path already exists: $worktreePath"
+  }
+
+  New-Item -ItemType Directory -Path $worktreesRoot -Force | Out-Null
+
+  Write-Host "Fetching origin/main..."
+  git fetch origin main
+
+  $ahead = Get-RevCount 'origin/main..HEAD'
+  if ($ahead -gt 0) {
+    throw "Shared checkout has $ahead local commit(s) ahead of origin/main. Reconcile them before creating another worktree."
+  }
+
+  Write-Host "Creating worktree $worktreePath on branch $branchName..."
+  git worktree add $worktreePath -b $branchName origin/main
+
+  foreach ($relativePath in @(
+    '.env.local',
+    '.mcp.json',
+    '.claude/settings.local.json'
+  )) {
+    Copy-LocalBootstrapFile -SourceRoot $repoRoot -WorktreeRoot $worktreePath -RelativePath $relativePath
+  }
+
+  $mainNodeModules = Join-Path $repoRoot 'node_modules'
+  $worktreeNodeModules = Join-Path $worktreePath 'node_modules'
+  $mainPackageJson = Join-Path $repoRoot 'package.json'
+  $worktreePackageJson = Join-Path $worktreePath 'package.json'
+  if (
+    -not $NoNodeModulesLink `
+    -and (Test-Path $mainNodeModules) `
+    -and -not (Test-Path $worktreeNodeModules) `
+    -and ((Get-FileHash $mainPackageJson).Hash -eq (Get-FileHash $worktreePackageJson).Hash)
+  ) {
+    New-Item -ItemType Junction -Path $worktreeNodeModules -Target $mainNodeModules | Out-Null
+    Write-Host "node_modules junction created."
+  }
+
+  Write-Host ""
+  Write-Host "Worktree ready:"
+  Write-Host "  Path:   $worktreePath"
+  Write-Host "  Branch: $branchName"
+  Write-Host ""
+  Write-Host "Next:"
+  Write-Host "  Set-Location '$worktreePath'"
+  Write-Host "  git status --short --branch"
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  exit 1
 }
-
-$slug = Get-Slug $Name
-$branchName = if ($Branch) { $Branch } else { "feat/$slug" }
-$worktreesRoot = Join-Path $repoRoot '.claude\worktrees'
-$worktreePath = Join-Path $worktreesRoot $slug
-
-if (Test-Path $worktreePath) {
-  throw "Target worktree path already exists: $worktreePath"
-}
-
-New-Item -ItemType Directory -Path $worktreesRoot -Force | Out-Null
-
-Write-Host "Fetching origin/main..."
-git fetch origin main
-
-Write-Host "Creating worktree $worktreePath on branch $branchName..."
-git worktree add $worktreePath -b $branchName origin/main
-
-foreach ($relativePath in @(
-  '.env.local',
-  '.mcp.json',
-  '.claude/settings.local.json'
-)) {
-  Copy-LocalBootstrapFile -SourceRoot $repoRoot -WorktreeRoot $worktreePath -RelativePath $relativePath
-}
-
-$mainNodeModules = Join-Path $repoRoot 'node_modules'
-$worktreeNodeModules = Join-Path $worktreePath 'node_modules'
-$mainPackageJson = Join-Path $repoRoot 'package.json'
-$worktreePackageJson = Join-Path $worktreePath 'package.json'
-if (
-  -not $NoNodeModulesLink `
-  -and (Test-Path $mainNodeModules) `
-  -and -not (Test-Path $worktreeNodeModules) `
-  -and ((Get-FileHash $mainPackageJson).Hash -eq (Get-FileHash $worktreePackageJson).Hash)
-) {
-  New-Item -ItemType Junction -Path $worktreeNodeModules -Target $mainNodeModules | Out-Null
-  Write-Host "node_modules junction created."
-}
-
-Write-Host ""
-Write-Host "Worktree ready:"
-Write-Host "  Path:   $worktreePath"
-Write-Host "  Branch: $branchName"
-Write-Host ""
-Write-Host "Next:"
-Write-Host "  Set-Location '$worktreePath'"
-Write-Host "  git status --short --branch"

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -157,9 +157,7 @@ function main() {
   const advisories = [];
 
   if (sharedCheckout && !['main', 'master'].includes(branch)) {
-    blockingIssues.push(
-      `Shared checkout should stay on main/master. Current branch: ${branch}.`,
-    );
+    blockingIssues.push(`Shared checkout should stay on main/master. Current branch: ${branch}.`);
   }
 
   if (statusLines.length > 0) {
@@ -221,7 +219,9 @@ function main() {
 
   printSection(
     'Dirty worktrees',
-    dirtyWorktrees.map((worktree) => `${worktree.branch} -> ${worktree.path} (${worktree.dirtyCount} changes)`),
+    dirtyWorktrees.map(
+      (worktree) => `${worktree.branch} -> ${worktree.path} (${worktree.dirtyCount} changes)`,
+    ),
   );
   console.log('');
 

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -3,6 +3,28 @@ const path = require('node:path');
 
 const { repoRoot, runCommand } = require('./lib/runtime');
 
+function parseArgs(argv) {
+  const options = {
+    strict: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--strict') {
+      options.strict = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node scripts/session-doctor.js [--strict]');
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
 function runOrEmpty(command, args, cwd = repoRoot) {
   const result = runCommand(command, args, { cwd });
   return result.status === 0 ? result.stdout.trimEnd() : '';
@@ -12,13 +34,13 @@ function getTopLevel() {
   return runOrEmpty('git', ['rev-parse', '--show-toplevel']);
 }
 
-function getBranch() {
-  const branch = runOrEmpty('git', ['branch', '--show-current']);
+function getBranch(cwd = repoRoot) {
+  const branch = runOrEmpty('git', ['branch', '--show-current'], cwd);
   return branch || '(detached)';
 }
 
-function getStatusLines() {
-  const status = runOrEmpty('git', ['status', '--short']);
+function getStatusLines(cwd = repoRoot) {
+  const status = runOrEmpty('git', ['status', '--short'], cwd);
   return status ? status.split(/\r?\n/).filter(Boolean) : [];
 }
 
@@ -48,10 +70,12 @@ function parseWorktrees() {
         worktree.branch = '(detached)';
       }
     }
+
     if (worktree.path) {
       worktrees.push(worktree);
     }
   }
+
   return worktrees;
 }
 
@@ -75,15 +99,98 @@ function printSection(title, lines) {
   }
 }
 
+function isSharedCheckout(topLevel) {
+  const gitDir = runOrEmpty('git', ['rev-parse', '--path-format=absolute', '--git-dir'], topLevel);
+  const commonDir = runOrEmpty(
+    'git',
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    topLevel,
+  );
+
+  if (!gitDir || !commonDir) {
+    return false;
+  }
+
+  return path.resolve(gitDir) === path.resolve(commonDir);
+}
+
+function hasGoneUpstream(branch) {
+  if (!branch || branch === '(detached)') {
+    return false;
+  }
+
+  const details = runOrEmpty('git', ['branch', '-vv', '--list', branch]);
+  return details.includes(': gone]');
+}
+
+function getWorktreeDiagnostics(worktrees, topLevel) {
+  const resolvedTopLevel = path.resolve(topLevel);
+
+  return worktrees.map((worktree) => {
+    const statusLines = getStatusLines(worktree.path);
+    const resolvedPath = path.resolve(worktree.path);
+
+    return {
+      ...worktree,
+      isCurrent: resolvedPath === resolvedTopLevel,
+      dirtyCount: statusLines.length,
+      goneUpstream: hasGoneUpstream(worktree.branch),
+    };
+  });
+}
+
 function main() {
+  const options = parseArgs(process.argv.slice(2));
   const topLevel = getTopLevel() || repoRoot;
   const branch = getBranch();
   const statusLines = getStatusLines();
   const stashLines = getStashLines();
   const worktrees = parseWorktrees();
+  const sharedCheckout = isSharedCheckout(topLevel);
+  const checkoutLabel = sharedCheckout ? 'shared checkout' : 'worktree';
+  const worktreeDiagnostics = getWorktreeDiagnostics(worktrees, topLevel);
+  const dirtyWorktrees = worktreeDiagnostics.filter(
+    (worktree) => worktree.dirtyCount > 0 && !worktree.isCurrent,
+  );
+  const goneUpstreamWorktrees = worktreeDiagnostics.filter((worktree) => worktree.goneUpstream);
+  const blockingIssues = [];
+  const advisories = [];
+
+  if (sharedCheckout && !['main', 'master'].includes(branch)) {
+    blockingIssues.push(
+      `Shared checkout should stay on main/master. Current branch: ${branch}.`,
+    );
+  }
+
+  if (statusLines.length > 0) {
+    blockingIssues.push(
+      `${sharedCheckout ? 'Shared checkout' : 'Current worktree'} has ${statusLines.length} local change(s).`,
+    );
+  }
+
+  if (stashLines.length > 0) {
+    blockingIssues.push(`Repo has ${stashLines.length} stash(es).`);
+  }
+
+  if (dirtyWorktrees.length > 0) {
+    blockingIssues.push(`Repo has ${dirtyWorktrees.length} other dirty worktree(s).`);
+  }
+
+  if (goneUpstreamWorktrees.length > 0) {
+    blockingIssues.push(
+      `${goneUpstreamWorktrees.length} worktree(s) track an upstream branch that is gone.`,
+    );
+  }
+
+  if (worktrees.length > 5) {
+    advisories.push(
+      `Repo has ${worktrees.length} worktrees open. Prune merged or abandoned worktrees before opening more.`,
+    );
+  }
 
   console.log('=== Session Doctor ===');
   console.log(`Repo: ${topLevel}`);
+  console.log(`Checkout: ${checkoutLabel}`);
   console.log(`Branch: ${branch}`);
   console.log(
     `Status: ${statusLines.length === 0 ? 'clean' : `dirty (${statusLines.length} changes)`}`,
@@ -112,12 +219,49 @@ function main() {
   );
   console.log('');
 
+  printSection(
+    'Dirty worktrees',
+    dirtyWorktrees.map((worktree) => `${worktree.branch} -> ${worktree.path} (${worktree.dirtyCount} changes)`),
+  );
+  console.log('');
+
+  printSection(
+    'Gone upstream worktrees',
+    goneUpstreamWorktrees.map((worktree) => `${worktree.branch} -> ${worktree.path}`),
+  );
+  console.log('');
+
   printSection('Session files', [
     fileLabel('.cursor/tasks/lessons.md'),
     fileLabel('.cursor/tasks/todo.md'),
   ]);
+  console.log('');
+
+  if (blockingIssues.length > 0) {
+    printSection(options.strict ? 'Blocking issues' : 'Warnings', blockingIssues);
+    console.log('');
+  }
+
+  if (advisories.length > 0) {
+    printSection('Advisories', advisories);
+    console.log('');
+  }
+
+  if (options.strict) {
+    if (blockingIssues.length > 0) {
+      console.error(`STRICT FAILED: ${blockingIssues.length} hygiene issue(s) found.`);
+      process.exit(1);
+    }
+
+    console.log('STRICT OK: local hygiene checks passed.');
+  }
 }
 
 if (require.main === module) {
-  main();
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message || String(error));
+    process.exit(1);
+  }
 }

--- a/scripts/session-doctor.ps1
+++ b/scripts/session-doctor.ps1
@@ -7,10 +7,11 @@ function Invoke-Git {
   param(
     [Parameter(Mandatory = $true)]
     [string[]]$Arguments,
-    [switch]$AllowFailure
+    [switch]$AllowFailure,
+    [string]$WorkingDirectory = (Get-Location).Path
   )
 
-  $output = & git @Arguments 2>&1
+  $output = & git -C $WorkingDirectory @Arguments 2>&1
   $exitCode = $LASTEXITCODE
   $text = (($output | ForEach-Object { $_.ToString() }) -join "`n").TrimEnd()
 
@@ -54,7 +55,7 @@ function Parse-Worktrees([string]$Porcelain) {
         $worktrees += $current
       }
 
-      $current = [ordered]@{
+      $current = [PSCustomObject][ordered]@{
         Path   = $line.Substring('worktree '.Length).Trim()
         Branch = '(detached)'
       }
@@ -213,50 +214,168 @@ function Print-Section([string]$Title, [string[]]$Lines) {
   }
 }
 
-$repoRoot = (Invoke-Git -Arguments @('rev-parse', '--show-toplevel')).Output
-$commonGitDir = (Invoke-Git -Arguments @('rev-parse', '--path-format=absolute', '--git-common-dir')).Output
-$mainCheckoutRoot = Split-Path -Parent $commonGitDir
-$branch = (Invoke-Git -Arguments @('branch', '--show-current') -AllowFailure).Output
-if ([string]::IsNullOrWhiteSpace($branch)) {
-  $branch = '(detached)'
+function Test-SharedCheckout([string]$TopLevel) {
+  $gitDir = (Invoke-Git -Arguments @('rev-parse', '--path-format=absolute', '--git-dir') -AllowFailure -WorkingDirectory $TopLevel).Output
+  $commonDir = (Invoke-Git -Arguments @('rev-parse', '--path-format=absolute', '--git-common-dir') -AllowFailure -WorkingDirectory $TopLevel).Output
+  if ([string]::IsNullOrWhiteSpace($gitDir) -or [string]::IsNullOrWhiteSpace($commonDir)) {
+    return $false
+  }
+
+  return [System.StringComparer]::OrdinalIgnoreCase.Equals(
+    [System.IO.Path]::GetFullPath($gitDir),
+    [System.IO.Path]::GetFullPath($commonDir)
+  )
 }
 
-$statusLines = Get-Lines ((Invoke-Git -Arguments @('status', '--short') -AllowFailure).Output)
-$stashLines = Get-Lines ((Invoke-Git -Arguments @('stash', 'list') -AllowFailure).Output)
-$worktrees = Parse-Worktrees ((Invoke-Git -Arguments @('worktree', 'list', '--porcelain') -AllowFailure).Output)
+function Test-GoneUpstream([string]$Branch) {
+  if ([string]::IsNullOrWhiteSpace($Branch) -or $Branch -eq '(detached)') {
+    return $false
+  }
 
-Write-Output '=== Session Doctor ==='
-Write-Output "Repo: $repoRoot"
-Write-Output "Branch: $branch"
-Write-Output ("Status: " + ($(if ($statusLines.Count -eq 0) { 'clean' } else { "dirty ($($statusLines.Count) changes)" })))
-Write-Output "Stashes: $($stashLines.Count)"
-Write-Output "Worktrees: $($worktrees.Count)"
-Write-Output ''
+  $details = (Invoke-Git -Arguments @('branch', '-vv', '--list', $Branch) -AllowFailure -WorkingDirectory $repoRoot).Output
+  return $details -like '*: gone]*'
+}
 
-if ($statusLines.Count -gt 0) {
-  Print-Section 'Changed files' ($statusLines | Select-Object -First 10)
-  if ($statusLines.Count -gt 10) {
-    Write-Output "  - ... and $($statusLines.Count - 10) more"
+try {
+  $strict = $false
+  foreach ($arg in $args) {
+    switch ($arg) {
+      '--strict' { $strict = $true }
+      '--help' {
+        Write-Output 'Usage: powershell -File scripts/session-doctor.ps1 [--strict]'
+        exit 0
+      }
+      '-h' {
+        Write-Output 'Usage: powershell -File scripts/session-doctor.ps1 [--strict]'
+        exit 0
+      }
+      default {
+        throw "Unknown option: $arg"
+      }
+    }
+  }
+
+  $repoRoot = (Invoke-Git -Arguments @('rev-parse', '--show-toplevel')).Output
+  $commonGitDir = (Invoke-Git -Arguments @('rev-parse', '--path-format=absolute', '--git-common-dir')).Output
+  $mainCheckoutRoot = Split-Path -Parent $commonGitDir
+  $branch = (Invoke-Git -Arguments @('branch', '--show-current') -AllowFailure -WorkingDirectory $repoRoot).Output
+  if ([string]::IsNullOrWhiteSpace($branch)) {
+    $branch = '(detached)'
+  }
+
+  $statusLines = Get-Lines ((Invoke-Git -Arguments @('status', '--short') -AllowFailure -WorkingDirectory $repoRoot).Output)
+  $stashLines = Get-Lines ((Invoke-Git -Arguments @('stash', 'list') -AllowFailure -WorkingDirectory $repoRoot).Output)
+  $worktrees = Parse-Worktrees ((Invoke-Git -Arguments @('worktree', 'list', '--porcelain') -AllowFailure -WorkingDirectory $repoRoot).Output)
+  $sharedCheckout = Test-SharedCheckout $repoRoot
+  $checkoutLabel = if ($sharedCheckout) { 'shared checkout' } else { 'worktree' }
+  $dirtyWorktrees = @()
+  $goneUpstreamWorktrees = @()
+  $blockingIssues = @()
+  $advisories = @()
+
+  foreach ($worktree in @($worktrees)) {
+    $isCurrent = [System.StringComparer]::OrdinalIgnoreCase.Equals(
+      [System.IO.Path]::GetFullPath($worktree.Path),
+      [System.IO.Path]::GetFullPath($repoRoot)
+    )
+    $worktreeStatus = Get-Lines ((Invoke-Git -Arguments @('status', '--short') -AllowFailure -WorkingDirectory $worktree.Path).Output)
+    $dirtyCount = @($worktreeStatus).Count
+    if ($dirtyCount -gt 0 -and -not $isCurrent) {
+      $dirtyWorktrees += "$($worktree.Branch) -> $($worktree.Path) ($dirtyCount changes)"
+    }
+
+    if (Test-GoneUpstream $worktree.Branch) {
+      $goneUpstreamWorktrees += "$($worktree.Branch) -> $($worktree.Path)"
+    }
+  }
+
+  if ($sharedCheckout -and $branch -notin @('main', 'master')) {
+    $blockingIssues += "Shared checkout should stay on main/master. Current branch: $branch."
+  }
+
+  if ($statusLines.Count -gt 0) {
+    $blockingIssues += "$(if ($sharedCheckout) { 'Shared checkout' } else { 'Current worktree' }) has $($statusLines.Count) local change(s)."
+  }
+
+  if ($stashLines.Count -gt 0) {
+    $blockingIssues += "Repo has $($stashLines.Count) stash(es)."
+  }
+
+  if ($dirtyWorktrees.Count -gt 0) {
+    $blockingIssues += "Repo has $($dirtyWorktrees.Count) other dirty worktree(s)."
+  }
+
+  if ($goneUpstreamWorktrees.Count -gt 0) {
+    $blockingIssues += "$($goneUpstreamWorktrees.Count) worktree(s) track an upstream branch that is gone."
+  }
+
+  if (@($worktrees).Count -gt 5) {
+    $advisories += "Repo has $(@($worktrees).Count) worktrees open. Prune merged or abandoned worktrees before opening more."
+  }
+
+  Write-Output '=== Session Doctor ==='
+  Write-Output "Repo: $repoRoot"
+  Write-Output "Checkout: $checkoutLabel"
+  Write-Output "Branch: $branch"
+  Write-Output ("Status: " + ($(if ($statusLines.Count -eq 0) { 'clean' } else { "dirty ($($statusLines.Count) changes)" })))
+  Write-Output "Stashes: $($stashLines.Count)"
+  Write-Output "Worktrees: $(@($worktrees).Count)"
+  Write-Output ''
+
+  if ($statusLines.Count -gt 0) {
+    Print-Section 'Changed files' ($statusLines | Select-Object -First 10)
+    if ($statusLines.Count -gt 10) {
+      Write-Output "  - ... and $($statusLines.Count - 10) more"
+    }
+    Write-Output ''
+  }
+
+  Print-Section 'Stashes' ($stashLines | Select-Object -First 5)
+  if ($stashLines.Count -gt 5) {
+    Write-Output "  - ... and $($stashLines.Count - 5) more"
   }
   Write-Output ''
+
+  Print-Section 'Worktrees' ($worktrees | ForEach-Object { "$($_.Branch) -> $($_.Path)" })
+  Write-Output ''
+
+  Print-Section 'Dirty worktrees' $dirtyWorktrees
+  Write-Output ''
+
+  Print-Section 'Gone upstream worktrees' $goneUpstreamWorktrees
+  Write-Output ''
+
+  Print-Section 'Repo bootstrap files' (Get-RepoBootstrapLines)
+  Write-Output ''
+
+  Print-Section 'Repo-scoped auth and MCP' (Get-RepoScopedToolLines)
+  Write-Output ''
+
+  Print-Section 'Session files' @(
+    (Test-RepoFile '.cursor/tasks/lessons.md'),
+    (Test-RepoFile '.cursor/tasks/todo.md')
+  )
+  Write-Output ''
+
+  if ($blockingIssues.Count -gt 0) {
+    Print-Section $(if ($strict) { 'Blocking issues' } else { 'Warnings' }) $blockingIssues
+    Write-Output ''
+  }
+
+  if ($advisories.Count -gt 0) {
+    Print-Section 'Advisories' $advisories
+    Write-Output ''
+  }
+
+  if ($strict) {
+    if ($blockingIssues.Count -gt 0) {
+      [Console]::Error.WriteLine("STRICT FAILED: $($blockingIssues.Count) hygiene issue(s) found.")
+      exit 1
+    }
+
+    Write-Output 'STRICT OK: local hygiene checks passed.'
+  }
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  exit 1
 }
-
-Print-Section 'Stashes' ($stashLines | Select-Object -First 5)
-if ($stashLines.Count -gt 5) {
-  Write-Output "  - ... and $($stashLines.Count - 5) more"
-}
-Write-Output ''
-
-Print-Section 'Worktrees' ($worktrees | ForEach-Object { "$($_.Branch) -> $($_.Path)" })
-Write-Output ''
-
-Print-Section 'Repo bootstrap files' (Get-RepoBootstrapLines)
-Write-Output ''
-
-Print-Section 'Repo-scoped auth and MCP' (Get-RepoScopedToolLines)
-Write-Output ''
-
-Print-Section 'Session files' @(
-  (Test-RepoFile '.cursor/tasks/lessons.md'),
-  (Test-RepoFile '.cursor/tasks/todo.md')
-)


### PR DESCRIPTION
## Summary
- add a strict `session:guard` entrypoint for local hygiene checks
- harden `session:doctor` to flag dirty shared checkouts, lingering stashes, dirty worktrees, and gone upstream branches
- block `worktree:new` when the shared checkout is not clean, not on `main`/`master`, or locally ahead of `origin/main`
- ignore recurring local artifact directories so Git status stays focused on real work

## Existing Code Audit
- the shared checkout had been cleaned back to a good local state, but the repo still lacked an enforceable hygiene gate
- `session:doctor` in `main` still miscounted a single worktree because the parsed worktree object shape was wrong on PowerShell
- `worktree:new` could still be run from a dirty or mispositioned shared checkout, which makes branch and stash sprawl easy to reintroduce

## Robustness
- keep the richer PowerShell bootstrap/auth diagnostics while adding strict failure modes
- use `git-dir` vs `git-common-dir` instead of filesystem heuristics to distinguish the shared checkout from linked worktrees on Windows
- preserve local bootstrap file copying for new worktrees while adding branch/status/stash/ahead guardrails

## Impact
- agents and humans get a fast, explicit blocker before starting new work from a bad local state
- the shared checkout can stay clean on `main` while feature work happens in isolated worktrees
- local artifact noise is less likely to hide real source changes or stale hygiene issues