### PR TITLE
fix: restore lockfile nested entries dropped by dependabot #894

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -727,6 +727,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@cardano-ogmios/client/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@cardano-ogmios/client/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -23426,6 +23441,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -28287,6 +28303,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {


### PR DESCRIPTION
## Summary

Main's `install` CI job is currently red: `Missing: utf-8-validate@5.0.10 from lock file` — same failure #893 fixed, re-introduced by #894 (dependabot `minor-updates` group). Every PR since #894 merged is blocked, and Railway never deployed #892 because the build halts at install.

Root cause: #894's lockfile regeneration ran under a newer npm (presumably npm 11) that doesn't emit the nested optional-peer entries npm 10 demands. When CI runs `npm ci` under node 20.20.2 / npm 10.8.2, it rejects the lockfile.

Fix: regenerate `package-lock.json` inside a clean `node:20.20.2-bookworm` container (matching CI's exact runtime). Restores the two nested `utf-8-validate@5.0.10` entries under `@cardano-ogmios/client` and `webpack-bundle-analyzer`.

## Existing Code Audit

- **Searched for**: recent lockfile-repair PRs and the dependabot minor-updates config.
- **Found**: #893 (previous fix for the same failure, one commit pattern earlier); `.github/workflows/ci.yml` pins `CI_NODE_VERSION: '20'`; dependabot config lives in `.github/dependabot.yml` (unchanged).
- **Decision**: minimum-surface fix only, matching #893's shape exactly. A broader fix (pin npm 10 in dependabot or suppress lockfile regeneration) is a follow-up tracked in the commit message.

## Robustness

- **Lockfile-only** — no source, no `package.json`, no workflow changes.
- **Surgical diff**: 32 lines added, restoring two nested `utf-8-validate@5.0.10` entries. Byte-for-byte the same shape as #893's diff against pre-drift main.
- **Verified**: `npm ci` under node 20.20.2 / npm 10.8.2 (CI's exact runtime) completes cleanly ("added 1898 packages in 16s", no errors).
- **Forward-compat**: npm 11 also accepts the new lockfile.

## Impact

- **What changed**: `package-lock.json` — 32 lines added, 0 removed.
- **User-facing**: No.
- **Risk**: Low — identical in shape to the merged-and-verified #893 fix. Restores CI and unblocks the queue; once main is green, Railway will deploy #892 on its next auto-deploy trigger.
- **Scope**: 1 file (`package-lock.json`). No migrations, no env vars, no Inngest, no analytics.

## Test plan

- [x] `npm ci` succeeds in a clean `node:20.20.2-bookworm` container
- [ ] CI `install` job passes on this PR
- [ ] Downstream `lint`, `type-check`, `test`, `build` pass
- [ ] After merge, Railway deploys current main (which includes #892's briefing-shell change)

> Followup: dependabot is re-dropping these nested entries on every lockfile regeneration. Either pin npm 10 / node 20 in dependabot runs, or use a lockfile-preserving strategy. Filing a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)