### PR TITLE
ci(workflows): add pass-through build job for docs-only PRs

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -16,6 +16,10 @@ on:
       - '.claude/**'
       - 'LICENSE'
 
+concurrency:
+  group: ci-skip-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,0 +1,23 @@
+# Pass-through CI for docs-only PRs.
+# ci.yml's paths-ignore excludes these paths, which leaves the required
+# `build` check forever pending on docs-only PRs (auto-merge never fires,
+# branch protection blocks). This sentinel workflow runs on the inverse
+# path set and reports `build` success so the required-check contract is
+# satisfied without weakening the real build for code PRs.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'tasks/**'
+      - '.cursor/**'
+      - '.claude/**'
+      - 'LICENSE'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "build pass-through for docs-only PR (matches ci.yml paths-ignore at .github/workflows/ci.yml)"


### PR DESCRIPTION
## Summary

- New `.github/workflows/ci-skip.yml` — a sentinel `CI / build` workflow that triggers on the inverse of `ci.yml`'s `paths-ignore` filter (`docs/**`, `tasks/**`, `.cursor/**`, `.claude/**`, `LICENSE`) and reports `build` success in seconds.
- Resolves the "required check + paths-ignore" trap that left PR #955's required `build` status forever pending and forced an admin-bypass merge.
- Same workflow `name: CI` and job `build` so branch protection's required-check contract is satisfied without modifying `ci.yml`; pure code PRs are unaffected.

## Existing Code Audit

- **Searched for**: existing skip/sentinel workflows, paths-include workflows, alternative pass-through patterns in `.github/workflows/`.
- **Found**: 9 existing workflows — `agent-config.yml`, `ci.yml`, `dependabot-auto-merge.yml`, `e2e.yml`, `load-test.yml`, `post-deploy.yml`, `pr-template.yml`, `preview.yml`, `seed-staging.yml`. None mirror `ci.yml`'s `name: CI` or use the inverse-paths-include pattern.
- **Decision**: new file. The canonical GitHub-recommended pattern for "required check + paths filter" is a parallel workflow with matching `name` + `job` IDs. Modifying `ci.yml` to remove `paths-ignore` and add job-level skip logic would have been more invasive and would have changed the real-build code path. New file is more surgical.

## Robustness

- 27-line workflow file; no runtime, build, test, schema, or migration impact on the app.
- `npm run agent:validate`: PASS.
- Concurrency group `ci-skip-${{ github.ref }}` is intentionally distinct from `ci.yml`'s `ci-${{ github.ref }}` to prevent cross-cancellation on mixed-path PRs.
- Edge cases reasoned through:
  - **Pure docs PR**: only `ci-skip` triggers → `build` reports success in ~10s.
  - **Pure code PR**: only `ci.yml` triggers → real build runs as before.
  - **Mixed PR**: both trigger; both must pass; `ci.yml`'s real build remains the gating result.

## Impact

- Future docs-only PRs (changes confined to `docs/**`, `tasks/**`, `.cursor/**`, `.claude/**`, or `LICENSE`) will satisfy the required `build` check automatically, allowing auto-merge to fire without admin override.
- Mirrors AGENTS.md prevention-first thinking: this is a level-1 infrastructure fix, not a process patch — eliminates the trap class rather than relying on contributors to remember to admin-merge.

## Brain Freshness

Not needed — CI infrastructure correction with no new product concept, decision, or workflow that the brain entry should track. The `build` required-check contract is unchanged from the brain's perspective.

## Review Gate v0

- **Tier**: light (single new file, 27 lines, no runtime impact).
- **Status**: completed via \`pre-ship-reviewer\` subagent prior to ready-for-review.
- **Findings**:
  - PASS — required-check name matching: branch protection matches by \`workflow.name + job.id\`; both workflows declare \`name: CI\` and a job named \`build\`.
  - PASS — path-list correctness: \`ci-skip\`'s include list exactly mirrors \`ci.yml\`'s \`paths-ignore\`.
  - PASS — branch filter, permissions, no \`pull_request_target\` or other GitHub Actions pitfalls.
  - PASS — mixed-PR scenario: both checks must pass; real \`ci.yml\` build remains the gating result.
  - WARN — concurrency cleanup for rapid pushes; addressed in second commit (f74ab73f) with a distinct group \`ci-skip-\${{ github.ref }}\`.
- **Resolution**: addressed; no outstanding issues.