### PR TITLE
Phase 0.5 mainnet delegation capture

### DIFF
--- a/__tests__/api/delegation-mainnet.test.ts
+++ b/__tests__/api/delegation-mainnet.test.ts
@@ -1,0 +1,174 @@
+import { NextResponse } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequest, parseJson } from '../helpers';
+
+const mockCaptureServerEvent = vi.fn();
+const mockGetRedis = vi.fn();
+const mockLimit = vi.fn();
+const mockRequireAuth = vi.fn();
+const mockLoggerWarn = vi.fn();
+
+vi.mock('@upstash/ratelimit', () => {
+  const Ratelimit = vi.fn().mockImplementation(() => ({
+    limit: (...args: unknown[]) => mockLimit(...args),
+  }));
+
+  Object.assign(Ratelimit, {
+    slidingWindow: vi.fn().mockReturnValue('window'),
+  });
+
+  return { Ratelimit };
+});
+
+vi.mock('@/lib/supabaseAuth', () => ({
+  requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+
+vi.mock('@/lib/posthog-server', () => ({
+  captureServerEvent: (...args: unknown[]) => mockCaptureServerEvent(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: (...args: unknown[]) => mockLoggerWarn(...args), error: vi.fn() },
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: () => mockGetRedis(),
+}));
+
+import { POST } from '@/app/api/delegation/mainnet/route';
+
+const stakeAddress = `stake1${'q'.repeat(51)}`;
+const validBody = {
+  stakeAddress,
+  targetDrepId: 'drep1_mainnet4',
+  txHash: 'a'.repeat(64),
+  previousDrepId: 'drep1_previous',
+  stakeRegistered: true,
+};
+
+describe('POST /api/delegation/mainnet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRedis.mockReturnValue({});
+    mockLimit.mockResolvedValue({ success: true, remaining: 29 });
+    mockRequireAuth.mockResolvedValue({ userId: 'user-1', wallet: stakeAddress });
+  });
+
+  it('rejects requests without auth', async () => {
+    mockRequireAuth.mockResolvedValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    );
+
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      body: validBody,
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+  });
+
+  it('captures both success events server-side for valid authenticated mainnet delegations', async () => {
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      headers: { referer: 'https://governada.io/dev/delegation-test' },
+      body: validBody,
+    });
+
+    const res = await POST(req);
+    const body = (await parseJson(res)) as { captured: boolean; mode: string; txHash: string };
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      captured: true,
+      mode: 'mainnet',
+      txHash: validBody.txHash,
+    });
+    expect(mockCaptureServerEvent).toHaveBeenCalledTimes(2);
+    expect(mockCaptureServerEvent).toHaveBeenNthCalledWith(
+      1,
+      'delegation_completed',
+      expect.objectContaining({
+        drep_id: 'drep1_mainnet4',
+        previous_drep_id: 'drep1_previous',
+        tx_hash: validBody.txHash,
+        stake_registered: true,
+        mode: 'mainnet',
+        $current_url: 'https://governada.io/dev/delegation-test',
+        $host: 'governada.io',
+      }),
+      stakeAddress,
+    );
+    expect(mockCaptureServerEvent).toHaveBeenNthCalledWith(
+      2,
+      'delegated',
+      expect.objectContaining({
+        drep_id: 'drep1_mainnet4',
+        tx_hash: validBody.txHash,
+        mode: 'mainnet',
+      }),
+      stakeAddress,
+    );
+  });
+
+  it('rejects captures when the body stake address does not match the authenticated wallet', async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 'user-1', wallet: `stake1${'z'.repeat(51)}` });
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      body: validBody,
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+  });
+
+  it('accepts captures when auth has no wallet and logs a warning', async () => {
+    mockRequireAuth.mockResolvedValue({ userId: 'user-1', wallet: undefined });
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      body: validBody,
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Mainnet delegation capture accepted without wallet on auth context',
+      expect.objectContaining({
+        context: 'api/delegation/mainnet',
+        userId: 'user-1',
+        stakeAddress,
+      }),
+    );
+    expect(mockCaptureServerEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects sandbox-shaped tx hashes', async () => {
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      body: { ...validBody, txHash: 'sandbox-2fe922f0-b59a-4b77-ae1e-20b4e96a8566' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed bodies', async () => {
+    const req = createRequest('/api/delegation/mainnet', {
+      method: 'POST',
+      body: { ...validBody, stakeRegistered: 'yes' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/user-route.test.ts
+++ b/__tests__/api/user-route.test.ts
@@ -62,7 +62,7 @@ import { PATCH } from '@/app/api/user/route';
 
 const stakeAddress = `stake1${'q'.repeat(51)}`;
 
-describe('PATCH /api/user delegation telemetry', () => {
+describe('PATCH /api/user delegation history', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireAuth.mockResolvedValue({ userId: 'user-1', wallet: 'addr1paymentwallet' });
@@ -88,7 +88,7 @@ describe('PATCH /api/user delegation telemetry', () => {
     });
   });
 
-  it('captures both delegation success events when delegation_history is appended', async () => {
+  it('updates delegation_history without capturing mainnet telemetry', async () => {
     const txHash = 'b'.repeat(64);
     const req = createRequest('/api/user', {
       method: 'PATCH',
@@ -120,27 +120,8 @@ describe('PATCH /api/user delegation telemetry', () => {
         ],
       }),
     );
-    expect(mockCaptureServerEvent).toHaveBeenCalledTimes(2);
-    expect(mockCaptureServerEvent).toHaveBeenNthCalledWith(
-      1,
-      'delegation_completed',
-      expect.objectContaining({
-        drep_id: 'drep_new',
-        previous_drep_id: 'drep_old',
-        tx_hash: txHash,
-        stake_registered: true,
-        mode: 'mainnet',
-        $current_url: 'https://governada.io/dev/delegation-test',
-        $host: 'governada.io',
-      }),
-      stakeAddress,
-    );
-    expect(mockCaptureServerEvent).toHaveBeenNthCalledWith(
-      2,
-      'delegated',
-      expect.objectContaining({ drep_id: 'drep_new', tx_hash: txHash, mode: 'mainnet' }),
-      stakeAddress,
-    );
+    expect(mockWalletMaybeSingle).not.toHaveBeenCalled();
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
   });
 
   it('does not capture when the PATCH body has no delegation_history', async () => {
@@ -180,7 +161,7 @@ describe('PATCH /api/user delegation telemetry', () => {
     expect(mockCaptureServerEvent).not.toHaveBeenCalled();
   });
 
-  it('does not capture sandbox history because the sandbox route owns sandbox telemetry', async () => {
+  it('updates sandbox history without capturing telemetry because the sandbox route owns events', async () => {
     const req = createRequest('/api/user', {
       method: 'PATCH',
       headers: { Authorization: 'Bearer valid-token' },
@@ -198,6 +179,17 @@ describe('PATCH /api/user delegation telemetry', () => {
     const res = await PATCH(req);
 
     expect(res.status).toBe(200);
+    expect(mockUserUpdatePayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegation_history: [
+          expect.objectContaining({ drepId: 'drep_old', txHash: 'a'.repeat(64) }),
+          expect.objectContaining({
+            drepId: 'drep_preview',
+            txHash: 'sandbox-cce5b91d-406e-4e20-a59e-9012095f9ff5',
+          }),
+        ],
+      }),
+    );
     expect(mockWalletMaybeSingle).not.toHaveBeenCalled();
     expect(mockCaptureServerEvent).not.toHaveBeenCalled();
   });

--- a/app/api/delegation/mainnet/route.ts
+++ b/app/api/delegation/mainnet/route.ts
@@ -1,0 +1,89 @@
+export const dynamic = 'force-dynamic';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
+import { logger } from '@/lib/logger';
+import { captureServerEvent } from '@/lib/posthog-server';
+
+const MainnetDelegationBody = z.object({
+  stakeAddress: z
+    .string()
+    .min(1, 'stakeAddress is required')
+    .min(57, 'Mainnet delegation requires a full mainnet stake address')
+    .max(59, 'Mainnet delegation requires a full mainnet stake address')
+    .regex(/^stake1[a-z0-9]+$/, 'Mainnet delegation requires a mainnet stake address'),
+  targetDrepId: z.string().min(1, 'targetDrepId is required'),
+  txHash: z.string().regex(/^[a-f0-9]{64}$/, 'Mainnet delegation requires a 64-character tx hash'),
+  previousDrepId: z.string().min(1).nullable().optional(),
+  stakeRegistered: z.boolean(),
+});
+
+function hostFromUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+
+  try {
+    return new URL(value).host;
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveAuthenticatedStakeAddress(wallet: string): Promise<string | null> {
+  if (wallet.startsWith('stake1')) {
+    return wallet;
+  }
+
+  try {
+    const { resolveRewardAddress } = await import('@meshsdk/core');
+    return resolveRewardAddress(wallet) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export const POST = withRouteHandler(
+  async (request: NextRequest, { requestId, userId, wallet }: RouteContext) => {
+    const body = MainnetDelegationBody.parse(await request.json());
+
+    if (wallet) {
+      const authenticatedStakeAddress = await resolveAuthenticatedStakeAddress(wallet);
+      if (authenticatedStakeAddress !== body.stakeAddress) {
+        return NextResponse.json(
+          { error: 'Stake address does not match authenticated wallet' },
+          { status: 403 },
+        );
+      }
+    }
+
+    if (!wallet) {
+      logger.warn('Mainnet delegation capture accepted without wallet on auth context', {
+        context: 'api/delegation/mainnet',
+        requestId,
+        userId,
+        stakeAddress: body.stakeAddress,
+      });
+    }
+
+    const currentUrl = request.headers.get('referer') ?? undefined;
+    const delegationPayload = {
+      drep_id: body.targetDrepId,
+      previous_drep_id: body.previousDrepId ?? null,
+      tx_hash: body.txHash,
+      stake_registered: body.stakeRegistered,
+      mode: 'mainnet',
+      $current_url: currentUrl,
+      $host: hostFromUrl(currentUrl) ?? request.headers.get('host') ?? undefined,
+    };
+
+    captureServerEvent('delegation_completed', delegationPayload, body.stakeAddress);
+    captureServerEvent('delegated', delegationPayload, body.stakeAddress);
+
+    return NextResponse.json({
+      captured: true,
+      mode: 'mainnet',
+      txHash: body.txHash,
+    });
+  },
+  { auth: 'required', rateLimit: { max: 30, window: 60 } },
+);

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -139,7 +139,10 @@ export const PATCH = withRouteHandler(
       const previousHistory = asDelegationHistory(
         (currentUser as { delegation_history?: unknown } | null)?.delegation_history,
       );
-      const nextHistory = buildDelegationHistoryUpdate(incomingDelegationHistory, previousHistory ?? []);
+      const nextHistory = buildDelegationHistoryUpdate(
+        incomingDelegationHistory,
+        previousHistory ?? [],
+      );
 
       sanitizedUpdates.delegation_history = nextHistory;
     }

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -7,7 +7,6 @@ import { logger } from '@/lib/logger';
 import { withRouteHandler, type RouteContext } from '@/lib/api/withRouteHandler';
 import { isValidDepth, getTunerEvents, getTunerDigestFrequency } from '@/lib/governanceTuner';
 import { EVENT_REGISTRY } from '@/lib/notificationRegistry';
-import { captureServerEvent } from '@/lib/posthog-server';
 
 type DelegationHistoryEntry = {
   drepId?: string;
@@ -23,36 +22,14 @@ function asDelegationHistory(value: unknown): DelegationHistoryEntry[] | null {
   return Array.isArray(value) && value.length > 0 ? (value as DelegationHistoryEntry[]) : null;
 }
 
-function drepIdFromEntry(entry: DelegationHistoryEntry | undefined): string | undefined {
-  return entry?.drepId ?? entry?.drep_id;
-}
-
 function txHashFromEntry(entry: DelegationHistoryEntry | undefined): string | undefined {
   return entry?.txHash ?? entry?.tx_hash;
-}
-
-function stakeRegisteredFromEntry(entry: DelegationHistoryEntry | undefined): boolean | undefined {
-  return entry?.stakeRegistered ?? entry?.stake_registered;
-}
-
-function hostFromUrl(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-
-  try {
-    return new URL(value).host;
-  } catch {
-    return undefined;
-  }
-}
-
-function isMainnetTxHash(txHash: string | undefined): txHash is string {
-  return /^[a-f0-9]{64}$/i.test(txHash ?? '');
 }
 
 function buildDelegationHistoryUpdate(
   incomingHistory: DelegationHistoryEntry[],
   previousHistory: DelegationHistoryEntry[],
-): { nextHistory: DelegationHistoryEntry[]; latestEntry: DelegationHistoryEntry; isNew: boolean } {
+): DelegationHistoryEntry[] {
   const latestEntry = incomingHistory[incomingHistory.length - 1]!;
   const incomingTxHash = txHashFromEntry(latestEntry);
   const previousLatestTxHash = txHashFromEntry(previousHistory[previousHistory.length - 1]);
@@ -63,14 +40,14 @@ function buildDelegationHistoryUpdate(
     : incomingHistory.length > previousHistory.length;
 
   if (!isNew && incomingHistory.length < previousHistory.length) {
-    return { nextHistory: previousHistory, latestEntry, isNew };
+    return previousHistory;
   }
 
   if (isNew && incomingHistory.length <= previousHistory.length) {
-    return { nextHistory: [...previousHistory, latestEntry], latestEntry, isNew };
+    return [...previousHistory, latestEntry];
   }
 
-  return { nextHistory: incomingHistory, latestEntry, isNew };
+  return incomingHistory;
 }
 
 export const GET = withRouteHandler(
@@ -98,7 +75,7 @@ export const GET = withRouteHandler(
 );
 
 export const PATCH = withRouteHandler(
-  async (request: NextRequest, { userId, wallet }: RouteContext) => {
+  async (request: NextRequest, { userId }: RouteContext) => {
     const updates: SupabaseUserUpdate = await request.json();
 
     const allowedFields: (keyof SupabaseUserUpdate)[] = [
@@ -144,8 +121,6 @@ export const PATCH = withRouteHandler(
     }
 
     const incomingDelegationHistory = asDelegationHistory(updates.delegation_history);
-    let delegationPayload: Record<string, unknown> | null = null;
-    let delegationDistinctId: string | null = null;
 
     if (incomingDelegationHistory) {
       const { data: currentUser, error: currentUserError } = await supabase
@@ -164,64 +139,9 @@ export const PATCH = withRouteHandler(
       const previousHistory = asDelegationHistory(
         (currentUser as { delegation_history?: unknown } | null)?.delegation_history,
       );
-      const { nextHistory, latestEntry, isNew } = buildDelegationHistoryUpdate(
-        incomingDelegationHistory,
-        previousHistory ?? [],
-      );
+      const nextHistory = buildDelegationHistoryUpdate(incomingDelegationHistory, previousHistory ?? []);
 
       sanitizedUpdates.delegation_history = nextHistory;
-
-      const txHash = txHashFromEntry(latestEntry);
-      const drepId = drepIdFromEntry(latestEntry);
-      const previousLatestEntry = previousHistory?.[previousHistory.length - 1];
-
-      if (isNew && txHash?.startsWith('sandbox-')) {
-        logger.info('Skipping user delegation telemetry for sandbox history entry', {
-          context: 'user',
-          txHash,
-        });
-      } else if (isNew && drepId && isMainnetTxHash(txHash)) {
-        const { data: walletRow, error: walletError } = await supabase
-          .from('user_wallets')
-          .select('stake_address')
-          .eq('user_id', userId!)
-          .maybeSingle();
-
-        if (walletError) {
-          logger.warn('Could not resolve stake address for delegation telemetry', {
-            context: 'user',
-            error: walletError.message,
-          });
-        }
-
-        const walletStakeAddress = (walletRow as { stake_address?: string } | null)?.stake_address;
-        const stakeAddress =
-          typeof walletStakeAddress === 'string'
-            ? walletStakeAddress
-            : wallet?.startsWith('stake1')
-              ? wallet
-              : null;
-
-        if (stakeAddress) {
-          const currentUrl = request.headers.get('referer') ?? undefined;
-          const stakeRegistered = stakeRegisteredFromEntry(latestEntry);
-          delegationDistinctId = stakeAddress;
-          delegationPayload = {
-            drep_id: drepId,
-            previous_drep_id: drepIdFromEntry(previousLatestEntry) ?? null,
-            tx_hash: txHash,
-            ...(stakeRegistered !== undefined ? { stake_registered: stakeRegistered } : {}),
-            mode: 'mainnet',
-            $current_url: currentUrl,
-            $host: hostFromUrl(currentUrl) ?? request.headers.get('host') ?? undefined,
-          };
-        } else {
-          logger.warn('Skipping delegation telemetry without a resolved stake address', {
-            context: 'user',
-            userId,
-          });
-        }
-      }
     }
 
     const { data, error } = await supabase
@@ -234,11 +154,6 @@ export const PATCH = withRouteHandler(
     if (error) {
       logger.error('User update error', { context: 'user', error: error?.message });
       return NextResponse.json({ error: 'Failed to update user' }, { status: 500 });
-    }
-
-    if (delegationPayload && delegationDistinctId) {
-      captureServerEvent('delegation_completed', delegationPayload, delegationDistinctId);
-      captureServerEvent('delegated', delegationPayload, delegationDistinctId);
     }
 
     return NextResponse.json(data as SupabaseUser);

--- a/hooks/useDelegation.ts
+++ b/hooks/useDelegation.ts
@@ -130,6 +130,26 @@ export function useDelegation() {
 
         setPhase({ status: 'success', txHash: result.txHash, confirmed: false });
 
+        if (result.mode === 'mainnet') {
+          const token = getStoredSession();
+          if (token) {
+            fetch('/api/delegation/mainnet', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+              body: JSON.stringify({
+                stakeAddress: preflight.rewardAddress,
+                targetDrepId: drepId,
+                txHash: result.txHash,
+                previousDrepId: delegatedDrepId ?? null,
+                stakeRegistered: preflight.stakeRegistered,
+                currentUrl: window.location.href,
+              }),
+            }).catch((error) => {
+              console.warn('Failed to capture mainnet delegation analytics', error);
+            });
+          }
+        }
+
         if (result.mode !== 'sandbox') {
           waitForTxConfirmation(result.txHash, {
             maxAttempts: 30,
@@ -164,7 +184,7 @@ export function useDelegation() {
         return null;
       }
     },
-    [wallet, connected, isAuthenticated, refreshDelegation],
+    [wallet, connected, isAuthenticated, refreshDelegation, delegatedDrepId],
   );
 
   const reset = useCallback(() => {


### PR DESCRIPTION
## Summary

Implements Option B from `governada-brain/governada/initiatives/homepage-redesign-prompts/phase-0-5-mainnet-capture-prompt.md`, closing the missing mainnet half from the original Phase 0.5 must-fix prompt.

- Adds an auth-gated `/api/delegation/mainnet` capture route.
- Emits `delegation_completed` and `delegated` server-side after validated mainnet delegation success.
- Wires the mainnet success branch in `hooks/useDelegation.ts` to fire-and-forget the new endpoint after `delegateToDRep` succeeds.
- Removes stale `/api/user` delegation telemetry so route-owned server telemetry cannot double-emit.

## Existing Code Audit

- `app/api/delegation/sandbox/route.ts` remains the reference for payload shape and server-side PostHog capture.
- `app/api/user/route.ts` still owns `delegation_history` updates, but no longer emits delegation telemetry. The new mainnet route owns mainnet telemetry, and the sandbox route owns sandbox telemetry.
- The deleted `/api/delegation/events` relay pattern is not reintroduced.
- No database persistence is added for mainnet delegations; the on-chain tx hash remains the source of truth.

## Robustness

- `auth: 'required'` is the mainnet trust boundary.
- The route rejects mismatches between the authenticated wallet identity and the submitted stake address.
- If auth resolves a user but no wallet, the route logs a warning and accepts the submitted stake address, matching the prompt.
- Mainnet tx hashes must match `^[a-f0-9]{64}$`; sandbox-shaped hashes are rejected.
- Client analytics capture failure is logged as a warning and does not block the delegation UX.

## Impact

- Real mainnet delegation completions can now reach the same funnel events as sandbox delegations.
- Sandbox behavior is unchanged.
- `/api/user` can still merge `delegation_history`, but it no longer attempts to derive telemetry from that history.
- No reader of `delegation_history` changes behavior in this slice.

## Verification

Final head: `28783b86bd6710cc934b53655e1fd837d8852719`

- `npm run test:unit -- __tests__/api/delegation-mainnet.test.ts` PASS
- `npm run test:unit -- __tests__/api/delegation-sandbox.test.ts` PASS
- `npm run test:unit -- __tests__/api/user-route.test.ts` PASS
- `npm run agent:validate` PASS
- `npm run format:check` PASS
- `npm run lint` PASS, with existing warnings only
- `npm run type-check` PASS
- `npm run preview:verify -- --pr=958` PASS, 4/4
- `grep -rn "/api/delegation/events\|captureDelegationSuccess" app/ hooks/ lib/ --include="*.ts" --include="*.tsx"` returned zero hits.
- GitHub PR checks are green: `install`, `checks`, `test`, `build`, `browser-smoke`, `e2e-critical`, `preview-smoke`, `validate-pr-body`, `Supabase Preview`, and Railway `governada-app - governada-app`.
- Railway preview URL: `https://governada-app-app-pr-958.up.railway.app`

Pending after merge:

- PostHog dev project query for real `delegation_completed` and `delegated` mainnet events requires an actual mainnet delegation. This is intentionally not blocked pre-merge.

## Open Follow-Up

`delegation_history` reconciliation remains deferred. `/api/user` PATCH has a dedicated delegation-history merge path outside the generic whitelist loop, and multiple read sites depend on that field with inconsistent shape expectations (`drepId` vs `drep_id`). This PR intentionally does not reconcile those readers or make `delegation_history` the telemetry source; that should be a separate slice if the product needs durable delegation-history behavior.
