### PR TITLE
fix: classify github app doctor runtime failures

### DIFF
--- a/__tests__/scripts/githubReadDoctor.test.ts
+++ b/__tests__/scripts/githubReadDoctor.test.ts
@@ -11,8 +11,10 @@ import {
   buildInstallationTokenRequestBody,
   createGithubAppJwt,
   getGithubReadLaneConfig,
+  githubApiRequest,
   githubReadPermissionFailures,
   githubWritePrPermissionFailures,
+  mintInstallationToken,
   redactSensitiveText,
   summarizeGithubReadPermissions,
   summarizeGithubWritePrPermissions,
@@ -161,6 +163,7 @@ describe('github read doctor guardrails', () => {
         'ghs_abc123',
         'ops_abc123.service-account-token',
         'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiIxMjMifQ.signature',
+        '-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----',
       ].join('\n'),
       ['service-account-token-value'],
     );
@@ -170,6 +173,8 @@ describe('github read doctor guardrails', () => {
     expect(redacted).toContain('[redacted-gh-installation-token]');
     expect(redacted).toContain('[redacted-op-service-account-token]');
     expect(redacted).toContain('[redacted-jwt]');
+    expect(redacted).toContain('[redacted-pem-block]');
+    expect(redacted).not.toContain('secret');
   });
 
   it('redacts the configured service-account token value exactly', () => {
@@ -209,5 +214,39 @@ describe('github read doctor guardrails', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it('classifies GitHub API fetch failures without throwing', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new DOMException('network unavailable for test', 'AbortError');
+    };
+
+    try {
+      const result = await githubApiRequest({
+        path: '/repos/governada/app',
+        token: 'ghs_example',
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        status: 0,
+      });
+      expect(result.data?.message).toContain('AbortError');
+      expect(result.data?.message).toContain('network unavailable for test');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('classifies malformed private keys before minting installation tokens', async () => {
+    const result = await mintInstallationToken({
+      appId: '12345',
+      installationId: '67890',
+      privateKey: 'not a pem key',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.error).toContain('GitHub App installation token mint failed before API request');
   });
 });

--- a/scripts/lib/github-app-auth.mjs
+++ b/scripts/lib/github-app-auth.mjs
@@ -57,6 +57,10 @@ export function redactSensitiveText(
   }
 
   return redacted
+    .replace(
+      /-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g,
+      '[redacted-pem-block]',
+    )
     .replace(/op:\/\/[^\r\n'"]+/g, 'op://[redacted]')
     .replace(/github_pat_[A-Za-z0-9_]+/g, 'github_pat_[redacted]')
     .replace(/\bghs_[A-Za-z0-9_]+\b/g, '[redacted-gh-installation-token]')
@@ -233,7 +237,7 @@ export async function githubApiRequest({
   path,
   token,
   method = 'GET',
-  body,
+  body = undefined,
   tokenType = 'Bearer',
   timeoutMs = 15000,
 }) {
@@ -269,6 +273,16 @@ export async function githubApiRequest({
       status: response.status,
       data,
     };
+  } catch (error) {
+    const errorName = error?.name || 'Error';
+    const errorMessage = error?.message ? `: ${error.message}` : '';
+    return {
+      ok: false,
+      status: 0,
+      data: {
+        message: redactSensitiveText(`${errorName}${errorMessage}`),
+      },
+    };
   } finally {
     clearTimeout(timeout);
   }
@@ -280,7 +294,18 @@ export async function mintInstallationToken({
   privateKey,
   permissions = EXPECTED_READ_PERMISSIONS,
 }) {
-  const jwt = createGithubAppJwt({ appId, privateKey });
+  let jwt;
+  try {
+    jwt = createGithubAppJwt({ appId, privateKey });
+  } catch (error) {
+    return {
+      error: redactSensitiveText(
+        `GitHub App installation token mint failed before API request: ${error?.message || String(error)}`,
+      ),
+      status: 0,
+    };
+  }
+
   const response = await githubApiRequest({
     path: `/app/installations/${installationId}/access_tokens`,
     token: jwt,
@@ -316,7 +341,18 @@ export function githubApiErrorMessage(response, prefix) {
 }
 
 export async function verifyGithubAppOwner({ appId, privateKey, expectedOwner = EXPECTED_OWNER }) {
-  const jwt = createGithubAppJwt({ appId, privateKey });
+  let jwt;
+  try {
+    jwt = createGithubAppJwt({ appId, privateKey });
+  } catch (error) {
+    return {
+      error: redactSensitiveText(
+        `GitHub App metadata read failed before API request: ${error?.message || String(error)}`,
+      ),
+      status: 0,
+    };
+  }
+
   const response = await githubApiRequest({
     path: '/app',
     token: jwt,


### PR DESCRIPTION
## Summary
- Classifies GitHub App doctor fetch/abort failures as non-throwing blocked results.
- Classifies malformed private-key signing failures before token minting.
- Redacts PEM-shaped private key material from diagnostics.
- Adds regression coverage for runtime failure classification and PEM redaction.

## Existing Code Audit
- Follow-up from post-merge Review Gate v0 for Phase 0B Slice 13.
- The doctor already failed closed; this patch makes failures use the standard doctor taxonomy.

## Robustness
- `npm run test -- __tests__/scripts/githubReadDoctor.test.ts`
- `npm run type-check`
- `npm run agent:validate`
- `npm run github:write-doctor` blocks as expected without `OP_SERVICE_ACCOUNT_TOKEN`

## Impact
- No repository write endpoints are added.
- No mutation authority is promoted.
- Improves auth doctor diagnostics before any future `github.write.pr` mutation wrapper.
