### PR TITLE
fix: harden Inngest serve guardrails

### DIFF
--- a/__tests__/lib/runtimeMetadata.test.ts
+++ b/__tests__/lib/runtimeMetadata.test.ts
@@ -38,6 +38,10 @@ describe('getRuntimeRelease', () => {
   });
 
   it('ignores legacy Vercel runtime metadata', () => {
+    for (const key of ['GITHUB_ACTIONS', 'GITHUB_SHA', 'SOURCE_VERSION', 'COMMIT_SHA']) {
+      vi.stubEnv(key, '');
+    }
+
     vi.stubEnv('VERCEL', '1');
     vi.stubEnv('VERCEL_ENV', 'production');
     vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'ABCDEF123456');

--- a/__tests__/lib/runtimeMetadata.test.ts
+++ b/__tests__/lib/runtimeMetadata.test.ts
@@ -22,9 +22,6 @@ describe('getRuntimeRelease', () => {
       'RAILWAY_ENVIRONMENT_ID',
       'RAILWAY_PROJECT_ID',
       'RAILWAY_GIT_COMMIT_SHA',
-      'VERCEL',
-      'VERCEL_ENV',
-      'VERCEL_GIT_COMMIT_SHA',
       'GITHUB_ACTIONS',
       'GITHUB_SHA',
       'SOURCE_VERSION',
@@ -32,6 +29,18 @@ describe('getRuntimeRelease', () => {
     ]) {
       vi.stubEnv(key, '');
     }
+
+    expect(getRuntimeRelease()).toEqual({
+      commit_sha: null,
+      source: null,
+      platform: 'unknown',
+    });
+  });
+
+  it('ignores legacy Vercel runtime metadata', () => {
+    vi.stubEnv('VERCEL', '1');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', 'ABCDEF123456');
 
     expect(getRuntimeRelease()).toEqual({
       commit_sha: null,

--- a/__tests__/scripts/agentConstraints.test.ts
+++ b/__tests__/scripts/agentConstraints.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   analyzeRouteRenderContract,
+  validateInngestServeMethods,
   validateRouteRenderContract,
 } from '@/scripts/lib/agentConstraints.mjs';
 import { getRouteRenderPolicy } from '@/scripts/lib/routeRenderPolicy.mjs';
@@ -57,5 +58,30 @@ describe('route render policy contract', () => {
       usesCachedData: true,
       usesRequestScopedRuntime: true,
     });
+  });
+});
+
+describe('Inngest serve method contract', () => {
+  it('allows the required Inngest serve methods', () => {
+    const content = "export const { GET, POST, PUT } = serve({ client: inngest, functions: [] });";
+
+    expect(validateInngestServeMethods('app/api/inngest/route.ts', content)).toEqual([]);
+  });
+
+  it('rejects unsupported Inngest serve method exports', () => {
+    const content = [
+      'export const {',
+      '  GET,',
+      '  POST,',
+      '  PUT,',
+      '  PATCH,',
+      '  OPTIONS: OPTIONSHandler,',
+      '  DELETE,',
+      '} = serve({ client: inngest, functions: [] });',
+    ].join('\n');
+
+    expect(validateInngestServeMethods('app/api/inngest/route.ts', content)).toEqual([
+      'app/api/inngest/route.ts: Inngest serve() must only export GET, POST, and PUT. Remove unsupported method export(s): PATCH, OPTIONS, DELETE.',
+    ]);
   });
 });

--- a/__tests__/scripts/agentConstraints.test.ts
+++ b/__tests__/scripts/agentConstraints.test.ts
@@ -63,7 +63,7 @@ describe('route render policy contract', () => {
 
 describe('Inngest serve method contract', () => {
   it('allows the required Inngest serve methods', () => {
-    const content = "export const { GET, POST, PUT } = serve({ client: inngest, functions: [] });";
+    const content = 'export const { GET, POST, PUT } = serve({ client: inngest, functions: [] });';
 
     expect(validateInngestServeMethods('app/api/inngest/route.ts', content)).toEqual([]);
   });

--- a/lib/runtimeMetadata.ts
+++ b/lib/runtimeMetadata.ts
@@ -1,12 +1,11 @@
 export interface RuntimeRelease {
   commit_sha: string | null;
   source: string | null;
-  platform: 'railway' | 'vercel' | 'github' | 'unknown';
+  platform: 'railway' | 'github' | 'unknown';
 }
 
 const COMMIT_SHA_KEYS = [
   'RAILWAY_GIT_COMMIT_SHA',
-  'VERCEL_GIT_COMMIT_SHA',
   'GITHUB_SHA',
   'SOURCE_VERSION',
   'COMMIT_SHA',
@@ -20,10 +19,6 @@ function normalizeCommitSha(value: string | undefined): string | null {
 function detectPlatform(): RuntimeRelease['platform'] {
   if (process.env.RAILWAY_ENVIRONMENT_ID || process.env.RAILWAY_PROJECT_ID) {
     return 'railway';
-  }
-
-  if (process.env.VERCEL || process.env.VERCEL_ENV) {
-    return 'vercel';
   }
 
   if (process.env.GITHUB_ACTIONS) {

--- a/scripts/lib/agentConstraints.mjs
+++ b/scripts/lib/agentConstraints.mjs
@@ -5,8 +5,7 @@ const cachedDataUsage =
   /from\s+['"]@\/lib\/data['"]|from\s+['"]@\/lib\/data\/[^'"]+['"]|import\s*\(\s*['"]@\/lib\/data(?:\/[^'"]+)?['"]\s*\)/;
 const requestScopedUsage =
   /process\.env\.[A-Z0-9_]+|from\s+['"]@\/lib\/(?:redis|supabase(?:[^'"]*)?)['"]|from\s+['"]@\/lib\/(?:redis|supabase(?:[^'"]*)?)\/[^'"]+['"]|from\s+['"]next\/headers['"]|(?:^|\W)(headers|cookies|draftMode|connection)\s*\(/m;
-const inngestServeExport =
-  /export\s+const\s*\{([\s\S]*?)\}\s*=\s*serve\s*\(/g;
+const inngestServeExport = /export\s+const\s*\{([\s\S]*?)\}\s*=\s*serve\s*\(/g;
 const forbiddenInngestServeMethods = new Set(['PATCH', 'OPTIONS', 'DELETE']);
 
 export function analyzeRouteRenderContract(relativePath, content) {

--- a/scripts/lib/agentConstraints.mjs
+++ b/scripts/lib/agentConstraints.mjs
@@ -5,6 +5,9 @@ const cachedDataUsage =
   /from\s+['"]@\/lib\/data['"]|from\s+['"]@\/lib\/data\/[^'"]+['"]|import\s*\(\s*['"]@\/lib\/data(?:\/[^'"]+)?['"]\s*\)/;
 const requestScopedUsage =
   /process\.env\.[A-Z0-9_]+|from\s+['"]@\/lib\/(?:redis|supabase(?:[^'"]*)?)['"]|from\s+['"]@\/lib\/(?:redis|supabase(?:[^'"]*)?)\/[^'"]+['"]|from\s+['"]next\/headers['"]|(?:^|\W)(headers|cookies|draftMode|connection)\s*\(/m;
+const inngestServeExport =
+  /export\s+const\s*\{([\s\S]*?)\}\s*=\s*serve\s*\(/g;
+const forbiddenInngestServeMethods = new Set(['PATCH', 'OPTIONS', 'DELETE']);
 
 export function analyzeRouteRenderContract(relativePath, content) {
   return {
@@ -43,6 +46,34 @@ export function validateRouteRenderContract(relativePath, content) {
     errors.push(
       `${analysis.relativePath}: classified as ${analysis.policy.mode} in scripts/lib/routeRenderPolicy.mjs and touches cached/request-scoped runtime data, so it must export "export const dynamic = 'force-dynamic'".`,
     );
+  }
+
+  return errors;
+}
+
+function parseDestructuredExportNames(exportClause) {
+  return exportClause
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => part.split(':')[0].trim())
+    .filter(Boolean);
+}
+
+export function validateInngestServeMethods(relativePath, content) {
+  const errors = [];
+
+  for (const match of content.matchAll(inngestServeExport)) {
+    const exportedMethods = parseDestructuredExportNames(match[1]);
+    const forbiddenMethods = exportedMethods.filter((method) =>
+      forbiddenInngestServeMethods.has(method),
+    );
+
+    if (forbiddenMethods.length > 0) {
+      errors.push(
+        `${relativePath}: Inngest serve() must only export GET, POST, and PUT. Remove unsupported method export(s): ${forbiddenMethods.join(', ')}.`,
+      );
+    }
   }
 
   return errors;

--- a/scripts/validate-agent-constraints.mjs
+++ b/scripts/validate-agent-constraints.mjs
@@ -1,6 +1,9 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import { validateRouteRenderContract } from './lib/agentConstraints.mjs';
+import {
+  validateInngestServeMethods,
+  validateRouteRenderContract,
+} from './lib/agentConstraints.mjs';
 
 const root = process.cwd();
 const errors = [];
@@ -104,6 +107,10 @@ function validateInngestRegistration() {
       );
     }
   }
+
+  errors.push(
+    ...validateInngestServeMethods('app/api/inngest/route.ts', routeContent),
+  );
 }
 
 function validateRequiredFiles() {

--- a/scripts/validate-agent-constraints.mjs
+++ b/scripts/validate-agent-constraints.mjs
@@ -108,9 +108,7 @@ function validateInngestRegistration() {
     }
   }
 
-  errors.push(
-    ...validateInngestServeMethods('app/api/inngest/route.ts', routeContent),
-  );
+  errors.push(...validateInngestServeMethods('app/api/inngest/route.ts', routeContent));
 }
 
 function validateRequiredFiles() {


### PR DESCRIPTION
## Summary
- Add an agent validation guard that rejects unsupported method exports from the Inngest `serve()` route.
- Remove Vercel from active runtime release detection so Railway remains the only app-hosting platform path.
- Add focused regression coverage for the Inngest route-method contract and legacy Vercel metadata handling.

## Existing Code Audit
- Confirmed `app/api/inngest/route.ts` currently exports only `GET`, `POST`, and `PUT`.
- Confirmed active Vercel references are limited to historical ADRs and a regression test; no active Vercel deployment config or scripts were changed.

## Robustness
- `npm run agent:validate` now fails if future changes export `PATCH`, `OPTIONS`, or `DELETE` from the Inngest `serve()` handler.
- Runtime metadata now ignores legacy Vercel environment metadata instead of reporting Vercel as an active platform.

## Impact
- Prevents future route-method regressions around the Inngest handler.
- Reduces deployment-platform ambiguity in health/release metadata.
- No runtime behavior changes to the current Inngest route, which already uses the required methods.

## Verification
- GitHub CI passed on the same head commit in draft PR #898 before opening this non-draft replacement.
- `npm run test:unit -- __tests__/lib/runtimeMetadata.test.ts __tests__/scripts/agentConstraints.test.ts`
- `GITHUB_ACTIONS=true GITHUB_SHA=651d3a33b08cbfc66ce2fd05951bfb1a62f03a3d npm run test:unit -- __tests__/lib/runtimeMetadata.test.ts __tests__/scripts/agentConstraints.test.ts`
- `npm run format:check`
- `npm run agent:validate`
- `npm run lint`
- `npm run type-check`
- `npm run pre-merge-check -- 898`