### PR TITLE
fix: render briefing shell during transient load failure

### DIFF
--- a/app/governance/briefing/BriefingTeaser.tsx
+++ b/app/governance/briefing/BriefingTeaser.tsx
@@ -101,10 +101,12 @@ export function BriefingTeaser() {
   });
 
   if (isLoading) return <BriefingTeaserSkeleton />;
-  if (!data) return null;
 
-  const { epoch, headlines, narrative, epochStats } = data;
-  const treasuryFormatted = epochStats.treasuryBalance
+  const epoch = data?.epoch;
+  const headlines = data?.headlines ?? [];
+  const narrative = data?.narrative ?? null;
+  const epochStats = data?.epochStats;
+  const treasuryFormatted = epochStats?.treasuryBalance
     ? epochStats.treasuryBalance >= 1_000_000_000
       ? `${(epochStats.treasuryBalance / 1_000_000_000).toFixed(1)}B`
       : epochStats.treasuryBalance >= 1_000_000
@@ -118,9 +120,11 @@ export function BriefingTeaser() {
       <div className="space-y-2">
         <div className="flex items-center gap-2">
           <Sparkles className="h-5 w-5 text-primary" />
-          <Badge variant="secondary" className="text-xs">
-            Epoch {epoch}
-          </Badge>
+          {epoch != null && (
+            <Badge variant="secondary" className="text-xs">
+              Epoch {epoch}
+            </Badge>
+          )}
         </div>
         <h1 className="text-2xl font-bold tracking-tight">Governance Briefing</h1>
         <p className="text-sm text-muted-foreground">
@@ -129,23 +133,25 @@ export function BriefingTeaser() {
       </div>
 
       {/* Stats bar */}
-      <div className="grid grid-cols-3 gap-3">
-        <StatCard
-          icon={Vote}
-          label="Active Proposals"
-          value={epochStats.activeProposals.toString()}
-        />
-        <StatCard
-          icon={Users}
-          label="Active DReps"
-          value={epochStats.totalDReps.toLocaleString()}
-        />
-        <StatCard
-          icon={Landmark}
-          label="Treasury"
-          value={treasuryFormatted ? `${treasuryFormatted} ADA` : '—'}
-        />
-      </div>
+      {epochStats && (
+        <div className="grid grid-cols-3 gap-3">
+          <StatCard
+            icon={Vote}
+            label="Active Proposals"
+            value={epochStats.activeProposals.toString()}
+          />
+          <StatCard
+            icon={Users}
+            label="Active DReps"
+            value={epochStats.totalDReps.toLocaleString()}
+          />
+          <StatCard
+            icon={Landmark}
+            label="Treasury"
+            value={treasuryFormatted ? `${treasuryFormatted} ADA` : '—'}
+          />
+        </div>
+      )}
 
       {/* Headlines */}
       {headlines.length > 0 && (


### PR DESCRIPTION
## Summary

`BriefingTeaser` previously returned `null` whenever the `/api/briefing/public` fetch failed or returned a non-OK response, leaving citizens with a completely blank page on return. The Hub is the "return ritual" — a blank briefing on a transient hiccup undermines the concept on the exact surface meant to answer *"what needs my attention?"*.

This change guards the data-dependent sections (epoch badge, stats bar, headlines, narrative) so they're skipped when data is missing, and always renders the page header and the connect-wallet CTA. When data loads normally, anonymous teaser behavior is unchanged.

## Existing Code Audit

- **Searched for**: existing "briefing" components, citizen brief routes, loading / empty-state patterns in the same surface.
- **Found**: `app/governance/briefing/BriefingTeaser.tsx` (the only briefing surface on this branch), `app/api/briefing/public/route.ts` (source API, unchanged), `BriefingTeaserSkeleton` (already reused for `isLoading`).
- **Decision**: Extended the existing `BriefingTeaser` component in place — no new files, no parallel component. Reused the existing skeleton for the `isLoading` branch.

## Robustness

- **Empty / failure state**: was `return null` (blank document) — now renders a page shell with header + connect-wallet CTA.
- **Loading state**: unchanged (`BriefingTeaserSkeleton`).
- **Normal state**: unchanged — all previous sections render exactly as before when data is present.
- **Data guards**: every section that consumes `data` now reads through `data?.` with safe fallbacks (`headlines ?? []`, `narrative ?? null`, stats grid rendered only when `epochStats` is present, epoch badge rendered only when `epoch != null`).
- **No new data sources, no new auth branches, no behavior change on the happy path.**

## Impact

- **What changed**: `app/governance/briefing/BriefingTeaser.tsx` no longer returns `null` when `useQuery` yields no data. Header + "connect to unlock" CTA always render; data-dependent sections render conditionally.
- **User-facing**: Yes — on transient fetch failure, visitors now see the page header and the Connect Wallet CTA instead of a blank document.
- **Risk**: Low — single client component, no API / data / auth changes, no new dependencies or data sources. Skeleton loading path and the normal data-loaded render are untouched.
- **Scope**: 1 file changed (`app/governance/briefing/BriefingTeaser.tsx`) + a lockfile refresh commit to unblock CI (pre-existing drift from merged dependabot updates on main; no source changes). No migrations, no env vars, no Inngest functions, no new analytics events.

## Test plan

- [x] `tsc --noEmit` clean
- [x] ESLint + Prettier clean (pre-commit hooks ran)
- [ ] Verify on production: `/governance/briefing` renders header + CTA when the API is unreachable (simulate via DevTools network throttle / offline)
- [ ] Confirm normal path (API healthy) still renders epoch badge, stats, headlines, narrative

> Local browser preview was blocked — no `.env.local` provisioned in this worktree — so visual verification happens in the Railway deploy smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)