### PR TITLE
docs(preview): distinguish Claude Preview vs Railway Preview/Staging

### DIFF
--- a/.claude/rules/archive/dev-preview.md
+++ b/.claude/rules/archive/dev-preview.md
@@ -10,6 +10,10 @@ paths:
 
 Rules for running the local dev server via Claude Preview tools. Worktree sync links `node_modules` when possible, but it no longer copies plaintext `.env.local`. Use `npm run env:doctor` to inspect local env readiness and `npm run env:run -- <command>` for 1Password-backed local env injection.
 
+## Scope vs Preview/Staging
+
+Claude Preview is the agent-internal inner-loop verification tool: local dev server plus headless browser, scoped to the current session. The integration-honest gate — real env vars, real services, real Supabase branch — is the Railway Preview/Staging flow with `preview:verify`, documented in `docs/architecture.md` Testing section. Don't substitute Claude Preview for it on env-resolution, cross-service, or migration-shaped changes.
+
 ## Starting the Dev Server
 
 1. **Start**: Use `preview_start` with name `"dev"` (configured in `.claude/launch.json`, port 3111 with `autoPort`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,12 @@ verification. The non-production stack is isolated from production writes, but
 it still reads mainnet governance data where the product experience depends on
 current chain state.
 
+Claude Preview (the agent-internal MCP tool, documented in
+`.claude/rules/archive/dev-preview.md`) is the inner-loop verification harness
+used during coding. It is not a substitute for the Railway preview deploy and
+`preview:verify` flow described below — those remain the integration-honest
+gate before merge.
+
 - Staging is a persistent Railway environment at `https://stg.governada.io`
   backed by a persistent Supabase staging branch, non-prod Redis, and the
   non-prod PostHog project.


### PR DESCRIPTION
## Summary

- Reciprocal cross-references between `.claude/rules/archive/dev-preview.md` (Claude Preview MCP tooling) and `docs/architecture.md` Testing section (Railway Preview/Staging flow + `preview:verify`).
- Distinguishes inner-loop verification (Claude Preview, agent-internal local dev server + headless browser) from the integration-honest gate (Railway preview deploy + per-PR Supabase branch + smoke verify).
- Prevents future agent sessions from substituting one for the other on env-resolution, cross-service, or migration-shaped changes — a real failure mode after the recent Preview/Staging buildout.

## Existing Code Audit

- **Searched for**: existing docs covering Preview/Staging, Claude Preview MCP tooling, dev verification, integration gates, and bridges between the two layers.
- **Found**: `docs/architecture.md` Testing section (Railway flow, lines 91-145, exhaustive); `.claude/rules/archive/dev-preview.md` (Claude Preview MCP tooling, path-scoped to app/components/lib); `AGENTS.md` "Verify before done" default (layer-agnostic). No existing doc bridged the two layers.
- **Decision**: extended both authoritative homes with one-paragraph reciprocal cross-references; no new file. Per AGENTS.md doc-placement-tree, this is "subsystem pattern" not "always-applies constraint" — `AGENTS.md` was deliberately left untouched to preserve its 76-line lean shape.

## Robustness

- Doc-only change; no runtime, build, test, schema, or migration impact.
- Heading hierarchy preserved in both files (`##` under `#`).
- `npm run agent:validate`: PASS.
- `lint-staged` prettier ran at commit time with no material changes.

## Impact

- Future agent sessions touching `app/**`, `components/**`, or `lib/**` auto-load the path-scoped `dev-preview.md` rule and now see the layer distinction at the top.
- Future readers of `architecture.md` Testing section get the framing before the Railway/staging mechanics bullet list.
- No code path, runtime, or schema affected. Safe to merge any time CI is green.

## Brain Freshness

Not needed — this is a cross-reference clarification within the existing doc tree. No new concepts, decisions, or workflows the brain entry (`agents/governada-context.md`) needs to track.

## Review Gate v0

- **Tier**: light (docs-only, 10 lines added across two tracked files, no code).
- **Status**: completed via `pre-ship-reviewer` subagent prior to ready-for-review.
- **Findings**: no substantive issues.
  - Cross-references factually correct: both target paths and section names verified to resolve.
  - Markdown well-formed: heading hierarchy preserved, no broken inline code, no stray formatting.
  - Path placement (`.claude/rules/archive/`) consistent with how that directory is already used for live path-scoped guidance.
- **Resolution**: none required.