### PR TITLE
fix(ci): upgrade npm to 11 in install job to accept dependabot lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           node-version: ${{ env.CI_NODE_VERSION }}
           cache: npm
+      # Upgrade bundled npm (10.x) to 11.x so `npm ci` accepts lockfiles
+      # produced by dependabot, which uses npm 11 and omits certain nested
+      # optional-peer entries that npm 10 demands. Keeps dependabot updates
+      # from repeatedly breaking main's install step.
+      - name: Upgrade npm to 11
+        run: npm install -g npm@11
       - name: Compute node_modules cache key
         id: node_modules_cache_key
         run: |


### PR DESCRIPTION
## Summary

Main's `install` CI job has been failing repeatedly with `Missing: utf-8-validate@5.0.10 from lock file` every time dependabot lands a minor/patch bump. Root cause: npm 10 (bundled with node 20) demands nested optional-peer lockfile entries that dependabot's npm 11 omits. #893 and #895 both tried to fix this by regenerating the lockfile under npm 10, but each subsequent dependabot PR drops the entries again — a Whack-a-Mole loop.

This upgrades CI's `install` job to npm 11 so it accepts the exact lockfile shape dependabot produces. Loop broken at the source.

## Existing Code Audit

- **Searched for**: previous lockfile-repair PRs (#893 merged, #895 abandoned), dependabot config, all `setup-node` usages in `.github/workflows/`.
- **Found**: the `install` job is the only place `npm ci` runs — all downstream jobs restore the `node_modules` cache produced by `install`. So the npm bump only needs to happen once, in that job.
- **Decision**: single added step (`npm install -g npm@11`) in the `install` job, directly after `setup-node`. No other workflow changes, no runtime node version change, no source changes, no `package.json` / lockfile changes.

## Robustness

- **Narrow scope**: 6 lines added to one job in one workflow file. Everything else is unchanged.
- **Verified locally**: inside a clean `node:20.20.2-bookworm` container, `npm install -g npm@11` + `rm -rf node_modules && npm ci` completes cleanly ("added 1896 packages in 20s") against current main's lockfile — the exact lockfile npm 10 rejects.
- **Durable fix**: future dependabot PRs stay green without human intervention. No more regen loop.
- **Backwards-compat**: npm 11 reads lockfiles npm 10 produced, so if dependabot ever switches back, CI still passes.

## Impact

- **What changed**: `.github/workflows/ci.yml` — one step added to the `install` job (`- name: Upgrade npm to 11` / `run: npm install -g npm@11`).
- **User-facing**: No (CI-only change).
- **Risk**: Low — the step is idempotent, well-understood (`npm install -g npm@11` is a standard CI pattern), and verified locally to produce a clean `npm ci` against the current lockfile. If it ever fails, it fails fast at the install step with a clear error.
- **Scope**: 1 file (`.github/workflows/ci.yml`), 6 lines added.

## Followup (not in this PR)

- Same bump can be applied to dependabot's own runtime if we want to go the other direction, but this PR's fix is sufficient and simpler.
- Once main is green again, Railway will auto-deploy main HEAD (which already includes #892's briefing-shell fix that's been stuck undeployed since the main install broke).

## Test plan

- [x] Verified locally in `node:20.20.2-bookworm` container with npm 11 upgrade
- [ ] CI `install` job passes on this PR
- [ ] Downstream `lint` / `type-check` / `test` / `build` / `browser-smoke` / `e2e-critical` pass
- [ ] After merge, main's CI flips back to green and Railway deploys main HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)