### PR TITLE
fix(build): upgrade npm to 11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ ENV NEXT_TELEMETRY_DISABLED=1
 FROM base AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+# Upgrade bundled npm (10.x) to 11.x so `npm ci` accepts lockfiles
+# produced by dependabot, which uses npm 11 and omits nested optional-peer
+# entries that npm 10 rejects. Matches the bump already applied in
+# .github/workflows/ci.yml's install job (#896).
+RUN npm install -g npm@11 && npm ci
 
 # ── Build ──
 FROM base AS builder


### PR DESCRIPTION
## Summary

#896 fixed CI's `install` job, but Railway's `Dockerfile` still runs `npm ci` under node 20's default npm 10 and rejects dependabot's lockfile with the same `Missing: utf-8-validate@5.0.10 from lock file` error. That's been blocking every production deploy — main's briefing-shell fix (#892) has been stuck on old code (`1df971c5`) since the install broke.

Applies the same bump (`npm install -g npm@11 && npm ci`) to the Dockerfile's `deps` stage. Verified locally: `docker build --target deps` completes cleanly (20.8s deps step, image built).

## Existing Code Audit

- **Searched for**: all `npm ci` call sites — `Dockerfile` + five GitHub Actions workflows.
- **Found**: `Dockerfile` (Railway build), `.github/workflows/{ci,post-deploy,e2e,preview,seed-staging}.yml`. CI's `install` job already bumped in #896.
- **Decision**: Dockerfile is the critical one — it directly blocks Railway deploys. The other four workflows still need the same bump, but they require the `workflow` scope on the push token which isn't available in this session. Splitting them into a follow-up PR to unblock Railway now.

## Robustness

- **Narrow scope**: 4 lines added to `Dockerfile` (1 step). No other files touched.
- **Verified locally**: `docker build --target deps` completes cleanly on my machine against current main's lockfile.
- **Same proven pattern**: identical to the change already landed and verified in #896's CI install job.

## Impact

- **What changed**: `Dockerfile` `deps` stage — adds `npm install -g npm@11 &&` before `npm ci`.
- **User-facing**: No directly. Indirectly yes — unblocks Railway so #892's briefing-shell UX fix finally ships.
- **Risk**: Low. Standard, idempotent pattern. Proven to work in an identical container earlier today. If it fails, it fails fast with a clear error at build time.
- **Scope**: 1 file (`Dockerfile`), 4 lines added.

## Follow-up

Four workflow files (`post-deploy.yml`, `e2e.yml`, `preview.yml`, `seed-staging.yml`) still run `npm ci` under npm 10 and will fail whenever they next trigger. Filing as a separate PR that requires `workflow`-scoped push credentials.

## Test plan

- [x] `docker build --target deps .` completes cleanly locally
- [ ] CI `install` passes (this PR doesn't change CI, inherits #896's fix)
- [ ] After merge, Railway rebuilds and deploys main HEAD — `/api/health` flips to new SHA
- [ ] `/governance/briefing` renders header + CTA shell when API fetch fails (the original #892 change finally live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)