### PR TITLE
[codex] Fix cleanup branch parsing

### DIFF
--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -122,6 +122,34 @@ function getBranchTrackingRemote(branch) {
   return result.status === 0 ? result.stdout.trim() : '';
 }
 
+function parseLocalBranches() {
+  const result = runCommand(
+    'git',
+    [
+      'for-each-ref',
+      'refs/heads',
+      '--format=%(refname:short)%09%(upstream:short)%09%(upstream:track)',
+    ],
+    { cwd: repoRoot },
+  );
+  if (result.status !== 0) {
+    return [];
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => {
+      const [name, upstream, track] = line.split('\t');
+      return {
+        name,
+        upstream: upstream || '',
+        track: track || '',
+      };
+    })
+    .filter((branch) => branch.name);
+}
+
 function compareMtime(a, b) {
   if (!fs.existsSync(a) || !fs.existsSync(b)) {
     return null;
@@ -272,24 +300,20 @@ runCommand('git', ['fetch', '--prune', '--quiet'], { cwd: repoRoot });
 
 const goneBranches = [];
 const localOnlyBranches = [];
-const branchResult = runCommand('git', ['branch', '-vv'], { cwd: repoRoot });
-if (branchResult.status === 0) {
-  for (const rawLine of branchResult.stdout.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line) {
-      continue;
-    }
-    const branch = line.replace(/^\*\s*/, '').split(/\s+/)[0];
-    if (branch === 'main' || branch === 'master') {
-      continue;
-    }
-    if (line.includes(': gone]')) {
-      goneBranches.push(branch);
-    } else if (!getBranchTrackingRemote(branch)) {
-      localOnlyBranches.push(branch);
-    }
+for (const branch of parseLocalBranches()) {
+  if (branch.name === 'main' || branch.name === 'master') {
+    continue;
+  }
+
+  if (branch.track.includes('[gone]')) {
+    goneBranches.push(branch.name);
+  } else if (!branch.upstream && !getBranchTrackingRemote(branch.name)) {
+    localOnlyBranches.push(branch.name);
   }
 }
+
+goneBranches.sort();
+localOnlyBranches.sort();
 
 if (goneBranches.length > 0) {
   console.log(


### PR DESCRIPTION
## Summary
- Replace human `git branch -vv` parsing in `scripts/cleanup.js` with structured `git for-each-ref` output.
- Sort stale/local-only branch reports for stable cleanup output.

## Existing Code Audit
- Confirmed the bug came from parsing human-formatted `git branch -vv` output.
- Branches checked out in other worktrees are prefixed with `+`, and the cleanup script treated that marker as the branch name.
- Verified the PR changes only `scripts/cleanup.js`.

## Robustness
- Uses structured Git ref fields instead of display-oriented branch output.
- Preserves existing stale/gone/local-only branch behavior while avoiding fake `+` branch names.
- Keeps report output deterministic by sorting stale and local-only branch lists.

## Impact
- Workspace cleanup reports real branch names and no longer attempts to delete a branch named `+`.
- No runtime application behavior changes.
- Validation: `node --check scripts/cleanup.js`; `npm run cleanup`.