### PR TITLE
fix(auth): harden agent auth doctors

### DIFF
--- a/scripts/env-doctor.mjs
+++ b/scripts/env-doctor.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
-import { existsSync, lstatSync } from 'node:fs';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import os from 'node:os';
 
 const AGENT_TOKEN_KEY = 'OP_AGENT_SERVICE_ACCOUNT_TOKEN';
 const DEFAULT_AGENT_VAULT = 'Governada-Agent';
 const HUMAN_SSH_HOST = process.env.GOVERNADA_ENV_DOCTOR_SSH_HOST || 'github-governada';
+const SSH_CONFIG = process.env.SSH_CONFIG || path.join(os.homedir(), '.ssh', 'config');
 
 function findRepoRoot(startDir) {
   let current = startDir;
@@ -34,24 +35,67 @@ function checkoutKind(repoRoot) {
   }
 }
 
-function hasHumanSshLane(repoRoot) {
+function stripSshConfigComment(value) {
+  let quote = '';
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? '' : char;
+      continue;
+    }
+
+    if (char === '#' && !quote) {
+      return value.slice(0, index).trim();
+    }
+  }
+
+  return value.trim();
+}
+
+function hostBlockMatches(line, host) {
+  const [, value = ''] = line.match(/^host\s+(.+)$/iu) || [];
+  return stripSshConfigComment(value)
+    .split(/\s+/u)
+    .some((pattern) => pattern.toLowerCase() === host.toLowerCase());
+}
+
+function hasHumanSshLane() {
   if (process.env.GOVERNADA_ENV_DOCTOR_DISABLE_HUMAN_LANE === '1') {
     return false;
   }
 
-  const result = spawnSync('ssh', ['-G', HUMAN_SSH_HOST], {
-    cwd: repoRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 5000,
-  });
-
-  if (result.status !== 0) {
+  if (!existsSync(SSH_CONFIG)) {
     return false;
   }
 
-  const output = result.stdout.toLowerCase();
-  return output.includes(`hostname ${HUMAN_SSH_HOST}`) || output.includes('identityagent ');
+  let inMatchingHostBlock = false;
+  let hasIdentityConfig = false;
+
+  for (const rawLine of readFileSync(SSH_CONFIG, 'utf8').split(/\r?\n/u)) {
+    const line = stripSshConfigComment(rawLine.trim());
+    if (!line) {
+      continue;
+    }
+
+    if (/^host\s+/iu.test(line)) {
+      if (inMatchingHostBlock && (hasIdentityConfig || process.env.SSH_AUTH_SOCK)) {
+        return true;
+      }
+      inMatchingHostBlock = hostBlockMatches(line, HUMAN_SSH_HOST);
+      hasIdentityConfig = false;
+      continue;
+    }
+
+    if (inMatchingHostBlock && /^(identityagent|identityfile)\s+/iu.test(line)) {
+      const [, value = ''] = line.match(/^\S+\s+(.+)$/u) || [];
+      if (value.trim() && value.trim().toLowerCase() !== 'none') {
+        hasIdentityConfig = true;
+      }
+    }
+  }
+
+  return inMatchingHostBlock && (hasIdentityConfig || Boolean(process.env.SSH_AUTH_SOCK));
 }
 
 function activeLaneLine(repoRoot) {
@@ -60,7 +104,7 @@ function activeLaneLine(repoRoot) {
     return `Active credential lane: agent (${AGENT_TOKEN_KEY}, vault=${vault})`;
   }
 
-  if (hasHumanSshLane(repoRoot)) {
+  if (hasHumanSshLane()) {
     return 'Active credential lane: human (SSH+1Password Desktop)';
   }
 

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -11,6 +11,7 @@ const ADDENDUM =
   '[[decisions/lean-agent-harness#addendum-3-2026-05-04--agent-sa-reads-the-github-pat-revises-addenda-1-and-2]]';
 const API_REPO = 'governada/app';
 const GH_WRAPPER = path.join(repoRoot, 'bin', 'gh.sh');
+const OP_AGENT_DOCTOR = path.join(repoRoot, 'scripts', 'op-agent-doctor.mjs');
 const ENV_REFS_FILE = '.env.local.refs';
 const DEFAULT_AGENT_RUNTIME_FILE = '/Users/tim/dev/agent-runtime/env/governada-agent.env';
 const EXPECTED_GH_TOKEN_OP_REF = 'op://Governada-Agent/governada-app-agent/credential';
@@ -303,6 +304,30 @@ function checkWrapperNoDesktopAuth(failures) {
   console.log('OK: bin/gh.sh does not invoke Desktop auth');
 }
 
+function checkOpAgentDoctorNoDesktopAuth(failures) {
+  const doctor = fs.existsSync(OP_AGENT_DOCTOR) ? fs.readFileSync(OP_AGENT_DOCTOR, 'utf8') : '';
+  if (!doctor) {
+    failures.push('scripts/op-agent-doctor.mjs is missing.');
+    return;
+  }
+
+  const unsafeReferences = doctor
+    .split(/\r?\n/u)
+    .map((line, index) => ({ line, lineNumber: index + 1 }))
+    .filter(({ line }) => line.includes('OP_ACCOUNT'))
+    .filter(({ line }) => !/^\s*delete\s+\w+\.OP_ACCOUNT\s*;\s*$/.test(line));
+
+  if (unsafeReferences.length > 0) {
+    const lines = unsafeReferences.map(({ lineNumber }) => lineNumber).join(', ');
+    failures.push(
+      `scripts/op-agent-doctor.mjs references OP_ACCOUNT outside env deletion on line(s): ${lines}.`,
+    );
+    return;
+  }
+
+  console.log('OK: scripts/op-agent-doctor.mjs only deletes OP_ACCOUNT before op subprocesses');
+}
+
 function checkWrapperCapabilityPolicy(failures) {
   const policyBlockPrefix = 'BLOCKED: bin/gh.sh allows only governed Governada GitHub operations';
   const preSecretProbeEnv = {
@@ -516,6 +541,7 @@ function main() {
   checkSshLane(failures);
   checkAgentServiceAccountRuntime(failures);
   checkWrapperNoDesktopAuth(failures);
+  checkOpAgentDoctorNoDesktopAuth(failures);
   checkWrapperCapabilityPolicy(failures);
   checkExpectedVaultLocation(failures);
   checkApiLane(failures);

--- a/scripts/op-agent-doctor.mjs
+++ b/scripts/op-agent-doctor.mjs
@@ -4,7 +4,11 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 const AGENT_TOKEN_KEY = 'OP_AGENT_SERVICE_ACCOUNT_TOKEN';
-const OP_CLI_SERVICE_ACCOUNT_TOKEN_KEY = ['OP', 'SERVICE', 'ACCOUNT', 'TOKEN'].join('_');
+// `op` CLI expects the literal env var name OP_SERVICE_ACCOUNT_TOKEN; this
+// doctor maps OP_AGENT_SERVICE_ACCOUNT_TOKEN into it for the subprocess only,
+// per ADR Addendum #1's rename. The literal must appear here for the CLI to
+// authenticate; live code paths use OP_AGENT_SERVICE_ACCOUNT_TOKEN.
+const OP_CLI_NATIVE_TOKEN_VAR = 'OP_SERVICE_ACCOUNT_TOKEN';
 const DEFAULT_ENV_FILE = '/Users/tim/dev/agent-runtime/env/governada-agent.env';
 const DEFAULT_VAULT = 'Governada-Agent';
 const DEFAULT_EXPECTED_ITEMS = [
@@ -300,7 +304,7 @@ function main() {
     ...process.env,
   };
   const token = mergedEnv[AGENT_TOKEN_KEY] || '';
-  const legacyToken = mergedEnv[OP_CLI_SERVICE_ACCOUNT_TOKEN_KEY] || '';
+  const legacyToken = mergedEnv[OP_CLI_NATIVE_TOKEN_VAR] || '';
   const sensitiveValues = [token, legacyToken];
   const vault = options.vault || mergedEnv.GOVERNADA_OP_AGENT_VAULT || DEFAULT_VAULT;
   const envItems = parseItemsEnv(mergedEnv.GOVERNADA_OP_AGENT_ITEMS || '');
@@ -326,9 +330,9 @@ function main() {
 
   if (legacyToken && !token) {
     failures.push(
-      `${OP_CLI_SERVICE_ACCOUNT_TOKEN_KEY} is set but no longer recognized for this lane - rename to ${AGENT_TOKEN_KEY} per the lean-agent-harness ADR addendum.`,
+      `${OP_CLI_NATIVE_TOKEN_VAR} is set but no longer recognized for this lane - rename to ${AGENT_TOKEN_KEY} per the lean-agent-harness ADR addendum.`,
     );
-    printCheck(false, `${OP_CLI_SERVICE_ACCOUNT_TOKEN_KEY} is not recognized for this lane`);
+    printCheck(false, `${OP_CLI_NATIVE_TOKEN_VAR} is not recognized for this lane`);
   } else if (!token) {
     failures.push(`${AGENT_TOKEN_KEY} is missing from process env and ${options.envFile}.`);
     printCheck(false, `${AGENT_TOKEN_KEY} is missing`);
@@ -349,7 +353,14 @@ function main() {
     printCheck(true, 'OP_CONNECT_HOST and OP_CONNECT_TOKEN are absent');
   }
 
-  const version = runOp(['--version'], mergedEnv, sensitiveValues);
+  const opProbeEnv = {
+    ...mergedEnv,
+  };
+  delete opProbeEnv.OP_CONNECT_HOST;
+  delete opProbeEnv.OP_CONNECT_TOKEN;
+  delete opProbeEnv.OP_ACCOUNT;
+
+  const version = runOp(['--version'], opProbeEnv, sensitiveValues);
   if (version.status !== 0) {
     failures.push(`1Password CLI probe failed: ${resultSummary(version, sensitiveValues)}`);
     printCheck(false, '1Password CLI (`op`) is not available');
@@ -377,11 +388,9 @@ function main() {
 
   if (failures.length === 0) {
     const opEnv = {
-      ...mergedEnv,
+      ...opProbeEnv,
     };
-    opEnv[OP_CLI_SERVICE_ACCOUNT_TOKEN_KEY] = token;
-    delete opEnv.OP_CONNECT_HOST;
-    delete opEnv.OP_CONNECT_TOKEN;
+    opEnv[OP_CLI_NATIVE_TOKEN_VAR] = token;
 
     const itemList = runOp(
       ['item', 'list', '--vault', vault, '--format', 'json'],


### PR DESCRIPTION
## Summary

- Fixes the `env:doctor` human SSH lane heuristic so arbitrary unknown SSH aliases no longer report as `human` just because `ssh -G` echoes the hostname.
- Ensures `op-agent-doctor` strips `OP_ACCOUNT` before every `op` subprocess, including `op --version`, so the agent service-account lane cannot silently route through 1Password Desktop.
- Replaces the obfuscated native 1Password CLI token env var construction with a documented named constant and extends `gh:auth-status` static inspection to catch future non-deletion `OP_ACCOUNT` references in `op-agent-doctor.mjs`.

## Existing Code Audit

Read the live PR #954 auth-doctor scripts after the merge landed: `scripts/env-doctor.mjs`, `scripts/op-agent-doctor.mjs`, and `scripts/gh-auth-status.js`. PR #954 was already merged before the requested amendment could be published in place, so this is a follow-up PR with only the reviewer must-fix delta on top of current `main`.

## Robustness

- `env:doctor` now checks `${SSH_CONFIG:-~/.ssh/config}` for an actual matching `Host` block plus identity evidence instead of treating `ssh -G <alias>` hostname echo as configuration proof.
- `op-agent-doctor` builds a shared sanitized `op` subprocess environment with `OP_CONNECT_HOST`, `OP_CONNECT_TOKEN`, and `OP_ACCOUNT` removed before any `op` call.
- `gh:auth-status` fails closed if `scripts/op-agent-doctor.mjs` contains `OP_ACCOUNT` outside a deletion statement.
- The native `OP_SERVICE_ACCOUNT_TOKEN` literal is kept in one named bridge constant with an explanatory comment; live lane input remains `OP_AGENT_SERVICE_ACCOUNT_TOKEN`.

## Impact

Agents get truthful local credential-lane reporting and a stronger guarantee that the service-account doctor does not fall back to Desktop-routed 1Password auth. No vault contents, docs, GitHub wrapper allowlist, production settings, migrations, or runtime credentials are changed.

## Brain Freshness

Not needed because this is a repo-local mechanical hotfix; no brain docs or addenda changed.

## Review Gate v0

Review tier: reviewer must-fix follow-up from PR #954.

Status: completed against the concrete reviewer repros before publish.

Findings resolved:

- SSH lane false positive now prints `Active credential lane: NONE` for an unconfigured alias.
- `OP_ACCOUNT=my.1password.com` no longer reaches `op` subprocesses in the fake-shim repro.
- The obfuscated `OP_SERVICE_ACCOUNT_TOKEN` construction was replaced with a documented named constant.

## Verification

- `node --check scripts/env-doctor.mjs scripts/op-agent-doctor.mjs scripts/gh-auth-status.js` passed.
- `npm run agent:validate` passed.
- `npm run env:doctor` passed.
- `env -u OP_AGENT_SERVICE_ACCOUNT_TOKEN GOVERNADA_ENV_DOCTOR_SSH_HOST=__governada_missing_host__ npm run env:doctor` printed `Active credential lane: NONE`.
- Fake `op` shim with inherited `OP_ACCOUNT=my.1password.com` and `OP_AGENT_SERVICE_ACCOUNT_TOKEN=ops_fake...` passed `npm run op:agent-doctor`, proving no `OP_ACCOUNT` reached the subprocess and the native CLI token bridge still works.
- `grep -R -n "\\['OP','SERVICE','ACCOUNT','TOKEN'\\]\\.join" scripts/` returned no matches.
- `npx prettier --check scripts/env-doctor.mjs scripts/op-agent-doctor.mjs scripts/gh-auth-status.js` passed.
- `git diff --check origin/main...HEAD` passed.
- `npm run op:agent-doctor` passed with the real service-account token after network approval; values redacted.
- `npm run gh:auth-status` passed, including the new `op-agent-doctor.mjs` static inspection.

## Open Follow-Up

- The `.gitignore /brain/` vs pre-existing tracked file collision from PR #948 remains a separate cleanup slice; this PR intentionally does not touch it.
