### PR TITLE
[codex] harden GitHub auth remotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -727,6 +727,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@cardano-ogmios/client/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@cardano-ogmios/client/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -23441,6 +23456,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -28296,6 +28312,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {

--- a/scripts/repair-gh-auth.mjs
+++ b/scripts/repair-gh-auth.mjs
@@ -3,7 +3,7 @@
 import { commandOutput, getScriptContext } from './lib/runtime.mjs';
 
 const EXPECTED_USER = 'governada';
-const CANONICAL_REMOTE = 'https://github.com/governada/governada-app.git';
+const CANONICAL_REMOTE = 'git@github-governada:governada/governada-app.git';
 const { repoRoot } = getScriptContext(import.meta.url);
 
 function log(message) {
@@ -55,7 +55,7 @@ commandOutput('gh', ['auth', 'setup-git', '--hostname', 'github.com'], { cwd: re
 log(`GitHub auth: ready as ${EXPECTED_USER}.`);
 
 const currentRemote = tryCommand('git', ['remote', 'get-url', 'origin']);
-if (currentRemote && embeddedCredentialRemote(currentRemote)) {
+if (currentRemote && (currentRemote !== CANONICAL_REMOTE || embeddedCredentialRemote(currentRemote))) {
   commandOutput('git', ['remote', 'set-url', 'origin', CANONICAL_REMOTE], { cwd: repoRoot });
-  log('GitHub remote: removed embedded credentials.');
+  log(`GitHub remote: set origin to ${CANONICAL_REMOTE}.`);
 }

--- a/scripts/repair-gh-auth.mjs
+++ b/scripts/repair-gh-auth.mjs
@@ -55,7 +55,10 @@ commandOutput('gh', ['auth', 'setup-git', '--hostname', 'github.com'], { cwd: re
 log(`GitHub auth: ready as ${EXPECTED_USER}.`);
 
 const currentRemote = tryCommand('git', ['remote', 'get-url', 'origin']);
-if (currentRemote && (currentRemote !== CANONICAL_REMOTE || embeddedCredentialRemote(currentRemote))) {
+if (
+  currentRemote &&
+  (currentRemote !== CANONICAL_REMOTE || embeddedCredentialRemote(currentRemote))
+) {
   commandOutput('git', ['remote', 'set-url', 'origin', CANONICAL_REMOTE], { cwd: repoRoot });
   log(`GitHub remote: set origin to ${CANONICAL_REMOTE}.`);
 }

--- a/scripts/repair-gh-auth.ps1
+++ b/scripts/repair-gh-auth.ps1
@@ -43,7 +43,7 @@ function Show-LoginHelp([string]$GhConfigDir) {
   Write-Output 'Run this once in PowerShell:'
   Write-Output "  `$env:GH_CONFIG_DIR = '$GhConfigDir'"
   Write-Output '  gh auth logout --hostname github.com'
-  Write-Output '  gh auth login --hostname github.com --git-protocol https --web'
+  Write-Output '  gh auth login --hostname github.com --git-protocol ssh --web'
   Write-Output ''
   Write-Output 'Then re-run: npm run auth:repair'
 }
@@ -53,7 +53,7 @@ function Test-EmbeddedCredentialRemote([string]$RemoteUrl) {
 }
 
 $expectedUser = 'governada'
-$canonicalRemote = 'https://github.com/governada/governada-app.git'
+$canonicalRemote = 'git@github-governada:governada/governada-app.git'
 $ghConfigDir = Set-RepoGhContext
 
 Write-Output 'Repairing GitHub auth for this repo...'
@@ -85,7 +85,7 @@ if ($login -ne $expectedUser) {
   Write-Output "Expected '$expectedUser'. Re-authenticate this profile instead of switching a global gh account:"
   Write-Output "  `$env:GH_CONFIG_DIR = '$GhConfigDir'"
   Write-Output '  gh auth logout --hostname github.com'
-  Write-Output '  gh auth login --hostname github.com --git-protocol https --web'
+  Write-Output '  gh auth login --hostname github.com --git-protocol ssh --web'
   exit 1
 }
 

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -3,6 +3,8 @@ const path = require('node:path');
 
 const { repoRoot, runCommand } = require('./lib/runtime');
 
+const EXPECTED_ORIGIN_REMOTE = 'git@github-governada:governada/governada-app.git';
+
 function parseArgs(argv) {
   const options = {
     strict: false,
@@ -47,6 +49,10 @@ function getStatusLines(cwd = repoRoot) {
 function getStashLines() {
   const stashes = runOrEmpty('git', ['stash', 'list']);
   return stashes ? stashes.split(/\r?\n/).filter(Boolean) : [];
+}
+
+function getOriginRemote() {
+  return runOrEmpty('git', ['remote', 'get-url', 'origin']);
 }
 
 function parseWorktrees() {
@@ -145,6 +151,7 @@ function main() {
   const branch = getBranch();
   const statusLines = getStatusLines();
   const stashLines = getStashLines();
+  const originRemote = getOriginRemote();
   const worktrees = parseWorktrees();
   const sharedCheckout = isSharedCheckout(topLevel);
   const checkoutLabel = sharedCheckout ? 'shared checkout' : 'worktree';
@@ -180,6 +187,12 @@ function main() {
     );
   }
 
+  if (originRemote !== EXPECTED_ORIGIN_REMOTE) {
+    blockingIssues.push(
+      `origin remote should be ${EXPECTED_ORIGIN_REMOTE}. Current: ${originRemote || '(missing)'}.`,
+    );
+  }
+
   if (worktrees.length > 5) {
     advisories.push(
       `Repo has ${worktrees.length} worktrees open. Prune merged or abandoned worktrees before opening more.`,
@@ -194,6 +207,7 @@ function main() {
     `Status: ${statusLines.length === 0 ? 'clean' : `dirty (${statusLines.length} changes)`}`,
   );
   console.log(`Stashes: ${stashLines.length}`);
+  console.log(`Origin: ${originRemote || '(missing)'}`);
   console.log(`Worktrees: ${worktrees.length}`);
   console.log('');
 

--- a/scripts/session-doctor.ps1
+++ b/scripts/session-doctor.ps1
@@ -237,6 +237,7 @@ function Test-GoneUpstream([string]$Branch) {
 }
 
 try {
+  $expectedOriginRemote = 'git@github-governada:governada/governada-app.git'
   $strict = $false
   foreach ($arg in $args) {
     switch ($arg) {
@@ -265,6 +266,7 @@ try {
 
   $statusLines = Get-Lines ((Invoke-Git -Arguments @('status', '--short') -AllowFailure -WorkingDirectory $repoRoot).Output)
   $stashLines = Get-Lines ((Invoke-Git -Arguments @('stash', 'list') -AllowFailure -WorkingDirectory $repoRoot).Output)
+  $originRemote = (Invoke-Git -Arguments @('remote', 'get-url', 'origin') -AllowFailure -WorkingDirectory $repoRoot).Output
   $worktrees = Parse-Worktrees ((Invoke-Git -Arguments @('worktree', 'list', '--porcelain') -AllowFailure -WorkingDirectory $repoRoot).Output)
   $sharedCheckout = Test-SharedCheckout $repoRoot
   $checkoutLabel = if ($sharedCheckout) { 'shared checkout' } else { 'worktree' }
@@ -309,6 +311,11 @@ try {
     $blockingIssues += "$($goneUpstreamWorktrees.Count) worktree(s) track an upstream branch that is gone."
   }
 
+  if ($originRemote -ne $expectedOriginRemote) {
+    $currentRemote = if ([string]::IsNullOrWhiteSpace($originRemote)) { '(missing)' } else { $originRemote }
+    $blockingIssues += "origin remote should be $expectedOriginRemote. Current: $currentRemote."
+  }
+
   if (@($worktrees).Count -gt 5) {
     $advisories += "Repo has $(@($worktrees).Count) worktrees open. Prune merged or abandoned worktrees before opening more."
   }
@@ -319,6 +326,7 @@ try {
   Write-Output "Branch: $branch"
   Write-Output ("Status: " + ($(if ($statusLines.Count -eq 0) { 'clean' } else { "dirty ($($statusLines.Count) changes)" })))
   Write-Output "Stashes: $($stashLines.Count)"
+  Write-Output "Origin: $(if ([string]::IsNullOrWhiteSpace($originRemote)) { '(missing)' } else { $originRemote })"
   Write-Output "Worktrees: $(@($worktrees).Count)"
   Write-Output ''
 


### PR DESCRIPTION
## Summary
- Make Governada auth repair helpers preserve the 1Password-backed SSH alias remote: `git@github-governada:governada/governada-app.git`.
- Make session doctor output and strict checks flag any checkout whose `origin` drifts back to HTTPS or bare `git@github.com`.
- Sync `package-lock.json` for npm 10 so CI install succeeds after the auth hardening branch updates.
- Keep the repo aligned with the machine-level SSH alias hardening that separates Governada and BlueCargo keys.

## Existing Code Audit
- Existing `repair-gh-auth` helpers were still canonicalizing the repo to HTTPS, which bypassed the SSH alias split.
- Existing session doctor checks covered branch/worktree hygiene but did not validate that `origin` used the repo-specific GitHub host alias.
- CI exposed an npm 10 lockfile mismatch for `utf-8-validate`; the lockfile is now regenerated with npm 10 semantics.

## Robustness
- `auth:repair` now resets `origin` to the Governada alias instead of HTTPS when it sees drift.
- `session:doctor` now reports the current origin and treats a non-aliased remote as a blocking hygiene issue in strict mode.
- This is intentionally narrow: no GitHub token flow, deployment flow, or unrelated worktree behavior was changed.

## Impact
- Future agents should be less likely to accidentally use a BlueCargo key or bare GitHub SSH remote while working in Governada.
- New BlueCargo repos can use the matching `github-bluecargo` alias without affecting Governada.
- CI install now matches the npm version used by GitHub Actions.

## Validation
- `node --check scripts/session-doctor.js`
- `node --check scripts/repair-gh-auth.mjs`
- `node scripts/session-doctor.js`
- `git diff --check`
- `npx --yes prettier@3.8.3 --check scripts/repair-gh-auth.mjs`
- `npx --yes npm@10.8.2 ci --dry-run --ignore-scripts --no-audit --no-fund`
- `ssh -T github-governada` authenticated as `governada`
- `git ls-remote --heads origin main` succeeded through the Governada alias
- GitHub `Agent Config` passed on head `88c74ecf235a8380c75c144c4d798f2cec2d70d8`
- GitHub `CI` passed on run `24703415373`