### PR TITLE
[codex] Harden sync health diagnostics

### DIFF
--- a/__tests__/api/health-deep.test.ts
+++ b/__tests__/api/health-deep.test.ts
@@ -6,7 +6,23 @@ const { checkKoiosHealthFast, ping } = vi.hoisted(() => ({
   ping: vi.fn(),
 }));
 
+const mockReadClient = {
+  value: {
+    status: 'healthy',
+    reason: 'ok',
+    message: 'Supabase read-client query succeeded',
+    latencyMs: 1,
+    env: {
+      url: 'present',
+      publishableKey: 'present',
+      legacyAnonKey: 'missing',
+      activeKey: 'publishable',
+    },
+  },
+};
+
 vi.mock('@/lib/supabase', () => ({
+  probeSupabaseReadClient: vi.fn(() => Promise.resolve(mockReadClient.value)),
   getSupabaseAdmin: () => ({
     from: () => ({
       select: vi.fn(() => ({
@@ -36,8 +52,22 @@ function makeReq() {
 
 describe('GET /api/health/deep', () => {
   beforeEach(() => {
+    mockReadClient.value = {
+      status: 'healthy',
+      reason: 'ok',
+      message: 'Supabase read-client query succeeded',
+      latencyMs: 1,
+      env: {
+        url: 'present',
+        publishableKey: 'present',
+        legacyAnonKey: 'missing',
+        activeKey: 'publishable',
+      },
+    };
     checkKoiosHealthFast.mockResolvedValue(true);
     ping.mockResolvedValue('PONG');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'publishable-key');
     vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://governada.io');
     vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@example.ingest.sentry.io/1');
     vi.stubEnv('HEARTBEAT_URL_PROPOSALS', 'https://betterstack.example/proposals');
@@ -54,12 +84,13 @@ describe('GET /api/health/deep', () => {
   it('returns healthy when dependencies and ops wiring are healthy', async () => {
     const response = await GET(makeReq());
     const body = (await parseJson(response)) as {
-      dependencies: { operational_env: { status: string } };
+      dependencies: { operational_env: { status: string }; supabase_read: { status: string } };
       status: string;
     };
 
     expect(response.status).toBe(200);
     expect(body.status).toBe('healthy');
+    expect(body.dependencies.supabase_read.status).toBe('healthy');
     expect(body.dependencies.operational_env.status).toBe('healthy');
   });
 
@@ -80,5 +111,30 @@ describe('GET /api/health/deep', () => {
     expect(body.dependencies.operational_env.missing).toEqual(
       expect.arrayContaining([expect.objectContaining({ key: 'NEXT_PUBLIC_SENTRY_DSN' })]),
     );
+  });
+
+  it('returns critical when the Supabase read client is unhealthy', async () => {
+    mockReadClient.value = {
+      status: 'unhealthy',
+      reason: 'query_error',
+      message: 'Invalid API key',
+      latencyMs: 5,
+      env: {
+        url: 'present',
+        publishableKey: 'present',
+        legacyAnonKey: 'missing',
+        activeKey: 'publishable',
+      },
+    };
+
+    const response = await GET(makeReq());
+    const body = (await parseJson(response)) as {
+      dependencies: { supabase_read: { status: string; reason: string } };
+      status: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe('critical');
+    expect(body.dependencies.supabase_read.reason).toBe('query_error');
   });
 });

--- a/__tests__/api/health-sync.test.ts
+++ b/__tests__/api/health-sync.test.ts
@@ -3,12 +3,29 @@ import { createRequest, parseJson } from '../helpers';
 
 const mockRows = {
   value: [] as Array<Record<string, unknown>>,
+  error: null as { message: string } | null,
+};
+
+const mockReadClient = {
+  value: {
+    status: 'healthy',
+    reason: 'ok',
+    message: 'Supabase read-client query succeeded',
+    latencyMs: 1,
+    env: {
+      url: 'present',
+      publishableKey: 'present',
+      legacyAnonKey: 'missing',
+      activeKey: 'publishable',
+    },
+  },
 };
 
 vi.mock('@/lib/supabase', () => ({
+  probeSupabaseReadClient: vi.fn(() => Promise.resolve(mockReadClient.value)),
   createClient: () => ({
     from: () => ({
-      select: vi.fn(() => Promise.resolve({ data: mockRows.value, error: null })),
+      select: vi.fn(() => Promise.resolve({ data: mockRows.value, error: mockRows.error })),
     }),
   }),
 }));
@@ -18,6 +35,19 @@ import { GET } from '@/app/api/health/sync/route';
 describe('GET /api/health/sync', () => {
   beforeEach(() => {
     mockRows.value = [];
+    mockRows.error = null;
+    mockReadClient.value = {
+      status: 'healthy',
+      reason: 'ok',
+      message: 'Supabase read-client query succeeded',
+      latencyMs: 1,
+      env: {
+        url: 'present',
+        publishableKey: 'present',
+        legacyAnonKey: 'missing',
+        activeKey: 'publishable',
+      },
+    };
     vi.clearAllMocks();
   });
 
@@ -27,6 +57,40 @@ describe('GET /api/health/sync', () => {
 
     expect(res.status).toBe(503);
     expect(body.status).toBe('unknown');
+  });
+
+  it('returns a structured 503 when the read client is unavailable', async () => {
+    mockReadClient.value = {
+      status: 'unhealthy',
+      reason: 'missing_read_key',
+      message: 'Supabase read-client environment is not usable: missing_read_key',
+      latencyMs: 0,
+      env: {
+        url: 'present',
+        publishableKey: 'missing',
+        legacyAnonKey: 'missing',
+        activeKey: 'none',
+      },
+    };
+
+    const res = await GET();
+    const body = (await parseJson(res)) as { status: string; reason: string };
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('error');
+    expect(body.reason).toBe('missing_read_key');
+  });
+
+  it('returns a structured 503 when v_sync_health fails', async () => {
+    mockRows.error = { message: 'permission denied for view v_sync_health' };
+
+    const res = await GET();
+    const body = (await parseJson(res)) as { status: string; reason: string; message: string };
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('error');
+    expect(body.reason).toBe('sync_health_query_error');
+    expect(body.message).toContain('permission denied');
   });
 
   it('keeps proposal sync healthy before the external threshold is crossed', async () => {

--- a/__tests__/api/health.test.ts
+++ b/__tests__/api/health.test.ts
@@ -7,9 +7,22 @@ const mockState = {
   currentEpoch: 0,
   snapshotError: null as Error | null,
   snapshotLatest: {} as Record<string, Record<string, unknown> | null>,
+  readClient: {
+    status: 'healthy',
+    reason: 'ok',
+    message: 'Supabase read-client query succeeded',
+    latencyMs: 1,
+    env: {
+      url: 'present',
+      publishableKey: 'present',
+      legacyAnonKey: 'missing',
+      activeKey: 'publishable',
+    },
+  },
 };
 
 vi.mock('@/lib/supabase', () => ({
+  probeSupabaseReadClient: vi.fn(() => Promise.resolve(mockState.readClient)),
   createClient: () => ({
     from: (table: string) => {
       if (table === 'v_sync_health') {
@@ -78,6 +91,20 @@ describe('GET /api/health', () => {
     mockState.currentEpoch = 0;
     mockState.snapshotError = null;
     mockState.snapshotLatest = {};
+    mockState.readClient = {
+      status: 'healthy',
+      reason: 'ok',
+      message: 'Supabase read-client query succeeded',
+      latencyMs: 1,
+      env: {
+        url: 'present',
+        publishableKey: 'present',
+        legacyAnonKey: 'missing',
+        activeKey: 'publishable',
+      },
+    };
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'publishable-key');
     vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://governada.io');
     vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@example.ingest.sentry.io/1');
     vi.stubEnv('HEARTBEAT_URL_PROPOSALS', 'https://betterstack.example/proposals');
@@ -251,13 +278,38 @@ describe('GET /api/health', () => {
     );
   });
 
-  it('returns 500 on unexpected sync query error', async () => {
+  it('returns structured critical status when the read client is unavailable', async () => {
+    mockState.readClient = {
+      status: 'unhealthy',
+      reason: 'query_error',
+      message: 'Invalid API key',
+      latencyMs: 12,
+      env: {
+        url: 'present',
+        publishableKey: 'present',
+        legacyAnonKey: 'missing',
+        activeKey: 'publishable',
+      },
+    };
+
+    const res = await GET(makeReq());
+    const body = (await parseJson(res)) as { status: string; reason: string; message: string };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('critical');
+    expect(body.reason).toBe('query_error');
+    expect(body.message).toBe('Supabase read client is unavailable');
+  });
+
+  it('returns structured critical status on unexpected sync query error', async () => {
     mockState.syncError = new Error('DB connection failed');
 
     const res = await GET(makeReq());
-    const body = (await parseJson(res)) as { error: string };
+    const body = (await parseJson(res)) as { status: string; reason: string; error: string };
 
-    expect(res.status).toBe(500);
-    expect(body.error).toBe('Internal server error');
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('critical');
+    expect(body.reason).toBe('sync_health_query_exception');
+    expect(body.error).toBe('DB connection failed');
   });
 });

--- a/__tests__/inngest/helpers.test.ts
+++ b/__tests__/inngest/helpers.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { callSyncRoute } from '@/inngest/helpers';
+
+describe('callSyncRoute', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('refuses to fall back to localhost in Railway production', async () => {
+    vi.stubEnv('RAILWAY_ENVIRONMENT_ID', 'env_prod');
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', '');
+    vi.stubEnv('CRON_SECRET', 'cron-secret');
+
+    await expect(callSyncRoute('/api/admin/api-health/alert', 1000)).rejects.toThrow(
+      'NEXT_PUBLIC_SITE_URL not configured',
+    );
+  });
+
+  it('keeps localhost fallback available outside production for local development', async () => {
+    vi.stubEnv('RAILWAY_ENVIRONMENT_ID', '');
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', '');
+    vi.stubEnv('CRON_SECRET', 'cron-secret');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const result = await callSyncRoute('/api/admin/api-health/alert', 1000);
+
+    expect(result.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/admin/api-health/alert',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer cron-secret' },
+      }),
+    );
+  });
+});

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -7,6 +7,8 @@ describe('getOpsEnvReport', () => {
   });
 
   it('reports healthy when all ops-critical wiring is present', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'publishable-key');
     vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://governada.io');
     vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@example.ingest.sentry.io/1');
     vi.stubEnv('HEARTBEAT_URL_PROPOSALS', 'https://betterstack.example/proposals');
@@ -23,6 +25,9 @@ describe('getOpsEnvReport', () => {
   });
 
   it('reports degraded when required ops wiring is missing', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '');
     vi.stubEnv('NEXT_PUBLIC_SITE_URL', '');
     vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', '');
     vi.stubEnv('HEARTBEAT_URL_PROPOSALS', 'https://betterstack.example/proposals');
@@ -36,8 +41,28 @@ describe('getOpsEnvReport', () => {
       expect.arrayContaining([
         expect.objectContaining({ key: 'NEXT_PUBLIC_SITE_URL' }),
         expect.objectContaining({ key: 'NEXT_PUBLIC_SENTRY_DSN' }),
+        expect.objectContaining({ key: 'NEXT_PUBLIC_SUPABASE_URL' }),
       ]),
     );
-    expect(report.missingGroups).toEqual([expect.objectContaining({ name: 'alert_webhook' })]);
+    expect(report.missingGroups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'alert_webhook' }),
+        expect.objectContaining({ name: 'supabase_read_key' }),
+      ]),
+    );
+  });
+
+  it('accepts the legacy anon key for the Supabase read key group', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'legacy-anon-key');
+    vi.stubEnv('NEXT_PUBLIC_SITE_URL', 'https://governada.io');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://public@example.ingest.sentry.io/1');
+    vi.stubEnv('HEARTBEAT_URL_PROPOSALS', 'https://betterstack.example/proposals');
+    vi.stubEnv('HEARTBEAT_URL_BATCH', 'https://betterstack.example/batch');
+    vi.stubEnv('HEARTBEAT_URL_DAILY', 'https://betterstack.example/daily');
+    vi.stubEnv('DISCORD_WEBHOOK_URL', 'https://discord.com/api/webhooks/123/abc');
+
+    expect(getOpsEnvReport().status).toBe('healthy');
   });
 });

--- a/__tests__/lib/supabase-read-client.test.ts
+++ b/__tests__/lib/supabase-read-client.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const supabaseMock = vi.hoisted(() => ({
+  createSupabaseClient: vi.fn(),
+  from: vi.fn(),
+  select: vi.fn(),
+  limit: vi.fn(),
+  abortSignal: vi.fn(),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: supabaseMock.createSupabaseClient,
+}));
+
+import { getSupabaseReadEnvStatus, probeSupabaseReadClient } from '@/lib/supabase';
+
+describe('Supabase read-client diagnostics', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'publishable-key');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '');
+
+    supabaseMock.createSupabaseClient.mockReturnValue({ from: supabaseMock.from });
+    supabaseMock.from.mockReturnValue({ select: supabaseMock.select });
+    supabaseMock.select.mockReturnValue({ limit: supabaseMock.limit });
+    supabaseMock.limit.mockReturnValue({ abortSignal: supabaseMock.abortSignal });
+    supabaseMock.abortSignal.mockResolvedValue({ error: null, status: 200 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('prefers the publishable key when both read keys exist', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'legacy-key');
+
+    expect(getSupabaseReadEnvStatus()).toMatchObject({
+      activeKey: 'publishable',
+      publishableKey: 'present',
+      legacyAnonKey: 'present',
+    });
+  });
+
+  it('accepts the legacy anon key when publishable key is absent', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'legacy-key');
+
+    expect(getSupabaseReadEnvStatus()).toMatchObject({
+      activeKey: 'legacy_anon',
+      publishableKey: 'missing',
+      legacyAnonKey: 'present',
+    });
+  });
+
+  it('fails closed before client creation when the read key is missing', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', '');
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', '');
+
+    const result = await probeSupabaseReadClient();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.reason).toBe('missing_read_key');
+    expect(supabaseMock.createSupabaseClient).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before client creation when the URL is invalid', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'not a url');
+
+    const result = await probeSupabaseReadClient();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.reason).toBe('invalid_url');
+    expect(supabaseMock.createSupabaseClient).not.toHaveBeenCalled();
+  });
+
+  it('surfaces query errors without exposing key values', async () => {
+    supabaseMock.abortSignal.mockResolvedValue({
+      error: { message: 'Invalid API key', code: 'PGRST301', status: 401 },
+      status: 401,
+    });
+
+    const result = await probeSupabaseReadClient();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.reason).toBe('query_error');
+    expect(result.errorCode).toBe('PGRST301');
+    expect(result.httpStatus).toBe(401);
+    expect(JSON.stringify(result)).not.toContain('publishable-key');
+  });
+
+  it('classifies aborts as read-client timeouts', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    supabaseMock.abortSignal.mockRejectedValue(abortError);
+
+    const result = await probeSupabaseReadClient();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.reason).toBe('timeout');
+  });
+});

--- a/__tests__/sync/sync-utils.test.ts
+++ b/__tests__/sync/sync-utils.test.ts
@@ -13,7 +13,14 @@ vi.mock('@/lib/posthog-server', () => ({
   captureServerEvent: vi.fn(),
 }));
 
-import { batchUpsert, errMsg, capMsg, alertDiscord, pingHeartbeat } from '@/lib/sync-utils';
+import {
+  batchUpsert,
+  errMsg,
+  capMsg,
+  alertDiscord,
+  pingHeartbeat,
+  fetchAll,
+} from '@/lib/sync-utils';
 
 describe('sync-utils', () => {
   beforeEach(() => {
@@ -79,6 +86,27 @@ describe('sync-utils', () => {
       const result = await batchUpsert(supabase, 'test', rows, 'id', 'test');
       expect(result.success).toBe(250);
       expect(mockUpsert).toHaveBeenCalledTimes(3); // 100 + 100 + 50
+    });
+  });
+
+  describe('fetchAll', () => {
+    it('paginates until a short page is returned', async () => {
+      const range = vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: Array.from({ length: 1000 }, (_, id) => ({ id })),
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: Array.from({ length: 179 }, (_, id) => ({ id: id + 1000 })),
+          error: null,
+        });
+
+      const rows = await fetchAll<{ id: number }>(() => ({ range }));
+
+      expect(rows).toHaveLength(1179);
+      expect(range).toHaveBeenNthCalledWith(1, 0, 999);
+      expect(range).toHaveBeenNthCalledWith(2, 1000, 1999);
     });
   });
 

--- a/app/api/admin/api-health/alert/route.ts
+++ b/app/api/admin/api-health/alert/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { getSupabaseAdmin, probeSupabaseReadClient } from '@/lib/supabase';
 import { broadcastDiscord } from '@/lib/notifications';
 import { alertEmail } from '@/lib/sync-utils';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
@@ -31,6 +31,17 @@ export const GET = withRouteHandler(async (request) => {
   const checks: HealthCheck[] = [];
   const fifteenMinAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString();
   const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+  const readClient = await probeSupabaseReadClient();
+  checks.push({
+    name: 'Supabase public read client',
+    severity: 'critical',
+    passed: readClient.status === 'healthy',
+    detail:
+      readClient.status === 'healthy'
+        ? `${readClient.env.activeKey} key responded in ${readClient.latencyMs}ms`
+        : `${readClient.reason}: ${readClient.message}`,
+  });
 
   // --- Check 1: 5xx Error Rate (15 min window) ---
   const { data: recentLogs } = await supabase
@@ -171,6 +182,11 @@ export const GET = withRouteHandler(async (request) => {
   const failures = checks.filter((c) => !c.passed);
   const criticalFailures = failures.filter((c) => c.severity === 'critical');
   const warnings = failures.filter((c) => c.severity === 'warning');
+  const failedChecks = failures.map((c) => ({
+    name: c.name,
+    severity: c.severity,
+    detail: c.detail,
+  }));
 
   if (criticalFailures.length > 0 || warnings.length > 0) {
     const lines: string[] = [];
@@ -220,6 +236,8 @@ export const GET = withRouteHandler(async (request) => {
       passed: checks.filter((c) => c.passed).length,
       critical_failures: criticalFailures.length,
       warnings: warnings.length,
+      failed_checks: failedChecks,
+      read_client: readClient,
     },
   });
 

--- a/app/api/admin/inbox-alert/route.ts
+++ b/app/api/admin/inbox-alert/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase';
+import { getSupabaseAdmin, probeSupabaseReadClient } from '@/lib/supabase';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { getCurrentEpoch } from '@/lib/constants';
@@ -35,8 +35,17 @@ export const GET = withRouteHandler(async (request) => {
     return NextResponse.json({ skipped: true, reason: 'No webhook URL configured' });
   }
 
-  const supabase = createClient();
+  const supabase = getSupabaseAdmin();
   const alerts: InboxAlert[] = [];
+
+  const readClient = await probeSupabaseReadClient();
+  if (readClient.status !== 'healthy') {
+    alerts.push({
+      level: 'critical',
+      title: 'Supabase read client unavailable',
+      detail: `${readClient.reason}: ${readClient.message}. Check Railway Supabase public read env without printing values.`,
+    });
+  }
 
   const activeDrepsRes = await supabase
     .from('dreps')
@@ -44,7 +53,7 @@ export const GET = withRouteHandler(async (request) => {
     .filter('info->>isActive', 'eq', 'true');
   const totalActiveDreps = activeDrepsRes.count ?? 0;
 
-  if (totalActiveDreps === 0) {
+  if (totalActiveDreps === 0 && alerts.length === 0) {
     return NextResponse.json({ alerts: 0, reason: 'No active DReps' });
   }
 
@@ -70,7 +79,7 @@ export const GET = withRouteHandler(async (request) => {
     .is('dropped_epoch', null)
     .is('expired_epoch', null);
 
-  if (!openProposals || openProposals.length === 0) {
+  if ((!openProposals || openProposals.length === 0) && alerts.length === 0) {
     return NextResponse.json({ alerts: 0, reason: 'No open proposals' });
   }
 
@@ -87,7 +96,9 @@ export const GET = withRouteHandler(async (request) => {
 
   let totalDrepVotes = 0;
 
-  for (const p of openProposals) {
+  const proposalsToCheck = openProposals ?? [];
+
+  for (const p of proposalsToCheck) {
     const vs = Array.isArray(p.proposal_voting_summary)
       ? p.proposal_voting_summary[0]
       : p.proposal_voting_summary;
@@ -96,7 +107,7 @@ export const GET = withRouteHandler(async (request) => {
       (vs?.drep_no_votes_cast ?? 0) +
       (vs?.drep_abstain_votes_cast ?? 0);
     totalDrepVotes += drepVotes;
-    const coverage = Math.round((drepVotes / totalActiveDreps) * 100);
+    const coverage = totalActiveDreps > 0 ? Math.round((drepVotes / totalActiveDreps) * 100) : 0;
     const expirationEpoch =
       p.expiration_epoch ?? (p.proposed_epoch != null ? p.proposed_epoch + 6 : null);
     const epochsRemaining =
@@ -122,20 +133,20 @@ export const GET = withRouteHandler(async (request) => {
   }
 
   const avgCoverage =
-    openProposals.length > 0
-      ? Math.round((totalDrepVotes / openProposals.length / totalActiveDreps) * 100)
+    proposalsToCheck.length > 0 && totalActiveDreps > 0
+      ? Math.round((totalDrepVotes / proposalsToCheck.length / totalActiveDreps) * 100)
       : 0;
-  if (avgCoverage < 30) {
+  if (proposalsToCheck.length > 0 && avgCoverage < 30) {
     alerts.push({
       level: 'warning',
       title: 'Low overall DRep engagement',
-      detail: `Average vote coverage across ${openProposals.length} open proposals is ${avgCoverage}% (threshold: 30%)`,
+      detail: `Average vote coverage across ${proposalsToCheck.length} open proposals is ${avgCoverage}% (threshold: 30%)`,
     });
   }
 
   captureServerEvent('inbox_engagement_alert_check', {
     alertCount: alerts.length,
-    openProposals: openProposals.length,
+    openProposals: proposalsToCheck.length,
     avgCoverage,
     currentEpoch,
   });

--- a/app/api/admin/integrity/alert/route.ts
+++ b/app/api/admin/integrity/alert/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createClient, getSupabaseAdmin } from '@/lib/supabase';
+import { getSupabaseAdmin, probeSupabaseReadClient } from '@/lib/supabase';
 import { inngest } from '@/lib/inngest';
 import { logger } from '@/lib/logger';
 import { getSyncPolicy, SYNC_POLICY, type SyncPolicy } from '@/lib/syncPolicy';
@@ -30,8 +30,20 @@ export const GET = withRouteHandler(async (request) => {
     return NextResponse.json({ skipped: true, reason: 'No webhook URL configured' });
   }
 
-  const supabase = createClient();
+  const supabase = getSupabaseAdmin();
   const alerts: Alert[] = [];
+
+  const readClient = await probeSupabaseReadClient();
+  if (readClient.status !== 'healthy') {
+    alerts.push({
+      level: 'critical',
+      metric: 'Supabase read client unavailable',
+      value: `${readClient.reason}: ${readClient.message}`,
+      threshold: 'public read client must answer a head-only DRep query',
+      action:
+        'Check Railway NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY / legacy NEXT_PUBLIC_SUPABASE_ANON_KEY. Do not print secret values.',
+    });
+  }
 
   const [{ data: vpc }, { data: hv }, { data: ai }, { data: sh }] = await Promise.all([
     supabase.from('v_vote_power_coverage').select('*').single(),
@@ -312,11 +324,11 @@ export const GET = withRouteHandler(async (request) => {
   {
     const { data: scoreDist } = await supabase
       .from('dreps')
-      .select('drep_score')
-      .not('drep_score', 'is', null);
+      .select('score')
+      .not('score', 'is', null);
 
     if (scoreDist && scoreDist.length > 10) {
-      const scores = scoreDist.map((d: { drep_score: number }) => d.drep_score);
+      const scores = scoreDist.map((d: { score: number }) => d.score);
       const avg = scores.reduce((a: number, b: number) => a + b, 0) / scores.length;
       const zeroCount = scores.filter((s: number) => s === 0).length;
       const zeroPct = (zeroCount / scores.length) * 100;
@@ -417,7 +429,7 @@ export const GET = withRouteHandler(async (request) => {
     }
   }
 
-  const admin = getSupabaseAdmin();
+  const admin = supabase;
 
   if (alerts.length === 0) {
     try {
@@ -427,7 +439,7 @@ export const GET = withRouteHandler(async (request) => {
         finished_at: new Date().toISOString(),
         duration_ms: 0,
         success: true,
-        metrics: { alerts: 0, recoveries },
+        metrics: { alerts: 0, recoveries, read_client: readClient },
       });
     } catch {
       /* best-effort */
@@ -506,7 +518,12 @@ export const GET = withRouteHandler(async (request) => {
         finished_at: new Date().toISOString(),
         duration_ms: 0,
         success: true,
-        metrics: { alerts: alerts.length, webhook_status: res.status, recoveries },
+        metrics: {
+          alerts: alerts.length,
+          webhook_status: res.status,
+          recoveries,
+          read_client: readClient,
+        },
       });
     } catch {
       /* best-effort */

--- a/app/api/health/deep/route.ts
+++ b/app/api/health/deep/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 import { getOpsEnvReport } from '@/lib/env';
 import { getRuntimeRelease } from '@/lib/runtimeMetadata';
-import { getSupabaseAdmin } from '@/lib/supabase';
+import { getSupabaseAdmin, probeSupabaseReadClient } from '@/lib/supabase';
 import { checkKoiosHealthFast } from '@/utils/koios';
 import { getRedis } from '@/lib/redis';
 
@@ -41,6 +41,10 @@ async function probeSupabase(): Promise<DepResult> {
   }
 }
 
+async function probeSupabaseRead(): Promise<Awaited<ReturnType<typeof probeSupabaseReadClient>>> {
+  return probeSupabaseReadClient();
+}
+
 async function probeKoios(): Promise<DepResult> {
   const start = Date.now();
   try {
@@ -76,8 +80,9 @@ function probeOperationalEnv(): EnvDepResult {
 
 export const GET = withRouteHandler(
   async () => {
-    const [supabase, koios, redis] = await Promise.all([
+    const [supabase, supabaseRead, koios, redis] = await Promise.all([
       probeSupabase(),
+      probeSupabaseRead(),
       probeKoios(),
       probeRedis(),
     ]);
@@ -87,7 +92,7 @@ export const GET = withRouteHandler(
     // supporting dependency for shared rate limits and cache-backed coordination,
     // but core reads stay available without it. Koios is background-only because
     // scheduled sync jobs, not page requests, depend on it.
-    const coreHealthy = supabase.status === 'healthy';
+    const coreHealthy = supabase.status === 'healthy' && supabaseRead.status === 'healthy';
     const allHealthy =
       coreHealthy &&
       koios.status === 'healthy' &&
@@ -96,7 +101,13 @@ export const GET = withRouteHandler(
 
     return NextResponse.json({
       status: allHealthy ? 'healthy' : coreHealthy ? 'degraded' : 'critical',
-      dependencies: { supabase, koios, redis, operational_env: operationalEnv },
+      dependencies: {
+        supabase,
+        supabase_read: supabaseRead,
+        koios,
+        redis,
+        operational_env: operationalEnv,
+      },
       release: getRuntimeRelease(),
       timestamp: new Date().toISOString(),
     });

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,23 +1,112 @@
 import { NextResponse } from 'next/server';
 import { getOpsEnvReport } from '@/lib/env';
 import { getRuntimeRelease } from '@/lib/runtimeMetadata';
-import { createClient } from '@/lib/supabase';
+import { createClient, probeSupabaseReadClient } from '@/lib/supabase';
 import { getSyncHealthLevel, getSyncPolicy, mergeSyncHealthLevel } from '@/lib/syncPolicy';
 import { withRouteHandler } from '@/lib/api/withRouteHandler';
 
 export const dynamic = 'force-dynamic';
 
+const SNAPSHOT_PROBE_TIMEOUT_MS = 2_500;
+
+type SyncHealthRow = {
+  sync_type: string;
+  last_run: string | null;
+  last_success: boolean | null;
+  success_count: number | null;
+  failure_count: number | null;
+};
+
+type SyncHealthQueryResult = {
+  data: SyncHealthRow[] | null;
+  error: { message: string } | null;
+};
+
+type SnapshotProbeResult = {
+  data: Record<string, unknown> | null;
+  error: { message: string } | null;
+};
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unknown error';
+}
+
+async function withProbeTimeout<T>(operation: PromiseLike<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${SNAPSHOT_PROBE_TIMEOUT_MS}ms`)),
+      SNAPSHOT_PROBE_TIMEOUT_MS,
+    );
+  });
+
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export const GET = withRouteHandler(async () => {
-  const supabase = createClient();
   const operations = getOpsEnvReport();
-  const { data: rows } = await supabase.from('v_sync_health').select('*');
+  const readClient = await probeSupabaseReadClient();
+
+  if (readClient.status !== 'healthy') {
+    return NextResponse.json({
+      status: 'critical',
+      message: 'Supabase read client is unavailable',
+      reason: readClient.reason,
+      syncs: [],
+      snapshots: null,
+      operations,
+      read_client: readClient,
+      release: getRuntimeRelease(),
+    });
+  }
+
+  const supabase = createClient();
+  let syncHealthResult: SyncHealthQueryResult;
+
+  try {
+    syncHealthResult = (await supabase.from('v_sync_health').select('*')) as SyncHealthQueryResult;
+  } catch (error) {
+    return NextResponse.json({
+      status: 'critical',
+      message: 'Sync health query failed',
+      reason: 'sync_health_query_exception',
+      error: getErrorMessage(error),
+      syncs: [],
+      snapshots: null,
+      operations,
+      read_client: readClient,
+      release: getRuntimeRelease(),
+    });
+  }
+
+  const { data: rows, error: syncHealthError } = syncHealthResult;
+
+  if (syncHealthError) {
+    return NextResponse.json({
+      status: 'critical',
+      message: 'Sync health query failed',
+      reason: 'sync_health_query_error',
+      error: syncHealthError.message,
+      syncs: [],
+      snapshots: null,
+      operations,
+      read_client: readClient,
+      release: getRuntimeRelease(),
+    });
+  }
 
   if (!rows?.length) {
     return NextResponse.json({
       status: operations.status === 'healthy' ? 'unknown' : 'degraded',
+      reason: 'no_sync_data',
       message: 'No sync data',
       syncs: [],
       operations,
+      read_client: readClient,
       release: getRuntimeRelease(),
     });
   }
@@ -77,12 +166,18 @@ export const GET = withRouteHandler(async () => {
       const snapshotChecks = await Promise.all(
         snapshotTables.map(
           async ({ name, col, isDate }: { name: string; col: string; isDate?: boolean }) => {
-            const { data: latest } = await supabase
+            const query = supabase
               .from(name)
               .select(col)
               .order(col, { ascending: false })
               .limit(1)
-              .maybeSingle();
+              .maybeSingle() as PromiseLike<SnapshotProbeResult>;
+
+            const { data: latest, error } = await withProbeTimeout(query, `snapshot ${name}`);
+
+            if (error) {
+              throw new Error(`${name}: ${error.message}`);
+            }
 
             if (isDate) {
               const latestDate = latest
@@ -144,10 +239,11 @@ export const GET = withRouteHandler(async () => {
       snapshotHealth = { status: snapshotLevel, epoch, checks: snapshotChecks };
       worstLevel = mergeSyncHealthLevel(worstLevel, snapshotLevel);
     }
-  } catch {
+  } catch (error) {
     snapshotHealth = {
       status: 'unavailable',
       error: 'snapshot health check failed',
+      reason: getErrorMessage(error),
     };
     worstLevel = mergeSyncHealthLevel(worstLevel, 'degraded');
   }
@@ -157,6 +253,7 @@ export const GET = withRouteHandler(async () => {
     syncs,
     snapshots: snapshotHealth,
     operations,
+    read_client: readClient,
     release: getRuntimeRelease(),
   });
 });

--- a/app/api/health/sync/route.ts
+++ b/app/api/health/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase';
+import { createClient, probeSupabaseReadClient } from '@/lib/supabase';
 import { CORE_SYNC_TYPES, getExternalSyncHealthLevel, getSyncPolicy } from '@/lib/syncPolicy';
 
 export const dynamic = 'force-dynamic';
@@ -11,12 +11,45 @@ export const dynamic = 'force-dynamic';
  */
 export async function GET() {
   try {
+    const readClient = await probeSupabaseReadClient();
+    if (readClient.status !== 'healthy') {
+      return NextResponse.json(
+        {
+          status: 'error',
+          reason: readClient.reason,
+          message: 'Supabase read client is unavailable',
+          read_client: readClient,
+          checked_at: new Date().toISOString(),
+        },
+        { status: 503 },
+      );
+    }
+
     const supabase = createClient();
-    const { data: rows } = await supabase.from('v_sync_health').select('*');
+    const { data: rows, error } = await supabase.from('v_sync_health').select('*');
+
+    if (error) {
+      return NextResponse.json(
+        {
+          status: 'error',
+          reason: 'sync_health_query_error',
+          message: error.message,
+          read_client: readClient,
+          checked_at: new Date().toISOString(),
+        },
+        { status: 503 },
+      );
+    }
 
     if (!rows?.length) {
       return NextResponse.json(
-        { status: 'unknown', message: 'No sync data available' },
+        {
+          status: 'unknown',
+          reason: 'no_sync_data',
+          message: 'No sync data available',
+          read_client: readClient,
+          checked_at: new Date().toISOString(),
+        },
         { status: 503 },
       );
     }
@@ -47,11 +80,20 @@ export async function GET() {
       {
         status: healthy ? 'healthy' : 'critical',
         core_syncs: coreStatuses,
+        read_client: readClient,
         checked_at: new Date().toISOString(),
       },
       { status: healthy ? 200 : 503 },
     );
-  } catch {
-    return NextResponse.json({ status: 'error', message: 'Health check failed' }, { status: 503 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        reason: 'unexpected_error',
+        message: error instanceof Error ? error.message : 'Health check failed',
+        checked_at: new Date().toISOString(),
+      },
+      { status: 503 },
+    );
   }
 }

--- a/app/api/og/vote-card/route.tsx
+++ b/app/api/og/vote-card/route.tsx
@@ -36,13 +36,14 @@ export async function GET(request: Request) {
 
     // Direct Supabase fetch compatible with edge runtime
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const supabaseReadKey =
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     let drepName = drepId.length > 20 ? `${drepId.slice(0, 12)}...${drepId.slice(-8)}` : drepId;
     let proposalTitle = 'Governance Proposal';
 
-    if (supabaseUrl && supabaseAnonKey) {
-      const supabase = createClient(supabaseUrl, supabaseAnonKey);
+    if (supabaseUrl && supabaseReadKey) {
+      const supabase = createClient(supabaseUrl, supabaseReadKey);
 
       // Fetch DRep name
       const { data: drep } = await supabase.from('dreps').select('info').eq('id', drepId).single();

--- a/brain/plans/sync-health-hardening.md
+++ b/brain/plans/sync-health-hardening.md
@@ -140,6 +140,8 @@ Commands run:
 - `git fetch origin main`
 - `git worktree add .claude/worktrees/sync-health-hardening -b codex/sync-health-hardening origin/main`
 - `rg` and `sed` over Supabase, health, alert, Inngest, and sync paths.
+- `npm run gh -- pr checks 961`
+- Supabase MCP `_list_branches` for project `pbfprhbaayvcrxokgicr`
 
 Claims verified:
 
@@ -148,3 +150,4 @@ Claims verified:
 - `lib/env.ts` accepts either read key but does not include the Supabase read key pair in `OPS_CRITICAL_KEYS`.
 - `inngest/helpers.ts` falls back to `http://localhost:3000` when `NEXT_PUBLIC_SITE_URL` is unset.
 - Integrity score distribution currently queries `drep_score`, while generated DB types expose `dreps.score`.
+- PR #961 GitHub Actions and Railway checks passed after publish; the external Supabase Preview check initially cancelled before a PR-specific Supabase branch appeared.

--- a/brain/plans/sync-health-hardening.md
+++ b/brain/plans/sync-health-hardening.md
@@ -1,0 +1,150 @@
+# Feature Plan
+
+## Spec Link
+
+Path or URL:
+
+- Tim request in current Codex thread: sync alerts, health review, independent reviewer feedback, implementation approval.
+- Supabase changelog reviewed for current REST/client behavior: `https://supabase.com/changelog`
+
+## Files Read
+
+- `AGENTS.md`
+- `docs/templates/feature-plan.md`
+- `lib/supabase.ts`
+- `lib/env.ts`
+- `app/api/health/route.ts`
+- `app/api/health/sync/route.ts`
+- `app/api/health/deep/route.ts`
+- `app/api/admin/api-health/alert/route.ts`
+- `app/api/admin/integrity/alert/route.ts`
+- `app/api/admin/inbox-alert/route.ts`
+- `app/api/og/vote-card/route.tsx`
+- `inngest/helpers.ts`
+- `inngest/functions/alert-api-health.ts`
+- `inngest/functions/alert-integrity.ts`
+- `inngest/functions/alert-inbox.ts`
+- `lib/data.ts`
+- `lib/sync-utils.ts`
+- `lib/sync/secondary.ts`
+- `lib/sync/dreps.ts`
+- `lib/sync/slow.ts`
+- `inngest/functions/generate-epoch-summary.ts`
+- `inngest/functions/generate-state-of-governance.ts`
+- `types/database.ts`
+- `railway.toml`
+- `app/api/health/ready/route.ts`
+- `__tests__/api/health.test.ts`
+- `__tests__/api/health-sync.test.ts`
+- `__tests__/api/health-deep.test.ts`
+- `__tests__/lib/env.test.ts`
+- `__tests__/sync/sync-utils.test.ts`
+- `__tests__/lib/supabase-read-client.test.ts`
+- `__tests__/inngest/helpers.test.ts`
+
+## Existing Implementations Found
+
+- Read Supabase access is centralized in `lib/supabase.ts`; current production-base code prefers `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and accepts legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+- Operational env reporting exists in `lib/env.ts`, but it does not currently validate the Supabase read URL/key pair.
+- Broad health lives at `/api/health`; core sync health lives at `/api/health/sync`; deep dependency health lives at `/api/health/deep`.
+- Alert cron functions self-fetch API routes through `inngest/helpers.ts`.
+- `lib/sync-utils.ts` already exports `fetchAll` for paginated Supabase reads.
+- Several sync and summary paths read all DReps without `fetchAll`.
+
+## Sites Affected
+
+Implementation files:
+
+- `lib/supabase.ts`
+- `lib/env.ts`
+- `app/api/health/route.ts`
+- `app/api/health/sync/route.ts`
+- `app/api/health/deep/route.ts`
+- `app/api/admin/api-health/alert/route.ts`
+- `app/api/admin/integrity/alert/route.ts`
+- `app/api/admin/inbox-alert/route.ts`
+- `inngest/helpers.ts`
+- `lib/sync/secondary.ts`
+- `lib/sync/dreps.ts`
+- `lib/sync/slow.ts`
+- `inngest/functions/generate-epoch-summary.ts`
+- `inngest/functions/generate-state-of-governance.ts`
+
+Test files referencing changed APIs:
+
+- `__tests__/api/health.test.ts`
+- `__tests__/api/health-sync.test.ts`
+- `__tests__/api/health-deep.test.ts`
+- `__tests__/lib/env.test.ts`
+- `__tests__/sync/sync-utils.test.ts`
+- New targeted tests as needed for alert helper and pagination behavior.
+
+Type definitions/usages:
+
+- No database type regeneration planned; no migrations in scope.
+- Existing `types/database.ts` confirms `dreps.score`, not `dreps.drep_score`.
+
+Documentation referencing changed names:
+
+- This feature plan only, unless tests reveal existing docs must be corrected.
+
+## ADRs That Apply
+
+- No ADR required: this is operational hardening of existing sync/read-health paths, not a new architecture or credential expansion.
+
+## Scope
+
+In:
+
+- Read-client viability probe that exercises Supabase with a safe head-only query.
+- Structured health output for read-client failures.
+- Supabase read-client env visibility in operational health.
+- Alerter-path failure visibility and production-safe URL handling.
+- Paginated DRep reads in sync paths where complete DRep coverage is expected.
+- Score-distribution integrity query fix from `drep_score` to `score`.
+- Tests for the changed contracts.
+
+Out:
+
+- Production env edits, secret printing, backfills, write-heavy syncs, migrations, or database mutations.
+- Changing public product API contracts beyond health/alert diagnostics unless required by tests.
+- Reworking Railway deploy healthcheck path in this slice.
+- Reconciliation semantic policy change beyond surfacing clearer alerts if local code already supports it.
+
+## Edge Cases
+
+- Loading: no frontend loading states changed.
+- Empty: health routes must distinguish empty sync/DRep data from read-client failure.
+- Error: missing env, invalid key/query error, timeout, and route self-fetch failures should surface distinct non-secret reasons where practical.
+- Mobile 375px: no UI changes.
+- A11y: no UI changes.
+- Auth: cron-protected alert routes remain protected by `CRON_SECRET`; no credential scope expansion.
+- Data freshness: sync health should continue applying existing `SYNC_POLICY` thresholds.
+
+## Verification Plan
+
+- URL: safe production read-only probes may be re-run after implementation if needed; no production writes.
+- Screenshot: not applicable; no UI changes.
+- Grep-similar: verify changed DRep full-table sync reads use `fetchAll` and no unrelated dirty files are included.
+- Tests/checks:
+  - `npm run agent:validate`
+  - Targeted API health tests
+  - Targeted env/read-client tests
+  - Targeted Inngest helper/alert tests
+  - Targeted sync pagination tests
+
+## Evidence Trail
+
+Commands run:
+
+- `git fetch origin main`
+- `git worktree add .claude/worktrees/sync-health-hardening -b codex/sync-health-hardening origin/main`
+- `rg` and `sed` over Supabase, health, alert, Inngest, and sync paths.
+
+Claims verified:
+
+- Clean implementation worktree starts at `a4bb1450`, matching the production release observed during review.
+- Production-base `lib/supabase.ts` prefers `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and falls back to legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+- `lib/env.ts` accepts either read key but does not include the Supabase read key pair in `OPS_CRITICAL_KEYS`.
+- `inngest/helpers.ts` falls back to `http://localhost:3000` when `NEXT_PUBLIC_SITE_URL` is unset.
+- Integrity score distribution currently queries `drep_score`, while generated DB types expose `dreps.score`.

--- a/inngest/functions/generate-epoch-summary.ts
+++ b/inngest/functions/generate-epoch-summary.ts
@@ -6,7 +6,7 @@
 import { inngest } from '@/lib/inngest';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { blockTimeToEpoch } from '@/lib/koios';
-import { errMsg, pingHeartbeat } from '@/lib/sync-utils';
+import { errMsg, fetchAll, pingHeartbeat } from '@/lib/sync-utils';
 import { logger } from '@/lib/logger';
 import { detectClusters } from '@/lib/globe/clusterDetection';
 import { nameAllClusters } from '@/lib/globe/clusterNaming';
@@ -510,14 +510,16 @@ Output ONLY the narrative paragraph, nothing else.`,
               .maybeSingle();
             if (existing) return { skipped: true };
 
-            const [votersResult, totalDrepsResult, totalPowerResult, rationaleResult] =
+            const [votersResult, totalDrepsResult, totalPowerRows, rationaleResult] =
               await Promise.all([
                 supabase.from('drep_votes').select('drep_id').eq('epoch_no', epoch),
                 supabase
                   .from('dreps')
                   .select('id', { count: 'exact', head: true })
                   .not('info->isActive', 'eq', false),
-                supabase.from('dreps').select('info').not('info->isActive', 'eq', false),
+                fetchAll<{ info: unknown }>(() =>
+                  supabase.from('dreps').select('info').not('info->isActive', 'eq', false),
+                ),
                 supabase
                   .from('drep_votes')
                   .select('vote_tx_hash', { count: 'exact', head: true })
@@ -535,7 +537,7 @@ Output ONLY the narrative paragraph, nothing else.`,
             const rationaleRate =
               totalVotes > 0 ? Math.round((rationaleCount / totalVotes) * 10000) / 100 : 0;
 
-            const totalPower = (totalPowerResult.data || []).reduce((sum, row) => {
+            const totalPower = totalPowerRows.reduce((sum, row) => {
               const info = row.info as Record<string, unknown>;
               return sum + BigInt((info?.votingPowerLovelace as string) || '0');
             }, BigInt(0));

--- a/inngest/functions/generate-state-of-governance.ts
+++ b/inngest/functions/generate-state-of-governance.ts
@@ -12,6 +12,7 @@ import { inngest } from '@/lib/inngest';
 import { generateAndStoreReport } from '@/lib/stateOfGovernance';
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
+import { fetchAll } from '@/lib/sync-utils';
 import {
   getCitizenMandate,
   computeSentimentDivergence,
@@ -70,12 +71,14 @@ export const generateStateOfGovernance = inngest.createFunction(
       }));
 
       // DRep participation
-      const { data: dreps } = await supabase.from('dreps').select('info').not('info', 'is', null);
+      const dreps = await fetchAll<{ info: unknown }>(() =>
+        supabase.from('dreps').select('info').not('info', 'is', null),
+      );
       const activeDreps = (dreps ?? []).filter(
         (d) => (d.info as Record<string, unknown> | null)?.isActive,
       );
       const participationRate =
-        dreps && dreps.length > 0 ? Math.round((activeDreps.length / dreps.length) * 100) : 0;
+        dreps.length > 0 ? Math.round((activeDreps.length / dreps.length) * 100) : 0;
 
       // Citizen engagement counts
       const [sentimentCount, priorityCount, assemblyCount] = await Promise.all([

--- a/inngest/helpers.ts
+++ b/inngest/helpers.ts
@@ -7,11 +7,23 @@
 import { alertDiscord, emitPostHog } from '@/lib/sync-utils';
 import type { SyncType } from '@/lib/sync-utils';
 
+function isProductionRuntime(): boolean {
+  return (
+    process.env.NODE_ENV === 'production' ||
+    Boolean(process.env.RAILWAY_ENVIRONMENT_ID || process.env.RAILWAY_SERVICE_ID)
+  );
+}
+
 export async function callSyncRoute(
   path: string,
   timeoutMs: number,
 ): Promise<{ status: number; body: unknown }> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+  const configuredBaseUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  if (!configuredBaseUrl && isProductionRuntime()) {
+    throw new Error('NEXT_PUBLIC_SITE_URL not configured; refusing to self-fetch sync route');
+  }
+
+  const baseUrl = configuredBaseUrl || 'http://localhost:3000';
   const cronSecret = process.env.CRON_SECRET;
 
   if (!cronSecret) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -73,6 +73,7 @@ const OPTIONAL_IGNORED_KEYS = new Set<string>([
 ]);
 
 const URL_SCHEMA = z.string().url();
+const NONEMPTY_SCHEMA = z.string().min(1);
 
 interface OpsCriticalIssue {
   key: string;
@@ -86,6 +87,11 @@ interface OpsCriticalGroupIssue {
 }
 
 const OPS_CRITICAL_KEYS = [
+  {
+    key: 'NEXT_PUBLIC_SUPABASE_URL',
+    reason: 'Supabase Data API base URL for public read client health and cached governance reads',
+    schema: URL_SCHEMA,
+  },
   {
     key: 'NEXT_PUBLIC_SITE_URL',
     reason: 'canonical base URL for production links, callbacks, and notifications',
@@ -114,6 +120,13 @@ const OPS_CRITICAL_KEYS = [
 ] as const;
 
 const OPS_CRITICAL_GROUPS = [
+  {
+    keys: ['NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'] as const,
+    name: 'supabase_read_key',
+    reason:
+      'Supabase public read client key; publishable key is canonical and anon key is accepted temporarily for legacy compatibility',
+    schema: NONEMPTY_SCHEMA,
+  },
   {
     keys: ['DISCORD_WEBHOOK_URL', 'SLACK_WEBHOOK_URL'] as const,
     name: 'alert_webhook',

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -5,10 +5,185 @@
 
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 
+type SupabaseReadKeyName = 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY' | 'NEXT_PUBLIC_SUPABASE_ANON_KEY';
+
+export type SupabaseReadProbeReason =
+  | 'ok'
+  | 'missing_url'
+  | 'invalid_url'
+  | 'missing_read_key'
+  | 'client_init_failed'
+  | 'query_error'
+  | 'timeout'
+  | 'unknown_error';
+
+export interface SupabaseReadEnvStatus {
+  url: 'present' | 'missing' | 'invalid';
+  publishableKey: 'present' | 'missing';
+  legacyAnonKey: 'present' | 'missing';
+  activeKey: 'publishable' | 'legacy_anon' | 'none';
+}
+
+export interface SupabaseReadProbeResult {
+  status: 'healthy' | 'unhealthy';
+  reason: SupabaseReadProbeReason;
+  message: string;
+  latencyMs: number;
+  env: SupabaseReadEnvStatus;
+  errorCode?: string;
+  httpStatus?: number;
+}
+
 function getSupabasePublishableKey(): string | undefined {
   return (
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
+}
+
+function getSupabaseReadKeyName(): SupabaseReadKeyName | null {
+  if (process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
+    return 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY';
+  }
+
+  if (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+    return 'NEXT_PUBLIC_SUPABASE_ANON_KEY';
+  }
+
+  return null;
+}
+
+export function getSupabaseReadEnvStatus(): SupabaseReadEnvStatus {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const activeKey = getSupabaseReadKeyName();
+
+  let url: SupabaseReadEnvStatus['url'] = 'present';
+  if (!supabaseUrl) {
+    url = 'missing';
+  } else {
+    try {
+      new URL(supabaseUrl);
+    } catch {
+      url = 'invalid';
+    }
+  }
+
+  return {
+    url,
+    publishableKey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ? 'present' : 'missing',
+    legacyAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? 'present' : 'missing',
+    activeKey:
+      activeKey === 'NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY'
+        ? 'publishable'
+        : activeKey === 'NEXT_PUBLIC_SUPABASE_ANON_KEY'
+          ? 'legacy_anon'
+          : 'none',
+  };
+}
+
+function getSupabaseReadEnvFailure(env: SupabaseReadEnvStatus): SupabaseReadProbeReason | null {
+  if (env.url === 'missing') return 'missing_url';
+  if (env.url === 'invalid') return 'invalid_url';
+  if (env.activeKey === 'none') return 'missing_read_key';
+  return null;
+}
+
+function getSafeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message.slice(0, 240);
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string') return message.slice(0, 240);
+  }
+
+  return 'Unknown Supabase read-client error';
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const value = (error as { code?: unknown }).code;
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getHttpStatus(error: unknown, fallback?: number): number | undefined {
+  if (typeof fallback === 'number') return fallback;
+  if (!error || typeof error !== 'object') return undefined;
+  const value = (error as { status?: unknown }).status;
+  return typeof value === 'number' ? value : undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === 'AbortError') ||
+    (error instanceof Error && error.name === 'AbortError') ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error as { name?: unknown }).name === 'AbortError')
+  );
+}
+
+export async function probeSupabaseReadClient(timeoutMs = 5_000): Promise<SupabaseReadProbeResult> {
+  const start = Date.now();
+  const env = getSupabaseReadEnvStatus();
+  const envFailure = getSupabaseReadEnvFailure(env);
+
+  if (envFailure) {
+    return {
+      status: 'unhealthy',
+      reason: envFailure,
+      message: `Supabase read-client environment is not usable: ${envFailure}`,
+      latencyMs: Date.now() - start,
+      env,
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const supabase = createClient();
+    const { error, status } = await supabase
+      .from('dreps')
+      .select('id', { count: 'exact', head: true })
+      .limit(1)
+      .abortSignal(controller.signal);
+
+    if (error) {
+      return {
+        status: 'unhealthy',
+        reason: 'query_error',
+        message: getSafeErrorMessage(error),
+        latencyMs: Date.now() - start,
+        env,
+        errorCode: getErrorCode(error),
+        httpStatus: getHttpStatus(error, typeof status === 'number' ? status : undefined),
+      };
+    }
+
+    return {
+      status: 'healthy',
+      reason: 'ok',
+      message: 'Supabase read-client query succeeded',
+      latencyMs: Date.now() - start,
+      env,
+      httpStatus: status,
+    };
+  } catch (error) {
+    const timeout = isAbortError(error);
+    return {
+      status: 'unhealthy',
+      reason: timeout ? 'timeout' : 'client_init_failed',
+      message: timeout ? 'Supabase read-client query timed out' : getSafeErrorMessage(error),
+      latencyMs: Date.now() - start,
+      env,
+      errorCode: getErrorCode(error),
+      httpStatus: getHttpStatus(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -22,7 +197,7 @@ export function createClient() {
 
   if (!supabaseUrl || !supabasePublishableKey) {
     throw new Error(
-      'Missing Supabase environment variables: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY are required',
+      'Missing Supabase environment variables: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY are required; NEXT_PUBLIC_SUPABASE_ANON_KEY is accepted temporarily for legacy compatibility',
     );
   }
 

--- a/lib/sync/dreps.ts
+++ b/lib/sync/dreps.ts
@@ -18,6 +18,7 @@ import {
   errMsg,
   capMsg,
   emitPostHog,
+  fetchAll,
   triggerAnalyticsDeploy,
   alertDiscord,
 } from '@/lib/sync-utils';
@@ -302,8 +303,10 @@ export async function phaseFetchDReps(
   // Read existing delegator counts from DB
   const delegatorCounts: Record<string, number> = {};
   try {
-    const { data: existing } = await supabase.from('dreps').select('id, info');
-    for (const row of existing || []) {
+    const existing = await fetchAll<{ id: string; info: unknown }>(() =>
+      supabase.from('dreps').select('id, info'),
+    );
+    for (const row of existing) {
       const info = row.info as Record<string, unknown> | null;
       const count = (info?.delegatorCount as number) || 0;
       delegatorCounts[row.id] = count;

--- a/lib/sync/secondary.ts
+++ b/lib/sync/secondary.ts
@@ -1,6 +1,6 @@
 import { getSupabaseAdmin } from '@/lib/supabase';
 import { logger } from '@/lib/logger';
-import { SyncLogger, batchUpsert, errMsg, emitPostHog } from '@/lib/sync-utils';
+import { SyncLogger, batchUpsert, errMsg, emitPostHog, fetchAll } from '@/lib/sync-utils';
 import { fetchDRepDelegatorCount } from '@/utils/koios';
 import { blockTimeToEpoch } from '@/lib/koios';
 import * as Sentry from '@sentry/nextjs';
@@ -28,12 +28,11 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
       // so that drep_power_snapshots have fresh Koios delegator counts.
       const step1Result = await Promise.allSettled([
         (async () => {
-          const { data: dreps } = await supabase
-            .from('dreps')
-            .select('id, info')
-            .filter('info->>isActive', 'eq', 'true');
+          const dreps = await fetchAll<{ id: string; info: unknown }>(() =>
+            supabase.from('dreps').select('id, info').filter('info->>isActive', 'eq', 'true'),
+          );
 
-          if (!dreps?.length) return 0;
+          if (!dreps.length) return 0;
 
           let updated = 0;
           for (let i = 0; i < dreps.length; i += DELEGATOR_CONCURRENCY) {
@@ -77,9 +76,11 @@ export async function executeSecondarySync(): Promise<Record<string, unknown>> {
         // Snapshot ALL DReps (not just active) so coverage matches the completeness check
         // which counts all rows in the dreps table.
         (async () => {
-          const { data: dreps } = await supabase.from('dreps').select('id, info');
+          const dreps = await fetchAll<{ id: string; info: unknown }>(() =>
+            supabase.from('dreps').select('id, info'),
+          );
 
-          if (!dreps?.length) return 0;
+          if (!dreps.length) return 0;
 
           const currentEpoch = blockTimeToEpoch(Math.floor(Date.now() / 1000));
           const rows = dreps.map((d) => {

--- a/lib/sync/slow.ts
+++ b/lib/sync/slow.ts
@@ -13,6 +13,7 @@ import {
   batchUpsert,
   emitPostHog,
   errMsg,
+  fetchAll,
 } from '@/lib/sync-utils';
 import { generateText } from '@/lib/ai';
 import { blake2bHex } from 'blakejs';
@@ -320,8 +321,10 @@ async function runSocialLinkChecks(supabase: SupabaseClient) {
   const LINK_CHECK_LIMIT = 50;
   const staleThreshold = new Date(Date.now() - 14 * 86_400_000).toISOString();
 
-  const { data: dreps } = await supabase.from('dreps').select('id, metadata');
-  if (!dreps?.length) return { checked: 0 };
+  const dreps = await fetchAll<{ id: string; metadata: unknown }>(() =>
+    supabase.from('dreps').select('id, metadata'),
+  );
+  if (!dreps.length) return { checked: 0 };
 
   const allLinks: { drep_id: string; uri: string }[] = [];
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary

Hardens the sync-health and alerting path so production read-client failures are visible instead of being hidden behind generic 500s or admin-only deep health. Adds a shared Supabase read-client probe that prefers `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and accepts the legacy anon key, then wires that probe into `/api/health`, `/api/health/sync`, `/api/health/deep`, and API/integrity/inbox alert routes.

Also sweeps sync-path full DRep reads through `fetchAll`, fixes the integrity alert score-distribution query from `drep_score` to `score`, and prevents production Inngest self-fetches from silently falling back to localhost when `NEXT_PUBLIC_SITE_URL` is missing.

## Existing Code Audit

The prior operational review found public health/read surfaces failing while deep admin health still reported healthy. Code inspection showed read paths use `createClient()` while deep health used `getSupabaseAdmin()`, so admin health could mask a broken public read-client contract. The review also found unpaginated full-DRep reads in sync/summary paths and a dead integrity alert query selecting `drep_score` even though generated DB types expose `dreps.score`.

## Robustness

- Adds structured read-client failure reasons for missing/invalid URL, missing read key, query error, timeout, and client init failure.
- Adds Supabase read URL/key checks to ops env reporting.
- Keeps alerters operational through admin reads while explicitly alerting when the public read client is down.
- Adds per-probe timeout handling for snapshot checks in broad health.
- Adds tests for read-client diagnostics, health route failure shapes, ops env reporting, Inngest helper behavior, and Supabase pagination through `fetchAll`.

Validation run locally:

- `npm run test:unit -- __tests__/lib/env.test.ts __tests__/lib/supabase-read-client.test.ts __tests__/api/health-sync.test.ts __tests__/api/health.test.ts __tests__/api/health-deep.test.ts __tests__/inngest/helpers.test.ts __tests__/sync/sync-utils.test.ts`
- `npm run type-check`
- `npm run format:check`
- `npm run agent:validate`
- `npm run lint` (passed with existing unrelated warnings only)
- `npm run gh:auth-status`

## Impact

After deploy, `/api/health`, `/api/health/sync`, and `/api/health/deep` should identify Supabase public read-client failures directly. Alert logs should distinguish public read-surface failures from sync writer failures. Secondary and related DRep sync reads should no longer truncate at PostgREST page limits when complete DRep coverage is expected.

Operational follow-up: confirm Railway production has either `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` or legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY` configured correctly, without printing values. This PR does not perform production env edits, write-heavy syncs, backfills, migrations, or deploy/merge actions.
