### PR TITLE
[codex] Stabilize Phase 0A reality checks

### DIFF
--- a/docs/operations/mac-agent-os-phase-0a-handoff.md
+++ b/docs/operations/mac-agent-os-phase-0a-handoff.md
@@ -1,0 +1,95 @@
+# Mac Agent OS Phase 0A Handoff
+
+Date: 2026-04-24
+Owner: Codex
+Scope: Phase 0A reality hygiene only. Broader roadmap phases were not implemented.
+
+## Research Performed
+
+- Read the requested control-plane docs in `governada-brain`: roadmap, system overview, agent operating model, tooling matrix, data boundaries, autonomy policy, plus `governada-app/AGENTS.md`.
+- Read additional drift targets: `current-state.md`, `milestones.md`, `retrieval-policy.md`, `retrieval-interfaces.md`, BlueCargo agent context and indexing policy, retrieval READMEs, worktree scripts, `docs-doctor`, `session-doctor`, and `gh-auth-status`.
+- Ran `npm run session:guard`, `npm run session:doctor`, `npm run docs:doctor`, and `npm run gh:auth-status`.
+- Checked Governada and BlueCargo retrieval wrappers, index timestamps, metadata chunk counts, and vault files newer than indexes.
+- Checked local tool availability for repo, retrieval, auth, browser testing, and local model claims.
+
+## Current Local Reality
+
+- `session:guard` passed before Phase 0A edits.
+- `session:doctor` passed before Phase 0A edits, with 13 registered worktrees and no dirty or gone-upstream registered worktrees. After creating this Phase 0A worktree, `session:doctor` reports 15 registered worktrees because it also sees an external detached Codex worktree at `/Users/tim/.codex/worktrees/f78c/governada-app`.
+- `docs:doctor` failed before Phase 0A edits because `build-manifest.md` had an Inngest count of 57 instead of 59, the manifest was older than `ultimate-vision.md`, and the generated registry index was stale.
+- `gh:auth-status` succeeded with repo context `governada/governada-app` and a 1Password token source, but its old implementation printed the raw `gh auth status` output, including a token-like masked line.
+- Governada retrieval runs through `/Users/tim/dev/governada/governada-retrieval/gr`; live metadata has 278 chunks. The index was built at 2026-04-23 18:55:47 -0400. `governada-brain/agents/system/roadmap.md` is newer than that index.
+- BlueCargo retrieval runs through `/Users/tim/dev/bluecargo/bluecargo-retrieval/br`; live metadata has 41 chunks. The index was built at 2026-04-22 00:39:35 -0400 and no BlueCargo vault markdown was newer than the index during this check.
+- Shell `PATH` did not expose `gr`, `gr_task`, `br`, or `br_task`; absolute wrappers are present and executable.
+- `governada-brain`, `governada-retrieval`, and `bluecargo-retrieval` were not Git repositories during this check.
+- Local tools observed: Node v25.9.0, npm 11.12.1, git 2.53.0, gh 2.90.0, op 2.34.0, Python 3.14.4 globally, ripgrep 15.1.0, and `@playwright/test` 1.59.1. LM Studio and `lms` exist, but the LM Studio server was off. Ollama, Open WebUI app, and Hammerspoon were not found.
+
+## Worktree Classification
+
+| Branch                             | Path                                             | Classification  | Notes                                                                           |
+| ---------------------------------- | ------------------------------------------------ | --------------- | ------------------------------------------------------------------------------- |
+| `main`                             | `/Users/tim/dev/governada/governada-app`         | keep            | Shared checkout; clean; stays on `main`.                                        |
+| `(detached)`                       | `/Users/tim/.codex/worktrees/f78c/governada-app` | keep            | Clean, exactly at main; appears Codex-managed and outside `.claude/worktrees/`. |
+| `codex/phase-0a-reality-hygiene`   | `.claude/worktrees/phase-0a-reality-hygiene`     | active          | Current Phase 0A worktree.                                                      |
+| `claude/amazing-tu-f1cc0e`         | `.claude/worktrees/amazing-tu-f1cc0e`            | unknown         | Clean, unmerged local work; no upstream in local branch metadata.               |
+| `codex/auth-hardening`             | `.claude/worktrees/auth-hardening`               | active          | Clean, unmerged, has upstream branch.                                           |
+| `fix/dockerfile-npm11-only`        | `.claude/worktrees/dockerfile-npm11`             | unknown         | Clean, unmerged local work; related npm 11 branch history exists.               |
+| `codex/inngest-security-followup`  | `.claude/worktrees/inngest-security-followup`    | active          | Clean, unmerged, has upstream branch.                                           |
+| `fix/lockfile-drift-npm10`         | `.claude/worktrees/lockfile-refresh`             | unknown         | Clean, one local commit relative to main; no upstream in local branch metadata. |
+| `feat/node24-lts`                  | `.claude/worktrees/node24-lts`                   | active          | Clean, one local commit ahead of main.                                          |
+| `feat/obsidian-runbook`            | `.claude/worktrees/obsidian-runbook`             | active          | Clean, three local commits ahead of main.                                       |
+| `fix/restore-894-deps`             | `.claude/worktrees/restore-894`                  | unknown         | Clean, one local commit relative to main; no upstream in local branch metadata. |
+| `claude/serene-liskov-38d43a`      | `.claude/worktrees/serene-liskov-38d43a`         | merged/prunable | Clean, no commits ahead of main.                                                |
+| `claude/upbeat-liskov-8f594e`      | `.claude/worktrees/upbeat-liskov-8f594e`         | merged/prunable | Clean, no commits ahead of main.                                                |
+| `claude/vigorous-euclid-f7df65`    | `.claude/worktrees/vigorous-euclid-f7df65`       | merged/prunable | Clean, exactly at main during this check.                                       |
+| `claude/xenodochial-agnesi-ec1509` | `.claude/worktrees/xenodochial-agnesi-ec1509`    | unknown         | Clean, one local commit ahead and behind main.                                  |
+
+Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not registered by `git worktree list`; its `.git` pointer references `/Users/tim/governada-app/.git/worktrees/auth-cookie-cleanup`. Treat as unknown/orphaned and do not delete without Tim confirming ownership.
+
+## Drift Found
+
+- `retrieval-policy.md` and `autonomy-policy.md` still say BlueCargo is not indexed; live wrappers, `retrieval-interfaces.md`, `tooling-matrix.md`, and retrieval execution show BlueCargo v1 exists locally.
+- `bluecargo-brain/agents/bluecargo-context.md` still says retrieval is not enabled, and that stale statement is included in the BlueCargo index.
+- `current-state.md` says Governada has about 93 indexed chunks; live metadata has 278.
+- `governada-retrieval/README.md` still lists adding BlueCargo retrieval as a next step.
+- `tooling-matrix.md` gives a portable absolute wrapper example for Governada only.
+- `scripts/new-worktree.mjs` and `scripts/sync-worktree.mjs` copy `.env.local` into worktrees; this should be replaced with a 1Password-backed reference/injection flow in a later slice.
+
+## Phase 0A Fixes Applied
+
+- `scripts/gh-auth-status.js` now verifies GitHub API auth and repo access without calling `gh auth status`, avoiding token-like output.
+- `scripts/session-doctor.js` now reports orphaned `.claude/worktrees/*` directories as advisories.
+- `docs/strategy/context/build-manifest.md` now records 59 Inngest functions.
+- `docs/strategy/context/registry/_index.generated.md` was regenerated.
+- This durable handoff note records current reality for Phase 0B.
+
+## Validation Plan
+
+- `npm run docs:doctor`
+- `npm run session:doctor`
+- `npm run session:guard`
+- `npm run gh:auth-status`
+- `npm run registry:index:check`
+- `npm run agent:validate`
+
+## Validation Results
+
+- `npm run docs:doctor`: pass after manifest and registry refresh.
+- `npm run registry:index:check`: pass.
+- `npm run gh:auth-status`: pass; output no longer includes token-like `gh auth status` lines.
+- `npm run session:doctor`: pass as a diagnostic command; reports the current dirty Phase 0A worktree, 15 registered worktrees, and one orphaned `.claude/worktrees` directory.
+- `npm run agent:validate`: pass.
+- `npm run format:check`: pass after formatting this handoff note.
+- Final strict `npm run session:guard`: run after committing this change set so the dirty-current-worktree warning can clear.
+
+## Phase 0B Recommended Scope
+
+- Decide and implement durability/versioning for `governada-brain`, `governada-retrieval`, and `bluecargo-retrieval`, or record accepted loss risk explicitly.
+- Add a retrieval doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and domain-policy drift.
+- Reconcile BlueCargo retrieval policy across `retrieval-policy.md`, `autonomy-policy.md`, `bluecargo-context.md`, `retrieval-interfaces.md`, and `tooling-matrix.md`.
+- Replace `.env.local` worktree copying with a 1Password-backed local injection/reference path.
+- Add a capability registry entry for LM Studio as installed but inactive/unproven; keep Ollama, Open WebUI, and Hammerspoon marked unavailable until installed and tested.
+
+## Ready Prompt For Phase 0B
+
+You are taking over Phase 0B: Brain, Retrieval, and Control-Plane Reliability for the Mac Agent Operating System initiative. Start by reading `/Users/tim/dev/governada/governada-app/docs/operations/mac-agent-os-phase-0a-handoff.md` and the roadmap/control-plane docs it references. Do not broaden into provider parity or model collaboration. Your first job is to decide or document durability/versioning for `governada-brain` and the retrieval projects, add executable retrieval/control-plane doctors where practical, and reconcile BlueCargo retrieval policy drift without merging domain indexes or changing secret flow.

--- a/docs/operations/mac-agent-os-phase-0a-handoff.md
+++ b/docs/operations/mac-agent-os-phase-0a-handoff.md
@@ -6,18 +6,21 @@ Scope: Phase 0A reality hygiene only. Broader roadmap phases were not implemente
 
 ## Research Performed
 
-- Read the requested control-plane docs in `governada-brain`: roadmap, system overview, agent operating model, tooling matrix, data boundaries, autonomy policy, plus `governada-app/AGENTS.md`.
+- Read the requested control-plane docs in `governada-brain`: roadmap, system overview, agent operating model, tooling matrix, data boundaries, autonomy policy, plus the auth map at `/Users/tim/dev/governada/governada-brain/agents/system/auth-and-identity.md` and `governada-app/AGENTS.md`.
 - Read additional drift targets: `current-state.md`, `milestones.md`, `retrieval-policy.md`, `retrieval-interfaces.md`, BlueCargo agent context and indexing policy, retrieval READMEs, worktree scripts, `docs-doctor`, `session-doctor`, and `gh-auth-status`.
-- Ran `npm run session:guard`, `npm run session:doctor`, `npm run docs:doctor`, and `npm run gh:auth-status`.
+- Ran `npm run session:guard`, `npm run session:doctor`, `npm run docs:doctor`, `npm run gh:auth-status`, and `npm run auth:doctor`.
 - Checked Governada and BlueCargo retrieval wrappers, index timestamps, metadata chunk counts, and vault files newer than indexes.
 - Checked local tool availability for repo, retrieval, auth, browser testing, and local model claims.
 
 ## Current Local Reality
 
 - `session:guard` passed before Phase 0A edits.
-- `session:doctor` passed before Phase 0A edits, with 13 registered worktrees and no dirty or gone-upstream registered worktrees. After creating this Phase 0A worktree, `session:doctor` reports 15 registered worktrees because it also sees an external detached Codex worktree at `/Users/tim/.codex/worktrees/f78c/governada-app`.
+- `session:doctor` passed before Phase 0A edits, with 13 registered worktrees and no dirty or gone-upstream registered worktrees. During PR #901 closeout, `session:doctor` reports 14 registered worktrees because it also sees an external detached Codex worktree at `/Users/tim/.codex/worktrees/f78c/governada-app`.
 - `docs:doctor` failed before Phase 0A edits because `build-manifest.md` had an Inngest count of 57 instead of 59, the manifest was older than `ultimate-vision.md`, and the generated registry index was stale.
 - `gh:auth-status` succeeded with repo context `governada/governada-app` and a 1Password token source, but its old implementation printed the raw `gh auth status` output, including a token-like masked line.
+- PR #901 exposed an auth-runtime gap after CI passed: Codex Desktop sandboxing may block 1Password desktop IPC even when the same `op read` succeeds outside the sandbox. This is an execution-boundary issue, not a reason to switch to global `gh auth login`, raw tokens, generic GitHub remotes, or BlueCargo credentials.
+- During the PR #901 closeout update, `gh:auth-status` and `auth:doctor` both reported the same blocked desktop 1Password lane from Codex. The shared wrapper now redacts secret references and times out deterministically instead of hanging or printing the full `op://...` reference.
+- The current Governada auth map lives at `/Users/tim/dev/governada/governada-brain/agents/system/auth-and-identity.md`. It defines desktop 1Password as the human-present lane and assigns sandbox-compatible autonomous auth design to Phase 0B / Phase 0.5.
 - Governada retrieval runs through `/Users/tim/dev/governada/governada-retrieval/gr`; live metadata has 278 chunks. The index was built at 2026-04-23 18:55:47 -0400. `governada-brain/agents/system/roadmap.md` is newer than that index.
 - BlueCargo retrieval runs through `/Users/tim/dev/bluecargo/bluecargo-retrieval/br`; live metadata has 41 chunks. The index was built at 2026-04-22 00:39:35 -0400 and no BlueCargo vault markdown was newer than the index during this check.
 - Shell `PATH` did not expose `gr`, `gr_task`, `br`, or `br_task`; absolute wrappers are present and executable.
@@ -41,7 +44,6 @@ Scope: Phase 0A reality hygiene only. Broader roadmap phases were not implemente
 | `fix/restore-894-deps`             | `.claude/worktrees/restore-894`                  | unknown         | Clean, one local commit relative to main; no upstream in local branch metadata. |
 | `claude/serene-liskov-38d43a`      | `.claude/worktrees/serene-liskov-38d43a`         | merged/prunable | Clean, no commits ahead of main.                                                |
 | `claude/upbeat-liskov-8f594e`      | `.claude/worktrees/upbeat-liskov-8f594e`         | merged/prunable | Clean, no commits ahead of main.                                                |
-| `claude/vigorous-euclid-f7df65`    | `.claude/worktrees/vigorous-euclid-f7df65`       | merged/prunable | Clean, exactly at main during this check.                                       |
 | `claude/xenodochial-agnesi-ec1509` | `.claude/worktrees/xenodochial-agnesi-ec1509`    | unknown         | Clean, one local commit ahead and behind main.                                  |
 
 Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not registered by `git worktree list`; its `.git` pointer references `/Users/tim/governada-app/.git/worktrees/auth-cookie-cleanup`. Treat as unknown/orphaned and do not delete without Tim confirming ownership.
@@ -58,6 +60,9 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 ## Phase 0A Fixes Applied
 
 - `scripts/gh-auth-status.js` now verifies GitHub API auth and repo access without calling `gh auth status`, avoiding token-like output.
+- `scripts/lib/gh-auth.js` now bounds `op read`, redacts token-like strings and `op://...` references from auth failures, and names desktop IPC/authorization timeout as the likely blocked lane.
+- `npm run auth:doctor` now reports the repo-pinned Governada GitHub lane, verifies the 1Password reference without printing it, classifies Codex sandbox desktop-IPC failure explicitly, and only runs child `gh` checks after the 1Password lane is ready.
+- `scripts/repair-gh-auth.mjs` no longer points agents at `gh auth login`; it directs them back through `auth:doctor` and the repo-scoped 1Password lane.
 - `scripts/session-doctor.js` now reports orphaned `.claude/worktrees/*` directories as advisories.
 - `docs/strategy/context/build-manifest.md` now records 59 Inngest functions.
 - `docs/strategy/context/registry/_index.generated.md` was regenerated.
@@ -69,6 +74,7 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 - `npm run session:doctor`
 - `npm run session:guard`
 - `npm run gh:auth-status`
+- `npm run auth:doctor`
 - `npm run registry:index:check`
 - `npm run agent:validate`
 
@@ -76,18 +82,23 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 
 - `npm run docs:doctor`: pass after manifest and registry refresh.
 - `npm run registry:index:check`: pass.
-- `npm run gh:auth-status`: pass; output no longer includes token-like `gh auth status` lines.
-- `npm run session:doctor`: pass as a diagnostic command; reports the current dirty Phase 0A worktree, 15 registered worktrees, and one orphaned `.claude/worktrees` directory.
+- `npm run gh:auth-status`: earlier Phase 0A run passed after the token-like `gh auth status` output was removed. Current PR #901 closeout runs from Codex, including a sandbox-escalated retry, block on 1Password desktop IPC / authorization timeout and now emit a deterministic redacted error.
+- `npm run auth:doctor`: diagnostic block in the Codex sandbox because 1Password desktop IPC is unavailable from this process, then skips child `gh` checks. Output does not print raw tokens or the full `op://...` reference. This is the PR #901 auth-runtime finding to carry into Phase 0B.
+- `npm run session:doctor`: pass as a diagnostic command; reports the current dirty Phase 0A worktree, 14 registered worktrees, and one orphaned `.claude/worktrees` directory.
+- Final strict `npm run session:guard`: pass after committing the auth-runtime closeout; worktree clean, no stashes, no dirty or gone-upstream registered worktrees. Advisories remain for 14 open worktrees and one orphaned `.claude/worktrees` directory.
 - `npm run agent:validate`: pass.
 - `npm run format:check`: pass after formatting this handoff note.
-- Final strict `npm run session:guard`: run after committing this change set so the dirty-current-worktree warning can clear.
 
 ## Phase 0B Recommended Scope
 
 - Decide and implement durability/versioning for `governada-brain`, `governada-retrieval`, and `bluecargo-retrieval`, or record accepted loss risk explicitly.
+- Use `/Users/tim/dev/governada/governada-brain/agents/system/auth-and-identity.md` as the auth/identity control-plane source and reconcile implementation details back to it.
+- Design the durable sandbox-compatible autonomous auth lane; do not treat desktop 1Password IPC as sufficient for unattended Codex work.
+- Add an auth capability registry entry covering owner, operation classes, account/vault boundary, verification command, fallback, and revocation path.
 - Add a retrieval doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and domain-policy drift.
 - Reconcile BlueCargo retrieval policy across `retrieval-policy.md`, `autonomy-policy.md`, `bluecargo-context.md`, `retrieval-interfaces.md`, and `tooling-matrix.md`.
 - Replace `.env.local` worktree copying with a 1Password-backed local injection/reference path.
+- Evaluate GitHub App installation tokens vs a narrow 1Password service account vs an interim fine-grained PAT; do not implement a new auth lane until Tim approves the chosen design.
 - Add a capability registry entry for LM Studio as installed but inactive/unproven; keep Ollama, Open WebUI, and Hammerspoon marked unavailable until installed and tested.
 
 ## Copy/Paste Prompt For Next Agent
@@ -99,6 +110,7 @@ You are taking over Phase 0B: Brain, Retrieval, and Control-Plane Reliability fo
 
 Start by reading:
 - /Users/tim/dev/governada/governada-app/docs/operations/mac-agent-os-phase-0a-handoff.md
+- /Users/tim/dev/governada/governada-brain/agents/system/auth-and-identity.md
 - /Users/tim/dev/governada/governada-brain/agents/system/roadmap.md
 - /Users/tim/dev/governada/governada-brain/agents/system/system-overview.md
 - /Users/tim/dev/governada/governada-brain/agents/system/agent-operating-model.md
@@ -110,15 +122,19 @@ Start by reading:
 Do not broaden into provider parity, model collaboration, desktop automation, source-of-truth vault writeback, or broader roadmap phases.
 
 Phase 0B goal:
-Make the brain, retrieval, and control-plane layer reliable enough that future agents can trust the doctors and handoff packets before doing deeper implementation.
+Make the brain, retrieval, auth-runtime, and control-plane layer reliable enough that future agents can trust the doctors and handoff packets before doing deeper implementation.
 
 Use the Phase 0A handoff as primary current-state evidence. Refresh reality where it is cheap and important, especially for drift-prone checks.
+
+Phase 0A auth-runtime finding:
+Codex Desktop sandboxing may block 1Password desktop IPC even when `op read` succeeds outside the sandbox. Preserve 1Password as the source of truth. Do not bypass this with global `gh auth login`, raw-token fallbacks, generic GitHub remotes, or cross-domain credentials.
 
 Required first checks:
 - npm run session:guard
 - npm run session:doctor
 - npm run docs:doctor
 - npm run gh:auth-status
+- npm run auth:doctor
 - Governada retrieval wrapper/index status
 - BlueCargo retrieval wrapper/index status
 - Git/versioning status for governada-brain, governada-retrieval, and bluecargo-retrieval
@@ -130,12 +146,16 @@ Boundaries:
 - Do not merge Governada and BlueCargo retrieval indexes.
 - Do not change .env.local or secret flow in this phase unless Tim explicitly approves the exact design.
 - Treat BlueCargo retrieval as local-only until docs and policy say otherwise.
+- Do not implement service accounts, GitHub App auth, or a new token lane until the Phase 0B design is explicit and Tim approves it.
 
 Recommended work slices:
 1. Decide with Tim whether governada-brain, governada-retrieval, and bluecargo-retrieval should be Git-versioned now or have accepted local-loss risk documented.
-2. Add a retrieval/control-plane doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and policy drift.
-3. Reconcile BlueCargo retrieval policy drift across retrieval-policy.md, autonomy-policy.md, bluecargo-context.md, retrieval-interfaces.md, and tooling-matrix.md.
-4. Update durable ops notes and/or roadmap current reality after checks and fixes.
+2. Extend the auth-runtime design from auth-and-identity.md into an implementation plan: sandbox-compatible autonomous lane, auth capability registry, operation classes, approval posture, fallback, and revocation path.
+3. Decide between GitHub App installation tokens, a narrow 1Password service account, and an interim fine-grained PAT for the first autonomous GitHub lane.
+4. Replace .env.local worktree copying with a 1Password-backed reference/injection design, then implement only after approval.
+5. Add a retrieval/control-plane doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and policy drift.
+6. Reconcile BlueCargo retrieval policy drift across retrieval-policy.md, autonomy-policy.md, bluecargo-context.md, retrieval-interfaces.md, and tooling-matrix.md.
+7. Update durable ops notes and/or roadmap current reality after checks and fixes.
 
 Before implementing, output:
 - Research Performed

--- a/docs/operations/mac-agent-os-phase-0a-handoff.md
+++ b/docs/operations/mac-agent-os-phase-0a-handoff.md
@@ -60,7 +60,7 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 ## Phase 0A Fixes Applied
 
 - `scripts/gh-auth-status.js` now verifies GitHub API auth and repo access without calling `gh auth status`, avoiding token-like output.
-- `scripts/lib/gh-auth.js` now bounds `op read`, redacts token-like strings and `op://...` references from auth failures, and names desktop IPC/authorization timeout as the likely blocked lane.
+- `scripts/lib/gh-auth.js` now bounds `op read`, redacts token-like strings and `op://...` references from auth failures, names desktop IPC/authorization timeout as the likely blocked lane, and prefers the configured 1Password reference over ambient raw GitHub token env.
 - `npm run auth:doctor` now reports the repo-pinned Governada GitHub lane, verifies the 1Password reference without printing it, classifies Codex sandbox desktop-IPC failure explicitly, and only runs child `gh` checks after the 1Password lane is ready.
 - `scripts/repair-gh-auth.mjs` no longer points agents at `gh auth login`; it directs them back through `auth:doctor` and the repo-scoped 1Password lane.
 - `scripts/session-doctor.js` now reports orphaned `.claude/worktrees/*` directories as advisories.
@@ -82,12 +82,30 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 
 - `npm run docs:doctor`: pass after manifest and registry refresh.
 - `npm run registry:index:check`: pass.
-- `npm run gh:auth-status`: earlier Phase 0A run passed after the token-like `gh auth status` output was removed. Current PR #901 closeout runs from Codex, including a sandbox-escalated retry, block on 1Password desktop IPC / authorization timeout and now emit a deterministic redacted error.
+- `npm run gh:auth-status`: no longer emits token-like `gh auth status` output. In current Codex runs it can still block on 1Password desktop IPC / authorization timeout, including after sandbox escalation, and emits a deterministic redacted error.
 - `npm run auth:doctor`: diagnostic block in the Codex sandbox because 1Password desktop IPC is unavailable from this process, then skips child `gh` checks. Output does not print raw tokens or the full `op://...` reference. This is the PR #901 auth-runtime finding to carry into Phase 0B.
 - `npm run session:doctor`: pass as a diagnostic command; reports the current dirty Phase 0A worktree, 14 registered worktrees, and one orphaned `.claude/worktrees` directory.
 - Final strict `npm run session:guard`: pass after committing the auth-runtime closeout; worktree clean, no stashes, no dirty or gone-upstream registered worktrees. Advisories remain for 14 open worktrees and one orphaned `.claude/worktrees` directory.
 - `npm run agent:validate`: pass.
 - `npm run format:check`: pass after formatting this handoff note.
+
+## Review Gate v0
+
+- Review gate tier: foundational auth/runtime/harness work. Minimum one independent review; preferred two perspectives when available.
+- Reviewers requested: fresh read-only Codex code/runtime reviewer, plus fresh read-only policy/boundary reviewer as the Claude Code fallback because managed Claude review is not wired in this session.
+- Prompts/focus used: code/runtime review focused on auth-runtime regressions, token/reference leakage, sandbox/escalation behavior, GitHub wrapper correctness, and Phase 0A scope creep. Policy/boundary review focused on policy consistency, auth-boundary correctness, Governada/BlueCargo isolation, Phase 0A vs Phase 0B scope, and handoff quality.
+- Review result summary: initial merge posture was blocked because both reviews found important auth-diagnostic gaps and the handoff lacked an explicit review-gate record.
+- Findings fixed:
+  - Raw token env could satisfy or distort `auth:doctor`; `auth:doctor` now blocks when `GH_TOKEN` or `GITHUB_TOKEN` is present.
+  - `gh:auth-status` could report a 1Password reference while `runGh` used an ambient raw token; the shared auth helper now resolves the configured 1Password reference whenever present and overrides ambient raw token env for child `gh`.
+  - `op://...` reference redaction stopped at whitespace; the shared redactor now covers references with spaces up to quotes or line breaks.
+  - `auth:doctor` classified authorization timeout less specifically than the shared helper; it now treats authorization timeout as the desktop IPC lane.
+  - Review Gate v0 metadata was missing from the handoff; this section records the tier, reviewers, prompts, findings, deferments, and merge posture.
+- Validation after fixes: `node --check` passed for the changed auth scripts; redactor smoke test removed full `op://...`, GitHub PAT, and `gh*` token-shaped strings; raw-token `auth:doctor` simulation blocked; `docs:doctor` and `agent:validate` passed. `gh:auth-status` remains blocked in the current Codex run by the documented 1Password desktop IPC / authorization timeout lane.
+- Findings deferred:
+  - Managed Claude Code Review is not confirmed wired; Phase 0B / Phase 0.5 should add review tools to the capability registry before making managed review automatic.
+  - The Codex-to-1Password desktop IPC blocker is not solved in Phase 0A; it is documented as the durable Phase 0B auth-runtime design problem.
+- Safe to merge: code/runtime and policy Review Gate v0 findings are fixed, but hold merge until the final review-gate commit is pushed, CI passes, and Tim explicitly accepts the documented Phase 0B auth-runtime deferment if local `pre-merge-check`/merge wrappers still block on desktop IPC. Do not merge through a bypassed auth path.
 
 ## Phase 0B Recommended Scope
 

--- a/docs/operations/mac-agent-os-phase-0a-handoff.md
+++ b/docs/operations/mac-agent-os-phase-0a-handoff.md
@@ -90,6 +90,63 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 - Replace `.env.local` worktree copying with a 1Password-backed local injection/reference path.
 - Add a capability registry entry for LM Studio as installed but inactive/unproven; keep Ollama, Open WebUI, and Hammerspoon marked unavailable until installed and tested.
 
-## Ready Prompt For Phase 0B
+## Copy/Paste Prompt For Next Agent
 
-You are taking over Phase 0B: Brain, Retrieval, and Control-Plane Reliability for the Mac Agent Operating System initiative. Start by reading `/Users/tim/dev/governada/governada-app/docs/operations/mac-agent-os-phase-0a-handoff.md` and the roadmap/control-plane docs it references. Do not broaden into provider parity or model collaboration. Your first job is to decide or document durability/versioning for `governada-brain` and the retrieval projects, add executable retrieval/control-plane doctors where practical, and reconcile BlueCargo retrieval policy drift without merging domain indexes or changing secret flow.
+Use this prompt verbatim to start Phase 0B with a fresh agent:
+
+```text
+You are taking over Phase 0B: Brain, Retrieval, and Control-Plane Reliability for the Mac Agent Operating System initiative.
+
+Start by reading:
+- /Users/tim/dev/governada/governada-app/docs/operations/mac-agent-os-phase-0a-handoff.md
+- /Users/tim/dev/governada/governada-brain/agents/system/roadmap.md
+- /Users/tim/dev/governada/governada-brain/agents/system/system-overview.md
+- /Users/tim/dev/governada/governada-brain/agents/system/agent-operating-model.md
+- /Users/tim/dev/governada/governada-brain/agents/system/tooling-matrix.md
+- /Users/tim/dev/governada/governada-brain/agents/system/data-boundaries.md
+- /Users/tim/dev/governada/governada-brain/agents/build-system/autonomy-policy.md
+- /Users/tim/dev/governada/governada-app/AGENTS.md
+
+Do not broaden into provider parity, model collaboration, desktop automation, source-of-truth vault writeback, or broader roadmap phases.
+
+Phase 0B goal:
+Make the brain, retrieval, and control-plane layer reliable enough that future agents can trust the doctors and handoff packets before doing deeper implementation.
+
+Use the Phase 0A handoff as primary current-state evidence. Refresh reality where it is cheap and important, especially for drift-prone checks.
+
+Required first checks:
+- npm run session:guard
+- npm run session:doctor
+- npm run docs:doctor
+- npm run gh:auth-status
+- Governada retrieval wrapper/index status
+- BlueCargo retrieval wrapper/index status
+- Git/versioning status for governada-brain, governada-retrieval, and bluecargo-retrieval
+- Drift between roadmap, current-state, milestones, retrieval-policy, tooling-matrix, data-boundaries, autonomy-policy, and BlueCargo agent context
+
+Boundaries:
+- Do not initialize Git in governada-brain or retrieval projects without Tim's explicit approval.
+- Do not move, delete, or cloud-sync vault or retrieval files without approval.
+- Do not merge Governada and BlueCargo retrieval indexes.
+- Do not change .env.local or secret flow in this phase unless Tim explicitly approves the exact design.
+- Treat BlueCargo retrieval as local-only until docs and policy say otherwise.
+
+Recommended work slices:
+1. Decide with Tim whether governada-brain, governada-retrieval, and bluecargo-retrieval should be Git-versioned now or have accepted local-loss risk documented.
+2. Add a retrieval/control-plane doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and policy drift.
+3. Reconcile BlueCargo retrieval policy drift across retrieval-policy.md, autonomy-policy.md, bluecargo-context.md, retrieval-interfaces.md, and tooling-matrix.md.
+4. Update durable ops notes and/or roadmap current reality after checks and fixes.
+
+Before implementing, output:
+- Research Performed
+- Current Local Reality
+- Blockers
+- Advisories
+- Drift Found
+- Assumptions Closed
+- Open Questions For Tim
+- Proposed Phase 0B Work Slices
+- Validation Plan
+
+At the end, produce a handoff packet for Phase 0.5 or the next Phase 0B slice. The handoff must include a section titled "Copy/Paste Prompt For Next Agent" with a literal fenced prompt Tim can paste into a fresh agent.
+```

--- a/docs/strategy/context/build-manifest.md
+++ b/docs/strategy/context/build-manifest.md
@@ -29,7 +29,7 @@ Backend intelligence engine. Do not modify unless fixing bugs or extending.
 - [x] SPO 6D alignment, SPO matching | `lib/alignment/`, `lib/matching/`
 - [x] CC Transparency Index | `lib/scoring/ccTransparency.ts`
 - [x] Daily snapshots: drep_score_history, alignment_snapshots, ghi_snapshots, decentralization_snapshots, spo_score_snapshots, spo_alignment_snapshots
-- [x] 57 Inngest sync functions | `inngest/functions/`
+- [x] 59 Inngest sync functions | `inngest/functions/`
 - [x] 75+ database tables
 - verify: `GET /api/v1/drep-scores`, `GET /api/v1/spo-scores`, `POST /api/governance/quick-match` return data
 

--- a/docs/strategy/context/registry/_index.generated.md
+++ b/docs/strategy/context/registry/_index.generated.md
@@ -13,7 +13,12 @@
 - `/admin/pipeline`
 - `/admin/preview`
 - `/admin/quality`
+- `/admin/systems/evidence`
+- `/admin/systems/history`
+- `/admin/systems/incidents`
+- `/admin/systems/launch`
 - `/admin/systems`
+- `/admin/systems/queue`
 - `/admin/users`
 - `/claim/[drepId]`
 - `/committee/[ccHotId]`
@@ -67,11 +72,13 @@
 - `/`
 - `/pool/[poolId]`
 - `/preview`
+- `/privacy`
 - `/proposal/[txHash]/[index]`
 - `/pulse/history`
 - `/pulse`
 - `/pulse/report/[epoch]`
 - `/share/epoch/[epoch]`
+- `/terms`
 - `/workspace/amendment/[draftId]`
 - `/workspace/author/[draftId]/debrief`
 - `/workspace/author/[draftId]/monitor`
@@ -182,10 +189,12 @@
 - `useRegisterReviewCommands.ts`
 - `useResearchAssistant.ts`
 - `useReviewableDrafts.ts`
+- `useReviewDecisionFlow.ts`
 - `useReviewerCache.ts`
 - `useReviewQueue.ts`
 - `useReviewSession.ts`
 - `useReviewTemplate.ts`
+- `useReviewWorkspaceController.ts`
 - `useRevision.ts`
 - `useRevisionNotifications.ts`
 - `useScrollDirection.ts`
@@ -216,14 +225,14 @@
 
 ## Lib Directories
 
-- `admin/` (5 files)
+- `admin/` (14 files)
 - `ai/` (11 files)
 - `alignment/` (12 files)
 - `api/` (10 files)
 - `cc/` (9 files)
 - `charts/` (5 files)
 - `citizen/` (1 files)
-- `constellation/` (5 files)
+- `constellation/` (7 files)
 - `constitution/` (4 files)
 - `crossChain/` (1 files)
 - `discovery/` (4 files)
@@ -232,21 +241,23 @@
 - `entity/` (1 files)
 - `ghi/` (6 files)
 - `globe/` (19 files)
-- `governance/` (1 files)
+- `governance/` (10 files)
 - `homepage/` (1 files)
-- `i18n/` (3 files)
+- `i18n/` (4 files)
 - `identity/` (1 files)
-- `intelligence/` (15 files)
-- `matching/` (9 files)
+- `intelligence/` (16 files)
+- `matching/` (10 files)
 - `nav/` (1 files)
+- `navigation/` (5 files)
 - `notifications/` (1 files)
 - `observatory/` (3 files)
 - `preview/` (0 files)
-- `reconciliation/` (3 files)
-- `scoring/` (25 files)
+- `reconciliation/` (4 files)
+- `scoring/` (29 files)
+- `security/` (1 files)
 - `spotlight/` (1 files)
-- `sync/` (7 files)
-- `workspace/` (21 files)
+- `sync/` (8 files)
+- `workspace/` (24 files)
 
 ## Lib Standalone Files
 
@@ -271,6 +282,7 @@
 - `data.ts`
 - `delegation.ts`
 - `delegationMilestones.ts`
+- `drep-votes.ts`
 - `drepIdentity.ts`
 - `drepUpdate.ts`
 - `editorialHeadline.ts`
@@ -279,6 +291,7 @@
 - `entityConnections.ts`
 - `env.ts`
 - `featureFlags.ts`
+- `founderNotifications.ts`
 - `funnel.ts`
 - `ghi.ts`
 - `glossary.ts`
@@ -287,6 +300,7 @@
 - `governanceFootprint.ts`
 - `governanceLevels.ts`
 - `governanceRings.ts`
+- `governanceThresholds.ts`
 - `governanceTuner.ts`
 - `haptics.ts`
 - `inngest.ts`
@@ -304,6 +318,7 @@
 - `og-utils.tsx`
 - `passagePrediction.ts`
 - `passport.ts`
+- `persistence.ts`
 - `posthog-server.ts`
 - `posthog.ts`
 - `preview.ts`
@@ -322,6 +337,7 @@
 - `redis.ts`
 - `representationMatch.ts`
 - `retry.ts`
+- `runtimeMetadata.ts`
 - `sentry-cron.ts`
 - `share.ts`
 - `shortcuts.ts`
@@ -332,11 +348,13 @@
 - `supabase.ts`
 - `supabaseAuth.ts`
 - `sync-utils.ts`
+- `syncPolicy.ts`
 - `treasury-categories.ts`
 - `treasury.ts`
 - `trustSignals.ts`
 - `utils.ts`
 - `viewTransitions.ts`
+- `vote-rationales.ts`
 - `voteImpact.ts`
 - `voteProjection.ts`
 - `voting.ts`
@@ -366,6 +384,7 @@
 
 - `ActionQueueCard.tsx`
 - `AdminViewAsPicker.tsx`
+- `AppShellProviders.tsx`
 - `CompassSigil.tsx`
 - `DepthPickerDropdown.tsx`
 - `DepthPromptModal.tsx`
@@ -380,6 +399,7 @@
 - `HeaderBreadcrumbs.tsx`
 - `HeaderSenecaInput.tsx`
 - `LanguagePicker.tsx`
+- `LegalLinks.tsx`
 - `MatchResultOverlay.tsx`
 - `MobilePeekSheet.tsx`
 - `MyGovClient.tsx`
@@ -423,6 +443,7 @@
 - `generate-governance-wrapped.ts`
 - `generate-proposal-briefs.ts`
 - `generate-state-of-governance.ts`
+- `generate-systems-review-draft.ts`
 - `generate-user-embedding.ts`
 - `generate-weekly-digest.ts`
 - `generateAiContent.ts`
@@ -432,6 +453,7 @@
 - `precompute-engagement-signals.ts`
 - `precompute-proposal-intelligence.ts`
 - `reconcile-data.ts`
+- `run-systems-automation-sweep.ts`
 - `score-ai-quality.ts`
 - `score-proposers.ts`
 - `snapshot-citizen-rings.ts`
@@ -456,5 +478,5 @@
 
 ---
 
-Checksum: `2b1d24120da3291d93000b248a8edc82f0ecfdd9289e320ad54836c245207772`
-Generated: 2026-04-03T03:38:02Z
+Checksum: `98826194bac11ac72465134930772e822eefc57e9e73871d1a74645ad8255908`
+Generated: 2026-04-24T04:35:30Z

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "notify": "node scripts/notify.js",
     "uptime-check": "node scripts/uptime-check.js",
     "gh:auth-status": "node scripts/gh-auth-status.js",
+    "auth:doctor": "node scripts/auth-doctor.js",
     "auth:repair": "node scripts/repair-gh-auth.mjs",
     "git:stage": "node scripts/git-stage.js",
     "git:commit": "node scripts/git-commit.js",

--- a/scripts/auth-doctor.js
+++ b/scripts/auth-doctor.js
@@ -1,0 +1,172 @@
+const { spawnSync } = require('node:child_process');
+
+const { redactSensitiveText } = require('./lib/gh-auth');
+const { loadLocalEnv, repoRoot, runGh } = require('./lib/runtime');
+const { getContext } = require('./set-gh-context');
+
+const EXPECTED_REPO = 'governada/governada-app';
+const EXPECTED_OP_ACCOUNT = 'my.1password.com';
+const EXPECTED_GH_USER = 'governada';
+const OP_READ_TIMEOUT_MS = 15000;
+
+function detailFrom(result) {
+  return redactSensitiveText(result.stderr || result.stdout || '').trim();
+}
+
+function pass(message) {
+  console.log(`OK: ${message}`);
+}
+
+function warn(message) {
+  console.log(`WARN: ${message}`);
+}
+
+function fail(failures, message) {
+  failures.push(message);
+  console.log(`BLOCKED: ${message}`);
+}
+
+function hasDesktopIpcFailure(detail) {
+  return /couldn'?t connect to the 1Password desktop app|connect to the 1Password desktop app|desktop app/i.test(
+    detail,
+  );
+}
+
+function main() {
+  const failures = [];
+  loadLocalEnv();
+
+  const context = getContext();
+  const env = {
+    ...process.env,
+    ...context,
+  };
+
+  console.log('Auth doctor: Governada GitHub lane');
+
+  if (context.GH_REPO === EXPECTED_REPO) {
+    pass(`repo context is pinned to ${EXPECTED_REPO}`);
+  } else {
+    fail(failures, `repo context is ${context.GH_REPO || 'unset'}, expected ${EXPECTED_REPO}`);
+  }
+
+  if (context.OP_ACCOUNT === EXPECTED_OP_ACCOUNT) {
+    pass(`1Password account is pinned to ${EXPECTED_OP_ACCOUNT}`);
+  } else {
+    fail(
+      failures,
+      `1Password account is ${context.OP_ACCOUNT || 'unset'}, expected ${EXPECTED_OP_ACCOUNT}`,
+    );
+  }
+
+  const tokenRefVar = process.env.GH_TOKEN_OP_REF
+    ? 'GH_TOKEN_OP_REF'
+    : process.env.GITHUB_TOKEN_OP_REF
+      ? 'GITHUB_TOKEN_OP_REF'
+      : '';
+  const tokenRef = process.env.GH_TOKEN_OP_REF || process.env.GITHUB_TOKEN_OP_REF || '';
+
+  if (tokenRefVar) {
+    pass(`${tokenRefVar} is present`);
+  } else {
+    fail(failures, 'no 1Password GitHub token reference is configured');
+  }
+
+  if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
+    warn('raw GitHub token env is present; repo automation should prefer the 1Password reference');
+  } else {
+    pass('raw GitHub token env is not present');
+  }
+
+  const opVersion = spawnSync('op', ['--version'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: OP_READ_TIMEOUT_MS,
+  });
+
+  if (opVersion.error?.code === 'ENOENT') {
+    fail(failures, '1Password CLI (`op`) is not installed or not on PATH');
+  } else if (opVersion.status !== 0) {
+    const detail = detailFrom(opVersion);
+    fail(failures, `1Password CLI is not runnable${detail ? `: ${detail}` : ''}`);
+  } else {
+    pass(`1Password CLI is available (${opVersion.stdout.trim() || 'version unknown'})`);
+  }
+
+  let desktopLaneReady = false;
+  if (tokenRef) {
+    const opRead = spawnSync('op', ['read', tokenRef], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: OP_READ_TIMEOUT_MS,
+    });
+
+    const detail = detailFrom(opRead);
+    if (opRead.error?.code === 'ETIMEDOUT' || opRead.signal) {
+      fail(
+        failures,
+        '1Password desktop IPC timed out from this process; if `op read` works outside Codex, rerun the repo wrapper with approved sandbox escalation rather than changing auth models',
+      );
+    } else if (opRead.status === 0 && opRead.stdout.trim()) {
+      desktopLaneReady = true;
+      pass('1Password desktop lane can resolve the GitHub token reference');
+    } else if (hasDesktopIpcFailure(detail)) {
+      fail(
+        failures,
+        '1Password desktop IPC is unavailable from this process; if `op read` works outside Codex, rerun the repo wrapper with approved sandbox escalation rather than changing auth models',
+      );
+    } else if (opRead.status === 0) {
+      fail(failures, '1Password token reference resolved to an empty value');
+    } else {
+      fail(
+        failures,
+        `1Password token reference could not be resolved${detail ? `: ${detail}` : ''}`,
+      );
+    }
+  }
+
+  if (desktopLaneReady) {
+    const user = runGh(['api', 'user', '--jq', '.login']);
+    if (user.status !== 0) {
+      const detail = detailFrom(user);
+      fail(failures, `child gh API auth failed${detail ? `: ${detail}` : ''}`);
+    } else {
+      const login = user.stdout.trim();
+      if (login === EXPECTED_GH_USER) {
+        pass(`child gh API auth works as ${EXPECTED_GH_USER}`);
+      } else {
+        fail(
+          failures,
+          `child gh API auth returned ${login || 'unknown'}, expected ${EXPECTED_GH_USER}`,
+        );
+      }
+    }
+
+    const repo = runGh(['api', `repos/${EXPECTED_REPO}`, '--jq', '.full_name']);
+    if (repo.status !== 0) {
+      const detail = detailFrom(repo);
+      fail(failures, `repo access failed for ${EXPECTED_REPO}${detail ? `: ${detail}` : ''}`);
+    } else {
+      pass(`repo access works for ${repo.stdout.trim() || EXPECTED_REPO}`);
+    }
+  } else {
+    warn(
+      'skipping child gh and repo access checks because the 1Password desktop lane is not ready',
+    );
+  }
+
+  if (failures.length > 0) {
+    console.log('');
+    console.log(`Auth doctor result: BLOCKED (${failures.length})`);
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('Auth doctor result: OK');
+}
+
+main();

--- a/scripts/auth-doctor.js
+++ b/scripts/auth-doctor.js
@@ -27,7 +27,7 @@ function fail(failures, message) {
 }
 
 function hasDesktopIpcFailure(detail) {
-  return /couldn'?t connect to the 1Password desktop app|connect to the 1Password desktop app|desktop app/i.test(
+  return /couldn'?t connect to the 1Password desktop app|connect to the 1Password desktop app|desktop app|authorization timeout/i.test(
     detail,
   );
 }
@@ -73,7 +73,10 @@ function main() {
   }
 
   if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN) {
-    warn('raw GitHub token env is present; repo automation should prefer the 1Password reference');
+    fail(
+      failures,
+      'raw GitHub token env is present; remove GH_TOKEN/GITHUB_TOKEN so this diagnostic proves the repo-scoped 1Password lane',
+    );
   } else {
     pass('raw GitHub token env is not present');
   }

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -1,20 +1,30 @@
 const { runGh } = require('./lib/runtime');
 
-function main() {
-  const status = runGh(['auth', 'status', '--hostname', 'github.com']);
-  process.stdout.write(status.stdout);
-  process.stderr.write(status.stderr);
+function redactSensitiveText(value) {
+  return value
+    .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_[redacted]')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, '[redacted-gh-token]');
+}
 
-  if (status.status !== 0) {
-    process.exit(status.status);
+function writeFailure(result) {
+  const detail = redactSensitiveText(result.stderr || result.stdout || '').trim();
+  if (detail) {
+    process.stderr.write(`${detail}\n`);
+  }
+}
+
+function main() {
+  const user = runGh(['api', 'user', '--jq', '.login']);
+  if (user.status !== 0) {
+    console.error('GitHub API auth: FAILED');
+    writeFailure(user);
+    process.exit(user.status);
   }
 
-  const user = runGh(['api', 'user', '--jq', '.login']);
-  if (user.status === 0) {
-    const login = user.stdout.trim();
-    if (login) {
-      console.log(`Active GitHub user: ${login}`);
-    }
+  const login = user.stdout.trim();
+  console.log('GitHub API auth: OK');
+  if (login) {
+    console.log(`Active GitHub user: ${login}`);
   }
 
   if (process.env.GH_TOKEN_OP_REF || process.env.GITHUB_TOKEN_OP_REF) {
@@ -22,7 +32,15 @@ function main() {
   }
 
   const repo = process.env.GH_REPO || 'governada/governada-app';
+  const repoCheck = runGh(['api', `repos/${repo}`, '--jq', '.full_name']);
+  if (repoCheck.status !== 0) {
+    console.error(`Repo access: FAILED (${repo})`);
+    writeFailure(repoCheck);
+    process.exit(repoCheck.status);
+  }
+
   console.log(`Repo context: ${repo}`);
+  console.log(`Repo access: OK (${repoCheck.stdout.trim() || repo})`);
 }
 
 main();

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -1,10 +1,5 @@
 const { runGh } = require('./lib/runtime');
-
-function redactSensitiveText(value) {
-  return value
-    .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_[redacted]')
-    .replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, '[redacted-gh-token]');
-}
+const { redactSensitiveText } = require('./lib/gh-auth');
 
 function writeFailure(result) {
   const detail = redactSensitiveText(result.stderr || result.stdout || '').trim();

--- a/scripts/lib/gh-auth.js
+++ b/scripts/lib/gh-auth.js
@@ -1,11 +1,27 @@
 const { spawnSync } = require('node:child_process');
 
+const OP_READ_TIMEOUT_MS = 15000;
+
+function redactSensitiveText(value) {
+  return value
+    .replace(/op:\/\/[^\s'"]+/g, 'op://[redacted]')
+    .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_[redacted]')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, '[redacted-gh-token]');
+}
+
+function hasDesktopIpcFailure(detail) {
+  return /couldn'?t connect to the 1Password desktop app|connect to the 1Password desktop app|desktop app|authorization timeout/i.test(
+    detail,
+  );
+}
+
 function readOnePasswordToken(tokenRef, env, cwd) {
   const result = spawnSync('op', ['read', tokenRef], {
     cwd,
     encoding: 'utf8',
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: OP_READ_TIMEOUT_MS,
   });
 
   if (result.error?.code === 'ENOENT') {
@@ -14,8 +30,22 @@ function readOnePasswordToken(tokenRef, env, cwd) {
     };
   }
 
+  if (result.error?.code === 'ETIMEDOUT' || result.signal) {
+    return {
+      error:
+        'GitHub auth: 1Password CLI timed out while reading GH_TOKEN_OP_REF. If `op read` works outside Codex, Codex sandbox may be blocking desktop IPC; rerun the repo wrapper with approved sandbox escalation rather than changing auth models.',
+    };
+  }
+
   if (result.status !== 0) {
-    const detail = (result.stderr || result.stdout || '').trim();
+    const detail = redactSensitiveText(result.stderr || result.stdout || '').trim();
+    if (hasDesktopIpcFailure(detail)) {
+      return {
+        error:
+          'GitHub auth: 1Password desktop IPC is unavailable from this process. If `op read` works outside Codex, rerun the repo wrapper with approved sandbox escalation rather than changing auth models.',
+      };
+    }
+
     return {
       error:
         `GitHub auth: could not read GH_TOKEN_OP_REF with 1Password CLI.` +
@@ -49,5 +79,6 @@ function withGhTokenFromOnePassword(env, cwd) {
 }
 
 module.exports = {
+  redactSensitiveText,
   withGhTokenFromOnePassword,
 };

--- a/scripts/lib/gh-auth.js
+++ b/scripts/lib/gh-auth.js
@@ -4,7 +4,7 @@ const OP_READ_TIMEOUT_MS = 15000;
 
 function redactSensitiveText(value) {
   return value
-    .replace(/op:\/\/[^\s'"]+/g, 'op://[redacted]')
+    .replace(/op:\/\/[^\r\n'"]+/g, 'op://[redacted]')
     .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_[redacted]')
     .replace(/\bgh[pousr]_[A-Za-z0-9_]+\b/g, '[redacted-gh-token]');
 }
@@ -65,7 +65,7 @@ function withGhTokenFromOnePassword(env, cwd) {
   const mergedEnv = { ...env };
   const tokenRef = mergedEnv.GH_TOKEN_OP_REF || mergedEnv.GITHUB_TOKEN_OP_REF;
 
-  if (!tokenRef || mergedEnv.GH_TOKEN || mergedEnv.GITHUB_TOKEN) {
+  if (!tokenRef) {
     return { env: mergedEnv };
   }
 
@@ -74,6 +74,7 @@ function withGhTokenFromOnePassword(env, cwd) {
     return { env: mergedEnv, error: result.error };
   }
 
+  delete mergedEnv.GITHUB_TOKEN;
   mergedEnv.GH_TOKEN = result.token;
   return { env: mergedEnv };
 }

--- a/scripts/repair-gh-auth.mjs
+++ b/scripts/repair-gh-auth.mjs
@@ -45,7 +45,7 @@ const currentUser = tryGh(['api', 'user', '--jq', '.login']);
 
 if (!currentUser) {
   console.error(
-    'GitHub auth is not ready. Set GH_TOKEN_OP_REF to a 1Password token reference or run gh auth login, then re-run this script.',
+    'GitHub auth is not ready. Set GH_TOKEN_OP_REF to a 1Password token reference and run `npm run auth:doctor`.',
   );
   process.exit(1);
 }
@@ -56,7 +56,7 @@ if (currentUser !== EXPECTED_USER) {
     ghOutput(['auth', 'switch', '--user', EXPECTED_USER], { cwd: repoRoot });
   } catch {
     console.error(
-      `Could not switch to ${EXPECTED_USER}. Run 'gh auth login' or 'gh auth switch --user ${EXPECTED_USER}' manually.`,
+      `Could not switch to ${EXPECTED_USER}. Run \`npm run auth:doctor\` and repair the repo-scoped 1Password lane before retrying.`,
     );
     process.exit(1);
   }

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -85,6 +85,44 @@ function parseWorktrees() {
   return worktrees;
 }
 
+function getSharedCheckoutRoot(topLevel) {
+  const commonDir = runOrEmpty(
+    'git',
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    topLevel,
+  );
+
+  return commonDir ? path.dirname(commonDir) : topLevel;
+}
+
+function getOrphanedWorktreeDirectories(worktrees, topLevel) {
+  const sharedRoot = getSharedCheckoutRoot(topLevel);
+  const worktreesRoot = path.join(sharedRoot, '.claude', 'worktrees');
+  if (!fs.existsSync(worktreesRoot)) {
+    return [];
+  }
+
+  const registeredPaths = new Set(worktrees.map((worktree) => path.resolve(worktree.path)));
+
+  return fs
+    .readdirSync(worktreesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(worktreesRoot, entry.name))
+    .filter((worktreePath) => !registeredPaths.has(path.resolve(worktreePath)))
+    .map((worktreePath) => {
+      const gitPointerPath = path.join(worktreePath, '.git');
+      const gitStatus = runCommand('git', ['-C', worktreePath, 'status', '--short'], {
+        cwd: repoRoot,
+      });
+      const reason =
+        fs.existsSync(gitPointerPath) && gitStatus.status !== 0
+          ? 'not registered; git metadata is broken or points outside this checkout'
+          : 'not registered by git worktree list';
+
+      return { path: worktreePath, reason };
+    });
+}
+
 function existsMaybe(relativePath) {
   return fs.existsSync(path.join(repoRoot, relativePath));
 }
@@ -156,6 +194,7 @@ function main() {
   const sharedCheckout = isSharedCheckout(topLevel);
   const checkoutLabel = sharedCheckout ? 'shared checkout' : 'worktree';
   const worktreeDiagnostics = getWorktreeDiagnostics(worktrees, topLevel);
+  const orphanedWorktreeDirectories = getOrphanedWorktreeDirectories(worktrees, topLevel);
   const dirtyWorktrees = worktreeDiagnostics.filter(
     (worktree) => worktree.dirtyCount > 0 && !worktree.isCurrent,
   );
@@ -196,6 +235,12 @@ function main() {
   if (worktrees.length > 5) {
     advisories.push(
       `Repo has ${worktrees.length} worktrees open. Prune merged or abandoned worktrees before opening more.`,
+    );
+  }
+
+  if (orphanedWorktreeDirectories.length > 0) {
+    advisories.push(
+      `Repo has ${orphanedWorktreeDirectories.length} orphaned .claude/worktrees director${orphanedWorktreeDirectories.length === 1 ? 'y' : 'ies'}. Confirm ownership before deleting.`,
     );
   }
 
@@ -242,6 +287,12 @@ function main() {
   printSection(
     'Gone upstream worktrees',
     goneUpstreamWorktrees.map((worktree) => `${worktree.branch} -> ${worktree.path}`),
+  );
+  console.log('');
+
+  printSection(
+    'Orphaned worktree directories',
+    orphanedWorktreeDirectories.map((worktree) => `${worktree.path} (${worktree.reason})`),
   );
   console.log('');
 


### PR DESCRIPTION
## Summary

- Refreshes Phase 0A reality hygiene so `docs:doctor` passes again.
- Updates `gh:auth-status` to verify GitHub API and repo access without printing token-like `gh auth status` output.
- Adds `npm run auth:doctor` for the repo-pinned Governada GitHub lane, with raw-token blocking, redacted 1Password failure output, and deterministic desktop-IPC timeout handling.
- Extends `session:doctor` to report orphaned `.claude/worktrees/*` directories as advisories.
- Adds a durable Phase 0A handoff packet for Phase 0B, including Review Gate v0 results and a literal copy/paste prompt for the next agent.

## Existing Code Audit

- Confirmed `docs:doctor` drift came from stale Inngest count and stale generated registry index.
- Confirmed `gh:auth-status` previously delegated to `gh auth status`, which surfaced token-like masked output despite repo-local 1Password auth working.
- Confirmed PR #901 exposed a separate auth-runtime gap: Codex Desktop sandboxing may block 1Password desktop IPC even when `op read` works outside the sandbox.
- Confirmed current worktree inventory includes an orphaned `.claude/worktrees/auth-cookie-cleanup` directory that was not represented by `git worktree list`.

## Robustness

- `gh:auth-status` now checks `gh api user` and `repos/governada/governada-app` directly, with sanitized failure output.
- The shared GH auth helper now redacts token-like strings and `op://...` references, bounds `op read`, names the blocked desktop 1Password lane, and prefers the configured 1Password reference over ambient raw token env.
- `auth:doctor` now blocks raw `GH_TOKEN`/`GITHUB_TOKEN` env so diagnostics cannot pass through a bypassed token lane.
- `session:doctor` now detects unregistered `.claude/worktrees/*` directories without blocking strict mode.
- Phase 0B concerns are documented rather than silently expanded into this slice.

## Review Gate v0

- Tier: foundational auth/runtime/harness work.
- Reviewers requested: fresh read-only Codex code/runtime reviewer; fresh read-only policy/boundary reviewer as the Claude Code fallback because managed Claude review is not wired in this session.
- Focus used: auth-runtime regressions, token/reference leakage, sandbox/escalation behavior, GitHub wrapper correctness, Phase 0A scope creep, policy consistency, auth-boundary correctness, Governada/BlueCargo isolation, and handoff quality.
- Findings fixed: raw-token `auth:doctor` bypass, `gh:auth-status` token-source misreporting, whitespace-limited `op://...` redaction, `auth:doctor` authorization-timeout classification, and missing review-gate record.
- Findings deferred: managed Claude review capability registry; durable sandbox-compatible auth lane; `.env.local` copy replacement.
- Merge posture: code/runtime and policy Review Gate v0 findings are fixed, but hold merge until final CI passes and Tim explicitly accepts the documented Phase 0B auth-runtime deferment if local `pre-merge-check`/merge wrappers still block on desktop IPC. Do not merge through a bypassed auth path.

## Impact

- Agents get more truthful local reality checks before deeper Mac Agent OS work begins.
- `docs:doctor` can again be used as a gate for documentation drift.
- Tim can hand Phase 0B to a fresh agent by copying the prompt from `docs/operations/mac-agent-os-phase-0a-handoff.md`.
- Remaining risks are preserved in the handoff: auth-runtime design, brain/retrieval durability, BlueCargo retrieval-policy drift, `.env.local` copying, local capability registry, and worktree cleanup.

## Validation

- `node --check scripts/lib/gh-auth.js` passed.
- `node --check scripts/auth-doctor.js` passed.
- Redactor smoke test removed full `op://...`, GitHub PAT, and `gh*` token-shaped strings.
- Raw-token `auth:doctor` simulation blocked as intended.
- `npm run docs:doctor` passed.
- `npm run agent:validate` passed.
- `npm run session:guard` passed after commit.
- `npm run auth:doctor` blocks in Codex on 1Password desktop IPC and emits a redacted diagnostic.
- `npm run gh:auth-status` can still block in Codex on 1Password desktop IPC / authorization timeout and emits a redacted diagnostic.