### PR TITLE
fix: allow implicit GitHub metadata read

### DIFF
--- a/__tests__/scripts/envBootstrap.test.ts
+++ b/__tests__/scripts/envBootstrap.test.ts
@@ -102,8 +102,14 @@ describe('env bootstrap guardrails', () => {
 
   it('strips inherited raw GitHub tokens from env:run child commands', () => {
     const cwd = createRepoTempDir();
+    const fakeBin = createTempDir('governada-env-bootstrap-bin-');
     writeFileSync(path.join(cwd, '.env.local'), 'NODE_ENV=test\n');
     writeFileSync(path.join(cwd, '.env.local.refs'), 'NODE_ENV=test\n');
+    writeFileSync(
+      path.join(fakeBin, 'op'),
+      '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "2.34.0"; exit 0; fi\nexit 1\n',
+      { mode: 0o755 },
+    );
 
     const result = spawnSync(
       'node',
@@ -119,6 +125,7 @@ describe('env bootstrap guardrails', () => {
         env: {
           ...process.env,
           GH_TOKEN: 'dummy-token',
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ''}`,
         },
       },
     );

--- a/__tests__/scripts/envBootstrap.test.ts
+++ b/__tests__/scripts/envBootstrap.test.ts
@@ -103,6 +103,7 @@ describe('env bootstrap guardrails', () => {
   it('strips inherited raw GitHub tokens from env:run child commands', () => {
     const cwd = createRepoTempDir();
     writeFileSync(path.join(cwd, '.env.local'), 'NODE_ENV=test\n');
+    writeFileSync(path.join(cwd, '.env.local.refs'), 'NODE_ENV=test\n');
 
     const result = spawnSync(
       'node',

--- a/__tests__/scripts/githubReadDoctor.test.ts
+++ b/__tests__/scripts/githubReadDoctor.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   EXPECTED_READ_PERMISSIONS,
+  EXPECTED_RETURNED_READ_PERMISSIONS,
   EXPECTED_REPO_NAME,
   buildInstallationTokenRequestBody,
   createGithubAppJwt,
@@ -51,7 +52,7 @@ describe('github read doctor guardrails', () => {
 
   it('rejects extra or elevated installation-token permissions', () => {
     const failures = githubReadPermissionFailures({
-      ...EXPECTED_READ_PERMISSIONS,
+      ...EXPECTED_RETURNED_READ_PERMISSIONS,
       contents: 'write',
       administration: 'write',
     });
@@ -62,10 +63,17 @@ describe('github read doctor guardrails', () => {
     ]);
     expect(
       summarizeGithubReadPermissions({
-        ...EXPECTED_READ_PERMISSIONS,
+        ...EXPECTED_RETURNED_READ_PERMISSIONS,
         administration: 'write',
       }),
     ).toContain('administration=write (unexpected permission)');
+  });
+
+  it('accepts GitHub metadata read as an implicit returned installation-token permission', () => {
+    expect(githubReadPermissionFailures(EXPECTED_RETURNED_READ_PERMISSIONS)).toEqual([]);
+    expect(summarizeGithubReadPermissions(EXPECTED_RETURNED_READ_PERMISSIONS)).toContain(
+      'metadata=read (expected read)',
+    );
   });
 
   it('creates a short-lived GitHub App JWT without embedding secret material in claims', () => {

--- a/scripts/lib/github-app-auth.mjs
+++ b/scripts/lib/github-app-auth.mjs
@@ -15,6 +15,10 @@ export const EXPECTED_READ_PERMISSIONS = Object.freeze({
   contents: 'read',
   pull_requests: 'read',
 });
+export const EXPECTED_RETURNED_READ_PERMISSIONS = Object.freeze({
+  ...EXPECTED_READ_PERMISSIONS,
+  metadata: 'read',
+});
 
 export const GITHUB_READ_ENV_KEYS = Object.freeze({
   appId: 'GOVERNADA_GITHUB_APP_ID',
@@ -100,18 +104,18 @@ export function buildInstallationTokenRequestBody(repoName = EXPECTED_REPO_NAME)
 }
 
 export function githubReadPermissionFailures(permissions = {}) {
-  const expectedKeys = new Set(Object.keys(EXPECTED_READ_PERMISSIONS));
+  const expectedKeys = new Set(Object.keys(EXPECTED_RETURNED_READ_PERMISSIONS));
   const failures = [];
 
   for (const [key, value] of Object.entries(permissions)) {
     if (!expectedKeys.has(key)) {
       failures.push(`${key}=${value} (unexpected permission)`);
-    } else if (value !== EXPECTED_READ_PERMISSIONS[key]) {
-      failures.push(`${key}=${value} (expected ${EXPECTED_READ_PERMISSIONS[key]})`);
+    } else if (value !== EXPECTED_RETURNED_READ_PERMISSIONS[key]) {
+      failures.push(`${key}=${value} (expected ${EXPECTED_RETURNED_READ_PERMISSIONS[key]})`);
     }
   }
 
-  for (const [key, expected] of Object.entries(EXPECTED_READ_PERMISSIONS)) {
+  for (const [key, expected] of Object.entries(EXPECTED_RETURNED_READ_PERMISSIONS)) {
     if (permissions[key] === undefined) {
       failures.push(`${key}=missing (expected ${expected})`);
     }
@@ -121,12 +125,12 @@ export function githubReadPermissionFailures(permissions = {}) {
 }
 
 export function summarizeGithubReadPermissions(permissions = {}) {
-  const expected = Object.entries(EXPECTED_READ_PERMISSIONS).map(
+  const expected = Object.entries(EXPECTED_RETURNED_READ_PERMISSIONS).map(
     ([key, expectedPermission]) =>
       `${key}=${permissions[key] || 'missing'} (expected ${expectedPermission})`,
   );
   const unexpected = Object.entries(permissions)
-    .filter(([key]) => !Object.hasOwn(EXPECTED_READ_PERMISSIONS, key))
+    .filter(([key]) => !Object.hasOwn(EXPECTED_RETURNED_READ_PERMISSIONS, key))
     .map(([key, value]) => `${key}=${value} (unexpected permission)`);
 
   return [...expected, ...unexpected].join(', ');


### PR DESCRIPTION
## Summary

Updates the GitHub App `github.read` doctor to accept GitHub's implicit returned `metadata=read` installation-token permission while still requesting only the explicit narrow read permissions needed for the autonomous lane.

## Existing Code Audit

The token request body remains limited to `actions`, `checks`, `contents`, and `pull_requests` at `read`.

The previous failure was in returned-permission validation: GitHub always returns `metadata=read` on installation tokens, and the doctor incorrectly treated that as an unexpected permission.

## Robustness

- Separates requested read permissions from returned read permissions.
- Keeps elevated or unrelated permissions rejected.
- Adds regression coverage for implicit `metadata=read`.
- Keeps the env bootstrap test isolated from the shared checkout's ignored `.env.local.refs` file.

## Impact

This lets the Phase 0B GitHub App service-account read lane pass live verification without broadening the requested GitHub App scope.

Live manual verification passed from Tim's terminal: the lane minted a short-lived token narrowed to `governada/app`, verified repo read, PR read, Actions workflow-run read, and check-run read.

## Validation

- `npm run test -- __tests__/scripts/githubReadDoctor.test.ts __tests__/scripts/envBootstrap.test.ts`
- `npm run agent:validate`
- `npm run type-check`
- `git diff --check`
- Tim-run token-bearing `npm run github:read-doctor`: OK

## Review Gate v0

Completed for Phase 0B Slice 10.

- Code/runtime review: passed, no findings.
- Policy/control-plane review: initial findings fixed, re-review passed.

Generated with assistance from Codex.
