### PR TITLE
feat: add github write doctor

### DIFF
--- a/__tests__/scripts/githubReadDoctor.test.ts
+++ b/__tests__/scripts/githubReadDoctor.test.ts
@@ -5,13 +5,17 @@ import { describe, expect, it } from 'vitest';
 import {
   EXPECTED_READ_PERMISSIONS,
   EXPECTED_RETURNED_READ_PERMISSIONS,
+  EXPECTED_RETURNED_WRITE_PR_PERMISSIONS,
   EXPECTED_REPO_NAME,
+  EXPECTED_WRITE_PR_PERMISSIONS,
   buildInstallationTokenRequestBody,
   createGithubAppJwt,
   getGithubReadLaneConfig,
   githubReadPermissionFailures,
+  githubWritePrPermissionFailures,
   redactSensitiveText,
   summarizeGithubReadPermissions,
+  summarizeGithubWritePrPermissions,
   verifyGithubAppOwner,
 } from '@/scripts/lib/github-app-auth.mjs';
 
@@ -50,6 +54,28 @@ describe('github read doctor guardrails', () => {
     expect(body).not.toHaveProperty('repository_ids');
   });
 
+  it('requests only the expected repository and bounded PR-write permissions for write-lane tokens', () => {
+    const body = buildInstallationTokenRequestBody(
+      EXPECTED_REPO_NAME,
+      EXPECTED_WRITE_PR_PERMISSIONS,
+    );
+
+    expect(body.repositories).toEqual([EXPECTED_REPO_NAME]);
+    expect(body.permissions).toEqual(EXPECTED_WRITE_PR_PERMISSIONS);
+    expect(body.permissions).toEqual({
+      actions: 'read',
+      checks: 'read',
+      contents: 'write',
+      issues: 'write',
+      pull_requests: 'write',
+    });
+    expect(body.permissions).not.toHaveProperty('administration');
+    expect(body.permissions).not.toHaveProperty('deployments');
+    expect(body.permissions).not.toHaveProperty('secrets');
+    expect(body.permissions).not.toHaveProperty('workflows');
+    expect(body).not.toHaveProperty('repository_ids');
+  });
+
   it('rejects extra or elevated installation-token permissions', () => {
     const failures = githubReadPermissionFailures({
       ...EXPECTED_RETURNED_READ_PERMISSIONS,
@@ -74,6 +100,35 @@ describe('github read doctor guardrails', () => {
     expect(summarizeGithubReadPermissions(EXPECTED_RETURNED_READ_PERMISSIONS)).toContain(
       'metadata=read (expected read)',
     );
+  });
+
+  it('accepts GitHub metadata read as an implicit returned write-lane permission', () => {
+    expect(githubWritePrPermissionFailures(EXPECTED_RETURNED_WRITE_PR_PERMISSIONS)).toEqual([]);
+    expect(summarizeGithubWritePrPermissions(EXPECTED_RETURNED_WRITE_PR_PERMISSIONS)).toContain(
+      'metadata=read (expected read)',
+    );
+  });
+
+  it('rejects missing, extra, or elevated write-lane installation-token permissions', () => {
+    const failures = githubWritePrPermissionFailures({
+      ...EXPECTED_RETURNED_WRITE_PR_PERMISSIONS,
+      checks: 'write',
+      administration: 'write',
+    });
+
+    expect(failures).toEqual([
+      'checks=write (expected read)',
+      'administration=write (unexpected permission)',
+    ]);
+    expect(
+      githubWritePrPermissionFailures({
+        actions: 'read',
+        checks: 'read',
+        contents: 'write',
+        pull_requests: 'write',
+        metadata: 'read',
+      }),
+    ).toEqual(['issues=missing (expected write)']);
   });
 
   it('creates a short-lived GitHub App JWT without embedding secret material in claims', () => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gh:auth-status": "node scripts/gh-auth-status.js",
     "auth:doctor": "node scripts/auth-doctor.js",
     "github:read-doctor": "node scripts/github-read-doctor.mjs",
+    "github:write-doctor": "node scripts/github-write-doctor.mjs",
     "auth:repair": "node scripts/repair-gh-auth.mjs",
     "env:doctor": "node scripts/env-doctor.mjs",
     "env:run": "node scripts/env-run.mjs",

--- a/scripts/github-write-doctor.mjs
+++ b/scripts/github-write-doctor.mjs
@@ -1,0 +1,318 @@
+import { createRequire } from 'node:module';
+
+import {
+  findFirstExisting,
+  getEnvRefsCandidates,
+  getForbiddenGithubReferenceKeys,
+  parseEnvEntries,
+} from './lib/env-bootstrap.mjs';
+import {
+  EXPECTED_REPO,
+  EXPECTED_WRITE_PR_PERMISSIONS,
+  GITHUB_READ_ENV_KEYS,
+  getGithubReadLaneConfig,
+  githubApiErrorMessage,
+  githubApiRequest,
+  githubWritePrPermissionFailures,
+  isValidOpReference,
+  mintInstallationToken,
+  readPrivateKeyFromOnePassword,
+  redactSensitiveText,
+  summarizeGithubWritePrPermissions,
+  verifyGithubAppOwner,
+} from './lib/github-app-auth.mjs';
+import { getScriptContext, loadLocalEnv } from './lib/runtime.mjs';
+
+const require = createRequire(import.meta.url);
+const { getContext } = require('./set-gh-context.js');
+
+const EXPECTED_OP_ACCOUNT = 'my.1password.com';
+const GITHUB_WRITE_REF_KEYS = new Set([
+  GITHUB_READ_ENV_KEYS.appId,
+  GITHUB_READ_ENV_KEYS.installationId,
+  GITHUB_READ_ENV_KEYS.privateKeyRef,
+]);
+
+function pass(message) {
+  console.log(`OK: ${message}`);
+}
+
+function advisory(advisories, message) {
+  advisories.push(message);
+  console.log(`ADVISORY: ${message}`);
+}
+
+function block(blockers, message) {
+  blockers.push(message);
+  console.log(`BLOCKED: ${message}`);
+}
+
+async function main() {
+  const blockers = [];
+  const advisories = [];
+  const { repoRoot } = getScriptContext(import.meta.url);
+  const envLocalPath = loadLocalEnv(import.meta.url, [
+    'GOVERNADA_GITHUB_APP_*',
+    'OP_*',
+    'GH_TOKEN',
+    'GITHUB_TOKEN',
+  ]);
+  const refsPath = loadGithubWriteReferenceEnv(repoRoot);
+
+  const context = getContext();
+  const env = {
+    ...process.env,
+    ...context,
+  };
+  const config = getGithubReadLaneConfig(env);
+
+  console.log('GitHub write doctor: Governada autonomous GitHub App lane');
+  console.log('Capability: github.app.installation.governada.pilot');
+  console.log('Operation class: github.write.pr');
+  console.log('Mutation policy: no repository write endpoint is called by this doctor');
+
+  if (refsPath) {
+    pass(
+      '.env.local.refs was inspected for github.write.pr reference metadata without resolving values',
+    );
+
+    const forbiddenRefsKeys = getForbiddenGithubReferenceKeys(refsPath);
+    if (forbiddenRefsKeys.length > 0) {
+      block(
+        blockers,
+        `.env.local.refs must not define ${forbiddenRefsKeys.join(', ')} for the autonomous write lane`,
+      );
+    }
+  }
+
+  if (envLocalPath && envLocalDefines(envLocalPath, GITHUB_READ_ENV_KEYS.serviceAccountToken)) {
+    block(
+      blockers,
+      `${GITHUB_READ_ENV_KEYS.serviceAccountToken} must not be defined in plaintext .env.local`,
+    );
+  }
+
+  if (context.GH_REPO === EXPECTED_REPO) {
+    pass(`repo context is pinned to ${EXPECTED_REPO}`);
+  } else {
+    block(blockers, `repo context is ${context.GH_REPO || 'unset'}, expected ${EXPECTED_REPO}`);
+  }
+
+  if (context.OP_ACCOUNT === EXPECTED_OP_ACCOUNT) {
+    pass(`1Password account is pinned to ${EXPECTED_OP_ACCOUNT}`);
+  } else {
+    block(
+      blockers,
+      `1Password account is ${context.OP_ACCOUNT || 'unset'}, expected ${EXPECTED_OP_ACCOUNT}`,
+    );
+  }
+
+  if (config.rawGithubTokenKeys.length > 0) {
+    block(
+      blockers,
+      `raw ${config.rawGithubTokenKeys.join('/')} env is present; autonomous github.write.pr must not use human or raw GitHub tokens`,
+    );
+  } else {
+    pass('raw GitHub token env is not present');
+  }
+
+  if (config.opConnectKeys.length > 0) {
+    block(
+      blockers,
+      `${config.opConnectKeys.join('/')} is present; clear 1Password Connect env before proving the service-account lane`,
+    );
+  } else {
+    pass('1Password Connect env is not present');
+  }
+
+  if (config.missingKeys.length > 0) {
+    block(
+      blockers,
+      `autonomous github.write.pr lane is not configured; missing ${config.missingKeys.join(', ')}`,
+    );
+  } else {
+    pass('all autonomous github.write.pr configuration keys are present');
+  }
+
+  if (config.privateKeyRef && isValidOpReference(config.privateKeyRef)) {
+    pass(`${GITHUB_READ_ENV_KEYS.privateKeyRef} is an op:// reference`);
+  } else if (config.privateKeyRef) {
+    block(blockers, `${GITHUB_READ_ENV_KEYS.privateKeyRef} must be an op:// reference`);
+  }
+
+  advisory(
+    advisories,
+    'This doctor proves token minting and permission scope only; PR creation, PR update, PR comments, branch pushes, merge, deploy, and secret changes remain approval-gated.',
+  );
+
+  if (blockers.length > 0) {
+    writeResult(blockers, advisories);
+    process.exit(1);
+  }
+
+  const privateKeyResult = readPrivateKeyFromOnePassword({
+    privateKeyRef: config.privateKeyRef,
+    env,
+    cwd: repoRoot,
+  });
+
+  if (privateKeyResult.error) {
+    block(blockers, privateKeyResult.error);
+  } else {
+    pass('1Password service-account lane resolved the GitHub App private key reference');
+  }
+
+  if (blockers.length === 0) {
+    const appOwnerResult = await verifyGithubAppOwner({
+      appId: config.appId,
+      privateKey: privateKeyResult.privateKey,
+    });
+
+    if (appOwnerResult.error) {
+      block(blockers, appOwnerResult.error);
+    } else {
+      pass(`GitHub App owner is ${appOwnerResult.ownerLogin}`);
+    }
+  }
+
+  if (blockers.length === 0) {
+    const mintResult = await mintInstallationToken({
+      appId: config.appId,
+      installationId: config.installationId,
+      permissions: EXPECTED_WRITE_PR_PERMISSIONS,
+      privateKey: privateKeyResult.privateKey,
+    });
+
+    if (mintResult.error) {
+      block(blockers, mintResult.error);
+    } else {
+      pass('minted short-lived GitHub App installation token for github.write.pr proof');
+      if (mintResult.expiresAt) {
+        pass(`installation token includes expiry ${mintResult.expiresAt}`);
+      }
+
+      const repoNames = mintResult.repositories.map((repo) => repo.full_name || repo.name);
+      if (repoNames.length === 1 && repoNames[0] === EXPECTED_REPO) {
+        pass(`installation token is narrowed to ${EXPECTED_REPO}`);
+      } else {
+        block(
+          blockers,
+          `installation token repository set is ${repoNames.join(', ') || 'not returned'}, expected only ${EXPECTED_REPO}`,
+        );
+      }
+
+      const permissionFailures = githubWritePrPermissionFailures(mintResult.permissions);
+      if (permissionFailures.length === 0) {
+        pass(
+          `installation token permissions satisfy github.write.pr: ${summarizeGithubWritePrPermissions(mintResult.permissions)}`,
+        );
+      } else {
+        block(
+          blockers,
+          `installation token permissions do not satisfy github.write.pr: ${summarizeGithubWritePrPermissions(mintResult.permissions)}`,
+        );
+      }
+
+      if (blockers.length === 0) {
+        await verifyNonMutatingWriteLaneAccess(mintResult.token, blockers);
+      }
+    }
+  }
+
+  writeResult(blockers, advisories);
+  process.exit(blockers.length > 0 ? 1 : 0);
+}
+
+function writeResult(blockers, advisories) {
+  console.log('');
+  if (blockers.length > 0) {
+    console.log(`GitHub write doctor result: BLOCKED (${blockers.length})`);
+    return;
+  }
+
+  if (advisories.length > 0) {
+    console.log(`GitHub write doctor result: PASS_WITH_ADVISORIES (${advisories.length})`);
+    return;
+  }
+
+  console.log('GitHub write doctor result: OK');
+}
+
+function envLocalDefines(filePath, key) {
+  return parseEnvEntries(filePath).some((entry) => entry.key === key);
+}
+
+function loadGithubWriteReferenceEnv(repoRoot) {
+  const refsPath = findFirstExisting(getEnvRefsCandidates(repoRoot));
+  if (!refsPath) {
+    return '';
+  }
+
+  for (const entry of parseEnvEntries(refsPath)) {
+    if (GITHUB_WRITE_REF_KEYS.has(entry.key) && process.env[entry.key] === undefined) {
+      process.env[entry.key] = entry.value;
+    }
+  }
+
+  return refsPath;
+}
+
+async function verifyNonMutatingWriteLaneAccess(token, blockers) {
+  const repo = await githubApiRequest({
+    path: `/repos/${EXPECTED_REPO}`,
+    token,
+  });
+  if (!repo.ok || repo.data?.full_name !== EXPECTED_REPO) {
+    block(blockers, githubApiErrorMessage(repo, `repo read failed for ${EXPECTED_REPO}`));
+    return;
+  }
+  pass(`repo read works for ${EXPECTED_REPO}`);
+
+  const pulls = await githubApiRequest({
+    path: `/repos/${EXPECTED_REPO}/pulls?state=open&per_page=1`,
+    token,
+  });
+  if (!pulls.ok) {
+    block(blockers, githubApiErrorMessage(pulls, `pull request read failed for ${EXPECTED_REPO}`));
+    return;
+  }
+  pass('pull request read works with write-capable token');
+
+  const issueComments = await githubApiRequest({
+    path: `/repos/${EXPECTED_REPO}/issues/comments?per_page=1`,
+    token,
+  });
+  if (!issueComments.ok) {
+    block(
+      blockers,
+      githubApiErrorMessage(issueComments, `issue comment read failed for ${EXPECTED_REPO}`),
+    );
+    return;
+  }
+  pass('issue comment read works with write-capable token');
+
+  const actions = await githubApiRequest({
+    path: `/repos/${EXPECTED_REPO}/actions/runs?per_page=1`,
+    token,
+  });
+  if (!actions.ok) {
+    block(blockers, githubApiErrorMessage(actions, `Actions read failed for ${EXPECTED_REPO}`));
+    return;
+  }
+  pass('Actions workflow-run read works with write-capable token');
+
+  const checkRuns = await githubApiRequest({
+    path: `/repos/${EXPECTED_REPO}/commits/main/check-runs?per_page=1`,
+    token,
+  });
+  if (!checkRuns.ok) {
+    block(blockers, githubApiErrorMessage(checkRuns, `check-run read failed for ${EXPECTED_REPO}`));
+    return;
+  }
+  pass('check-run read works with write-capable token');
+}
+
+main().catch((error) => {
+  console.error(redactSensitiveText(error?.message || String(error)));
+  process.exit(1);
+});

--- a/scripts/lib/github-app-auth.mjs
+++ b/scripts/lib/github-app-auth.mjs
@@ -19,6 +19,17 @@ export const EXPECTED_RETURNED_READ_PERMISSIONS = Object.freeze({
   ...EXPECTED_READ_PERMISSIONS,
   metadata: 'read',
 });
+export const EXPECTED_WRITE_PR_PERMISSIONS = Object.freeze({
+  actions: 'read',
+  checks: 'read',
+  contents: 'write',
+  issues: 'write',
+  pull_requests: 'write',
+});
+export const EXPECTED_RETURNED_WRITE_PR_PERMISSIONS = Object.freeze({
+  ...EXPECTED_WRITE_PR_PERMISSIONS,
+  metadata: 'read',
+});
 
 export const GITHUB_READ_ENV_KEYS = Object.freeze({
   appId: 'GOVERNADA_GITHUB_APP_ID',
@@ -96,26 +107,33 @@ export function isValidOpReference(value) {
   return /^op:\/\/[^/\s]+\/[^/\s]+\/[^/\s]+/.test(value);
 }
 
-export function buildInstallationTokenRequestBody(repoName = EXPECTED_REPO_NAME) {
+/**
+ * @param {string} repoName
+ * @param {Record<string, string>} permissions
+ */
+export function buildInstallationTokenRequestBody(
+  repoName = EXPECTED_REPO_NAME,
+  permissions = EXPECTED_READ_PERMISSIONS,
+) {
   return {
     repositories: [repoName],
-    permissions: EXPECTED_READ_PERMISSIONS,
+    permissions,
   };
 }
 
-export function githubReadPermissionFailures(permissions = {}) {
-  const expectedKeys = new Set(Object.keys(EXPECTED_RETURNED_READ_PERMISSIONS));
+export function githubPermissionFailures(permissions = {}, expectedPermissions = {}) {
+  const expectedKeys = new Set(Object.keys(expectedPermissions));
   const failures = [];
 
   for (const [key, value] of Object.entries(permissions)) {
     if (!expectedKeys.has(key)) {
       failures.push(`${key}=${value} (unexpected permission)`);
-    } else if (value !== EXPECTED_RETURNED_READ_PERMISSIONS[key]) {
-      failures.push(`${key}=${value} (expected ${EXPECTED_RETURNED_READ_PERMISSIONS[key]})`);
+    } else if (value !== expectedPermissions[key]) {
+      failures.push(`${key}=${value} (expected ${expectedPermissions[key]})`);
     }
   }
 
-  for (const [key, expected] of Object.entries(EXPECTED_RETURNED_READ_PERMISSIONS)) {
+  for (const [key, expected] of Object.entries(expectedPermissions)) {
     if (permissions[key] === undefined) {
       failures.push(`${key}=missing (expected ${expected})`);
     }
@@ -124,16 +142,32 @@ export function githubReadPermissionFailures(permissions = {}) {
   return failures;
 }
 
-export function summarizeGithubReadPermissions(permissions = {}) {
-  const expected = Object.entries(EXPECTED_RETURNED_READ_PERMISSIONS).map(
+export function summarizeGithubPermissions(permissions = {}, expectedPermissions = {}) {
+  const expected = Object.entries(expectedPermissions).map(
     ([key, expectedPermission]) =>
       `${key}=${permissions[key] || 'missing'} (expected ${expectedPermission})`,
   );
   const unexpected = Object.entries(permissions)
-    .filter(([key]) => !Object.hasOwn(EXPECTED_RETURNED_READ_PERMISSIONS, key))
+    .filter(([key]) => !Object.hasOwn(expectedPermissions, key))
     .map(([key, value]) => `${key}=${value} (unexpected permission)`);
 
   return [...expected, ...unexpected].join(', ');
+}
+
+export function githubReadPermissionFailures(permissions = {}) {
+  return githubPermissionFailures(permissions, EXPECTED_RETURNED_READ_PERMISSIONS);
+}
+
+export function summarizeGithubReadPermissions(permissions = {}) {
+  return summarizeGithubPermissions(permissions, EXPECTED_RETURNED_READ_PERMISSIONS);
+}
+
+export function githubWritePrPermissionFailures(permissions = {}) {
+  return githubPermissionFailures(permissions, EXPECTED_RETURNED_WRITE_PR_PERMISSIONS);
+}
+
+export function summarizeGithubWritePrPermissions(permissions = {}) {
+  return summarizeGithubPermissions(permissions, EXPECTED_RETURNED_WRITE_PR_PERMISSIONS);
 }
 
 export function base64UrlEncodeJson(value) {
@@ -240,13 +274,18 @@ export async function githubApiRequest({
   }
 }
 
-export async function mintInstallationToken({ appId, installationId, privateKey }) {
+export async function mintInstallationToken({
+  appId,
+  installationId,
+  privateKey,
+  permissions = EXPECTED_READ_PERMISSIONS,
+}) {
   const jwt = createGithubAppJwt({ appId, privateKey });
   const response = await githubApiRequest({
     path: `/app/installations/${installationId}/access_tokens`,
     token: jwt,
     method: 'POST',
-    body: buildInstallationTokenRequestBody(),
+    body: buildInstallationTokenRequestBody(EXPECTED_REPO_NAME, permissions),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- add `npm run github:write-doctor` for the Governada autonomous GitHub App write lane
- prove bounded `github.write.pr` permissions without calling repository write endpoints
- extend shared GitHub App auth helpers to support read and PR-write permission profiles

## Existing Code Audit
- `github:read-doctor` already proved the read lane using the Governada GitHub App, 1Password private-key reference, and one-time `OP_SERVICE_ACCOUNT_TOKEN`.
- No repo-local wrapper existed to prove the next bounded write posture before adding mutating PR helpers.
- The GitHub connector does not automatically inherit the Governada GitHub App installation token, so this lane needs repo-local proof and wrappers.

## Robustness
- The write doctor blocks raw `GH_TOKEN` / `GITHUB_TOKEN` inheritance.
- It blocks 1Password Connect env usage for this lane.
- It requires the GitHub App owner to be `governada`.
- It mints a short-lived installation token narrowed to `governada/app`.
- It verifies exact returned permissions: `actions=read`, `checks=read`, `contents=write`, `issues=write`, `pull_requests=write`, and GitHub’s implicit `metadata=read`.
- It performs only non-mutating reads after token minting.

## Impact
- Establishes the approved `github.write.pr` credential lane for future PR/comment/review wrappers.
- Does not create PRs, comments, branches, merges, deploys, token lanes, service accounts, or secret changes.
- Actual GitHub mutations remain approval-gated until a later wrapper slice wires this token into bounded write commands.

## Validation
- `npm run test -- __tests__/scripts/githubReadDoctor.test.ts`
- `npm run type-check`
- `npm run agent:validate`
- `npm run format:check -- scripts/github-write-doctor.mjs scripts/lib/github-app-auth.mjs __tests__/scripts/githubReadDoctor.test.ts package.json`
- `npm run lint -- scripts/github-write-doctor.mjs scripts/lib/github-app-auth.mjs __tests__/scripts/githubReadDoctor.test.ts`  
  Note: ESLint reported warnings only because these files are ignored by the current lint config.
- `npm run github:write-doctor` with one-time `OP_SERVICE_ACCOUNT_TOKEN`: `PASS_WITH_ADVISORIES`

## Review Gate v0
- Review tier: foundational auth/runtime reliability
- Review focus: secret handling, permission scope, non-mutating proof behavior, repo/org pinning, approval boundaries
- Human acceptance needed: confirm that `github.write.pr` may remain doctor-proven but non-mutating until the next wrapper slice
