### PR TITLE
fix: repair lockfile drift after dependabot merges on main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -727,6 +727,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@cardano-ogmios/client/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@cardano-ogmios/client/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -23441,6 +23456,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -28296,6 +28312,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {


### PR DESCRIPTION
## Summary

`npm ci` in CI (node 20.20.2 / npm 10.8.2) was failing on every new PR with:

```
npm error Missing: utf-8-validate@5.0.10 from lock file
```

Dependabot merges #886 (minor-updates) and #888 (patch-updates) landed on main since the last full CI pass (April 12, #883), leaving two nested optional-peer entries out of `package-lock.json` in a way that npm 10 rejects but npm 11 accepts (why it slipped past local preflights).

Regenerated the lockfile via `npm install` inside a clean `node:20.20.2-bookworm` container, then confirmed `npm ci` against the result ("added 1898 packages in 18s", no errors).

## Existing Code Audit

- **Searched for**: existing lockfile-refresh / dependency-repair patterns; `npm ci` usage in CI.
- **Found**: `.github/workflows/ci.yml` pins `CI_NODE_VERSION: '20'` and uses `npm ci` in the `install` job. Main's last green CI run was #883 on April 12; every PR since then has been blocked by this same install step.
- **Decision**: minimum-surface lockfile regeneration — no changes to `package.json`, no version bumps, just the missing nested entries npm 10 demands. Any alternative (pinning `utf-8-validate` as a direct dep, bumping `@cardano-ogmios/client`) would change runtime behavior; this change doesn't.

## Robustness

- **Change is lockfile-only** — no source files, no `package.json`, no workflows touched.
- **Diff is surgical**: adds two nested `utf-8-validate@5.0.10` entries (optional peers under `@cardano-ogmios/client` and `webpack-bundle-analyzer`) + a `dev: true` flag on `fsevents`. Nothing else changes.
- **Verified**: `npm ci` under node 20.20.2 / npm 10.8.2 (CI's exact runtime) succeeds cleanly against the new lockfile.
- **Backwards compatible**: npm 11 and later also accept the new lockfile — no local workflow regression.

## Impact

- **What changed**: `package-lock.json` — 32 lines added, 0 removed. No source changes.
- **User-facing**: No.
- **Risk**: Low — lockfile restoration matches what `npm install` would produce today on node 20; runtime behavior is unchanged. Risk is bounded to "CI install step still fails for a different reason," which smoke tests in this PR will expose.
- **Scope**: 1 file (`package-lock.json`). No migrations, no env vars, no Inngest, no analytics.

## Test plan

- [x] `npm ci` succeeds in a clean `node:20.20.2-bookworm` container (verified locally)
- [ ] CI `install` job passes on this PR
- [ ] Downstream `lint`, `type-check`, `test`, `build` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)