### PR TITLE
feat(auth): pivot agents to GitHub App tokens

### DIFF
--- a/.env.local.refs
+++ b/.env.local.refs
@@ -1,0 +1,4 @@
+GOVERNADA_GITHUB_CLIENT_ID_OP_REF=op://Governada-Agent/governada-agent-app/client_id
+GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF=op://Governada-Agent/governada-agent-app/installation_id
+GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF=op://Governada-Agent/governada-agent-app/private_key
+GOVERNADA_GITHUB_APP_PRIVATE_KEY_ROTATE_AFTER=2027-05-05

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,18 +47,16 @@ Canonical agent guide for `governada/app`. Provider adapters in `.claude/`, Curs
 
 ## Auth
 
-**Two lanes, both 1Password-sourced:**
+**Two lanes for git/GitHub:**
 
-- **git push/pull:** SSH + 1Password Desktop. Remotes use `git@github-governada:...`.
-- **GitHub API (PR create, comments, status):** `GH_TOKEN_OP_REF` resolved at runtime via `bin/gh.sh` (or `npm run gh -- ...`) using the agent service account. PAT is fine-grained, scoped to `governada/app` only with `Contents:write`, `Pull requests:write`, `Metadata:read`, `Workflows:read`. Stored in 1Password `Governada-Agent` vault as `governada-app-agent`.
+- **Human (Tim) git push/pull and signed commits:** SSH + 1Password Desktop. Remotes use `git@github-governada:...`. Manual; biometric-gated. Used for Tim's direct work.
+- **Autonomous agent (read non-git secrets, GitHub API, branch publication):** GitHub App installation tokens, minted from `governada-agent-app` in 1Password `Governada-Agent` vault via the agent service account `OP_AGENT_SERVICE_ACCOUNT_TOKEN`. Wrappers: `bin/gh.sh` (or `npm run gh -- ...`) for API; `bin/git-push.sh` (or `npm run git:push -- ...`) for branch publication. Both are governed capability lanes — see Addendum #4 for scope.
 
-`bin/gh.sh` is a governed capability lane, not a generic `gh` shell. It allowlists read/status, draft PR creation, PR metadata edits, and PR comments; it blocks token-printing, merge, ready-for-review, destructive API, admin, secret, workflow-dispatch, and other-repo operations before secret resolution.
+If broken, run `npm run gh:auth-status` (probes both lanes plus App mint chain, API capability, and push capability/blocked-target).
 
-If GitHub/API auth is broken, run `npm run gh:auth-status` (probes both lanes plus API capability and token expiry separately). If routine automation secret access is broken, run `npm run op:agent-doctor`; do not move provider secrets into `.env.local`. Use `npm run env:doctor` when you need the first-line active credential lane indicator.
+The agent service-account vault `Governada-Agent` contains: PostHog staging credentials and the GitHub App's client_id + installation_id + private_key. Expanding vault contents requires an explicit ADR addendum.
 
-The autonomous-agent secret-read lane (`OP_AGENT_SERVICE_ACCOUNT_TOKEN`, vault `Governada-Agent`) reads the GitHub PAT and the PostHog dev credential from `Governada-Agent`. Per ADR Addendum #3, this is exactly one bounded GitHub credential; expanding the agent's GitHub access requires an explicit ADR addendum, not a vault-content change.
-
-Do not print, copy, or store raw secrets. Token rotation is a Tim manual action.
+Do not print, copy, or store raw secrets. Token rotation: installation tokens are auto-rotated hourly by GitHub; App private key is rotated annually or on suspected compromise (Tim manual action).
 
 ## Where to Find More
 

--- a/__tests__/scripts/mint-installation-token.test.mjs
+++ b/__tests__/scripts/mint-installation-token.test.mjs
@@ -1,0 +1,128 @@
+import { generateKeyPairSync, createVerify } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  main,
+  mintAppJwt,
+  normalizePrivateKey,
+  requestInstallationToken,
+} from '../../scripts/mint-installation-token.mjs';
+
+function keyPair() {
+  return generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+function decodeSegment(segment) {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+}
+
+describe('mint-installation-token', () => {
+  it('mints an installation token with valid env', async () => {
+    const { privateKey } = keyPair();
+    const fetchImpl = vi.fn(async () => ({
+      status: 201,
+      json: async () => ({ token: 'ghs_test123', expires_at: '2026-05-05T00:00:00Z' }),
+    }));
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await main(
+      {
+        GOVERNADA_GITHUB_CLIENT_ID: 'Iv23test',
+        GOVERNADA_GITHUB_INSTALLATION_ID: '123',
+        GOVERNADA_GITHUB_APP_PRIVATE_KEY: privateKey,
+      },
+      fetchImpl,
+    );
+
+    expect(write).toHaveBeenCalledWith('ghs_test123\n');
+    write.mockRestore();
+  });
+
+  it('normalizes escaped newlines in PEM env values', () => {
+    const { privateKey, publicKey } = keyPair();
+    const jwt = mintAppJwt({
+      clientId: 'Iv23test',
+      privateKey: privateKey.replaceAll('\n', '\\n'),
+      now: 1_777_777_777,
+    });
+    const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
+
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(`${encodedHeader}.${encodedPayload}`);
+    verifier.end();
+    expect(verifier.verify(publicKey, Buffer.from(encodedSignature, 'base64url'))).toBe(true);
+  });
+
+  it('normalizes one-line PEM values from concealed fields', () => {
+    const { privateKey, publicKey } = keyPair();
+    const oneLinePem = privateKey.replace(/\n/gu, '');
+    const normalized = normalizePrivateKey(oneLinePem);
+    expect(normalized.split('\n').length).toBeGreaterThan(3);
+
+    const jwt = mintAppJwt({
+      clientId: 'Iv23test',
+      privateKey: oneLinePem,
+      now: 1_777_777_777,
+    });
+    const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
+
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(`${encodedHeader}.${encodedPayload}`);
+    verifier.end();
+    expect(verifier.verify(publicKey, Buffer.from(encodedSignature, 'base64url'))).toBe(true);
+  });
+
+  it('fails closed when client id is missing', async () => {
+    await expect(main({}, vi.fn())).rejects.toThrow('GOVERNADA_GITHUB_CLIENT_ID is missing');
+  });
+
+  it('fails closed when the private key is malformed', async () => {
+    await expect(
+      requestInstallationToken({
+        clientId: 'Iv23test',
+        installationId: '123',
+        privateKey: 'not a pem',
+        fetchImpl: vi.fn(),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('fails closed on GitHub API 401 with redacted error text', async () => {
+    const { privateKey } = keyPair();
+    const fetchImpl = vi.fn(async () => ({
+      status: 401,
+      json: async () => ({ message: 'bad credentials', token: 'ghs_should_not_leak_12345' }),
+    }));
+
+    await expect(
+      requestInstallationToken({
+        clientId: 'Iv23test',
+        installationId: '123',
+        privateKey,
+        fetchImpl,
+      }),
+    ).rejects.toThrow('[redacted-github-token]');
+  });
+
+  it('mints a JWT with the expected RS256 shape and claims', () => {
+    const { privateKey, publicKey } = keyPair();
+    const jwt = mintAppJwt({ clientId: 'Iv23test', privateKey, now: 1_777_777_777 });
+    const [encodedHeader, encodedPayload, encodedSignature] = jwt.split('.');
+
+    expect(decodeSegment(encodedHeader)).toEqual({ alg: 'RS256', typ: 'JWT' });
+    expect(decodeSegment(encodedPayload)).toEqual({
+      iss: 'Iv23test',
+      iat: 1_777_777_717,
+      exp: 1_777_778_317,
+    });
+
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(`${encodedHeader}.${encodedPayload}`);
+    verifier.end();
+    expect(verifier.verify(publicKey, Buffer.from(encodedSignature, 'base64url'))).toBe(true);
+  });
+});

--- a/bin/gh.sh
+++ b/bin/gh.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ADDENDUM='[[decisions/lean-agent-harness#addendum-3-2026-05-04--agent-sa-reads-the-github-pat-revises-addenda-1-and-2]]'
+ADDENDUM='[[decisions/lean-agent-harness#addendum-4-2026-05-05--pivot-from-user-pat-to-github-app-for-autonomous-agent-operations]]'
 DEFAULT_AGENT_RUNTIME_FILE='/Users/tim/dev/agent-runtime/env/governada-agent.env'
 
 redact() {
   sed -E \
-    -e 's/(gh[pousr]_|github_pat_)[A-Za-z0-9_]{12,}/[redacted-github-token]/g' \
+    -e 's/gh[pousr]_[A-Za-z0-9_]{12,}/[redacted-github-token]/g' \
     -e 's/ops_[A-Za-z0-9_=-]{20,}/[redacted-op-token]/g' \
     -e 's#op://[^[:space:]]+#op://[redacted]#g' \
     -e 's/item [^: ]+/item [redacted]/g' \
@@ -387,18 +387,37 @@ read_ref_value() {
     sed -E 's/[[:space:]]+#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//'
 }
 
-gh_token_ref="${GH_TOKEN_OP_REF:-}"
-if [[ -z "$gh_token_ref" ]]; then
-  gh_token_ref="$(read_ref_value GH_TOKEN_OP_REF "$refs_file")"
-fi
+app_ref_value() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_ref_value "$key" "$refs_file")"
+  fi
+  printf '%s' "$value"
+}
 
-if [[ -z "$gh_token_ref" ]]; then
-  {
-    echo "BLOCKED: GH_TOKEN_OP_REF is not set in the process environment or .env.local.refs."
-    echo "Remediation: configure GH_TOKEN_OP_REF per ${ADDENDUM}, then run npm run gh:auth-status."
-  } >&2
-  exit 1
-fi
+assert_op_ref() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    {
+      echo "BLOCKED: ${key} is not set in the process environment or .env.local.refs."
+      echo "Remediation: configure GitHub App op-refs per ${ADDENDUM}, then run npm run gh:auth-status."
+    } >&2
+    exit 1
+  fi
+  if [[ "$value" != op://* ]]; then
+    echo "BLOCKED: ${key} must be an op:// 1Password reference." >&2
+    exit 1
+  fi
+}
+
+client_id_ref="$(app_ref_value GOVERNADA_GITHUB_CLIENT_ID_OP_REF)"
+installation_id_ref="$(app_ref_value GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF)"
+private_key_ref="$(app_ref_value GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF)"
+assert_op_ref GOVERNADA_GITHUB_CLIENT_ID_OP_REF "$client_id_ref"
+assert_op_ref GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF "$installation_id_ref"
+assert_op_ref GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF "$private_key_ref"
 
 agent_runtime_file="${OP_AGENT_RUNTIME_FILE:-$DEFAULT_AGENT_RUNTIME_FILE}"
 agent_token="$(read_ref_value OP_AGENT_SERVICE_ACCOUNT_TOKEN "$agent_runtime_file")"
@@ -417,9 +436,29 @@ if [[ "$agent_token" != ops_* ]]; then
 fi
 
 if ! command -v op >/dev/null 2>&1; then
-  echo 'BLOCKED: 1Password CLI (`op`) is not available for GH_TOKEN_OP_REF resolution.' >&2
+  echo 'BLOCKED: 1Password CLI (`op`) is not available for GitHub App op-ref resolution.' >&2
   exit 1
 fi
+
+op_read_secret() {
+  local op_ref="$1"
+  local err_file
+  err_file="$(mktemp "${TMPDIR:-/tmp}/governada-op-read.XXXXXX")" || return 1
+  (
+    export OP_SERVICE_ACCOUNT_TOKEN="$agent_token"
+    unset OP_AGENT_SERVICE_ACCOUNT_TOKEN
+    unset OP_ACCOUNT
+    unset OP_CONNECT_HOST
+    unset OP_CONNECT_TOKEN
+    op read "$op_ref"
+  ) 2>"$err_file"
+  local status=$?
+  if [[ -s "$err_file" ]]; then
+    redact <"$err_file" >&2
+  fi
+  rm -f "$err_file"
+  return "$status"
+}
 
 gh_bin="${GOVERNADA_SYSTEM_GH:-$(command -v gh || true)}"
 if [[ -z "$gh_bin" ]]; then
@@ -431,25 +470,60 @@ unset GH_TOKEN
 unset GITHUB_TOKEN
 unset GH_HOST
 set +e
-(
-  export OP_SERVICE_ACCOUNT_TOKEN="$agent_token"
-  unset OP_AGENT_SERVICE_ACCOUNT_TOKEN
-  unset OP_ACCOUNT
-  unset OP_CONNECT_HOST
-  unset OP_CONNECT_TOKEN
-  op run --env-file <(printf 'GH_TOKEN=%s\n' "$gh_token_ref") -- \
-    env -u OP_SERVICE_ACCOUNT_TOKEN \
-      -u OP_AGENT_SERVICE_ACCOUNT_TOKEN \
-      -u OP_ACCOUNT \
-      -u OP_CONNECT_HOST \
-      -u OP_CONNECT_TOKEN \
-      "$gh_bin" "$@"
-) > >(redact) 2> >(redact >&2)
-status=$?
+client_id="$(op_read_secret "$client_id_ref")"
+client_id_status=$?
+installation_id="$(op_read_secret "$installation_id_ref")"
+installation_id_status=$?
+private_key="$(op_read_secret "$private_key_ref")"
+private_key_status=$?
 set -e
 
-if [[ "$status" -ne 0 ]]; then
-  echo 'Remediation: confirm GH_TOKEN_OP_REF points at the Governada-Agent/governada-app-agent credential item and the agent runtime SA token is valid, then run npm run gh:auth-status.' >&2
+if [[ "$client_id_status" -ne 0 || "$installation_id_status" -ne 0 || "$private_key_status" -ne 0 ]]; then
+  echo "Remediation: confirm GitHub App op-refs and the agent runtime SA token per ${ADDENDUM}." >&2
+  exit 1
 fi
+
+export GOVERNADA_GITHUB_CLIENT_ID="$client_id"
+export GOVERNADA_GITHUB_INSTALLATION_ID="$installation_id"
+export GOVERNADA_GITHUB_APP_PRIVATE_KEY="$private_key"
+mint_err_file="$(mktemp "${TMPDIR:-/tmp}/governada-mint.XXXXXX")"
+set +e
+minted_token="$(
+  env -u OP_SERVICE_ACCOUNT_TOKEN \
+    -u OP_AGENT_SERVICE_ACCOUNT_TOKEN \
+    -u OP_ACCOUNT \
+    -u OP_CONNECT_HOST \
+    -u OP_CONNECT_TOKEN \
+    node "$repo_root/scripts/mint-installation-token.mjs" 2>"$mint_err_file"
+)"
+mint_status=$?
+set -e
+unset GOVERNADA_GITHUB_CLIENT_ID
+unset GOVERNADA_GITHUB_INSTALLATION_ID
+unset GOVERNADA_GITHUB_APP_PRIVATE_KEY
+if [[ -s "$mint_err_file" ]]; then
+  redact <"$mint_err_file" >&2
+fi
+rm -f "$mint_err_file"
+
+if [[ "$mint_status" -ne 0 || -z "$minted_token" ]]; then
+  echo "Remediation: confirm GitHub App op-refs and the agent runtime SA token per ${ADDENDUM}." >&2
+  if [[ "$mint_status" -ne 0 ]]; then
+    exit "$mint_status"
+  fi
+  exit 1
+fi
+
+export GH_TOKEN="$minted_token"
+unset GITHUB_TOKEN
+set +e
+env -u OP_SERVICE_ACCOUNT_TOKEN \
+  -u OP_AGENT_SERVICE_ACCOUNT_TOKEN \
+  -u OP_ACCOUNT \
+  -u OP_CONNECT_HOST \
+  -u OP_CONNECT_TOKEN \
+  "$gh_bin" "$@" > >(redact) 2> >(redact >&2)
+status=$?
+set -e
 
 exit "$status"

--- a/bin/git-push.sh
+++ b/bin/git-push.sh
@@ -90,6 +90,7 @@ parse_push_args() {
 
   local remote="origin"
   local ref=""
+  local target_ref=""
   local parsed=()
   local positional=()
   local arg
@@ -138,14 +139,30 @@ parse_push_args() {
     block_policy "could not determine branch; pass origin feat/<branch> or origin codex/<branch>."
   fi
 
-  case "$ref" in
+  if [[ "$ref" == +* ]]; then
+    block_policy "force refspecs are outside the autonomous branch-publication lane."
+  fi
+
+  target_ref="$ref"
+  if [[ "$ref" == *:* ]]; then
+    local source_ref="${ref%%:*}"
+    target_ref="${ref#*:}"
+    if [[ "$source_ref" != "HEAD" ]]; then
+      block_policy "explicit refspec pushes must use HEAD as the source ref."
+    fi
+    if [[ -z "$target_ref" ]]; then
+      block_policy "delete-style refspecs are outside the autonomous branch-publication lane."
+    fi
+  fi
+
+  case "$target_ref" in
     main | refs/heads/main | master | refs/heads/master | release/* | refs/heads/release/* | production* | refs/heads/production*)
-      block_policy "target ${ref} is protected."
+      block_policy "target ${target_ref} is protected."
       ;;
   esac
 
-  if [[ ! "$ref" =~ ^(refs/heads/)?(feat|codex)/.+$ ]]; then
-    block_policy "target ${ref} must match feat/* or codex/*."
+  if [[ ! "$target_ref" =~ ^(refs/heads/)?(feat|codex)/.+$ ]]; then
+    block_policy "target ${target_ref} must match feat/* or codex/*."
   fi
 
   PUSH_ARGS=("origin" "$ref")
@@ -248,7 +265,8 @@ fi
 
 export GH_TOKEN="$minted_token"
 set +e
-git -C "$repo_root" \
+HUSKY=0 git -C "$repo_root" \
+  -c core.hooksPath=/dev/null \
   -c remote.origin.pushurl=https://github.com/governada/app.git \
   -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
   push "${PUSH_ARGS[@]}" > >(redact) 2> >(redact >&2)

--- a/bin/git-push.sh
+++ b/bin/git-push.sh
@@ -148,7 +148,10 @@ parse_push_args() {
     block_policy "target ${ref} must match feat/* or codex/*."
   fi
 
-  PUSH_ARGS=("${parsed[@]}" "origin" "$ref")
+  PUSH_ARGS=("origin" "$ref")
+  if [[ "${#parsed[@]}" -gt 0 ]]; then
+    PUSH_ARGS=("${parsed[@]}" "${PUSH_ARGS[@]}")
+  fi
 }
 
 parse_push_args "$@"

--- a/bin/git-push.sh
+++ b/bin/git-push.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADDENDUM='[[decisions/lean-agent-harness#addendum-4-2026-05-05--pivot-from-user-pat-to-github-app-for-autonomous-agent-operations]]'
+DEFAULT_AGENT_RUNTIME_FILE='/Users/tim/dev/agent-runtime/env/governada-agent.env'
+
+redact() {
+  sed -E \
+    -e 's/gh[pousr]_[A-Za-z0-9_]{12,}/[redacted-github-token]/g' \
+    -e 's/ops_[A-Za-z0-9_=-]{20,}/[redacted-op-token]/g' \
+    -e 's#op://[^[:space:]]+#op://[redacted]#g' \
+    -e 's/item [^: ]+/item [redacted]/g' \
+    -e 's/vault [a-z0-9]{20,}/vault [redacted]/g'
+}
+
+block_policy() {
+  echo "BLOCKED: bin/git-push.sh allows only governed Governada branch publication: $1" >&2
+  exit 1
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if repo_root="$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  repo_root="$(cd "$script_dir/.." && pwd -P)"
+fi
+
+read_ref_value() {
+  local key="$1"
+  local file="$2"
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  sed -n -E "s/^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=[[:space:]]*//p" "$file" |
+    tail -n 1 |
+    sed -E 's/[[:space:]]+#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//'
+}
+
+refs_file="${GOVERNADA_GH_ENV_REFS_FILE:-}"
+if [[ -z "$refs_file" ]]; then
+  refs_file="$repo_root/.env.local.refs"
+  if [[ ! -f "$refs_file" && "$repo_root" == *'/.claude/worktrees/'* ]]; then
+    shared_root="${repo_root%%/.claude/worktrees/*}"
+    if [[ -f "$shared_root/.env.local.refs" ]]; then
+      refs_file="$shared_root/.env.local.refs"
+    fi
+  fi
+fi
+
+app_ref_value() {
+  local key="$1"
+  local value="${!key:-}"
+  if [[ -z "$value" ]]; then
+    value="$(read_ref_value "$key" "$refs_file")"
+  fi
+  printf '%s' "$value"
+}
+
+assert_op_ref() {
+  local key="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    {
+      echo "BLOCKED: ${key} is not set in the process environment or .env.local.refs."
+      echo "Remediation: configure GitHub App op-refs per ${ADDENDUM}, then run npm run gh:auth-status."
+    } >&2
+    exit 1
+  fi
+  if [[ "$value" != op://* ]]; then
+    echo "BLOCKED: ${key} must be an op:// 1Password reference." >&2
+    exit 1
+  fi
+}
+
+contains_blocked_flag() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --force | -f | --force-with-lease | --force-with-lease=* | --delete | -d | --mirror | --all | --tags | --prune | --repo | --repo=*)
+        block_policy "flag ${arg} is outside the autonomous branch-publication lane."
+        ;;
+    esac
+  done
+}
+
+parse_push_args() {
+  contains_blocked_flag "$@"
+
+  local remote="origin"
+  local ref=""
+  local parsed=()
+  local positional=()
+  local arg
+
+  for arg in "$@"; do
+    case "$arg" in
+      --dry-run | -u | --set-upstream)
+        parsed+=("$arg")
+        ;;
+      --*)
+        block_policy "flag ${arg} is not in the allowlist."
+        ;;
+      -*)
+        block_policy "short flag ${arg} is not in the allowlist."
+        ;;
+      *)
+        positional+=("$arg")
+        ;;
+    esac
+  done
+
+  if [[ "${#positional[@]}" -gt 2 ]]; then
+    block_policy "expected at most remote and ref positional arguments."
+  fi
+
+  if [[ "${#positional[@]}" -eq 1 ]]; then
+    if [[ "${positional[0]}" == "origin" ]]; then
+      remote="origin"
+    else
+      ref="${positional[0]}"
+    fi
+  elif [[ "${#positional[@]}" -eq 2 ]]; then
+    remote="${positional[0]}"
+    ref="${positional[1]}"
+  fi
+
+  if [[ "$remote" != "origin" ]]; then
+    block_policy "remote must be origin."
+  fi
+
+  if [[ -z "$ref" ]]; then
+    ref="$(git -C "$repo_root" branch --show-current)"
+  fi
+
+  if [[ -z "$ref" ]]; then
+    block_policy "could not determine branch; pass origin feat/<branch> or origin codex/<branch>."
+  fi
+
+  case "$ref" in
+    main | refs/heads/main | master | refs/heads/master | release/* | refs/heads/release/* | production* | refs/heads/production*)
+      block_policy "target ${ref} is protected."
+      ;;
+  esac
+
+  if [[ ! "$ref" =~ ^(refs/heads/)?(feat|codex)/.+$ ]]; then
+    block_policy "target ${ref} must match feat/* or codex/*."
+  fi
+
+  PUSH_ARGS=("${parsed[@]}" "origin" "$ref")
+}
+
+parse_push_args "$@"
+
+client_id_ref="$(app_ref_value GOVERNADA_GITHUB_CLIENT_ID_OP_REF)"
+installation_id_ref="$(app_ref_value GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF)"
+private_key_ref="$(app_ref_value GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF)"
+assert_op_ref GOVERNADA_GITHUB_CLIENT_ID_OP_REF "$client_id_ref"
+assert_op_ref GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF "$installation_id_ref"
+assert_op_ref GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF "$private_key_ref"
+
+agent_runtime_file="${OP_AGENT_RUNTIME_FILE:-$DEFAULT_AGENT_RUNTIME_FILE}"
+agent_token="$(read_ref_value OP_AGENT_SERVICE_ACCOUNT_TOKEN "$agent_runtime_file")"
+if [[ -z "$agent_token" ]]; then
+  echo "BLOCKED: OP_AGENT_SERVICE_ACCOUNT_TOKEN is missing from ${agent_runtime_file}." >&2
+  exit 1
+fi
+if [[ "$agent_token" != ops_* ]]; then
+  echo 'BLOCKED: OP_AGENT_SERVICE_ACCOUNT_TOKEN does not have the expected 1Password service-account token shape.' >&2
+  exit 1
+fi
+if ! command -v op >/dev/null 2>&1; then
+  echo 'BLOCKED: 1Password CLI (`op`) is not available for GitHub App op-ref resolution.' >&2
+  exit 1
+fi
+
+op_read_secret() {
+  local op_ref="$1"
+  local err_file
+  err_file="$(mktemp "${TMPDIR:-/tmp}/governada-op-read.XXXXXX")" || return 1
+  (
+    export OP_SERVICE_ACCOUNT_TOKEN="$agent_token"
+    unset OP_AGENT_SERVICE_ACCOUNT_TOKEN
+    unset OP_ACCOUNT
+    unset OP_CONNECT_HOST
+    unset OP_CONNECT_TOKEN
+    op read "$op_ref"
+  ) 2>"$err_file"
+  local status=$?
+  if [[ -s "$err_file" ]]; then
+    redact <"$err_file" >&2
+  fi
+  rm -f "$err_file"
+  return "$status"
+}
+
+unset GH_TOKEN
+unset GITHUB_TOKEN
+unset GH_HOST
+set +e
+client_id="$(op_read_secret "$client_id_ref")"
+client_id_status=$?
+installation_id="$(op_read_secret "$installation_id_ref")"
+installation_id_status=$?
+private_key="$(op_read_secret "$private_key_ref")"
+private_key_status=$?
+set -e
+
+if [[ "$client_id_status" -ne 0 || "$installation_id_status" -ne 0 || "$private_key_status" -ne 0 ]]; then
+  echo "Remediation: confirm GitHub App op-refs and the agent runtime SA token per ${ADDENDUM}." >&2
+  exit 1
+fi
+
+export GOVERNADA_GITHUB_CLIENT_ID="$client_id"
+export GOVERNADA_GITHUB_INSTALLATION_ID="$installation_id"
+export GOVERNADA_GITHUB_APP_PRIVATE_KEY="$private_key"
+mint_err_file="$(mktemp "${TMPDIR:-/tmp}/governada-mint.XXXXXX")"
+set +e
+minted_token="$(
+  env -u OP_SERVICE_ACCOUNT_TOKEN \
+    -u OP_AGENT_SERVICE_ACCOUNT_TOKEN \
+    -u OP_ACCOUNT \
+    -u OP_CONNECT_HOST \
+    -u OP_CONNECT_TOKEN \
+    node "$repo_root/scripts/mint-installation-token.mjs" 2>"$mint_err_file"
+)"
+mint_status=$?
+set -e
+unset GOVERNADA_GITHUB_CLIENT_ID
+unset GOVERNADA_GITHUB_INSTALLATION_ID
+unset GOVERNADA_GITHUB_APP_PRIVATE_KEY
+if [[ -s "$mint_err_file" ]]; then
+  redact <"$mint_err_file" >&2
+fi
+rm -f "$mint_err_file"
+
+if [[ "$mint_status" -ne 0 || -z "$minted_token" ]]; then
+  echo "Remediation: confirm GitHub App op-refs and the agent runtime SA token per ${ADDENDUM}." >&2
+  if [[ "$mint_status" -ne 0 ]]; then
+    exit "$mint_status"
+  fi
+  exit 1
+fi
+
+export GH_TOKEN="$minted_token"
+set +e
+git -C "$repo_root" \
+  -c remote.origin.pushurl=https://github.com/governada/app.git \
+  -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+  push "${PUSH_ARGS[@]}" > >(redact) 2> >(redact >&2)
+status=$?
+set -e
+
+exit "$status"

--- a/docs/operations/agent-secret-access.md
+++ b/docs/operations/agent-secret-access.md
@@ -133,7 +133,7 @@ Blocked command groups include:
 Use the GitHub App branch-publication wrapper for autonomous pushes:
 
 ```bash
-bin/git-push.sh --dry-run origin feat/gh-auth-doctor-probe
+bin/git-push.sh --dry-run origin HEAD:refs/heads/feat/gh-auth-doctor-probe
 npm run git:push -- --set-upstream origin feat/my-branch
 ```
 
@@ -142,12 +142,12 @@ The wrapper:
 - Mints an installation token using the same service-account and helper path as `bin/gh.sh`.
 - Pushes to `https://github.com/governada/app.git` for this invocation only.
 - Leaves the persistent `origin` remote unchanged.
-- Supplies credentials through a transient git credential helper sourced from env.
+- Supplies credentials through a transient git credential helper sourced from env and disables hooks for the wrapped push so repo hook code cannot inherit the installation token.
 - Allows only `feat/*` and `codex/*` branch targets.
 - Allows `--dry-run`, `-u`, and `--set-upstream`.
 - Blocks `main`, `master`, `release/*`, `production*`, force-push flags, delete/mirror/all/tags/prune flags, and non-`origin` remotes.
 
-`feat/gh-auth-doctor-probe` is the known feature branch used by `npm run gh:auth-status` for non-mutating push capability checks.
+`HEAD:refs/heads/feat/gh-auth-doctor-probe` is the self-contained refspec used by `npm run gh:auth-status` for non-mutating push capability checks.
 
 ## Allowlist Extension Policy
 
@@ -187,7 +187,7 @@ npm run env:doctor
 - The agent service account can read the App private key without printing it.
 - JWT and installation-token minting succeeds.
 - GitHub API read works for `governada/app`.
-- `bin/git-push.sh --dry-run origin feat/gh-auth-doctor-probe` succeeds.
+- `bin/git-push.sh --dry-run origin HEAD:refs/heads/feat/gh-auth-doctor-probe` succeeds.
 - Push to `main` and force-push attempts fail closed with `BLOCKED:` before secret resolution.
 
 `npm run op:agent-doctor` checks the broader 1Password service-account lane and expected vault items. It fails closed if `OP_CONNECT_HOST` or `OP_CONNECT_TOKEN` are set, because those override service-account auth. It must not print secret values.

--- a/docs/operations/agent-secret-access.md
+++ b/docs/operations/agent-secret-access.md
@@ -2,10 +2,10 @@
 
 Governada has two separate credential lanes:
 
-- Service-account automation lane: routine approved agent reads and GitHub API operations.
+- Service-account automation lane: routine approved agent reads, GitHub API operations, and guarded branch publication.
 - Tim/manual approval lane: SSH signing, PR merge approval, production deploy approval, secret rotation, production data writes, and destructive or administrative actions.
 
-This document implements the `lean-agent-harness` service-account addenda. Git push/pull stays SSH+1Password Desktop. GitHub API operations use `GH_TOKEN_OP_REF` resolved through the agent service account per Addendum #3.
+This document implements the `lean-agent-harness` service-account addenda. Addendum #4 is canonical for the GitHub App pivot; this operations doc describes how the local lane behaves.
 
 ## Lane Contract
 
@@ -21,16 +21,18 @@ Service account:
 
 Vault scope:
 
-- Contains only non-production preview/staging credentials and read-only credentials needed to verify autonomous agent work, plus the single bounded GitHub API credential approved in Addendum #3.
+- Contains only non-production preview/staging credentials and the GitHub App credential approved in Addendum #4.
 - Production credentials are never in this vault and are structurally inaccessible to the service account.
 - The doctor treats obvious production/admin item names as blockers, but the monthly manual vault audit is the definitive control.
 
 ## Items In Vault
 
-| Item                        | Fields                                                                       | Scope                                                                                                                 |
-| --------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `governada-posthog-staging` | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `NEXT_PUBLIC_POSTHOG_HOST` | PostHog dev/staging project read/query access.                                                                        |
-| `governada-app-agent`       | `credential`                                                                 | Fine-grained GitHub PAT for `governada/app` only: Contents:write, Pull requests:write, Metadata:read, Workflows:read. |
+| Item                        | Fields                                                                       | Scope                                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `governada-posthog-staging` | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID`, `NEXT_PUBLIC_POSTHOG_HOST` | PostHog dev/staging project read/query access.                                                  |
+| `governada-agent-app`       | `client_id`, `installation_id`, `private_key`                                | GitHub App installed only on `governada/app` for API operations and guarded branch publication. |
+
+The old `governada-app-agent` user token item is being decommissioned by Tim after the Addendum #4 PR merges. Expanding the App's repository access, permissions, or vault contents requires an explicit ADR addendum, not a vault-content change.
 
 Sentry is intentionally deferred. Add it only after observed need, by adding the item to `Governada-Agent` and configuring the relevant doctor expectation; do not make this lane fail closed on an anticipated Sentry item.
 
@@ -41,15 +43,13 @@ Never place any of these in `Governada-Agent`:
 - Production credentials.
 - GitHub admin tokens.
 - Merge-capable credentials or bypass tokens.
-- PATs or app credentials for any repo other than `governada/app`.
+- App credentials for any repo other than `governada/app`.
 - Deploy-trigger tokens.
 - Secret-rotation tokens.
 - On-chain submit credentials.
 - Admin tokens for any provider.
 - Mainnet wallet keys.
 - Production Supabase, Railway, database, or infrastructure credentials.
-
-The `governada-app-agent` PAT is the only GitHub credential allowed in this vault. Expanding its scope requires an explicit ADR addendum, not a vault-content change.
 
 ## Local Runtime Token Placement
 
@@ -77,6 +77,18 @@ chmod 600 /Users/tim/dev/agent-runtime/env/governada-agent.env
 
 The runtime env file is a local bootstrap copy. Provider credentials remain canonical in 1Password.
 
+## GitHub App Lane
+
+The autonomous GitHub lane uses a GitHub App installation token minted per command invocation:
+
+1. `.env.local.refs` names the three 1Password references for `governada-agent-app`: client ID, installation ID, and private key.
+2. The wrapper reads `OP_AGENT_SERVICE_ACCOUNT_TOKEN` from `/Users/tim/dev/agent-runtime/env/governada-agent.env`.
+3. The wrapper maps that token to `OP_SERVICE_ACCOUNT_TOKEN` only for the `op` subprocess and unsets Desktop/Connect override env vars.
+4. `scripts/mint-installation-token.mjs` mints a short-lived GitHub App JWT, exchanges it for an installation token, and prints only that token to stdout.
+5. The wrapper injects the installation token into the child process as `GH_TOKEN` and redacts token-shaped output.
+
+The helper has no external dependencies beyond Node's `crypto` module and global `fetch`. It does not cache, persist, or log tokens.
+
 ## GitHub API Lane
 
 Run GitHub API commands through the wrapper:
@@ -88,16 +100,13 @@ npm run gh -- pr view 952 --repo governada/app
 
 The wrapper:
 
-- Reads `GH_TOKEN_OP_REF=op://Governada-Agent/governada-app-agent/credential`.
-- Reads `OP_AGENT_SERVICE_ACCOUNT_TOKEN` from `/Users/tim/dev/agent-runtime/env/governada-agent.env`.
-- Maps that token to `OP_SERVICE_ACCOUNT_TOKEN` only for the `op` subprocess.
-- Unsets `OP_ACCOUNT`, `OP_CONNECT_HOST`, and `OP_CONNECT_TOKEN` so 1Password Desktop and Connect do not override service-account auth.
+- Resolves `GOVERNADA_GITHUB_CLIENT_ID_OP_REF`, `GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF`, and `GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF`.
 - Enforces a command and endpoint allowlist before any 1Password token resolution.
 - Blocks token-printing `gh auth` commands.
 - Redacts GitHub token, service-account token, and op-ref shapes from stdout and stderr.
 - Never prints or writes the GitHub token.
 
-This is the GitHub API write lane from `lean-agent-harness` Addendum #3. It can create draft PRs and update PR metadata within the PAT scope. It is not a merge lane.
+This is the GitHub API write lane from `lean-agent-harness` Addendum #4. It can create draft PRs and update PR metadata within the App installation scope. It is not a merge lane.
 
 ### Capability Allowlist
 
@@ -119,24 +128,43 @@ Blocked command groups include:
 - Destructive or administrative `gh api` methods/endpoints such as `DELETE`, repo settings, secrets, variables, environments, branch protection, workflow dispatch, releases, deployments, and actions mutation.
 - Any repo target other than `governada/app`.
 
-### Allowlist Extension Policy
+## Branch Publication Lane
+
+Use the GitHub App branch-publication wrapper for autonomous pushes:
+
+```bash
+bin/git-push.sh --dry-run origin feat/gh-auth-doctor-probe
+npm run git:push -- --set-upstream origin feat/my-branch
+```
+
+The wrapper:
+
+- Mints an installation token using the same service-account and helper path as `bin/gh.sh`.
+- Pushes to `https://github.com/governada/app.git` for this invocation only.
+- Leaves the persistent `origin` remote unchanged.
+- Supplies credentials through a transient git credential helper sourced from env.
+- Allows only `feat/*` and `codex/*` branch targets.
+- Allows `--dry-run`, `-u`, and `--set-upstream`.
+- Blocks `main`, `master`, `release/*`, `production*`, force-push flags, delete/mirror/all/tags/prune flags, and non-`origin` remotes.
+
+`feat/gh-auth-doctor-probe` is the known feature branch used by `npm run gh:auth-status` for non-mutating push capability checks.
+
+## Allowlist Extension Policy
 
 The allowlist is intentionally narrow. Extending it is a deliberate action, not a silent edit.
 
-1. An agent flow hits `BLOCKED: ...` from `bin/gh.sh`. The blocked operation is recorded with its exact command shape.
-2. Tim decides whether the operation is in scope for the autonomous lane (gut check: would I be comfortable if this PAT were exercised by a compromised agent runtime executing this exact operation against `governada/app`?).
-3. If yes: a one-line entry is added to ADR Addendum #2's "What's added" list (or whichever addendum scopes the lane), the wrapper allowlist gets the new entry, and `gh-auth-status` gets a positive probe (the operation now succeeds) and a negative probe (a near-miss variant still fails closed).
-4. The change ships as a single PR reviewed against the addendum diff. The wrapper allowlist edit is never reviewed in isolation; it always lands with the addendum line and the doctor probes.
-
-A near-miss negative probe is required because the value of the allowlist is closed-default, and that default is only as good as its boundary tests. Adding a permission without testing the surrounding restrictions weakens the lane.
+1. An agent flow hits `BLOCKED: ...` from a wrapper. The blocked operation is recorded with its exact command shape.
+2. Tim decides whether the operation is in scope for the autonomous lane.
+3. If yes: a one-line entry is added to the relevant ADR addendum, the wrapper allowlist gets the new entry, and `gh-auth-status` gets a positive probe plus a near-miss negative probe.
+4. The change ships as a single PR reviewed against the addendum diff.
 
 ## Expiration And Rotation Policy
 
 - Service-account token rotation cadence: every 90 days, plus immediately after suspected exposure, machine loss, role/scope change, or accidental log/chat disclosure.
-- GitHub PAT rotation target: `GH_TOKEN_ROTATE_AFTER=2026-08-02`, then every 90 days.
-- Rotation overlap: update the real credential in 1Password, run `npm run gh:auth-status`, then revoke/expire the old token after the doctor is green.
-- Emergency compromise: rotate and expire the old token immediately, then audit service-account usage.
-- Scope change: record the change in the ADR addendum before changing the vault item or PAT permissions.
+- GitHub installation tokens auto-rotate hourly and are minted per wrapper invocation.
+- GitHub App private-key rotation: annually, plus immediately on suspected compromise. Tim performs this manual action in GitHub and 1Password.
+- Emergency compromise: rotate the App private key and service-account token immediately, then audit service-account usage.
+- Scope change: record the change in the ADR addendum before changing the vault item or App permissions.
 - Review cadence: monthly vault and usage-report check.
 
 ## Doctors
@@ -151,14 +179,16 @@ npm run env:doctor
 
 `npm run gh:auth-status` checks:
 
-- SSH + 1Password git lane still works.
+- SSH + 1Password git lane still works for Tim's manual lane.
 - Agent service-account env file exists, is owner-only, and contains an `ops_` token shape.
 - `bin/gh.sh` does not invoke Desktop auth.
 - `bin/gh.sh` blocks token-printing commands, merge commands, unsafe API methods, direct non-draft PR creation, API-layer merge bypass, ref-overwrite via API, and the GraphQL endpoint before secret resolution.
-- `bin/gh.sh` resolves the GitHub token through service-account auth without prompt-shaped output.
+- The three GitHub App op-refs are configured.
+- The agent service account can read the App private key without printing it.
+- JWT and installation-token minting succeeds.
 - GitHub API read works for `governada/app`.
-- PR-create capability reaches GitHub validation with `pull_requests:write`.
-- GitHub PAT rotation date is valid and outside the 14-day warning window.
+- `bin/git-push.sh --dry-run origin feat/gh-auth-doctor-probe` succeeds.
+- Push to `main` and force-push attempts fail closed with `BLOCKED:` before secret resolution.
 
 `npm run op:agent-doctor` checks the broader 1Password service-account lane and expected vault items. It fails closed if `OP_CONNECT_HOST` or `OP_CONNECT_TOKEN` are set, because those override service-account auth. It must not print secret values.
 
@@ -167,8 +197,6 @@ npm run env:doctor
 - `Active credential lane: agent (OP_AGENT_SERVICE_ACCOUNT_TOKEN, vault=Governada-Agent)`
 - `Active credential lane: human (SSH+1Password Desktop)`
 - `Active credential lane: NONE`
-
-The lane indicator is intentionally one line. Per-secret read logging is deferred until the 2026-06-01 audit if lane confusion actually happens.
 
 ## Manual Gates Stay Manual
 
@@ -187,14 +215,13 @@ Always pause for Tim's explicit approval before:
 
 1. Confirm service account `governada-agent-automation` exists.
 2. Confirm it is scoped only to `Governada-Agent`.
-3. Confirm `Governada-Agent` contains exactly `governada-posthog-staging` and `governada-app-agent`, unless a future ADR addendum explicitly changes this list.
+3. Confirm `Governada-Agent` contains `governada-posthog-staging` and `governada-agent-app`; during the transition it may also contain the soon-to-be-decommissioned old token item until Tim removes it after merge.
 4. Confirm the PostHog token is dev/staging project read/query scope, not production and not admin.
-5. Confirm the GitHub PAT is scoped to `governada/app` only with Contents:write, Pull requests:write, Metadata:read, and Workflows:read.
-6. Confirm first rotation dates are set for the service-account token and GitHub PAT.
-7. Confirm `/Users/tim/dev/agent-runtime/env/governada-agent.env` exists with mode `600`.
-8. Run `npm run op:agent-doctor`.
-9. Run `npm run env:doctor`.
-10. Run `npm run gh:auth-status`.
+5. Confirm the GitHub App is installed only on `governada/app` with Contents:read+write, Pull requests:read+write, Metadata:read, Actions:read, and Workflows:read.
+6. Confirm `/Users/tim/dev/agent-runtime/env/governada-agent.env` exists with mode `600`.
+7. Run `npm run op:agent-doctor`.
+8. Run `npm run env:doctor`.
+9. Run `npm run gh:auth-status`.
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "auth:repair": "node scripts/repair-gh-auth.mjs",
     "git:stage": "node scripts/git-stage.js",
     "git:commit": "node scripts/git-commit.js",
-    "git:push": "node scripts/git-push.js",
+    "git:push": "bin/git-push.sh",
     "rollback": "node scripts/rollback.mjs",
     "cleanup": "node scripts/cleanup.js",
     "cleanup:clean": "node scripts/cleanup.js --clean",

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -210,7 +210,9 @@ function printRemediation() {
   console.error(
     `- If service-account auth failed: confirm ${process.env.OP_AGENT_RUNTIME_FILE || DEFAULT_AGENT_RUNTIME_FILE} has OP_AGENT_SERVICE_ACCOUNT_TOKEN, then run npm run op:agent-doctor.`,
   );
-  console.error('- App private-key rotation is a Tim manual action; no automated repair is attempted.');
+  console.error(
+    '- App private-key rotation is a Tim manual action; no automated repair is attempted.',
+  );
 }
 
 function checkSshLane(failures) {

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -566,15 +566,17 @@ function checkPushLane(failures) {
   const preSecretProbeEnv = {
     OP_AGENT_RUNTIME_FILE: '/private/tmp/governada-git-push-policy-probe-no-secret-env',
   };
+  const pushPolicyPrefix =
+    'BLOCKED: bin/git-push.sh allows only governed Governada branch publication';
   const mainBlocked = runGitPush(['origin', 'main'], preSecretProbeEnv);
-  if (mainBlocked.status === 0 || !firstLine(mainBlocked.stderr).startsWith('BLOCKED:')) {
+  if (mainBlocked.status === 0 || !firstLine(mainBlocked.stderr).startsWith(pushPolicyPrefix)) {
     failures.push(`bin/git-push.sh did not block push to main: ${resultSummary(mainBlocked)}`);
     return;
   }
   console.log('OK: bin/git-push.sh blocks push to main before secret resolution');
 
   const forceBlocked = runGitPush(['--force', 'origin', 'feat/something'], preSecretProbeEnv);
-  if (forceBlocked.status === 0 || !firstLine(forceBlocked.stderr).startsWith('BLOCKED:')) {
+  if (forceBlocked.status === 0 || !firstLine(forceBlocked.stderr).startsWith(pushPolicyPrefix)) {
     failures.push(`bin/git-push.sh did not block force-push: ${resultSummary(forceBlocked)}`);
     return;
   }

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -10,7 +10,7 @@ const EXPECTED_USER = 'tim-governada';
 const ADDENDUM =
   '[[decisions/lean-agent-harness#addendum-4-2026-05-05--pivot-from-user-pat-to-github-app-for-autonomous-agent-operations]]';
 const API_REPO = 'governada/app';
-const PUSH_PROBE_BRANCH = 'feat/gh-auth-doctor-probe';
+const PUSH_PROBE_REFSPEC = 'HEAD:refs/heads/feat/gh-auth-doctor-probe';
 const GH_WRAPPER = path.join(repoRoot, 'bin', 'gh.sh');
 const GIT_PUSH_WRAPPER = path.join(repoRoot, 'bin', 'git-push.sh');
 const OP_AGENT_DOCTOR = path.join(repoRoot, 'scripts', 'op-agent-doctor.mjs');
@@ -554,10 +554,10 @@ function checkApiLane(failures) {
 }
 
 function checkPushLane(failures) {
-  const dryRun = runGitPush(['--dry-run', 'origin', PUSH_PROBE_BRANCH]);
+  const dryRun = runGitPush(['--dry-run', 'origin', PUSH_PROBE_REFSPEC]);
   assertNoDesktopPromptShape(dryRun, failures, 'git push dry-run');
   if (dryRun.status === 0) {
-    console.log(`OK: bin/git-push.sh dry-run push capability passed for ${PUSH_PROBE_BRANCH}`);
+    console.log(`OK: bin/git-push.sh dry-run push capability passed for ${PUSH_PROBE_REFSPEC}`);
   } else {
     failures.push(`git push dry-run failed: ${resultSummary(dryRun)}`);
     return;

--- a/scripts/gh-auth-status.js
+++ b/scripts/gh-auth-status.js
@@ -8,14 +8,21 @@ const { repoRoot, runCommand } = require('./lib/runtime');
 const CANONICAL_REMOTE = 'git@github-governada:governada/app.git';
 const EXPECTED_USER = 'tim-governada';
 const ADDENDUM =
-  '[[decisions/lean-agent-harness#addendum-3-2026-05-04--agent-sa-reads-the-github-pat-revises-addenda-1-and-2]]';
+  '[[decisions/lean-agent-harness#addendum-4-2026-05-05--pivot-from-user-pat-to-github-app-for-autonomous-agent-operations]]';
 const API_REPO = 'governada/app';
+const PUSH_PROBE_BRANCH = 'feat/gh-auth-doctor-probe';
 const GH_WRAPPER = path.join(repoRoot, 'bin', 'gh.sh');
+const GIT_PUSH_WRAPPER = path.join(repoRoot, 'bin', 'git-push.sh');
 const OP_AGENT_DOCTOR = path.join(repoRoot, 'scripts', 'op-agent-doctor.mjs');
+const MINT_HELPER = path.join(repoRoot, 'scripts', 'mint-installation-token.mjs');
 const ENV_REFS_FILE = '.env.local.refs';
 const DEFAULT_AGENT_RUNTIME_FILE = '/Users/tim/dev/agent-runtime/env/governada-agent.env';
-const EXPECTED_GH_TOKEN_OP_REF = 'op://Governada-Agent/governada-app-agent/credential';
 const DESKTOP_PROMPT_PATTERN = /touch id|passcode|biometric|1password desktop|desktop app|prompt/i;
+const APP_REF_KEYS = [
+  'GOVERNADA_GITHUB_CLIENT_ID_OP_REF',
+  'GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF',
+  'GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF',
+];
 
 function firstLine(text) {
   return (
@@ -35,11 +42,9 @@ function outputOf(result) {
 
 function redactSensitiveText(text) {
   return String(text || '')
-    .replace(
-      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/gu,
-      '[redacted-github-token]',
-    )
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{12,}\b/gu, '[redacted-github-token]')
     .replace(/\bops_[A-Za-z0-9_=-]{20,}\b/gu, '[redacted-op-token]')
+    .replace(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/gu, '[redacted-pem]')
     .replace(/op:\/\/[^\s'"]+/gu, 'op://[redacted]')
     .replace(/\bitem [^:\s]+/gu, 'item [redacted]')
     .replace(/\bvault [a-z0-9]{20,}/gu, 'vault [redacted]');
@@ -141,15 +146,6 @@ function parseHttpStatus(output) {
   return lastMatch ? Number.parseInt(lastMatch[1], 10) : 0;
 }
 
-function headerValues(output, headerName) {
-  const prefix = `${headerName.toLowerCase()}:`;
-  return String(output || '')
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) => line.toLowerCase().startsWith(prefix))
-    .map((line) => line.slice(prefix.length).trim());
-}
-
 function resultSummary(result) {
   return firstLine(redactSensitiveText(outputOf(result))) || `exit ${result.status}`;
 }
@@ -163,6 +159,35 @@ function runGhApi(args, env = {}) {
     },
     stripDisabledLocalProxyEnv: true,
     timeoutMs: 90000,
+  });
+}
+
+function runGitPush(args, env = {}) {
+  return runCommand(GIT_PUSH_WRAPPER, args, {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stripDisabledLocalProxyEnv: true,
+    timeoutMs: 90000,
+  });
+}
+
+function runOpRead(opRef, agentToken) {
+  const env = {
+    ...process.env,
+    OP_SERVICE_ACCOUNT_TOKEN: agentToken,
+  };
+  delete env.OP_AGENT_SERVICE_ACCOUNT_TOKEN;
+  delete env.OP_ACCOUNT;
+  delete env.OP_CONNECT_HOST;
+  delete env.OP_CONNECT_TOKEN;
+
+  return runCommand('op', ['read', opRef], {
+    cwd: repoRoot,
+    env,
+    timeoutMs: 30000,
   });
 }
 
@@ -180,13 +205,12 @@ function printRemediation() {
     '- If SSH failed: enable/unlock 1Password SSH agent and verify ssh -T git@github-governada.',
   );
   console.error(
-    '- If API failed: confirm GH_TOKEN_OP_REF points at the Governada-Agent/governada-app-agent credential.',
+    '- If App auth failed: confirm the three GitHub App op-refs, App installation permissions, and governada-agent-app item per Addendum #4.',
   );
   console.error(
     `- If service-account auth failed: confirm ${process.env.OP_AGENT_RUNTIME_FILE || DEFAULT_AGENT_RUNTIME_FILE} has OP_AGENT_SERVICE_ACCOUNT_TOKEN, then run npm run op:agent-doctor.`,
   );
-  console.error(`- If PR-create failed: confirm the PAT has pull_requests:write per ${ADDENDUM}.`);
-  console.error('- Token rotation is a Tim manual action; no automated repair is attempted.');
+  console.error('- App private-key rotation is a Tim manual action; no automated repair is attempted.');
 }
 
 function checkSshLane(failures) {
@@ -255,33 +279,34 @@ function checkSshLane(failures) {
   console.log('OK: SSH + 1Password git lane passed');
 }
 
-function checkAgentServiceAccountRuntime(failures) {
+function agentServiceAccountToken(failures) {
   const runtimeFile = process.env.OP_AGENT_RUNTIME_FILE || DEFAULT_AGENT_RUNTIME_FILE;
   if (!fs.existsSync(runtimeFile)) {
     failures.push(
       `${runtimeFile} is missing; configure OP_AGENT_SERVICE_ACCOUNT_TOKEN per ${ADDENDUM}.`,
     );
-    return;
+    return '';
   }
 
   const stat = fs.statSync(runtimeFile);
   if ((stat.mode & 0o077) !== 0) {
     failures.push(`${runtimeFile} is group/world readable; run chmod 600 before using it.`);
-    return;
+    return '';
   }
 
   const token = parseEnvFile(runtimeFile).OP_AGENT_SERVICE_ACCOUNT_TOKEN || '';
   if (!token) {
     failures.push(`${runtimeFile} does not contain OP_AGENT_SERVICE_ACCOUNT_TOKEN.`);
-    return;
+    return '';
   }
 
   if (!token.startsWith('ops_')) {
     failures.push('OP_AGENT_SERVICE_ACCOUNT_TOKEN does not have the expected ops_ shape.');
-    return;
+    return '';
   }
 
   console.log('OK: agent service account env file is present and owner-only');
+  return token;
 }
 
 function checkWrapperNoDesktopAuth(failures) {
@@ -389,75 +414,125 @@ function checkWrapperCapabilityPolicy(failures) {
   console.log('OK: bin/gh.sh capability allowlist blocks token, merge, and unsafe API commands');
 }
 
+function checkAppOpRefs(failures) {
+  const refs = {};
+  for (const key of APP_REF_KEYS) {
+    const resolved = resolveEnvValue(key);
+    if (!resolved.value) {
+      failures.push(`${key} is missing. Configure it per ${ADDENDUM}.`);
+      return null;
+    }
+    if (!resolved.value.startsWith('op://')) {
+      failures.push(`${key} must be an op:// 1Password reference.`);
+      return null;
+    }
+    refs[key] = resolved.value;
+  }
+
+  console.log('OK: GitHub App op-refs configured (values redacted)');
+  return refs;
+}
+
+function readAppSecrets(refs, agentToken, failures) {
+  const secrets = {};
+  const mapping = {
+    GOVERNADA_GITHUB_CLIENT_ID_OP_REF: 'GOVERNADA_GITHUB_CLIENT_ID',
+    GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF: 'GOVERNADA_GITHUB_INSTALLATION_ID',
+    GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF: 'GOVERNADA_GITHUB_APP_PRIVATE_KEY',
+  };
+
+  for (const [refKey, envKey] of Object.entries(mapping)) {
+    const result = runOpRead(refs[refKey], agentToken);
+    assertNoDesktopPromptShape(result, failures, `op read ${refKey}`);
+    if (result.status !== 0) {
+      failures.push(`agent SA could not read ${refKey}: ${resultSummary(result)}`);
+      return null;
+    }
+    secrets[envKey] = result.stdout.trim();
+  }
+
+  if (!/^-----BEGIN (RSA )?PRIVATE KEY-----/u.test(secrets.GOVERNADA_GITHUB_APP_PRIVATE_KEY)) {
+    failures.push('agent SA read private_key, but it does not have a PEM private-key shape.');
+    return null;
+  }
+
+  console.log('OK: agent SA reads GitHub App private key (value not printed)');
+  return secrets;
+}
+
+function checkMintHelper(secrets, failures) {
+  const result = runCommand(process.execPath, [MINT_HELPER], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...secrets,
+    },
+    stripDisabledLocalProxyEnv: true,
+    timeoutMs: 90000,
+  });
+
+  assertNoDesktopPromptShape(result, failures, 'installation-token mint');
+  const token = result.stdout.trim();
+  if (result.status !== 0) {
+    failures.push(`installation-token mint failed: ${resultSummary(result)}`);
+    return;
+  }
+  if (!/^ghs_[A-Za-z0-9_]+$/u.test(token)) {
+    failures.push('installation-token mint did not return the expected ghs_ token shape.');
+    return;
+  }
+
+  console.log('OK: JWT mint and installation-token mint succeeded (ghs_ token shape)');
+}
+
 function checkApiLane(failures) {
   const apiFailuresAtStart = failures.length;
-  const opRef = resolveEnvValue('GH_TOKEN_OP_REF');
-  const rotateAfter = resolveEnvValue('GH_TOKEN_ROTATE_AFTER');
-
-  if (!opRef.value) {
-    failures.push(`GH_TOKEN_OP_REF is missing. Configure it per ${ADDENDUM}.`);
-    return;
-  }
-
-  if (!opRef.value.startsWith('op://')) {
-    failures.push('GH_TOKEN_OP_REF must be an op:// 1Password reference.');
-    return;
-  }
-
-  console.log(`OK: GH_TOKEN_OP_REF configured (${opRef.source}; value redacted)`);
-
-  const wrapperEnv = {
-    GH_TOKEN_OP_REF: opRef.value,
-  };
-  if (rotateAfter.value) {
-    wrapperEnv.GH_TOKEN_ROTATE_AFTER = rotateAfter.value;
-  }
-
-  const userProbe = runGhApi(['api', 'user', '--jq', '.login'], wrapperEnv);
+  const userProbe = runGhApi(['api', 'user', '--jq', '.login']);
   assertNoDesktopPromptShape(userProbe, failures, 'bin/gh.sh api user');
   if (failures.length > apiFailuresAtStart) {
     return;
   }
-  if (userProbe.status === 0 && userProbe.stdout.trim() === EXPECTED_USER) {
-    console.log('OK: bin/gh.sh resolved GH_TOKEN via service-account auth (no Desktop prompt)');
+  if (userProbe.status === 0 && firstLine(userProbe.stdout)) {
+    console.log(`OK: bin/gh.sh authenticates as ${firstLine(userProbe.stdout)} via App token`);
+  } else if (
+    userProbe.status !== 0 &&
+    outputOf(userProbe).includes('Resource not accessible by integration')
+  ) {
+    console.log('OK: App installation token minted; GitHub rejects user-only /user endpoint');
   } else {
     failures.push(`gh API user probe failed: ${resultSummary(userProbe)}`);
     return;
   }
 
-  const repoRead = runGhApi(['api', `repos/${API_REPO}`, '-i'], wrapperEnv);
+  const repoRead = runGhApi(['api', `repos/${API_REPO}`, '--jq', '.full_name']);
   assertNoDesktopPromptShape(repoRead, failures, `repos/${API_REPO} read`);
   if (failures.length > apiFailuresAtStart) {
     return;
   }
-  const repoReadStatus = parseHttpStatus(`${repoRead.stdout}\n${repoRead.stderr}`);
-  if (repoRead.status === 0 && repoReadStatus === 200) {
+  if (repoRead.status === 0 && repoRead.stdout.trim() === API_REPO) {
     console.log(`OK: gh API can read repos/${API_REPO}`);
   } else {
     failures.push(`gh API read failed: ${resultSummary(repoRead)}`);
     return;
   }
 
-  const prCreateProbe = runGhApi(
-    [
-      'api',
-      '-i',
-      '-X',
-      'POST',
-      `repos/${API_REPO}/pulls`,
-      '-f',
-      'title=Governada auth capability probe',
-      '-f',
-      'head=governada:__governada_auth_probe_missing_head__',
-      '-f',
-      'base=main',
-      '-F',
-      'draft=true',
-      '-f',
-      `body=Capability probe for ${ADDENDUM}. Expected result is validation failure, not PR creation.`,
-    ],
-    wrapperEnv,
-  );
+  const prCreateProbe = runGhApi([
+    'api',
+    '-i',
+    '-X',
+    'POST',
+    `repos/${API_REPO}/pulls`,
+    '-f',
+    'title=Governada auth capability probe',
+    '-f',
+    'head=governada:__governada_auth_probe_missing_head__',
+    '-f',
+    'base=main',
+    '-F',
+    'draft=true',
+    '-f',
+    `body=Capability probe for ${ADDENDUM}. Expected result is validation failure, not PR creation.`,
+  ]);
   const prProbeOutput = `${prCreateProbe.stdout}\n${prCreateProbe.stderr}`;
   assertNoDesktopPromptShape(prCreateProbe, failures, 'PR-create capability probe');
   if (failures.length > apiFailuresAtStart) {
@@ -466,85 +541,62 @@ function checkApiLane(failures) {
   const prProbeStatus = parseHttpStatus(prProbeOutput);
 
   if (prProbeStatus === 422) {
-    const acceptedPermissions = headerValues(prProbeOutput, 'x-accepted-github-permissions').join(
-      '; ',
-    );
-    if (acceptedPermissions && !acceptedPermissions.includes('pull_requests=write')) {
-      failures.push(`PAT lacks pull_requests:write - rotate per ${ADDENDUM}.`);
-      return;
-    }
-
-    // GitHub does not expose a stable granted-permissions header for every token type.
-    // A 422 from the PR-create endpoint with a deliberately missing head proves the
-    // token reached create-pull-request validation instead of failing authz at 401/403.
     console.log('OK: gh API PR-create capability reached validation (pull_requests:write)');
-    checkTokenRotation(rotateAfter, failures);
     return;
   }
 
   if (prProbeStatus === 401 || prProbeStatus === 403) {
-    failures.push(`PAT lacks pull_requests:write - rotate per ${ADDENDUM}.`);
+    failures.push(`App installation lacks pull_requests:write - review ${ADDENDUM}.`);
     return;
   }
 
   failures.push(`gh API PR-create capability probe failed: ${resultSummary(prCreateProbe)}`);
 }
 
-function checkTokenRotation(rotateAfter, failures) {
-  if (!rotateAfter.value) {
-    failures.push('GH_TOKEN_ROTATE_AFTER is missing.');
+function checkPushLane(failures) {
+  const dryRun = runGitPush(['--dry-run', 'origin', PUSH_PROBE_BRANCH]);
+  assertNoDesktopPromptShape(dryRun, failures, 'git push dry-run');
+  if (dryRun.status === 0) {
+    console.log(`OK: bin/git-push.sh dry-run push capability passed for ${PUSH_PROBE_BRANCH}`);
+  } else {
+    failures.push(`git push dry-run failed: ${resultSummary(dryRun)}`);
     return;
   }
 
-  const rotationDate = new Date(`${rotateAfter.value}T00:00:00Z`);
-  if (Number.isNaN(rotationDate.getTime())) {
-    failures.push(`GH_TOKEN_ROTATE_AFTER is not a valid YYYY-MM-DD date: ${rotateAfter.value}`);
+  const preSecretProbeEnv = {
+    OP_AGENT_RUNTIME_FILE: '/private/tmp/governada-git-push-policy-probe-no-secret-env',
+  };
+  const mainBlocked = runGitPush(['origin', 'main'], preSecretProbeEnv);
+  if (mainBlocked.status === 0 || !firstLine(mainBlocked.stderr).startsWith('BLOCKED:')) {
+    failures.push(`bin/git-push.sh did not block push to main: ${resultSummary(mainBlocked)}`);
     return;
   }
+  console.log('OK: bin/git-push.sh blocks push to main before secret resolution');
 
-  const daysUntilRotation = Math.ceil((rotationDate.getTime() - Date.now()) / 86_400_000);
-  if (daysUntilRotation < 0) {
-    failures.push(
-      `GH_TOKEN_ROTATE_AFTER is past due: ${rotateAfter.value}. Rotate per ${ADDENDUM}.`,
-    );
+  const forceBlocked = runGitPush(['--force', 'origin', 'feat/something'], preSecretProbeEnv);
+  if (forceBlocked.status === 0 || !firstLine(forceBlocked.stderr).startsWith('BLOCKED:')) {
+    failures.push(`bin/git-push.sh did not block force-push: ${resultSummary(forceBlocked)}`);
     return;
   }
-
-  if (daysUntilRotation <= 14) {
-    console.warn(
-      `WARN: GH_TOKEN_ROTATE_AFTER is within ${daysUntilRotation} day(s): ${rotateAfter.value}.`,
-    );
-    return;
-  }
-
-  console.log(
-    `OK: GH_TOKEN_ROTATE_AFTER ${rotateAfter.value} is outside the 14-day warning window`,
-  );
-}
-
-function checkExpectedVaultLocation(failures) {
-  const opRef = resolveEnvValue('GH_TOKEN_OP_REF');
-  if (opRef.value && opRef.value.includes('Governada-Human/governada-app-agent')) {
-    failures.push(`GH_TOKEN_OP_REF still points at Governada-Human; update it per ${ADDENDUM}.`);
-    return;
-  }
-
-  if (opRef.value && opRef.value !== EXPECTED_GH_TOKEN_OP_REF) {
-    failures.push(`GH_TOKEN_OP_REF must be ${EXPECTED_GH_TOKEN_OP_REF} per ${ADDENDUM}.`);
-  }
+  console.log('OK: bin/git-push.sh blocks force-push before secret resolution');
 }
 
 function main() {
   const failures = [];
 
-  console.log('GitHub auth: SSH + 1Password and GH_TOKEN_OP_REF probes');
+  console.log('GitHub auth: SSH + 1Password and GitHub App installation-token probes');
   checkSshLane(failures);
-  checkAgentServiceAccountRuntime(failures);
+  const agentToken = agentServiceAccountToken(failures);
   checkWrapperNoDesktopAuth(failures);
   checkOpAgentDoctorNoDesktopAuth(failures);
   checkWrapperCapabilityPolicy(failures);
-  checkExpectedVaultLocation(failures);
+  const refs = checkAppOpRefs(failures);
+  const secrets = refs && agentToken ? readAppSecrets(refs, agentToken, failures) : null;
+  if (secrets) {
+    checkMintHelper(secrets, failures);
+  }
   checkApiLane(failures);
+  checkPushLane(failures);
 
   if (failures.length > 0) {
     for (const failure of failures) {

--- a/scripts/mint-installation-token.mjs
+++ b/scripts/mint-installation-token.mjs
@@ -52,9 +52,7 @@ export function mintAppJwt({ clientId, privateKey, now = Math.floor(Date.now() /
     iat: now - 60,
     exp: now + 540,
   };
-  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(
-    JSON.stringify(payload),
-  )}`;
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(payload))}`;
   const signer = createSign('RSA-SHA256');
   signer.update(signingInput);
   signer.end();
@@ -82,9 +80,7 @@ export async function requestInstallationToken({
 
   const jwt = mintAppJwt({ clientId, privateKey });
   const response = await fetchImpl(
-    `https://api.github.com/app/installations/${encodeURIComponent(
-      installationId,
-    )}/access_tokens`,
+    `https://api.github.com/app/installations/${encodeURIComponent(installationId)}/access_tokens`,
     {
       method: 'POST',
       headers: {
@@ -108,7 +104,9 @@ export async function requestInstallationToken({
 
   if (response.status !== 201) {
     const detail = redactSensitiveText(JSON.stringify(body));
-    throw new Error(`GitHub installation-token mint failed with HTTP ${response.status}: ${detail}`);
+    throw new Error(
+      `GitHub installation-token mint failed with HTTP ${response.status}: ${detail}`,
+    );
   }
 
   if (!body?.token || typeof body.token !== 'string') {

--- a/scripts/mint-installation-token.mjs
+++ b/scripts/mint-installation-token.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { createSign } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_ENV = [
+  'GOVERNADA_GITHUB_CLIENT_ID',
+  'GOVERNADA_GITHUB_INSTALLATION_ID',
+  'GOVERNADA_GITHUB_APP_PRIVATE_KEY',
+];
+
+function base64Url(input) {
+  return Buffer.from(input)
+    .toString('base64')
+    .replaceAll('=', '')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_');
+}
+
+function redactSensitiveText(text) {
+  return String(text || '')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{12,}\b/gu, '[redacted-github-token]')
+    .replace(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/gu, '[redacted-pem]')
+    .replace(/"token"\s*:\s*"[^"]+"/gu, '"token":"[redacted-github-token]"');
+}
+
+export function normalizePrivateKey(privateKey) {
+  const normalized = privateKey.replace(/\\n/gu, '\n').replace(/\\r/gu, '\r').trim();
+  if (normalized.includes('\n')) {
+    return normalized;
+  }
+
+  const match = normalized.match(/^(-----BEGIN [^-]+-----)(.+)(-----END [^-]+-----)$/u);
+  if (!match) {
+    return normalized;
+  }
+
+  const [, begin, body, end] = match;
+  const wrappedBody = body
+    .replace(/\s/gu, '')
+    .match(/.{1,64}/gu)
+    ?.join('\n');
+
+  return `${begin}\n${wrappedBody || body}\n${end}`;
+}
+
+export function mintAppJwt({ clientId, privateKey, now = Math.floor(Date.now() / 1000) }) {
+  const normalizedPrivateKey = normalizePrivateKey(privateKey);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: clientId,
+    iat: now - 60,
+    exp: now + 540,
+  };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(
+    JSON.stringify(payload),
+  )}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(normalizedPrivateKey);
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+function validateEnv(env) {
+  for (const key of REQUIRED_ENV) {
+    if (!env[key]) {
+      throw new Error(`${key} is missing.`);
+    }
+  }
+}
+
+export async function requestInstallationToken({
+  clientId,
+  installationId,
+  privateKey,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('global fetch is not available.');
+  }
+
+  const jwt = mintAppJwt({ clientId, privateKey });
+  const response = await fetchImpl(
+    `https://api.github.com/app/installations/${encodeURIComponent(
+      installationId,
+    )}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'governada-agent-app-token-minter',
+      },
+    },
+  );
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new Error(
+      `GitHub installation-token response was not JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (response.status !== 201) {
+    const detail = redactSensitiveText(JSON.stringify(body));
+    throw new Error(`GitHub installation-token mint failed with HTTP ${response.status}: ${detail}`);
+  }
+
+  if (!body?.token || typeof body.token !== 'string') {
+    throw new Error('GitHub installation-token response did not include a token.');
+  }
+
+  return body.token;
+}
+
+export async function main(env = process.env, fetchImpl = globalThis.fetch) {
+  validateEnv(env);
+  const token = await requestInstallationToken({
+    clientId: env.GOVERNADA_GITHUB_CLIENT_ID,
+    installationId: env.GOVERNADA_GITHUB_INSTALLATION_ID,
+    privateKey: env.GOVERNADA_GITHUB_APP_PRIVATE_KEY,
+    fetchImpl,
+  });
+  process.stdout.write(`${token}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(redactSensitiveText(`BLOCKED: ${message}`));
+    process.exit(1);
+  });
+}

--- a/scripts/op-agent-doctor.mjs
+++ b/scripts/op-agent-doctor.mjs
@@ -174,7 +174,7 @@ function redactSensitiveText(text, sensitiveValues = []) {
   return redacted
     .replace(/\bops_[A-Za-z0-9_=-]{20,}\b/gu, '[redacted-op-service-account-token]')
     .replace(
-      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/gu,
+      /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu,
       '[redacted-token]',
     )
     .replace(/op:\/\/[^\r\n'"]+/gu, 'op://[redacted]');

--- a/scripts/op-agent-doctor.mjs
+++ b/scripts/op-agent-doctor.mjs
@@ -173,10 +173,7 @@ function redactSensitiveText(text, sensitiveValues = []) {
 
   return redacted
     .replace(/\bops_[A-Za-z0-9_=-]{20,}\b/gu, '[redacted-op-service-account-token]')
-    .replace(
-      /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu,
-      '[redacted-token]',
-    )
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu, '[redacted-token]')
     .replace(/op:\/\/[^\r\n'"]+/gu, 'op://[redacted]');
 }
 

--- a/scripts/repair-gh-auth.mjs
+++ b/scripts/repair-gh-auth.mjs
@@ -29,7 +29,7 @@ console.error('');
 console.error('Auth repair hint: this repo uses two lanes.');
 console.error('  - git push/pull: SSH + 1Password Desktop (probed by SSH lines above)');
 console.error(
-  '  - GitHub API: GH_TOKEN_OP_REF resolved via bin/gh.sh using the agent service account',
+  '  - Autonomous GitHub API + branch publication: GitHub App installation tokens minted by bin/gh.sh and bin/git-push.sh',
 );
 console.error(
   '1. If SSH probe failed: open 1Password Developer -> SSH agent. Run: ssh -T git@github-governada',
@@ -42,12 +42,12 @@ console.error(
 );
 console.error('   - Run: npm run op:agent-doctor.');
 console.error(
-  '   - Check .env.local.refs has GH_TOKEN_OP_REF=op://Governada-Agent/governada-app-agent/credential.',
+  '   - Check .env.local.refs has GOVERNADA_GITHUB_CLIENT_ID_OP_REF, GOVERNADA_GITHUB_INSTALLATION_ID_OP_REF, and GOVERNADA_GITHUB_APP_PRIVATE_KEY_OP_REF.',
 );
 console.error(
-  '   - If 401/403 from gh API: PAT scope is wrong. See [[decisions/lean-agent-harness#addendum-3]].',
+  '   - If 401/403 from gh API: App installation permissions or private-key material are wrong. See [[decisions/lean-agent-harness#addendum-4]].',
 );
 console.error('No GitHub token, Keychain cache, LaunchAgent, or broker repair is attempted.');
-console.error('No automated rotation is performed - token rotation is a Tim manual action.');
+console.error('No automated private-key rotation is performed - App private-key rotation is a Tim manual action.');
 
 process.exit(result.status ?? 1);

--- a/scripts/repair-gh-auth.mjs
+++ b/scripts/repair-gh-auth.mjs
@@ -48,6 +48,8 @@ console.error(
   '   - If 401/403 from gh API: App installation permissions or private-key material are wrong. See [[decisions/lean-agent-harness#addendum-4]].',
 );
 console.error('No GitHub token, Keychain cache, LaunchAgent, or broker repair is attempted.');
-console.error('No automated private-key rotation is performed - App private-key rotation is a Tim manual action.');
+console.error(
+  'No automated private-key rotation is performed - App private-key rotation is a Tim manual action.',
+);
 
 process.exit(result.status ?? 1);

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -188,7 +188,7 @@ function redactSensitiveText(text) {
   return String(text)
     .replace(/op:\/\/[^\s'"`]+/gu, 'op://[redacted]')
     .replace(
-      /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/gu,
+      /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu,
       '[redacted-token]',
     );
 }

--- a/scripts/session-doctor.js
+++ b/scripts/session-doctor.js
@@ -187,10 +187,7 @@ function outputOf(result) {
 function redactSensitiveText(text) {
   return String(text)
     .replace(/op:\/\/[^\s'"`]+/gu, 'op://[redacted]')
-    .replace(
-      /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu,
-      '[redacted-token]',
-    );
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/gu, '[redacted-token]');
 }
 
 function firstLine(text) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         resolve: sharedResolve,
         test: {
           name: 'unit',
-          include: ['__tests__/**/*.test.ts'],
+          include: ['__tests__/**/*.test.ts', '__tests__/**/*.test.mjs'],
           environment: 'node',
         },
       },


### PR DESCRIPTION
## Summary

- Implements ADR Addendum #4 by replacing the autonomous GitHub user-token lane with GitHub App installation-token minting.
- Adds `scripts/mint-installation-token.mjs` for in-process JWT + installation-token minting and `bin/git-push.sh` for governed HTTPS branch publication.
- Updates the App auth doctor, agent auth docs, `AGENTS.md`, and `.env.local.refs` to the three App op-refs.

## Existing Code Audit

- Preserved the existing `bin/gh.sh` capability allowlist, token-oracle blocks, and redaction posture while swapping the credential materialization layer.
- Removed live runtime references to the old token ref and old token prefix outside historical archive docs.
- Kept archived Phase 0B machinery archived: no LaunchAgent, no Keychain helper, no broker, no cache, no fallback lane.

## Robustness

- Unit coverage added for successful minting, missing env, malformed PEM, GitHub API 401 redaction, JWT claims/RS256 shape, escaped-newline PEM values, and one-line concealed PEM values.
- `gh-auth-status` now probes: SSH lane, agent SA runtime, wrapper policy blocks before secret resolution, App op-refs, private-key read, JWT/install-token mint, repo API read, PR-create capability validation, dry-run branch publication, push-to-main block, and force-push block.
- Push-negative probes now require the exact `bin/git-push.sh` policy prefix so a fallthrough to later secret-resolution errors does not count as a pass.

## Impact

- After merge, future autonomous agent flows can mint App installation tokens for API work and branch publication without biometric prompts.
- Tim still owns manual merge/deploy/rotation gates. This PR does not revoke the old token; that remains a Tim post-merge audit action.
- Note: `gh api user` returns `403 Resource not accessible by integration` with GitHub App installation tokens because `/user` is user-token-only. The doctor records this semantic and verifies installation identity through `repos/governada/app` plus PR-create validation.

## Verification

- `node --check scripts/mint-installation-token.mjs`
- `bash -n bin/gh.sh bin/git-push.sh`
- `npm run test:unit -- __tests__/scripts/mint-installation-token.test.mjs` — 7 tests passed
- `npm run agent:validate` — passed
- `rg -n "GH_TOKEN_OP_REF|github_pat_" bin scripts docs AGENTS.md .env.local.refs --glob '!docs/archive/**'` — no matches
- `bin/gh.sh api repos/governada/app --jq .full_name` — `governada/app`
- `bin/git-push.sh --dry-run origin HEAD:refs/heads/feat/gh-auth-doctor-probe` — succeeded
- `bin/git-push.sh origin main` — blocked before secret resolution
- `bin/git-push.sh --force origin feat/something` — blocked before secret resolution
- `npm run gh:auth-status` — green, including App private-key read, JWT mint, installation-token mint, API read, dry-run push, push-to-main blocked, force-push blocked
- Five consecutive `npm run gh:auth-status` runs — all green, prompt-pattern grep quiet

## Review Fixes

- Disabled git hooks for the token-bearing `bin/git-push.sh` invocation with `HUSKY=0` and `-c core.hooksPath=/dev/null`, so repo-controlled hook code cannot inherit the App installation token.
- Made the push doctor self-contained by dry-running `HEAD:refs/heads/feat/gh-auth-doctor-probe` instead of relying on a preexisting local feature branch.
- Kept explicit refspec support narrow: source must be `HEAD`, target must be `refs/heads/feat/*` or `refs/heads/codex/*`, and protected/force/delete refspecs still fail closed before secret resolution.

## Regression-Catch Evidence

- Push-negative probes now assert the exact branch-publication policy prefix, not a generic `BLOCKED:` prefix.
- Control commands with a bogus `OP_AGENT_RUNTIME_FILE` proved `origin main` and `--force origin feat/something` stop at wrapper policy before any secret resolution.

## Tim Audits Before Merge Consideration

- [ ] GitHub App `governada-agent-read-pilot` is installed only on `governada/app`, with the documented permissions and no others.
- [ ] `governada-agent-app` 1Password item exists in `Governada-Agent` vault with all three fields populated.
- [ ] `Governada-Agent` vault now contains exactly: `governada-posthog-staging`, `governada-app-agent` (old token, to be revoked post-merge), `governada-agent-app` (the new App credential).
- [ ] `Governada-Human` vault is unchanged (still contains all production-touching credentials).
- [ ] Five successive `npm run gh:auth-status` runs produce zero biometric prompts.
- [ ] After merge: revoke the old user token on github.com (`governada-app-agent`).
- [ ] After merge: delete the `governada-app-agent` 1Password item from `Governada-Agent`.
