### PR TITLE
[codex] Add 1Password env bootstrap wrappers

### DIFF
--- a/.claude/commands/adversarial-review.md
+++ b/.claude/commands/adversarial-review.md
@@ -262,7 +262,7 @@ If SHIP:
 - The UX agent MUST take screenshots. Findings without visual evidence are downgraded.
 - Neither agent should pad with minor style nits to seem thorough — only real problems.
 - The code agent reads files directly. The UX agent uses Preview tools exclusively (not Chrome).
-- The UX agent MUST test auth-gated pages using `/api/auth/dev-mock`. Requires `DEV_MOCK_AUTH=true` in `.env.local`.
+- The UX agent MUST test auth-gated pages using `/api/auth/dev-mock`. Requires `DEV_MOCK_AUTH=true` through `npm run env:run -- <command>` or a local fallback env file.
 - For auth-gated pages, test as the most relevant persona (e.g., `/workspace` as `drep`). Test at least 2 personas per auth-gated route if time permits.
 - This command does NOT deploy. It reviews what's ready to deploy. Use `/ship` after.
 - **Entity type coverage**: When reviewing any list/directory/discovery interface, the UX agent MUST test ALL entity types (DReps, proposals, pools, CC members), not just one. Entity types often have different code paths and data shapes. Bugs hide in the less-common types.

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -2,8 +2,8 @@ Initialize the session properly before writing any code.
 
 ## Steps
 
-1. Run `npm run session:doctor` and read the snapshot before making changes. Inspect the `Repo bootstrap files` and `Repo-scoped auth and MCP` sections before reaching for GitHub or MCP tooling.
-2. Resolve repo tooling in this order: current checkout first, shared checkout fallback second, repo-scoped user paths referenced by repo files third, global defaults last. In this repo that means `.mcp.json`, `.claude/settings.local.json`, `.env.local`, `package.json`, `scripts/lib/runtime.js`, and `scripts/set-gh-context.*` before generic home-directory config.
+1. Run `npm run session:doctor` and read the snapshot before making changes. Use `npm run env:doctor` for local env readiness and `npm run gh:auth-status` before reaching for GitHub tooling.
+2. Resolve repo tooling in this order: current checkout first, shared checkout fallback second, repo-scoped user paths referenced by repo files third, global defaults last. In this repo that means `.mcp.json`, `.claude/settings.local.json`, `.env.local.refs`, `.env.local`, `package.json`, `scripts/env-doctor.mjs`, `scripts/env-run.mjs`, `scripts/lib/runtime.js`, and `scripts/set-gh-context.*` before generic home-directory config.
 3. If the repo is on main and feature work is needed, create an in-repo worktree with `npm run worktree:new -- <name>` and continue there. Do NOT create branches in the main checkout. Hotfixes (`ALLOW_MAIN_EDIT=1`) are the only exception.
 4. Stay rooted at the shared repo root. Do not open a separate Codex project from an individual worktree folder for this repo.
 5. If GitHub auth or MCP access is missing, use `npm run gh:auth-status`, `npm run auth:repair`, and the wrapper commands referenced by `.mcp.json` before falling back to generic `gh auth status` or global MCP settings.

--- a/.claude/hooks/report-worktree-status.sh
+++ b/.claude/hooks/report-worktree-status.sh
@@ -42,8 +42,10 @@ else
 fi
 
 if [ "$checkout_kind" = "worktree" ]; then
-  if [ ! -f ".env.local" ]; then
-    echo ".env.local: missing. Run 'npm run worktree:sync' to copy it from the main checkout."
+  if [ -f ".env.local.refs" ]; then
+    echo ".env.local.refs: present. Use 'npm run env:run -- <command>' for 1Password-backed local env."
+  elif [ ! -f ".env.local" ]; then
+    echo ".env.local.refs: missing. Run 'npm run env:doctor'; worktree sync no longer copies plaintext .env.local."
   fi
 
   if [ ! -d "node_modules" ] && [ ! -L "node_modules" ]; then

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "dev",
-      "runtimeExecutable": "npx",
-      "runtimeArgs": ["next", "dev", "--turbopack"],
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "env:run", "--", "npx", "next", "dev", "--turbopack"],
       "port": 3111,
       "autoPort": true
     }

--- a/.claude/rules/dev-preview.md
+++ b/.claude/rules/dev-preview.md
@@ -8,7 +8,7 @@ paths:
 
 # Dev Preview in Worktrees
 
-Rules for running the local dev server via Claude Preview tools. The `npm run worktree:sync` session-start hook auto-provisions `.env.local` and `node_modules`, so agents can usually start previewing immediately.
+Rules for running the local dev server via Claude Preview tools. Worktree sync links `node_modules` when possible, but it no longer copies plaintext `.env.local`. Use `npm run env:doctor` to inspect local env readiness and `npm run env:run -- <command>` for 1Password-backed local env injection.
 
 ## Starting the Dev Server
 
@@ -40,7 +40,7 @@ Test Globe pages only after the rest of the app is confirmed working.
 
 ## Auth Mocking
 
-The dev server supports mock auth via `/api/auth/dev-mock` (requires `DEV_MOCK_AUTH=true` in `.env.local`, which is set by default).
+The dev server supports mock auth via `/api/auth/dev-mock` when `DEV_MOCK_AUTH=true` is available through `npm run env:run -- <command>` or a local fallback env file.
 
 Switch personas with `preview_eval`:
 
@@ -70,16 +70,16 @@ For responsive: `preview_resize` with presets `"mobile"` (375x812), `"tablet"` (
 
 ## Troubleshooting
 
-| Symptom                                                  | Cause                                      | Fix                                                     |
-| -------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
-| `MODULE_NOT_FOUND` errors                                | `node_modules` missing or junction broken  | Run `npm install` in the worktree                       |
-| Missing env var errors                                   | `.env.local` not copied                    | Run `npm run worktree:sync`                             |
-| Port already in use                                      | Another dev server running                 | `autoPort: true` handles this automatically             |
-| Turbopack panic: "Symlink points out of filesystem root" | `turbopack.root` not set in next.config.ts | Confirm `next.config.ts` sets `turbopack.root`          |
-| Browser hangs / all preview calls timeout                | Globe/Three.js page loaded first           | Stop server, restart, navigate to `/governance` first   |
-| Stale build cache                                        | `.next/` has bad state                     | `rm -rf .next` then restart                             |
-| Auth mock returns 401                                    | `DEV_MOCK_AUTH` not set                    | Verify `.env.local` contains `DEV_MOCK_AUTH=true`       |
-| `node_modules` link won't create                         | package.json differs from main             | Run `npm install` - the hook only links when deps match |
+| Symptom                                                  | Cause                                           | Fix                                                      |
+| -------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------- |
+| `MODULE_NOT_FOUND` errors                                | `node_modules` missing or junction broken       | Run `npm install` in the worktree                        |
+| Missing env var errors                                   | Local env references missing or fallback absent | Run `npm run env:doctor`                                 |
+| Port already in use                                      | Another dev server running                      | `autoPort: true` handles this automatically              |
+| Turbopack panic: "Symlink points out of filesystem root" | `turbopack.root` not set in next.config.ts      | Confirm `next.config.ts` sets `turbopack.root`           |
+| Browser hangs / all preview calls timeout                | Globe/Three.js page loaded first                | Stop server, restart, navigate to `/governance` first    |
+| Stale build cache                                        | `.next/` has bad state                          | `rm -rf .next` then restart                              |
+| Auth mock returns 401                                    | `DEV_MOCK_AUTH` not set                         | Verify `DEV_MOCK_AUTH=true` through `npm run env:doctor` |
+| `node_modules` link won't create                         | package.json differs from main                  | Run `npm install` - the hook only links when deps match  |
 
 ## Compilation Times (Turbopack)
 
@@ -95,7 +95,7 @@ The server accepts connections immediately but holds requests until the route co
 The `npm run worktree:sync` hook runs on session start and handles:
 
 - Fetching and rebasing onto `origin/main` (skips with warning if the working tree is dirty)
-- Copying `.env.local` from the main checkout if missing
+- Reporting local env bootstrap status without copying `.env.local`
 - Linking `node_modules` from the main checkout, with `npm install` fallback when linking is not possible
 - Preserving the 1Password-backed SSH alias remote for Git operations
 

--- a/.claude/rules/runtime-bootstrap.md
+++ b/.claude/rules/runtime-bootstrap.md
@@ -12,8 +12,11 @@ Before using GitHub, MCP, or other external tooling, resolve repo-scoped bootstr
 1. Current checkout
    - `.mcp.json`
    - `.claude/settings.local.json`
+   - `.env.local.refs`
    - `.env.local`
    - `package.json`
+   - `scripts/env-doctor.mjs`
+   - `scripts/env-run.mjs`
    - `scripts/lib/runtime.js`
    - `scripts/set-gh-context.js`
    - `scripts/gh-auth-status.js`
@@ -33,7 +36,8 @@ Before using GitHub, MCP, or other external tooling, resolve repo-scoped bootstr
 ## Rules
 
 - Repo bootstrap files are authoritative when present. Do not let a working global `gh` login or global MCP profile override repo-scoped settings.
-- Prefer `GH_TOKEN_OP_REF` or `GITHUB_TOKEN_OP_REF` with an `op://...` 1Password reference over stored plaintext GitHub tokens. Repo `gh` wrappers pin `OP_ACCOUNT=my.1password.com`, resolve the reference at runtime, and do not print the token.
+- Prefer `GH_TOKEN_OP_REF` or `GITHUB_TOKEN_OP_REF` with an `op://...` 1Password reference over stored plaintext GitHub tokens. Repo `gh` wrappers pin `OP_ACCOUNT=my.1password.com`, resolve the reference at runtime, and do not print the token. Do not place those GitHub token reference keys in `.env.local.refs`; they must remain unresolved references for the repo GitHub wrappers.
+- Use `npm run env:doctor` to inspect local env readiness and `npm run env:run -- <command>` to run commands with ignored `.env.local.refs` values injected from 1Password. Worktree setup must not copy plaintext `.env.local`.
 - Run `npm run session:doctor` before guessing about missing auth or missing MCP tools.
 - If GitHub auth is broken, use `npm run gh:auth-status` and `npm run auth:repair` before generic `gh auth login`.
 - If MCP tools are missing, inspect `.mcp.json` and the wrapper commands it references before assuming the MCP server is not installed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,11 @@ Always resolve credentials and tool wrappers from the repo before falling back t
 
 - Search order: current checkout -> shared checkout fallback -> repo-scoped user paths named by repo files -> global/home-directory config.
 - In worktrees, ignored local files may be absent even when they exist in the shared checkout. If `.mcp.json` or `.claude/settings.local.json` is missing in `.claude/worktrees/<name>`, check the shared checkout next before assuming the repo is unconfigured.
-- Treat these files as authoritative when present: `.mcp.json`, `.claude/settings.local.json`, `.env.local`, `package.json`, `scripts/lib/runtime.js`, `scripts/set-gh-context.js`, `scripts/gh-auth-status.js`, and `scripts/repair-gh-auth.mjs`.
+- Treat these files as authoritative when present: `.mcp.json`, `.claude/settings.local.json`, `.env.local.refs`, `.env.local`, `docs/examples/env-local-refs.example.md`, `package.json`, `scripts/env-doctor.mjs`, `scripts/env-run.mjs`, `scripts/lib/runtime.js`, `scripts/set-gh-context.js`, `scripts/gh-auth-status.js`, and `scripts/repair-gh-auth.mjs`.
 - Governada Git remotes should use the 1Password-backed SSH alias `git@github-governada:governada/governada-app.git`. Do not replace it with HTTPS or bare `git@github.com`.
 - GitHub CLI tokens should come from 1Password when possible: set `GH_TOKEN_OP_REF` or `GITHUB_TOKEN_OP_REF` to an `op://...` reference in local environment, never the raw token. Repo `gh` wrappers pin `OP_ACCOUNT=my.1password.com` and resolve that reference with the 1Password CLI without printing the secret.
+- Local app/runtime secrets should use ignored `.env.local.refs` files with `op://...` references and `npm run env:run -- <command>` where possible. Use `npm run env:doctor` to inspect readiness without printing values. Do not place `GH_TOKEN_OP_REF` or `GITHUB_TOKEN_OP_REF` in `.env.local.refs`; keep them unresolved for repo GitHub wrappers.
+- Worktree setup must not copy plaintext `.env.local` from the shared checkout. Existing `.env.local` files are temporary production-connected fallbacks only; never read, print, commit, or propagate them.
 - Repo-scoped user paths referenced by those files are part of the repo bootstrap, not global fallbacks. That includes `GH_CONFIG_DIR` and any wrapper commands referenced by `.mcp.json`.
 - Before generic troubleshooting, run `npm run session:doctor`, then `npm run gh:auth-status`, then inspect `.mcp.json` and the referenced wrapper commands.
 
@@ -76,5 +78,6 @@ Always resolve credentials and tool wrappers from the repo before falling back t
 
 - Local MCP credentials belong in `.mcp.json`, which stays ignored.
 - Local Claude overrides belong in `.claude/settings.local.json`, which stays ignored.
+- Local 1Password env references belong in `.env.local.refs`, which stays ignored. Use `docs/examples/env-local-refs.example.md` as the sanitized template.
 - Use `.mcp.example.json` as the sanitized template for new machines.
 - Use `npm run auth:repair` if GitHub auth or the remote URL needs repair.

--- a/__tests__/scripts/envBootstrap.test.ts
+++ b/__tests__/scripts/envBootstrap.test.ts
@@ -1,0 +1,143 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  forbiddenLiteralEntries,
+  getForbiddenGithubReferenceKeys,
+  parseEnvEntries,
+} from '@/scripts/lib/env-bootstrap.mjs';
+
+const require = createRequire(import.meta.url);
+const { withGhTokenFromOnePassword } = require(path.join(process.cwd(), 'scripts/lib/gh-auth.js'));
+
+const repoRoot = process.cwd();
+const tempPaths: string[] = [];
+
+function createTempDir(prefix = 'governada-env-bootstrap-') {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tempPaths.push(dir);
+  return dir;
+}
+
+function createRepoTempDir(prefix = '.tmp-env-bootstrap-') {
+  const dir = mkdtempSync(path.join(repoRoot, prefix));
+  tempPaths.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempPaths.length > 0) {
+    const dir = tempPaths.pop();
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+describe('env bootstrap guardrails', () => {
+  it('detects GitHub token reference keys in .env.local.refs', () => {
+    const dir = createTempDir();
+    const refsPath = path.join(dir, '.env.local.refs');
+    writeFileSync(
+      refsPath,
+      ['GH_TOKEN_OP_REF=op://Governada/item/token', 'GITHUB_TOKEN_OP_REF=op://x/y/z'].join('\n'),
+    );
+
+    expect(getForbiddenGithubReferenceKeys(refsPath)).toEqual([
+      'GH_TOKEN_OP_REF',
+      'GITHUB_TOKEN_OP_REF',
+    ]);
+  });
+
+  it('blocks non-allowlisted literal values while allowing op refs and public literals', () => {
+    const dir = createTempDir();
+    const refsPath = path.join(dir, '.env.local.refs');
+    writeFileSync(
+      refsPath,
+      [
+        'NODE_ENV=development',
+        'NEXT_PUBLIC_SITE_URL=https://governada.local',
+        'DATABASE_URL=postgres://example',
+        'KOIOS_API_KEY=op://Governada/item/koios',
+      ].join('\n'),
+    );
+
+    expect(forbiddenLiteralEntries(parseEnvEntries(refsPath))).toEqual([
+      { key: 'DATABASE_URL', value: 'postgres://example' },
+    ]);
+  });
+
+  it('rejects raw GitHub token env in repo GitHub wrappers', () => {
+    const result = withGhTokenFromOnePassword({ GH_TOKEN: 'dummy-token' }, repoRoot);
+
+    expect(result.error).toContain('raw GH_TOKEN env is not allowed');
+    expect(result.env.GH_TOKEN).toBeUndefined();
+  });
+
+  it('strips inherited raw GitHub tokens from env:run child commands', () => {
+    const result = spawnSync(
+      'node',
+      [
+        path.join(repoRoot, 'scripts/env-run.mjs'),
+        'node',
+        '-e',
+        "process.stdout.write(process.env.GH_TOKEN ? 'raw-token-present' : 'raw-token-stripped')",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GH_TOKEN: 'dummy-token',
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('raw-token-stripped');
+  });
+
+  it('blocks local .env.local fallback when it contains a raw GitHub token', () => {
+    const cwd = createRepoTempDir();
+    writeFileSync(path.join(cwd, '.env.local'), 'GH_TOKEN=dummy-token\n');
+
+    const result = spawnSync(
+      'node',
+      [path.join(repoRoot, 'scripts/env-run.mjs'), 'node', '-e', "console.log('should-not-run')"],
+      {
+        cwd,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GH_TOKEN: '',
+          GITHUB_TOKEN: '',
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('.env.local must not define GH_TOKEN or GITHUB_TOKEN');
+    expect(result.stdout).not.toContain('should-not-run');
+  });
+
+  it('keeps worktree setup from copying plaintext .env.local files', () => {
+    const newWorktree = readFileSync(path.join(repoRoot, 'scripts/new-worktree.mjs'), 'utf8');
+    const syncWorktree = readFileSync(path.join(repoRoot, 'scripts/sync-worktree.mjs'), 'utf8');
+
+    expect(newWorktree).not.toContain('copyFileSync');
+    expect(syncWorktree).not.toContain('copyFileSync');
+  });
+
+  it('does not load shared-checkout .env.local from runtime helpers', () => {
+    const cjsRuntime = readFileSync(path.join(repoRoot, 'scripts/lib/runtime.js'), 'utf8');
+    const esmRuntime = readFileSync(path.join(repoRoot, 'scripts/lib/runtime.mjs'), 'utf8');
+
+    expect(cjsRuntime).not.toContain("sharedRoot ? path.join(sharedRoot, '.env.local')");
+    expect(esmRuntime).not.toContain("sharedRoot ? path.join(sharedRoot, '.env.local')");
+  });
+});

--- a/__tests__/scripts/envBootstrap.test.ts
+++ b/__tests__/scripts/envBootstrap.test.ts
@@ -80,6 +80,9 @@ describe('env bootstrap guardrails', () => {
   });
 
   it('strips inherited raw GitHub tokens from env:run child commands', () => {
+    const cwd = createRepoTempDir();
+    writeFileSync(path.join(cwd, '.env.local'), 'NODE_ENV=test\n');
+
     const result = spawnSync(
       'node',
       [
@@ -89,7 +92,7 @@ describe('env bootstrap guardrails', () => {
         "process.stdout.write(process.env.GH_TOKEN ? 'raw-token-present' : 'raw-token-stripped')",
       ],
       {
-        cwd: repoRoot,
+        cwd,
         encoding: 'utf8',
         env: {
           ...process.env,
@@ -125,6 +128,30 @@ describe('env bootstrap guardrails', () => {
     expect(result.stdout).not.toContain('should-not-run');
   });
 
+  it('blocks raw GitHub tokens in local .env.local even when .env.local.refs exists', () => {
+    const cwd = createRepoTempDir();
+    writeFileSync(path.join(cwd, '.env.local'), 'GITHUB_TOKEN=dummy-token\n');
+    writeFileSync(path.join(cwd, '.env.local.refs'), 'NODE_ENV=test\n');
+
+    const result = spawnSync(
+      'node',
+      [path.join(repoRoot, 'scripts/env-run.mjs'), 'node', '-e', "console.log('should-not-run')"],
+      {
+        cwd,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GH_TOKEN: '',
+          GITHUB_TOKEN: '',
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('.env.local must not define GH_TOKEN or GITHUB_TOKEN');
+    expect(result.stdout).not.toContain('should-not-run');
+  });
+
   it('keeps worktree setup from copying plaintext .env.local files', () => {
     const newWorktree = readFileSync(path.join(repoRoot, 'scripts/new-worktree.mjs'), 'utf8');
     const syncWorktree = readFileSync(path.join(repoRoot, 'scripts/sync-worktree.mjs'), 'utf8');
@@ -139,5 +166,32 @@ describe('env bootstrap guardrails', () => {
 
     expect(cjsRuntime).not.toContain("sharedRoot ? path.join(sharedRoot, '.env.local')");
     expect(esmRuntime).not.toContain("sharedRoot ? path.join(sharedRoot, '.env.local')");
+  });
+
+  it('keeps direct gh shellouts inside auth-wrapping runtime helpers only', () => {
+    const directGhPatterns = [
+      /runCommand\(['"]gh['"]/u,
+      /commandOutput\(['"]gh['"]/u,
+      /spawnSync\(['"]gh['"]/u,
+      /execFileSync\(['"]gh['"]/u,
+    ];
+    const checkedFiles = [
+      'scripts/pre-merge-check.mjs',
+      'scripts/rollback.js',
+      'scripts/rollback.mjs',
+      'scripts/lib/runtime.js',
+      'scripts/lib/runtime.mjs',
+    ];
+
+    for (const relativePath of checkedFiles) {
+      const content = readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      const violations = directGhPatterns.filter((pattern) => pattern.test(content));
+
+      if (relativePath.includes('runtime.')) {
+        expect(violations).toHaveLength(1);
+      } else {
+        expect(violations, relativePath).toHaveLength(0);
+      }
+    }
   });
 });

--- a/docs/examples/env-local-refs.example.md
+++ b/docs/examples/env-local-refs.example.md
@@ -1,0 +1,41 @@
+# `.env.local.refs` Example
+
+Copy the environment block to an ignored `.env.local.refs` file for local use.
+Keep GitHub CLI token reference variables out of this file:
+`GH_TOKEN_OP_REF` and `GITHUB_TOKEN_OP_REF` must remain unresolved references
+for the repo's GitHub wrappers.
+Also keep raw GitHub token variables out of this file: `GH_TOKEN` and
+`GITHUB_TOKEN`.
+
+Literal values are accepted only for non-secret allowlisted keys. Secret-bearing
+keys must use `op://...` references.
+
+```dotenv
+KOIOS_API_KEY=op://<vault>/<item>/koios-api-key
+NEXT_PUBLIC_KOIOS_BASE_URL=https://api.koios.rest/api/v1
+
+ADMIN_WALLETS=op://<vault>/<item>/admin-wallets
+
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=op://<vault>/<item>/vapid-public-key
+VAPID_PRIVATE_KEY=op://<vault>/<item>/vapid-private-key
+VAPID_SUBJECT=op://<vault>/<item>/vapid-subject
+
+SUPABASE_ACCESS_TOKEN=op://<vault>/<item>/supabase-access-token
+
+UPSTASH_REDIS_REST_URL=op://<vault>/<item>/upstash-redis-rest-url
+UPSTASH_REDIS_REST_TOKEN=op://<vault>/<item>/upstash-redis-rest-token
+
+POSTHOG_PERSONAL_API_KEY=op://<vault>/<item>/posthog-personal-api-key
+POSTHOG_PROJECT_ID=op://<vault>/<item>/posthog-project-id
+
+DEV_MOCK_AUTH=true
+DEV_ADMIN_WALLETS=op://<vault>/<item>/dev-admin-wallets
+
+HEARTBEAT_URL_PROPOSALS=op://<vault>/<item>/heartbeat-url-proposals
+HEARTBEAT_URL_BATCH=op://<vault>/<item>/heartbeat-url-batch
+HEARTBEAT_URL_DAILY=op://<vault>/<item>/heartbeat-url-daily
+HEARTBEAT_URL_SCORING=op://<vault>/<item>/heartbeat-url-scoring
+HEARTBEAT_URL_ALIGNMENT=op://<vault>/<item>/heartbeat-url-alignment
+HEARTBEAT_URL_FRESHNESS_GUARD=op://<vault>/<item>/heartbeat-url-freshness-guard
+HEARTBEAT_URL_EPOCH_SUMMARY=op://<vault>/<item>/heartbeat-url-epoch-summary
+```

--- a/docs/operations/mac-agent-os-phase-0a-handoff.md
+++ b/docs/operations/mac-agent-os-phase-0a-handoff.md
@@ -55,7 +55,7 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 - `current-state.md` says Governada has about 93 indexed chunks; live metadata has 278.
 - `governada-retrieval/README.md` still lists adding BlueCargo retrieval as a next step.
 - `tooling-matrix.md` gives a portable absolute wrapper example for Governada only.
-- `scripts/new-worktree.mjs` and `scripts/sync-worktree.mjs` copy `.env.local` into worktrees; this should be replaced with a 1Password-backed reference/injection flow in a later slice.
+- `scripts/new-worktree.mjs` and `scripts/sync-worktree.mjs` copied `.env.local` into worktrees at Phase 0A handoff time; Phase 0B superseded this with `env:doctor`, `env:run`, and no new plaintext `.env.local` worktree copying.
 
 ## Phase 0A Fixes Applied
 
@@ -115,7 +115,7 @@ Additional stale directory: `.claude/worktrees/auth-cookie-cleanup` is not regis
 - Add an auth capability registry entry covering owner, operation classes, account/vault boundary, verification command, fallback, and revocation path.
 - Add a retrieval doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and domain-policy drift.
 - Reconcile BlueCargo retrieval policy across `retrieval-policy.md`, `autonomy-policy.md`, `bluecargo-context.md`, `retrieval-interfaces.md`, and `tooling-matrix.md`.
-- Replace `.env.local` worktree copying with a 1Password-backed local injection/reference path.
+- Validate and adopt the Phase 0B `env:doctor` / `env:run` local injection/reference path; do not restore plaintext `.env.local` worktree copying.
 - Evaluate GitHub App installation tokens vs a narrow 1Password service account vs an interim fine-grained PAT; do not implement a new auth lane until Tim approves the chosen design.
 - Add a capability registry entry for LM Studio as installed but inactive/unproven; keep Ollama, Open WebUI, and Hammerspoon marked unavailable until installed and tested.
 
@@ -170,7 +170,7 @@ Recommended work slices:
 1. Decide with Tim whether governada-brain, governada-retrieval, and bluecargo-retrieval should be Git-versioned now or have accepted local-loss risk documented.
 2. Extend the auth-runtime design from auth-and-identity.md into an implementation plan: sandbox-compatible autonomous lane, auth capability registry, operation classes, approval posture, fallback, and revocation path.
 3. Decide between GitHub App installation tokens, a narrow 1Password service account, and an interim fine-grained PAT for the first autonomous GitHub lane.
-4. Replace .env.local worktree copying with a 1Password-backed reference/injection design, then implement only after approval.
+4. Validate and adopt the Phase 0B .env.local.refs / env:run path; do not restore plaintext .env.local worktree copying.
 5. Add a retrieval/control-plane doctor that reports wrapper availability, PATH exposure, index timestamp, chunk count, vault files newer than index, and policy drift.
 6. Reconcile BlueCargo retrieval policy drift across retrieval-policy.md, autonomy-policy.md, bluecargo-context.md, retrieval-interfaces.md, and tooling-matrix.md.
 7. Update durable ops notes and/or roadmap current reality after checks and fixes.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "gh:auth-status": "node scripts/gh-auth-status.js",
     "auth:doctor": "node scripts/auth-doctor.js",
     "auth:repair": "node scripts/repair-gh-auth.mjs",
+    "env:doctor": "node scripts/env-doctor.mjs",
+    "env:run": "node scripts/env-run.mjs",
     "git:stage": "node scripts/git-stage.js",
     "git:commit": "node scripts/git-commit.js",
     "git:push": "node scripts/git-push.js",

--- a/scripts/env-doctor.mjs
+++ b/scripts/env-doctor.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import {
+  ENV_LOCAL_FILE,
+  ENV_REFS_EXAMPLE,
+  ENV_REFS_FILE,
+  findFirstExisting,
+  forbiddenLiteralEntries,
+  getCheckoutKind,
+  getEnvLocalCandidates,
+  getEnvRefsCandidates,
+  getForbiddenGithubReferenceKeys,
+  gitCheckIgnored,
+  gitCheckTracked,
+  parseEnvEntries,
+  RAW_GITHUB_TOKEN_KEYS,
+  runOpVersion,
+} from './lib/env-bootstrap.mjs';
+import { getScriptContext } from './lib/runtime.mjs';
+
+const require = createRequire(import.meta.url);
+const { getContext } = require('./set-gh-context.js');
+
+function ok(message) {
+  console.log(`OK: ${message}`);
+}
+
+function warn(warnings, message) {
+  warnings.push(message);
+  console.log(`WARN: ${message}`);
+}
+
+function block(blockers, message) {
+  blockers.push(message);
+  console.log(`BLOCKED: ${message}`);
+}
+
+function describePath(repoRoot, filePath) {
+  const relative = path.relative(repoRoot, filePath);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : filePath;
+}
+
+function checkIgnored(blockers, warnings, repoRoot, filePath, label) {
+  const ignored = gitCheckIgnored(repoRoot, filePath);
+
+  if (ignored === true) {
+    ok(`${label} is ignored by Git`);
+    return;
+  }
+
+  if (ignored === false) {
+    block(blockers, `${label} is not ignored by Git`);
+    return;
+  }
+
+  warn(warnings, `could not verify Git ignore status for ${label}`);
+}
+
+function isLocalFile(repoRoot, filePath) {
+  if (!filePath) {
+    return false;
+  }
+
+  const relative = path.relative(repoRoot, filePath);
+  return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function main() {
+  const blockers = [];
+  const warnings = [];
+  const { repoRoot } = getScriptContext(import.meta.url);
+  const context = getContext();
+  const env = {
+    ...process.env,
+    ...context,
+  };
+
+  console.log('Env doctor: Governada local environment bootstrap');
+  ok(`checkout kind: ${getCheckoutKind(repoRoot)}`);
+  ok(`1Password account context: ${context.OP_ACCOUNT}`);
+
+  const rawGitHubTokens = [...RAW_GITHUB_TOKEN_KEYS].filter((key) => process.env[key]);
+  if (rawGitHubTokens.length > 0) {
+    block(
+      blockers,
+      'raw GitHub token env is present; remove GH_TOKEN/GITHUB_TOKEN so repo wrappers prove the 1Password lane',
+    );
+  } else {
+    ok('raw GitHub token env is not present');
+  }
+
+  const envLocalPath = findFirstExisting(getEnvLocalCandidates(repoRoot));
+  const envRefsPath = findFirstExisting(getEnvRefsCandidates(repoRoot));
+  const examplePath = path.join(repoRoot, ENV_REFS_EXAMPLE);
+
+  if (envLocalPath) {
+    ok(`${ENV_LOCAL_FILE} is present (${describePath(repoRoot, envLocalPath)})`);
+    checkIgnored(blockers, warnings, repoRoot, envLocalPath, ENV_LOCAL_FILE);
+    if (!isLocalFile(repoRoot, envLocalPath)) {
+      warn(
+        warnings,
+        `${ENV_LOCAL_FILE} exists only outside this checkout and will not be injected by env:run`,
+      );
+    }
+  } else {
+    warn(warnings, `${ENV_LOCAL_FILE} is absent`);
+  }
+
+  if (envRefsPath) {
+    ok(`${ENV_REFS_FILE} is present (${describePath(repoRoot, envRefsPath)})`);
+    checkIgnored(blockers, warnings, repoRoot, envRefsPath, ENV_REFS_FILE);
+
+    const forbiddenKeys = getForbiddenGithubReferenceKeys(envRefsPath);
+    if (forbiddenKeys.length > 0) {
+      block(
+        blockers,
+        `${ENV_REFS_FILE} contains GitHub token reference key(s); keep GH_TOKEN_OP_REF/GITHUB_TOKEN_OP_REF outside op-run style injection`,
+      );
+    } else {
+      ok(`${ENV_REFS_FILE} does not define GitHub token reference keys`);
+    }
+
+    const entries = parseEnvEntries(envRefsPath);
+    const forbiddenRawTokenKeys = entries
+      .map((entry) => entry.key)
+      .filter((key) => RAW_GITHUB_TOKEN_KEYS.has(key));
+    if (forbiddenRawTokenKeys.length > 0) {
+      block(
+        blockers,
+        `${ENV_REFS_FILE} contains raw GitHub token key(s); keep GH_TOKEN/GITHUB_TOKEN out of env injection`,
+      );
+    } else {
+      ok(`${ENV_REFS_FILE} does not define raw GitHub token keys`);
+    }
+
+    const forbiddenLiterals = forbiddenLiteralEntries(entries);
+    if (forbiddenLiterals.length > 0) {
+      block(
+        blockers,
+        `${ENV_REFS_FILE} contains non-allowlisted literal env assignment(s); use op:// references for secret-bearing keys`,
+      );
+    } else {
+      ok(`${ENV_REFS_FILE} literals are limited to allowlisted non-secret keys`);
+    }
+
+    const opVersion = runOpVersion(repoRoot, env);
+    if (opVersion.error?.code === 'ENOENT') {
+      block(blockers, '1Password CLI (`op`) is not installed or not on PATH');
+    } else if (opVersion.error || opVersion.status !== 0) {
+      block(blockers, '1Password CLI (`op`) is not runnable from this process');
+    } else {
+      ok(`1Password CLI is available (${opVersion.stdout.trim() || 'version unknown'})`);
+    }
+  } else {
+    warn(
+      warnings,
+      `${ENV_REFS_FILE} is absent; commands can use process env or local ${ENV_LOCAL_FILE} fallback only when present in this checkout`,
+    );
+  }
+
+  if (!existsSync(examplePath)) {
+    block(blockers, `${ENV_REFS_EXAMPLE} is missing`);
+  } else {
+    ok(`${ENV_REFS_EXAMPLE} exists`);
+
+    const exampleIgnored = gitCheckIgnored(repoRoot, examplePath);
+    if (exampleIgnored === true) {
+      block(blockers, `${ENV_REFS_EXAMPLE} is ignored by Git`);
+    } else if (exampleIgnored === false) {
+      ok(`${ENV_REFS_EXAMPLE} is eligible for Git tracking`);
+    } else {
+      warn(warnings, `could not verify Git ignore status for ${ENV_REFS_EXAMPLE}`);
+    }
+
+    if (gitCheckTracked(repoRoot, ENV_REFS_EXAMPLE)) {
+      ok(`${ENV_REFS_EXAMPLE} is tracked or staged`);
+    } else {
+      warn(warnings, `${ENV_REFS_EXAMPLE} is not tracked yet`);
+    }
+  }
+
+  if (blockers.length > 0) {
+    console.log(`Env doctor result: BLOCKED (${blockers.length} blocker(s))`);
+    process.exit(1);
+  }
+
+  if (warnings.length > 0) {
+    console.log(`Env doctor result: PASS_WITH_ADVISORIES (${warnings.length} advisory item(s))`);
+    return;
+  }
+
+  console.log('Env doctor result: PASS');
+}
+
+main();

--- a/scripts/env-doctor.mjs
+++ b/scripts/env-doctor.mjs
@@ -69,6 +69,12 @@ function isLocalFile(repoRoot, filePath) {
   return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function getRawGitHubTokenKeys(filePath) {
+  return parseEnvEntries(filePath)
+    .map((entry) => entry.key)
+    .filter((key) => RAW_GITHUB_TOKEN_KEYS.has(key));
+}
+
 function main() {
   const blockers = [];
   const warnings = [];
@@ -100,6 +106,17 @@ function main() {
   if (envLocalPath) {
     ok(`${ENV_LOCAL_FILE} is present (${describePath(repoRoot, envLocalPath)})`);
     checkIgnored(blockers, warnings, repoRoot, envLocalPath, ENV_LOCAL_FILE);
+
+    const rawEnvLocalTokenKeys = getRawGitHubTokenKeys(envLocalPath);
+    if (rawEnvLocalTokenKeys.length > 0) {
+      block(
+        blockers,
+        `${ENV_LOCAL_FILE} contains raw GitHub token key(s); remove GH_TOKEN/GITHUB_TOKEN and keep GitHub auth on the 1Password reference lane`,
+      );
+    } else {
+      ok(`${ENV_LOCAL_FILE} does not define raw GitHub token keys`);
+    }
+
     if (!isLocalFile(repoRoot, envLocalPath)) {
       warn(
         warnings,

--- a/scripts/env-run.mjs
+++ b/scripts/env-run.mjs
@@ -49,6 +49,12 @@ function isLocalFile(repoRoot, filePath) {
   return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function getRawGitHubTokenKeys(filePath) {
+  return parseEnvEntries(filePath)
+    .map((entry) => entry.key)
+    .filter((key) => RAW_GITHUB_TOKEN_KEYS.has(key));
+}
+
 function resolveReference(repoRoot, entry, env) {
   if (!isOpReference(entry.value)) {
     return entry.value;
@@ -108,6 +114,11 @@ function main() {
 
   if (!refsPath) {
     if (envLocalPath && isLocalFile(repoRoot, envLocalPath)) {
+      const rawEnvLocalTokenKeys = getRawGitHubTokenKeys(envLocalPath);
+      if (rawEnvLocalTokenKeys.length > 0) {
+        fail(`${ENV_LOCAL_FILE} must not define GH_TOKEN or GITHUB_TOKEN`);
+      }
+
       console.error(
         `${ENV_REFS_FILE}: absent; running command directly so existing ${ENV_LOCAL_FILE} fallback behavior can apply.`,
       );

--- a/scripts/env-run.mjs
+++ b/scripts/env-run.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import {
+  ENV_LOCAL_FILE,
+  ENV_REFS_FILE,
+  findFirstExisting,
+  forbiddenLiteralEntries,
+  getEnvLocalCandidates,
+  getEnvRefsCandidates,
+  getForbiddenGithubReferenceKeys,
+  isOpReference,
+  parseEnvEntries,
+  RAW_GITHUB_TOKEN_KEYS,
+  runOpRead,
+  runOpVersion,
+} from './lib/env-bootstrap.mjs';
+import { getScriptContext } from './lib/runtime.mjs';
+
+const require = createRequire(import.meta.url);
+const { getContext } = require('./set-gh-context.js');
+
+const usage = 'npm run env:run -- <command> [args...]';
+
+function parseArgs(argv) {
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.error(`Usage: ${usage}`);
+    process.exit(args.length === 0 ? 1 : 0);
+  }
+
+  return args;
+}
+
+function fail(message) {
+  console.error(`BLOCKED: ${message}`);
+  process.exit(1);
+}
+
+function isLocalFile(repoRoot, filePath) {
+  if (!filePath) {
+    return false;
+  }
+
+  const relative = path.relative(repoRoot, filePath);
+  return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function resolveReference(repoRoot, entry, env) {
+  if (!isOpReference(entry.value)) {
+    return entry.value;
+  }
+
+  const result = runOpRead(repoRoot, entry.value, env);
+  if (result.error?.code === 'ENOENT') {
+    fail('1Password CLI (`op`) is not installed or not on PATH');
+  }
+
+  if (result.error?.code === 'ETIMEDOUT' || result.signal) {
+    fail(`1Password timed out while resolving ${entry.key}`);
+  }
+
+  if (result.error || result.status !== 0) {
+    fail(`1Password could not resolve ${entry.key}; unlock 1Password or check the reference`);
+  }
+
+  return result.stdout.replace(/\r?\n$/u, '');
+}
+
+function runCommand(command, env) {
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: process.cwd(),
+    env,
+    stdio: 'inherit',
+  });
+
+  if (result.error?.code === 'ENOENT') {
+    fail(`command not found: ${command[0]}`);
+  }
+
+  if (result.error) {
+    fail(`command failed to start: ${result.error.message}`);
+  }
+
+  if (result.signal) {
+    console.error(`Command terminated by signal ${result.signal}`);
+    process.exit(1);
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+function main() {
+  const command = parseArgs(process.argv.slice(2));
+  const { repoRoot } = getScriptContext(import.meta.url);
+  const context = getContext();
+  const baseEnv = { ...process.env };
+  for (const key of RAW_GITHUB_TOKEN_KEYS) {
+    delete baseEnv[key];
+  }
+  Object.assign(baseEnv, context);
+
+  const refsPath = findFirstExisting(getEnvRefsCandidates(repoRoot));
+  const envLocalPath = findFirstExisting(getEnvLocalCandidates(repoRoot));
+
+  if (!refsPath) {
+    if (envLocalPath && isLocalFile(repoRoot, envLocalPath)) {
+      console.error(
+        `${ENV_REFS_FILE}: absent; running command directly so existing ${ENV_LOCAL_FILE} fallback behavior can apply.`,
+      );
+      runCommand(command, baseEnv);
+    }
+
+    if (envLocalPath) {
+      fail(
+        `${ENV_REFS_FILE} is absent and ${ENV_LOCAL_FILE} exists only outside this checkout; create ignored ${ENV_REFS_FILE} instead of copying plaintext env files`,
+      );
+    }
+
+    fail(`no ${ENV_REFS_FILE} or ${ENV_LOCAL_FILE} found; run npm run env:doctor`);
+  }
+
+  const forbiddenKeys = getForbiddenGithubReferenceKeys(refsPath);
+  if (forbiddenKeys.length > 0) {
+    fail(`${ENV_REFS_FILE} must not define GH_TOKEN_OP_REF or GITHUB_TOKEN_OP_REF`);
+  }
+
+  const entries = parseEnvEntries(refsPath);
+  const forbiddenRawTokenKeys = entries
+    .map((entry) => entry.key)
+    .filter((key) => RAW_GITHUB_TOKEN_KEYS.has(key));
+  if (forbiddenRawTokenKeys.length > 0) {
+    fail(`${ENV_REFS_FILE} must not define GH_TOKEN or GITHUB_TOKEN`);
+  }
+
+  const forbiddenLiterals = forbiddenLiteralEntries(entries);
+  if (forbiddenLiterals.length > 0) {
+    fail(`${ENV_REFS_FILE} contains non-allowlisted literal env assignment(s)`);
+  }
+
+  const opVersion = runOpVersion(repoRoot, baseEnv);
+  if (opVersion.error?.code === 'ENOENT') {
+    fail('1Password CLI (`op`) is not installed or not on PATH');
+  }
+
+  if (opVersion.error || opVersion.status !== 0) {
+    fail('1Password CLI (`op`) is not runnable from this process');
+  }
+
+  const injectedEnv = { ...baseEnv };
+  for (const entry of entries) {
+    injectedEnv[entry.key] = resolveReference(repoRoot, entry, baseEnv);
+  }
+
+  runCommand(command, injectedEnv);
+}
+
+main();

--- a/scripts/env-run.mjs
+++ b/scripts/env-run.mjs
@@ -112,13 +112,15 @@ function main() {
   const refsPath = findFirstExisting(getEnvRefsCandidates(repoRoot));
   const envLocalPath = findFirstExisting(getEnvLocalCandidates(repoRoot));
 
+  if (envLocalPath && isLocalFile(repoRoot, envLocalPath)) {
+    const rawEnvLocalTokenKeys = getRawGitHubTokenKeys(envLocalPath);
+    if (rawEnvLocalTokenKeys.length > 0) {
+      fail(`${ENV_LOCAL_FILE} must not define GH_TOKEN or GITHUB_TOKEN`);
+    }
+  }
+
   if (!refsPath) {
     if (envLocalPath && isLocalFile(repoRoot, envLocalPath)) {
-      const rawEnvLocalTokenKeys = getRawGitHubTokenKeys(envLocalPath);
-      if (rawEnvLocalTokenKeys.length > 0) {
-        fail(`${ENV_LOCAL_FILE} must not define GH_TOKEN or GITHUB_TOKEN`);
-      }
-
       console.error(
         `${ENV_REFS_FILE}: absent; running command directly so existing ${ENV_LOCAL_FILE} fallback behavior can apply.`,
       );

--- a/scripts/lib/env-bootstrap.mjs
+++ b/scripts/lib/env-bootstrap.mjs
@@ -1,0 +1,213 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { commandOutput } from './runtime.mjs';
+
+export const ENV_REFS_FILE = '.env.local.refs';
+export const ENV_LOCAL_FILE = '.env.local';
+export const ENV_REFS_EXAMPLE = path.join('docs', 'examples', 'env-local-refs.example.md');
+export const GITHUB_REFERENCE_KEYS = new Set(['GH_TOKEN_OP_REF', 'GITHUB_TOKEN_OP_REF']);
+export const RAW_GITHUB_TOKEN_KEYS = new Set(['GH_TOKEN', 'GITHUB_TOKEN']);
+export const OP_READ_TIMEOUT_MS = 15000;
+export const LITERAL_ENV_ALLOWLIST = new Set([
+  'DEV_MOCK_AUTH',
+  'NODE_ENV',
+  'NEXT_PUBLIC_KOIOS_BASE_URL',
+  'NEXT_PUBLIC_POSTHOG_HOST',
+  'NEXT_PUBLIC_SITE_URL',
+]);
+
+function uniquePaths(paths) {
+  const seen = new Set();
+  const result = [];
+
+  for (const filePath of paths.filter(Boolean)) {
+    const resolved = path.resolve(filePath);
+    if (seen.has(resolved)) {
+      continue;
+    }
+
+    seen.add(resolved);
+    result.push(resolved);
+  }
+
+  return result;
+}
+
+export function getCheckoutKind(repoRoot) {
+  try {
+    const gitEntry = lstatSync(path.join(repoRoot, '.git'));
+    return gitEntry.isDirectory() ? 'shared checkout' : 'worktree';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export function getSharedCheckoutRoot(repoRoot) {
+  const commonDir = commandOutput(
+    'git',
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    {
+      allowFailure: true,
+      cwd: repoRoot,
+    },
+  );
+
+  if (!commonDir) {
+    return '';
+  }
+
+  const sharedRoot = path.dirname(commonDir);
+  return path.resolve(sharedRoot);
+}
+
+export function getEnvLocalCandidates(repoRoot, cwd = process.cwd()) {
+  const sharedRoot = getSharedCheckoutRoot(repoRoot);
+  return uniquePaths([
+    path.join(cwd, ENV_LOCAL_FILE),
+    path.join(repoRoot, ENV_LOCAL_FILE),
+    sharedRoot ? path.join(sharedRoot, ENV_LOCAL_FILE) : '',
+  ]);
+}
+
+export function getEnvRefsCandidates(repoRoot, cwd = process.cwd()) {
+  const sharedRoot = getSharedCheckoutRoot(repoRoot);
+  return uniquePaths([
+    path.join(cwd, ENV_REFS_FILE),
+    path.join(repoRoot, ENV_REFS_FILE),
+    sharedRoot ? path.join(sharedRoot, ENV_REFS_FILE) : '',
+  ]);
+}
+
+export function findFirstExisting(paths) {
+  return paths.find((filePath) => existsSync(filePath)) || '';
+}
+
+export function findRepoRootForPath(repoRoot, filePath) {
+  const sharedRoot = getSharedCheckoutRoot(repoRoot);
+  const candidates = uniquePaths([repoRoot, sharedRoot]);
+  const resolvedFile = path.resolve(filePath);
+
+  return (
+    candidates.find((candidate) => {
+      const relative = path.relative(candidate, resolvedFile);
+      return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+    }) || repoRoot
+  );
+}
+
+export function parseEnvKeys(filePath) {
+  return parseEnvEntries(filePath).map((entry) => entry.key);
+}
+
+export function parseEnvEntries(filePath) {
+  const keys = [];
+  const contents = readFileSync(filePath, 'utf8');
+
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const normalizedLine = line.startsWith('export ') ? line.slice(7).trimStart() : line;
+    const separatorIndex = normalizedLine.indexOf('=');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = normalizedLine.slice(0, separatorIndex).trim();
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) {
+      keys.push({
+        key,
+        value: normalizeEnvValue(normalizedLine.slice(separatorIndex + 1).trim()),
+      });
+    }
+  }
+
+  return keys;
+}
+
+function normalizeEnvValue(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value.replace(/\s+#.*$/u, '').trim();
+}
+
+export function isOpReference(value) {
+  return value.startsWith('op://');
+}
+
+export function literalEntries(entries) {
+  return entries.filter((entry) => entry.value && !isOpReference(entry.value));
+}
+
+export function forbiddenLiteralEntries(entries) {
+  return literalEntries(entries).filter((entry) => !LITERAL_ENV_ALLOWLIST.has(entry.key));
+}
+
+export function getForbiddenGithubReferenceKeys(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return [];
+  }
+
+  return parseEnvKeys(filePath).filter((key) => GITHUB_REFERENCE_KEYS.has(key));
+}
+
+export function gitCheckIgnored(repoRoot, filePath) {
+  const root = findRepoRootForPath(repoRoot, filePath);
+  const relativePath = path.relative(root, filePath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  const result = spawnSync('git', ['check-ignore', '--quiet', '--', relativePath], {
+    cwd: root,
+    stdio: 'ignore',
+  });
+
+  if (result.status === 0) {
+    return true;
+  }
+
+  if (result.status === 1) {
+    return false;
+  }
+
+  return null;
+}
+
+export function gitCheckTracked(repoRoot, relativePath) {
+  const result = spawnSync('git', ['ls-files', '--error-unmatch', '--', relativePath], {
+    cwd: repoRoot,
+    stdio: 'ignore',
+  });
+
+  return result.status === 0;
+}
+
+export function runOpVersion(repoRoot, env = process.env) {
+  return spawnSync('op', ['--version'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 15000,
+  });
+}
+
+export function runOpRead(repoRoot, reference, env = process.env) {
+  return spawnSync('op', ['read', reference], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: OP_READ_TIMEOUT_MS,
+  });
+}

--- a/scripts/lib/gh-auth.js
+++ b/scripts/lib/gh-auth.js
@@ -1,6 +1,7 @@
 const { spawnSync } = require('node:child_process');
 
 const OP_READ_TIMEOUT_MS = 15000;
+const RAW_GITHUB_TOKEN_KEYS = ['GH_TOKEN', 'GITHUB_TOKEN'];
 
 function redactSensitiveText(value) {
   return value
@@ -64,9 +65,27 @@ function readOnePasswordToken(tokenRef, env, cwd) {
 function withGhTokenFromOnePassword(env, cwd) {
   const mergedEnv = { ...env };
   const tokenRef = mergedEnv.GH_TOKEN_OP_REF || mergedEnv.GITHUB_TOKEN_OP_REF;
+  const rawTokenKeys = RAW_GITHUB_TOKEN_KEYS.filter((key) => mergedEnv[key]);
 
   if (!tokenRef) {
+    if (rawTokenKeys.length > 0) {
+      for (const key of rawTokenKeys) {
+        delete mergedEnv[key];
+      }
+
+      return {
+        env: mergedEnv,
+        error:
+          `GitHub auth: raw ${rawTokenKeys.join('/')} env is not allowed for repo wrappers. ` +
+          'Set GH_TOKEN_OP_REF or GITHUB_TOKEN_OP_REF to an op:// reference instead.',
+      };
+    }
+
     return { env: mergedEnv };
+  }
+
+  for (const key of RAW_GITHUB_TOKEN_KEYS) {
+    delete mergedEnv[key];
   }
 
   const result = readOnePasswordToken(tokenRef, mergedEnv, cwd);
@@ -74,12 +93,12 @@ function withGhTokenFromOnePassword(env, cwd) {
     return { env: mergedEnv, error: result.error };
   }
 
-  delete mergedEnv.GITHUB_TOKEN;
   mergedEnv.GH_TOKEN = result.token;
   return { env: mergedEnv };
 }
 
 module.exports = {
+  RAW_GITHUB_TOKEN_KEYS,
   redactSensitiveText,
   withGhTokenFromOnePassword,
 };

--- a/scripts/lib/runtime.js
+++ b/scripts/lib/runtime.js
@@ -7,21 +7,6 @@ const { withGhTokenFromOnePassword } = require('./gh-auth');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 
-function getSharedCheckoutRoot() {
-  const result = spawnSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-
-  if (result.status !== 0) {
-    return '';
-  }
-
-  const commonDir = result.stdout.trim();
-  return commonDir ? path.dirname(commonDir) : '';
-}
-
 function resolveCommand(command) {
   if (process.platform !== 'win32') {
     return command;
@@ -43,11 +28,9 @@ function usesShell(command) {
 }
 
 function loadLocalEnv() {
-  const sharedRoot = getSharedCheckoutRoot();
   const candidates = [
     path.join(process.cwd(), '.env.local'),
     path.join(repoRoot, '.env.local'),
-    sharedRoot ? path.join(sharedRoot, '.env.local') : '',
   ].filter(Boolean);
 
   const seen = new Set();

--- a/scripts/lib/runtime.mjs
+++ b/scripts/lib/runtime.mjs
@@ -33,19 +33,6 @@ export function getScriptContext(metaUrl) {
   return { repoRoot, scriptDir, scriptPath };
 }
 
-function getSharedCheckoutRoot(repoRoot) {
-  const commonDir = commandOutput(
-    'git',
-    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
-    {
-      allowFailure: true,
-      cwd: repoRoot,
-    },
-  );
-
-  return commonDir ? path.dirname(commonDir) : '';
-}
-
 function keyAllowed(key, keyFilter) {
   if (!keyFilter) {
     return true;
@@ -62,11 +49,9 @@ function keyAllowed(key, keyFilter) {
 
 export function loadLocalEnv(metaUrl, keyFilter = null) {
   const { repoRoot } = getScriptContext(metaUrl);
-  const sharedRoot = getSharedCheckoutRoot(repoRoot);
   const candidates = [
     path.join(process.cwd(), '.env.local'),
     path.join(repoRoot, '.env.local'),
-    sharedRoot ? path.join(sharedRoot, '.env.local') : '',
   ].filter(Boolean);
   const seen = new Set();
 

--- a/scripts/new-worktree.mjs
+++ b/scripts/new-worktree.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, symlinkSync } from 'node:fs';
 import path from 'node:path';
+import { ENV_LOCAL_FILE, ENV_REFS_FILE } from './lib/env-bootstrap.mjs';
 import { commandOutput, getScriptContext } from './lib/runtime.mjs';
 
 const usage = 'npm run worktree:new -- <name> [--branch <branch>] [--no-node-modules-link]';
@@ -157,6 +158,29 @@ function ensureNodeModulesLink(worktreePath, noNodeModulesLink) {
   }
 }
 
+function reportEnvBootstrap() {
+  const sharedRefs = path.join(repoRoot, ENV_REFS_FILE);
+  const sharedEnv = path.join(repoRoot, ENV_LOCAL_FILE);
+
+  if (existsSync(sharedRefs)) {
+    console.log(
+      `${ENV_REFS_FILE}: available from shared checkout; no env file was copied. Use npm run env:run -- <command>.`,
+    );
+    return;
+  }
+
+  if (existsSync(sharedEnv)) {
+    console.log(
+      `${ENV_LOCAL_FILE}: present in shared checkout but not copied. Run npm run env:doctor for migration status.`,
+    );
+    return;
+  }
+
+  console.log(
+    `${ENV_REFS_FILE}: not found. Run npm run env:doctor before commands that need local secrets.`,
+  );
+}
+
 const { repoRoot } = getScriptContext(import.meta.url);
 
 function main() {
@@ -188,13 +212,7 @@ function main() {
   console.log(`Creating worktree ${worktreePath} on branch ${branchName}...`);
   git(['worktree', 'add', worktreePath, '-b', branchName, 'origin/main']);
 
-  const mainEnv = path.join(repoRoot, '.env.local');
-  const worktreeEnv = path.join(worktreePath, '.env.local');
-  if (existsSync(mainEnv) && !existsSync(worktreeEnv)) {
-    copyFileSync(mainEnv, worktreeEnv);
-    console.log('.env.local copied.');
-  }
-
+  reportEnvBootstrap();
   ensureNodeModulesLink(worktreePath, options.noNodeModulesLink);
 
   console.log('');
@@ -203,7 +221,7 @@ function main() {
   console.log(`  Branch: ${branchName}`);
   console.log('');
   console.log('Next:');
-  console.log(`  Set-Location '${worktreePath}'`);
+  console.log(`  cd '${worktreePath}'`);
   console.log('  git status --short --branch');
 }
 

--- a/scripts/pre-merge-check.mjs
+++ b/scripts/pre-merge-check.mjs
@@ -1,4 +1,4 @@
-import { commandOutput, getScriptContext, ghJson, requireArg } from './lib/runtime.mjs';
+import { commandOutput, getScriptContext, ghJson, ghOutput, requireArg } from './lib/runtime.mjs';
 
 const prNumber = Number.parseInt(
   requireArg(process.argv.slice(2), 0, 'pre-merge-check.mjs <pr-number>'),
@@ -77,7 +77,7 @@ if (mergeStateStatus === 'BEHIND') {
   process.exit(1);
 }
 
-const prStatus = commandOutput('gh', ['pr', 'checks', `${prNumber}`, '--repo', repo], {
+const prStatus = ghOutput(['pr', 'checks', `${prNumber}`, '--repo', repo], {
   allowFailure: true,
   cwd: repoRoot,
 });

--- a/scripts/rollback.js
+++ b/scripts/rollback.js
@@ -2,7 +2,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { sendNotification } = require('./notify.js');
-const { loadLocalEnv, repoRoot, runCommand, runGhJson, sleep } = require('./lib/runtime');
+const { loadLocalEnv, repoRoot, runCommand, runGh, runGhJson, sleep } = require('./lib/runtime');
 
 loadLocalEnv();
 
@@ -79,24 +79,20 @@ async function createRevertPr(currentSha, currentMessage) {
       throw new Error((pushResult.stderr || pushResult.stdout || 'git push failed').trim());
     }
 
-    const createPr = runCommand(
-      'gh',
-      [
-        'pr',
-        'create',
-        '--repo',
-        repo,
-        '--title',
-        `revert: rollback ${shortSha(currentSha)} (${currentMessage})`,
-        '--body',
-        `Automated rollback of ${shortSha(currentSha)} due to production failure.\n\nOriginal: ${currentMessage}`,
-        '--head',
-        branchName,
-        '--base',
-        'main',
-      ],
-      { cwd: worktreePath },
-    );
+    const createPr = runGh([
+      'pr',
+      'create',
+      '--repo',
+      repo,
+      '--title',
+      `revert: rollback ${shortSha(currentSha)} (${currentMessage})`,
+      '--body',
+      `Automated rollback of ${shortSha(currentSha)} due to production failure.\n\nOriginal: ${currentMessage}`,
+      '--head',
+      branchName,
+      '--base',
+      'main',
+    ]);
 
     if (createPr.status !== 0) {
       throw new Error((createPr.stderr || createPr.stdout || 'gh pr create failed').trim());
@@ -208,7 +204,7 @@ async function main() {
       .filter(Boolean)
       .join('\n');
 
-    const issueResult = runCommand('gh', [
+    const issueResult = runGh([
       'issue',
       'create',
       '--repo',

--- a/scripts/rollback.mjs
+++ b/scripts/rollback.mjs
@@ -6,6 +6,8 @@ import {
   commandOutput,
   fetchWithTimeout,
   getScriptContext,
+  ghJson,
+  ghOutput,
   normalizeBaseUrl,
 } from './lib/runtime.mjs';
 
@@ -46,7 +48,7 @@ async function fetchHealth() {
 }
 
 function ghApi(pathname) {
-  return JSON.parse(commandOutput('gh', ['api', pathname], { cwd: repoRoot }));
+  return ghJson(['api', pathname], { cwd: repoRoot });
 }
 
 function notify(alertType, title, details) {
@@ -96,8 +98,7 @@ function createRollbackPr(currentSha, currentMessage) {
       '- **Scope**: main branch revert only.',
     ].join('\n');
 
-    const prUrl = commandOutput(
-      'gh',
+    const prUrl = ghOutput(
       [
         'pr',
         'create',
@@ -140,8 +141,7 @@ function createIncidentIssue({ currentShortSha, currentMessage, currentHealth, r
     '- [ ] Investigate root cause and land a forward fix before re-deploying.',
   ].join('\n');
 
-  return commandOutput(
-    'gh',
+  return ghOutput(
     [
       'issue',
       'create',

--- a/scripts/sync-worktree.mjs
+++ b/scripts/sync-worktree.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, existsSync, lstatSync, readFileSync, symlinkSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync, symlinkSync } from 'node:fs';
 import path from 'node:path';
+import { ENV_LOCAL_FILE, ENV_REFS_FILE } from './lib/env-bootstrap.mjs';
 import { getScriptContext } from './lib/runtime.mjs';
 
 const { repoRoot } = getScriptContext(import.meta.url);
@@ -100,17 +101,50 @@ function revCount(range) {
   return Number.isFinite(value) ? value : 0;
 }
 
-function ensureEnvLocal() {
+function reportEnvBootstrap() {
   if (isSharedCheckout) {
+    if (existsSync(path.join(repoRoot, ENV_REFS_FILE))) {
+      console.log(`${ENV_REFS_FILE}: present in shared checkout.`);
+    } else if (existsSync(path.join(repoRoot, ENV_LOCAL_FILE))) {
+      console.log(
+        `${ENV_LOCAL_FILE}: present in shared checkout as a fallback; run npm run env:doctor for migration status.`,
+      );
+    } else {
+      console.log(`${ENV_REFS_FILE}: not found. Run npm run env:doctor.`);
+    }
     return;
   }
 
-  const worktreeEnv = path.join(repoRoot, '.env.local');
-  const mainEnv = path.join(mainCheckoutRoot, '.env.local');
-  if (!existsSync(worktreeEnv) && existsSync(mainEnv)) {
-    copyFileSync(mainEnv, worktreeEnv);
-    console.log('.env.local: copied from main checkout.');
+  const worktreeRefs = path.join(repoRoot, ENV_REFS_FILE);
+  const sharedRefs = path.join(mainCheckoutRoot, ENV_REFS_FILE);
+  const worktreeEnv = path.join(repoRoot, ENV_LOCAL_FILE);
+  const sharedEnv = path.join(mainCheckoutRoot, ENV_LOCAL_FILE);
+
+  if (existsSync(worktreeRefs)) {
+    console.log(`${ENV_REFS_FILE}: present in worktree. Use npm run env:run -- <command>.`);
+    return;
   }
+
+  if (existsSync(sharedRefs)) {
+    console.log(
+      `${ENV_REFS_FILE}: available from shared checkout. Use npm run env:run -- <command>; no env file was copied.`,
+    );
+    return;
+  }
+
+  if (existsSync(worktreeEnv)) {
+    console.log(`${ENV_LOCAL_FILE}: present in worktree as a fallback.`);
+    return;
+  }
+
+  if (existsSync(sharedEnv)) {
+    console.log(
+      `${ENV_LOCAL_FILE}: present in shared checkout but not copied. Run npm run env:doctor for migration status.`,
+    );
+    return;
+  }
+
+  console.log(`${ENV_REFS_FILE}: not found. Run npm run env:doctor.`);
 }
 
 function ensureNodeModulesLink() {
@@ -214,5 +248,5 @@ if (behind > 0) {
   console.log(`Git: already up to date with origin/main (ahead ${ahead} commit(s)).`);
 }
 
-ensureEnvLocal();
+reportEnvBootstrap();
 ensureNodeModulesLink();


### PR DESCRIPTION
## Summary

Adds the Phase 0B env-bootstrap implementation for Governada app worktrees:

- adds `npm run env:doctor` for value-safe local env readiness checks
- adds `npm run env:run -- <command>` for ignored `.env.local.refs` based command execution
- stops future `worktree:new` and `worktree:sync` runs from copying plaintext `.env.local`
- adds a sanitized tracked `.env.local.refs` template
- updates agent, preview, and Phase 0A handoff docs to match the new model

## Existing Code Audit

The previous worktree bootstrap copied the shared checkout's ignored `.env.local` into new or synced worktrees. That kept local workflows running but propagated production-connected plaintext env files across worktrees. The repo already had 1Password-centered auth rules and repo-local wrapper patterns, so this PR keeps the existing boundary and replaces copying with explicit diagnostics and command wrapping.

## Robustness

- `env:doctor` reports only presence, ignore/tracking state, account context, and policy status; it does not print values.
- `env:run` strips inherited `GH_TOKEN` / `GITHUB_TOKEN` before launching child commands.
- `.env.local.refs` is blocked from defining `GH_TOKEN_OP_REF`, `GITHUB_TOKEN_OP_REF`, `GH_TOKEN`, or `GITHUB_TOKEN`.
- Non-allowlisted literal values in `.env.local.refs` are blocked so secret-bearing keys must use `op://...` references.
- Fresh worktrees with only a shared-checkout `.env.local` no longer silently treat that file as injected env.

Review Gate v0 was completed with two read-only reviewers. Initial findings around raw GitHub token inheritance, raw token refs injection, literal values, and shared `.env.local` false fallback were fixed before this PR.

## Impact

User-facing: no direct product UI impact.

Developer/agent impact: future worktrees stop receiving copied plaintext `.env.local` files. Local dev flows can continue through existing local fallback during migration, but the intended path is ignored `.env.local.refs` plus `npm run env:run -- <command>`.

Risk: moderate workflow risk because dev preview and worktree bootstrap behavior change. Mitigated by preserving existing local `.env.local` files, adding explicit diagnostics, and keeping the tracked template sanitized.

## Validation

- `npm run env:doctor` passes with expected advisory because `.env.local.refs` is not created yet
- `npm run env:run -- node -e "console.log(process.env.GH_TOKEN ? 'raw-token-present' : 'raw-token-stripped')"`
- `env GH_TOKEN=dummy npm run env:run -- node -e "..."` confirms inherited raw token stripping
- temp `.env.local.refs` with `GH_TOKEN=op://dummy/item/token` blocks before `op read`
- `npm run agent:validate`
- `npm run format:check`
- `git diff --check`
- post-commit `npm run session:guard`

Known pre-existing issue: `npm run docs:doctor` still reports manifest freshness drift (`build-manifest.md` older than `ultimate-vision.md`).